### PR TITLE
Add notification indicators for chat and wallet tabs

### DIFF
--- a/app.js
+++ b/app.js
@@ -1334,6 +1334,7 @@ async function switchView(view) {
 
     // Update lists when switching views
     if (view === 'chats') {
+        document.getElementById('switchToChats').classList.remove('has-notification');
         await updateChatList('force');
         if (isOnline) {
             if (wsManager && !wsManager.isSubscribed()) {
@@ -1345,6 +1346,7 @@ async function switchView(view) {
     } else if (view === 'wallet') {
 //        await updateAssetPricesIfNeeded(); // New function to update asset prices
 //        await updateWalletBalances();
+        document.getElementById('switchToWallet').classList.remove('has-notification');
         await updateWalletView();
     }
     
@@ -4090,15 +4092,22 @@ async function processChats(chats, keys) {
                     const senderName = contact.name || contact.username || `${from.slice(0,8)}...`
                     
                     if (added > 0) {
-                        showToast(`New message from ${senderName}`, 3000, 'info');
+                        // Add notification indicator to Chats tab if we're not on it
+                        const chatsButton = document.getElementById('switchToChats');
+                        if (!document.getElementById('chatsScreen').classList.contains('active')) {
+                            chatsButton.classList.add('has-notification');
+                        }
                     }
                 }
             }
             
             // Show transfer notification even if no messages were added
             if (hasNewTransfer && !inActiveChatWithSender) {
-                const senderName = contact.name || contact.username || `${from.slice(0,8)}...`        
-                showToast(`New transfer received from ${senderName}`, 3000, 'success');
+                // Add notification indicator to Wallet tab if we're not on it
+                const walletButton = document.getElementById('switchToWallet');
+                if (!document.getElementById('walletScreen').classList.contains('active')) {
+                    walletButton.classList.add('has-notification');
+                }
             }
             
             if (newTimestamp > 0){

--- a/styles.css
+++ b/styles.css
@@ -697,8 +697,28 @@ button:disabled {
   transition: all 0.2s ease;
   flex: 1;
   border-radius: 8px;
-  position: relative; /* Added for positioning the bottom border */
+  position: relative; /* Added for positioning the notification indicator */
 }
+
+/* Notification indicator */
+.nav-button::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  right: 25%;
+  width: 8px;
+  height: 8px;
+  background-color: #3d3dce;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+/* Show notification when has-notification class is present */
+.nav-button.has-notification::after {
+  opacity: 1;
+}
+
 
 .nav-button::before {
   content: "";


### PR DESCRIPTION
- Implemented visual notification indicators for the Chats and Wallet tabs when new messages or transfers are received while not on the respective screens.
- Updated CSS to style the notification indicators and ensure they appear correctly when the 'has-notification' class is applied.

![image](https://github.com/user-attachments/assets/1b5f743d-172e-4ae1-a19c-094f716d8c49)
