### PR TITLE
Remove unnecessary modal close logic from logs and gateway form event…

### DIFF
--- a/app.js
+++ b/app.js
@@ -834,8 +834,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     document.getElementById('openLogs').addEventListener('click', () => {
-        // Close the menu modal first
-        document.getElementById('menuModal').classList.remove('active');
         // Then open the logs modal and update view
         document.getElementById('logsModal').classList.add('active');
         //updateLogsView();
@@ -5526,9 +5524,6 @@ function initializeGatewayConfig() {
 
 // Function to open the gateway form
 function openGatewayForm() {
-    // Close menu modal
-    document.getElementById('menuModal').classList.remove('active');
-
     // Initialize gateway configuration if needed
     initializeGatewayConfig();
 


### PR DESCRIPTION
… handlers to return back to menu instead of Screens

When the user  clicks the back button from the “Gateway Settings” page or “View Logs” page, it goes back to the home page instead of going back to the Menu list