### PR TITLE
Reference Error while calling openSendModal

### DIFF
--- a/app.js
+++ b/app.js
@@ -2945,7 +2945,7 @@ async function closeSendModal() {
     await updateChatList()
     document.getElementById('sendModal').classList.remove('active');
     document.getElementById('sendForm').reset();
-    opensendModal.username = null
+    openSendModal.username = null
 }
 
 function updateSendAddresses() {


### PR DESCRIPTION
This error occurred because the `closeSendModal` function was attempting to reset a property on a non-existent object `opensendModal` (with lowercase 's').

## Root Cause

The codebase consistently uses `openSendModal` (with capital 'S') as both a function and an object with properties:

1. As a function, it opens the send modal UI
2. As an object, it stores state through the property `openSendModal.username`

However, in the `closeSendModal` function, this was incorrectly referenced as `opensendModal.username` (lowercase 's'), causing a ReferenceError since that object doesn't exist.

## Fix

```diff
async function closeSendModal() {
    await updateChatList()
    document.getElementById('sendModal').classList.remove('active');
    document.getElementById('sendForm').reset();
-   opensendModal.username = null
+   openSendModal.username = null
}
```

This simple but important fix ensures proper capitalization consistency throughout the codebase, preventing the reference error when users close the send modal.

## Testing

- Verified that opening and closing the send modal now works without console errors
- Confirmed that the username property is properly reset when the modal is closed
- Tested with different workflows (opening from contacts, wallet, etc.)

## Additional Notes

JavaScript is case-sensitive for variable and property names, making it important to maintain consistent capitalization throughout the codebase. While this approach of using a function as both a callable entity and state container is valid in JavaScript, it requires careful attention to naming consistency.