### PR TITLE
Added variables to maintain navigation history

### DIFF
--- a/app.js
+++ b/app.js
@@ -2008,7 +2008,6 @@ function createNewContact(addr, username){
 let openChatModalSource = null;
 let openChatModalSourceAddress = null;
 
-// Update the openChatModal function
 function openChatModal(address) {
     const modal = document.getElementById('chatModal');
     const modalAvatar = modal.querySelector('.modal-avatar');
@@ -2091,11 +2090,8 @@ function openChatModal(address) {
     }
 }
 
-// Update the closeChatModal function
 function closeChatModal() {
     document.getElementById('chatModal').classList.remove('active');
-    
-    // If chat was opened from contact info modal, reopen it
     if (openChatModalSource === 'contactInfo' && openChatModalSourceAddress) {
         // Use the stored address directly instead of appendChatModal.address
         const contactAddress = openChatModalSourceAddress;

--- a/index.html
+++ b/index.html
@@ -463,7 +463,7 @@
         </div>
       </div>
 
-      <!-- Contact Info Modal (placed before Chat Modal) -->
+      <!-- Contact Info Modal (BEFORE Chat Modal) -->
       <div class="modal fixed-header" id="contactInfoModal">
         <div class="modal-header">
           <button class="back-button" id="closeContactInfoModal"></button>
@@ -537,7 +537,7 @@
         </div>
       </div>
 
-      <!-- Chat Modal (placed after Contact Info Modal) -->
+      <!-- Chat Modal (AFTER Contact Info Modal) -->
       <div class="modal fixed-header" id="chatModal">
         <div class="modal-header">
           <button class="back-button" id="closeChatModal"></button>

--- a/index.html
+++ b/index.html
@@ -1090,11 +1090,11 @@
           </div>
         </div>
       </div>
+    </div>
 
-      <!-- Toast container -->
-      <div class="toast-container" id="toastContainer">
-        <!-- Toasts will be added here -->
-      </div>
+    <!-- Toast container (moved outside #app, before closing body) -->
+    <div class="toast-container" id="toastContainer">
+      <!-- Toasts will be added here -->
     </div>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -182,6 +182,8 @@
         </div>
       </footer>
 
+      <!-- Modals -->
+      
       <!-- New Chat Modal -->
       <div class="modal" id="newChatModal">
         <div class="modal-header">
@@ -461,46 +463,7 @@
         </div>
       </div>
 
-      <!-- Chat Modal -->
-      <div class="modal fixed-header" id="chatModal">
-        <div class="modal-header">
-          <button class="back-button" id="closeChatModal"></button>
-          <div class="chat-user-info">
-            <div class="modal-avatar"></div>
-            <div class="modal-title"></div>
-          </div>
-          <!-- Add header actions container for the edit button and send money button -->
-
-          <div class="header-actions">
-            <button
-              class="icon-button send-money-icon"
-              id="chatSendMoneyButton"
-              aria-label="Send money"
-            ></button>
-            <button
-              class="icon-button edit-icon"
-              id="chatEditButton"
-              aria-label="Edit contact"
-            ></button>
-          </div>
-        </div>
-        <div class="messages-container">
-          <div class="messages-list"></div>
-        </div>
-        <div class="message-input-container">
-          <textarea
-            class="message-input"
-            placeholder="Type a message..."
-          ></textarea>
-          <button class="send-button" id="handleSendMessage">
-            <svg viewBox="0 0 24 24">
-              <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      <!-- Contact Info Modal -->
+      <!-- Contact Info Modal (placed before Chat Modal) -->
       <div class="modal fixed-header" id="contactInfoModal">
         <div class="modal-header">
           <button class="back-button" id="closeContactInfoModal"></button>
@@ -571,6 +534,44 @@
               <div class="contact-info-value" id="contactInfoX"></div>
             </div>
           </div>
+        </div>
+      </div>
+
+      <!-- Chat Modal (placed after Contact Info Modal) -->
+      <div class="modal fixed-header" id="chatModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeChatModal"></button>
+          <div class="chat-user-info">
+            <div class="modal-avatar"></div>
+            <div class="modal-title"></div>
+          </div>
+          <!-- Add header actions container for the edit button and send money button -->
+          <div class="header-actions">
+            <button
+              class="icon-button send-money-icon"
+              id="chatSendMoneyButton"
+              aria-label="Send money"
+            ></button>
+            <button
+              class="icon-button edit-icon"
+              id="chatEditButton"
+              aria-label="Edit contact"
+            ></button>
+          </div>
+        </div>
+        <div class="messages-container">
+          <div class="messages-list"></div>
+        </div>
+        <div class="message-input-container">
+          <textarea
+            class="message-input"
+            placeholder="Type a message..."
+          ></textarea>
+          <button class="send-button" id="handleSendMessage">
+            <svg viewBox="0 0 24 24">
+              <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
+            </svg>
+          </button>
         </div>
       </div>
 
@@ -988,7 +989,7 @@
         </div>
       </div>
 
-      <!-- Add search modal before the other modals -->
+      <!-- Search Messages Modal -->
       <div class="modal search-modal" id="searchModal">
         <div class="modal-header">
           <button class="back-button" id="closeSearchModal"></button>
@@ -1012,7 +1013,7 @@
         </div>
       </div>
 
-      <!-- Add new contact search modal before closing body tag -->
+      <!-- Search Contacts Modal -->
       <div class="modal search-modal" id="contactSearchModal">
         <div class="modal-header">
           <button class="back-button" id="closeContactSearchModal"></button>
@@ -1089,8 +1090,11 @@
           </div>
         </div>
       </div>
+
+      <!-- Toast container -->
+      <div class="toast-container" id="toastContainer">
+        <!-- Toasts will be added here -->
+      </div>
     </div>
-    <!-- Toast container -->
-    <div class="toast-container" id="toastContainer"></div>
   </body>
 </html>


### PR DESCRIPTION
# Fix Navigation Flow When Returning from Contact's Chat

## Issue

When navigating from a contact's details page to the chat screen (by clicking the chat icon), pressing the back button would incorrectly return to the contacts list instead of going back to the contact's details page. This broke the expected navigation flow and created a poor user experience.

## Root Cause

The application wasn't tracking navigation history properly. When opening a chat from the contact details screen, the contact modal was closed first, then the chat modal was opened. When closing the chat, there was no mechanism to know it was opened from contact details.

## Solution

Implemented a navigation history tracking mechanism:

1. Added global tracking variables to remember where the chat was opened from
2. Enhanced the contact modal's chat button handler to set these variables before navigation
3. Modified the chat close handler to check this history and return to contact details when appropriate

## Testing

Tested the following navigation paths:
- Opening a chat from the contacts list and pressing back (returns to contacts list)
- Opening a chat from the chat list and pressing back (returns to chat list)
- Opening a chat from a contact's details page and pressing back (now correctly returns to the contact details page)

This improvement makes the application's navigation more intuitive and matches user expectations for a back button.