### PR TITLE
Optimize QR Codes for Max Memo Length and Improve Receive Modal Layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -2367,7 +2367,10 @@ function createQRPaymentData() {
 // Update QR code with current payment data
 function updateQRCode() {
     const qrcodeContainer = document.getElementById('qrcode');
+    const previewElement = document.getElementById('qrDataPreview'); // Get preview element
     qrcodeContainer.innerHTML = '';
+    previewElement.style.display = 'none'; // Hide preview/error area initially
+    previewElement.innerHTML = ''; // Clear any previous error message
     
     try {
         // Get payment data
@@ -2396,8 +2399,6 @@ function updateQRCode() {
         // Add the image to the container
         qrcodeContainer.appendChild(img);
 
-        // Update preview
-        previewQRData(paymentData);
         
         return qrText;
     } catch (error) {
@@ -2429,14 +2430,10 @@ function updateQRCode() {
             console.log("Fallback QR code generated with username URI");
             console.error("Error generating full QR", error);
 
-            // Show error in preview (pointing to the inner content div)
-            const previewElement = document.getElementById('qrDataPreview');
-            const previewContent = previewElement.querySelector('.preview-content'); 
-            if (previewContent) {
-                previewContent.innerHTML = `<span style="color: red;">Error generating full QR</span><br> Generating QR with only username. <br> Username: ${myAccount.username}`;
-                
-            } else {
-                previewElement.innerHTML = `Error generating full QR. Username: ${myAccount.username}`;
+            // Show error directly in the preview element
+            if (previewElement) {
+                previewElement.innerHTML = `<span style="color: red;">Error generating full QR</span><br> Generating QR with only username. <br> Username: ${myAccount.username}`;
+                previewElement.style.display = 'block'; // Make the error visible
             }
             
             return fallbackQrText; // Return the generated fallback URI
@@ -2444,9 +2441,9 @@ function updateQRCode() {
             // If even the fallback fails (e.g., username missing), show a simple error
             console.error("Error generating fallback QR code:", fallbackError);
             qrcodeContainer.innerHTML = '<p style="color: red; text-align: center;">Failed to generate QR code.</p>';
-            const previewElement = document.getElementById('qrDataPreview');
             if (previewElement) {
                 previewElement.innerHTML = '<p style="color: red;">Error generating QR code.</p>';
+                previewElement.style.display = 'block'; // Make the error visible
             }
             return null; // Indicate complete failure
         }

--- a/app.js
+++ b/app.js
@@ -2179,11 +2179,6 @@ function openReceiveModal() {
     const amountInput = document.getElementById('receiveAmount');
     const memoInput = document.getElementById('receiveMemo');
     const qrDataPreview = document.getElementById('qrDataPreview');
-    const qrDataToggle = document.getElementById('qrDataToggle');
-    const toggleButton = document.getElementById('toggleQROptions');
-    const optionsContainer = document.getElementById('qrOptionsContainer');
-    const toggleText = document.getElementById('toggleQROptionsText');
-    const toggleIcon = document.getElementById('toggleQROptionsIcon');
     
     // Store these references on the modal element for later cleanup
     modal.receiveElements = {
@@ -2191,11 +2186,6 @@ function openReceiveModal() {
         amountInput,
         memoInput,
         qrDataPreview,
-        qrDataToggle,
-        toggleButton,
-        optionsContainer,
-        toggleText,
-        toggleIcon
     };
     
     // Define event handlers and store references to them
@@ -2203,37 +2193,11 @@ function openReceiveModal() {
     const handleAmountInput = () => updateQRCode();
     const handleMemoInput = () => updateQRCode();
     
-    const handleQRDataToggle = () => {
-        qrDataPreview.classList.toggle('minimized');
-        
-        // Adjust height based on state
-        if (qrDataPreview.classList.contains('minimized')) {
-            qrDataPreview.style.height = '40px';
-        } else {
-            // Set height to auto to fit content
-            qrDataPreview.style.height = 'auto';
-        }
-    };
-    
-    const handleOptionsToggle = () => {
-        if (optionsContainer.style.display === 'none') {
-            optionsContainer.style.display = 'block';
-            toggleButton.classList.add('active');
-            toggleText.textContent = 'Hide Payment Request Options';
-        } else {
-            optionsContainer.style.display = 'none';
-            toggleButton.classList.remove('active');
-            toggleText.textContent = 'Show Payment Request Options';
-        }
-    };
-    
     // Store event handlers on the modal for later removal
     modal.receiveHandlers = {
         handleAssetChange,
         handleAmountInput,
         handleMemoInput,
-        handleQRDataToggle,
-        handleOptionsToggle
     };
     
     // Populate assets dropdown
@@ -2267,20 +2231,6 @@ function openReceiveModal() {
     assetSelect.addEventListener('change', handleAssetChange);
     amountInput.addEventListener('input', handleAmountInput);
     memoInput.addEventListener('input', handleMemoInput);
-    
-    // Reset QR data preview state
-    qrDataPreview.classList.remove('minimized');
-    
-    // Add toggle event listener
-    qrDataToggle.addEventListener('click', handleQRDataToggle);
-    
-    // Reset toggle state
-    toggleButton.classList.remove('active');
-    optionsContainer.style.display = 'none';
-    toggleText.textContent = 'Show Payment Request Options';
-    
-    // Add toggle event listener
-    toggleButton.addEventListener('click', handleOptionsToggle);
 
     // Update addresses for first asset
     updateReceiveAddresses();
@@ -2291,15 +2241,13 @@ function closeReceiveModal() {
     
     // Remove event listeners if they were added
     if (modal.receiveElements && modal.receiveHandlers) {
-        const { assetSelect, amountInput, memoInput, qrDataToggle, toggleButton } = modal.receiveElements;
-        const { handleAssetChange, handleAmountInput, handleMemoInput, handleQRDataToggle, handleOptionsToggle } = modal.receiveHandlers;
+        const { assetSelect, amountInput, memoInput } = modal.receiveElements; // Adjusted destructuring
+        const { handleAssetChange, handleAmountInput, handleMemoInput } = modal.receiveHandlers; // Adjusted destructuring
         
         // Remove event listeners
         if (assetSelect) assetSelect.removeEventListener('change', handleAssetChange);
         if (amountInput) amountInput.removeEventListener('input', handleAmountInput);
         if (memoInput) memoInput.removeEventListener('input', handleMemoInput);
-        if (qrDataToggle) qrDataToggle.removeEventListener('click', handleQRDataToggle);
-        if (toggleButton) toggleButton.removeEventListener('click', handleOptionsToggle);
         
         // Clean up references
         delete modal.receiveElements;
@@ -2315,23 +2263,6 @@ function previewQRData(paymentData) {
     const previewElement = document.getElementById('qrDataPreview');
     const previewContent = previewElement.querySelector('.preview-content');
     
-    // Create human-readable preview
-    let preview = `<strong>QR Code Data:</strong><br>`;
-    preview += `<span class="preview-label">Username:</span> ${paymentData.u}<br>`;
-    preview += `<span class="preview-label">Asset:</span> ${paymentData.s}<br>`;
-    
-    if (paymentData.amount) {
-        preview += `<span class="preview-label">Amount:</span> ${paymentData.amount} ${paymentData.symbol}<br>`;
-    }
-    
-    if (paymentData.m) {
-        preview += `<span class="preview-label">Memo:</span> ${paymentData.m}<br>`;
-    }
-    
-    // Add timestamp in readable format
-    const date = new Date(paymentData.t); 
-    preview += `<span class="preview-label">Generated:</span> ${date.toLocaleString()}`;
-    
     // Create minimized version (single line)
     let minimizedPreview = `${paymentData.u} • ${paymentData.s}`;
     if (paymentData.a) {
@@ -2344,14 +2275,12 @@ function previewQRData(paymentData) {
         minimizedPreview += ` • Memo: ${shortMemo}`;
     }
     
-    // Set preview text
-    previewContent.innerHTML = preview;
-    previewContent.setAttribute('data-minimized', minimizedPreview);
+    // SET minimizedPreview directly as innerHTML
+    previewContent.innerHTML = minimizedPreview;
     
-    // Ensure the container fits the content when maximized
-    if (!previewElement.classList.contains('minimized')) {
-        previewElement.style.height = 'auto';
-    }
+    // Ensure consistent height and style for the single line preview
+    previewElement.style.height = 'auto'; // Let content determine height initially
+    previewElement.classList.remove('minimized'); // Ensure minimized class is not present
 }
 
 function updateReceiveAddresses() {
@@ -2417,9 +2346,6 @@ function createQRPaymentData() {
     // Build payment data object
     const paymentData = {
         u: myAccount.username, // username
-        // TODO: remove timestamp and version to save space
-        t: Date.now(), // timestamp
-        v: "1.0", // version
         i: assetId, // assetId
         s: symbol // symbol
     };

--- a/app.js
+++ b/app.js
@@ -2241,8 +2241,8 @@ function closeReceiveModal() {
     
     // Remove event listeners if they were added
     if (modal.receiveElements && modal.receiveHandlers) {
-        const { assetSelect, amountInput, memoInput } = modal.receiveElements; // Adjusted destructuring
-        const { handleAssetChange, handleAmountInput, handleMemoInput } = modal.receiveHandlers; // Adjusted destructuring
+        const { assetSelect, amountInput, memoInput } = modal.receiveElements;
+        const { handleAssetChange, handleAmountInput, handleMemoInput } = modal.receiveHandlers;
         
         // Remove event listeners
         if (assetSelect) assetSelect.removeEventListener('change', handleAssetChange);

--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
               id="receiveMemo"
               class="form-control"
               placeholder="Add a note for the payment"
-              maxlength="140"
+              maxlength="300"
             ></textarea>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -612,10 +612,12 @@
             ></div>
 
             <!-- QR Code Preview (Moved here) -->
-            <div id="qrDataPreview" class="form-control qr-data-preview">
-              <div class="preview-content">
-                <!-- Will show what data will be encoded in QR -->
-              </div>
+            <div
+              id="qrDataPreview"
+              class="form-control qr-data-preview"
+              style="display: none"
+            >
+              <!-- Error messages will be placed here directly by JS -->
             </div>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -616,55 +616,35 @@
               <div class="preview-content">
                 <!-- Will show what data will be encoded in QR -->
               </div>
-              <button
-                type="button"
-                id="qrDataToggle"
-                class="qr-data-toggle"
-                aria-label="Toggle QR data view"
-              ></button>
             </div>
-          </div>
-
-          <!-- Toggle for Payment Request Options -->
-          <div class="form-group">
-            <button
-              id="toggleQROptions"
-              class="secondary-button"
-              style="width: 100%"
-            >
-              <span id="toggleQROptionsText">Show Payment Request Options</span>
-              <span id="toggleQROptionsIcon" style="margin-left: 5px">▼</span>
-            </button>
           </div>
 
           <!-- Payment Request Options (New) -->
-          <div id="qrOptionsContainer" class="form-group" style="display: none">
-            <div class="form-group">
-              <label for="receiveAsset">Asset</label>
-              <select id="receiveAsset" class="form-control">
-                <!-- Will be populated with assets in JavaScript -->
-              </select>
-            </div>
-            <div class="form-group">
-              <label for="receiveAmount">Amount (Optional)</label>
-              <input
-                type="number"
-                id="receiveAmount"
-                class="form-control"
-                placeholder="Enter amount"
-                step="any"
-                min="0"
-              />
-            </div>
-            <div class="form-group">
-              <label for="receiveMemo">Memo (Optional)</label>
-              <textarea
-                id="receiveMemo"
-                class="form-control"
-                placeholder="Add a note for the payment"
-                maxlength="140"
-              ></textarea>
-            </div>
+          <div class="form-group">
+            <label for="receiveAsset">Asset</label>
+            <select id="receiveAsset" class="form-control">
+              <!-- Will be populated with assets in JavaScript -->
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="receiveAmount">Amount (Optional)</label>
+            <input
+              type="number"
+              id="receiveAmount"
+              class="form-control"
+              placeholder="Enter amount"
+              step="any"
+              min="0"
+            />
+          </div>
+          <div class="form-group">
+            <label for="receiveMemo">Memo (Optional)</label>
+            <textarea
+              id="receiveMemo"
+              class="form-control"
+              placeholder="Add a note for the payment"
+              maxlength="140"
+            ></textarea>
           </div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -1431,22 +1431,22 @@ input[type="file"].form-control {
 
 /* Receive Modal Styles */
 #receiveModal .form-group label {
-  margin-bottom: 0.1rem; /* Slightly reduce space below label */
+  margin-bottom: 0.1rem;
 }
 
 #receiveModal .form-group div[style*="display: flex"]:has(#displayAddress) {
   display: flex !important;
-  align-items: flex-start !important; /* Use flex-start for multi-line address */
-  gap: 8px !important; /* Reduce gap */
-  min-height: auto; /* Remove min-height */
+  align-items: flex-start !important;
+  gap: 8px !important;
+  min-height: auto;
 }
 
 #displayAddress {
   background-color: #f6f6f6 !important;
   font-family: var(--font-primary);
-  font-size: 0.8rem !important; /* Decrease font size */
-  line-height: 1.3 !important; /* Adjust line height */
-  padding: 6px 10px !important; /* Decrease padding */
+  font-size: 0.8rem !important;
+  line-height: 1.3 !important;
+  padding: 6px 10px !important;
   height: auto;
   cursor: default;
   color: #333;
@@ -1454,12 +1454,12 @@ input[type="file"].form-control {
   word-break: break-all;
   white-space: normal;
   border: 1px solid #d6d6de;
-  border-radius: 12px; /* Match other form controls */
+  border-radius: 12px;
 }
 
 /* Reduce bottom margin for the form-group containing the address */
 #receiveModal .form-group:has(#displayAddress) {
-  margin-bottom: 0.5rem; /* Reduce margin below address group */
+  margin-bottom: 0.5rem;
 }
 
 #copyAddress {
@@ -1498,23 +1498,22 @@ input[type="file"].form-control {
 
 /* QR code container */
 #qrcode {
-  margin: 0.75rem auto !important; /* Reduced top/bottom margin */
-  padding: 0.75rem; /* Reduced padding */
+  margin: 0.75rem auto !important;
+  padding: 0.75rem;
   background-color: #f6f6f6;
-  border-radius: 8px; /* Slightly smaller radius */
+  border-radius: 8px;
   width: fit-content;
-  display: flex; /* Use flex to center */
+  display: flex;
   justify-content: center;
   align-items: center;
 }
 
 #qrcode img,
 #qrcode canvas {
-  /* Target both image and canvas */
   display: block;
-  width: 160px; /* Reduced size */
-  height: 160px; /* Reduced size */
-  max-width: 100%; /* Ensure responsive */
+  width: 160px;
+  height: 160px;
+  max-width: 100%;
 }
 
 /* Select element specific styles */
@@ -2911,52 +2910,135 @@ mark {
 /* QR Code Payment Styles */
 .qr-data-preview {
   font-size: 0.875rem;
-  padding: 10px 15px; /* Adjust padding for single line */
-  word-break: keep-all; /* Prevent wrapping mid-word */
-  white-space: nowrap; /* Prevent line breaks */
-  overflow: hidden; /* Hide overflow */
-  text-overflow: ellipsis; /* Show ellipsis for overflow */
+  padding: 10px 15px;
+  word-break: keep-all;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   line-height: 1.4;
   background-color: #f8f9fa;
   cursor: default;
-  height: auto; /* Let content determine height */
+  height: auto;
   margin-top: 1rem;
   border-radius: 4px;
   border: 1px solid #dee2e6;
   color: #495057;
-  position: relative; /* Keep relative for potential future absolute elements */
-  transition: none; /* Remove transitions */
+  position: relative;
+  transition: none;
 }
 
 /* Adjust media query styles */
 @media (max-width: 400px), (max-height: 700px) {
   #receiveModal .qr-data-preview {
     font-size: 0.8rem;
-    padding: 8px 12px; /* Adjust padding for single line */
-    min-height: auto; /* Remove min-height */
-    height: auto; /* Ensure height is auto */
+    padding: 8px 12px;
+    min-height: auto;
+    height: auto;
   }
 
   #receiveModal #displayAddress {
-    font-size: 0.75rem !important; /* Further decrease font size */
-    padding: 5px 8px !important; /* Further decrease padding */
+    font-size: 0.75rem !important;
+    padding: 5px 8px !important;
     line-height: 1.25 !important;
   }
 
   #receiveModal .form-group div[style*="display: flex"]:has(#displayAddress) {
-    gap: 6px !important; /* Further reduce gap */
+    gap: 6px !important;
   }
 
   #receiveModal #qrcode {
-    margin: 0.5rem auto !important; /* Further reduced margin */
-    padding: 0.5rem; /* Further reduced padding */
+    margin: 0.5rem auto !important;
+    padding: 0.5rem;
   }
 
   #receiveModal #qrcode img,
   #receiveModal #qrcode canvas {
-    width: 140px; /* Further reduced size */
-    height: 140px; /* Further reduced size */
+    width: 140px;
+    height: 140px;
   }
 }
 
-/* ... rest of styles ... */
+.icon-button.edit-icon {
+  width: 30px;
+  height: 40px;
+  padding: 8px;
+  border-radius: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 20px;
+  opacity: 0.7;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7'%3E%3C/path%3E%3Cpath d='M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z'%3E%3C/path%3E%3C/svg%3E");
+}
+
+.icon-button.edit-icon:hover {
+  background-color: var(--hover-background);
+  opacity: 1;
+}
+
+.contact-info-value-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  position: relative;
+}
+
+.contact-info-value-container .contact-info-value {
+  text-align: center;
+}
+
+.contact-info-value-container .icon-button {
+  padding: 4px;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+  position: absolute;
+  left: calc(50% + 50px);
+  top: -16px; /* Move the icon up slightly */
+}
+
+.contact-info-value-container .icon-button:hover {
+  opacity: 1;
+}
+
+/* Send money icon button */
+.icon-button.send-money-icon {
+  width: 30px;
+  height: 40px;
+  padding: 8px;
+  border-radius: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--primary-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 20px;
+  opacity: 0.7;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='12' y1='1' x2='12' y2='23'%3E%3C/line%3E%3Cpath d='M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6'%3E%3C/path%3E%3C/svg%3E");
+}
+
+.icon-button.send-money-icon:hover {
+  background-color: var(--hover-background);
+  opacity: 1;
+}
+
+.hidden {
+  display: none;
+}
+
+/* Explicitly prevent background change on :active for iOS quirks */
+#uploadQRButton:hover,
+#scanQRButton:hover {
+  background-color: transparent !important;
+}

--- a/styles.css
+++ b/styles.css
@@ -1430,25 +1430,36 @@ input[type="file"].form-control {
 }
 
 /* Receive Modal Styles */
-#receiveModal .form-group div[style*="display: flex"] {
+#receiveModal .form-group label {
+  margin-bottom: 0.1rem; /* Slightly reduce space below label */
+}
+
+#receiveModal .form-group div[style*="display: flex"]:has(#displayAddress) {
   display: flex !important;
-  align-items: center !important; /* Center items vertically */
-  gap: 12px !important;
-  min-height: 56px; /* Match form-control height */
+  align-items: flex-start !important; /* Use flex-start for multi-line address */
+  gap: 8px !important; /* Reduce gap */
+  min-height: auto; /* Remove min-height */
 }
 
 #displayAddress {
   background-color: #f6f6f6 !important;
   font-family: var(--font-primary);
-  font-size: var(--font-size-base) !important;
-  line-height: 24px !important;
-  padding: 15px !important;
+  font-size: 0.8rem !important; /* Decrease font size */
+  line-height: 1.3 !important; /* Adjust line height */
+  padding: 6px 10px !important; /* Decrease padding */
   height: auto;
   cursor: default;
   color: #333;
   flex: 1;
   word-break: break-all;
   white-space: normal;
+  border: 1px solid #d6d6de;
+  border-radius: 12px; /* Match other form controls */
+}
+
+/* Reduce bottom margin for the form-group containing the address */
+#receiveModal .form-group:has(#displayAddress) {
+  margin-bottom: 0.5rem; /* Reduce margin below address group */
 }
 
 #copyAddress {
@@ -1487,17 +1498,23 @@ input[type="file"].form-control {
 
 /* QR code container */
 #qrcode {
-  margin: 1.5rem auto !important;
-  padding: 1.5rem;
+  margin: 0.75rem auto !important; /* Reduced top/bottom margin */
+  padding: 0.75rem; /* Reduced padding */
   background-color: #f6f6f6;
-  border-radius: 12px;
+  border-radius: 8px; /* Slightly smaller radius */
   width: fit-content;
+  display: flex; /* Use flex to center */
+  justify-content: center;
+  align-items: center;
 }
 
-#qrcode img {
+#qrcode img,
+#qrcode canvas {
+  /* Target both image and canvas */
   display: block;
-  width: 200px;
-  height: 200px;
+  width: 160px; /* Reduced size */
+  height: 160px; /* Reduced size */
+  max-width: 100%; /* Ensure responsive */
 }
 
 /* Select element specific styles */
@@ -2894,645 +2911,52 @@ mark {
 /* QR Code Payment Styles */
 .qr-data-preview {
   font-size: 0.875rem;
-  padding: 8px 12px;
-  word-break: break-all;
+  padding: 10px 15px; /* Adjust padding for single line */
+  word-break: keep-all; /* Prevent wrapping mid-word */
+  white-space: nowrap; /* Prevent line breaks */
+  overflow: hidden; /* Hide overflow */
+  text-overflow: ellipsis; /* Show ellipsis for overflow */
   line-height: 1.4;
   background-color: #f8f9fa;
   cursor: default;
-  max-height: 100px;
-  overflow-y: auto;
+  height: auto; /* Let content determine height */
   margin-top: 1rem;
   border-radius: 4px;
   border: 1px solid #dee2e6;
   color: #495057;
+  position: relative; /* Keep relative for potential future absolute elements */
+  transition: none; /* Remove transitions */
 }
 
-#receiveModal .form-group .form-group {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-#receiveModal textarea.form-control {
-  resize: vertical;
-  min-height: 60px;
-  max-height: 120px;
-}
-
-#receiveModal input[type="number"] {
-  -moz-appearance: textfield;
-  appearance: textfield;
-}
-
-#receiveModal input[type="number"]::-webkit-outer-spin-button,
-#receiveModal input[type="number"]::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-#qrOptionsContainer {
-  background-color: #f8f9fa;
-  border-radius: 4px;
-  padding: 15px;
-  margin-top: 10px;
-  border: 1px solid #dee2e6;
-  transition: all 0.3s ease;
-}
-
-#toggleQROptions {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background-color 0.2s;
-}
-
-#toggleQROptionsIcon {
-  transition: transform 0.3s ease;
-}
-
-#toggleQROptions.active #toggleQROptionsIcon {
-  transform: rotate(180deg);
-}
-
-#qrcode {
-  margin-top: 1rem;
-  display: flex;
-  justify-content: center;
-  background-color: white;
-  padding: 10px;
-  border-radius: 4px;
-  border: 1px solid #dee2e6;
-}
-
-/* QR Code Scan Button */
-#scanQRButton {
-  background-color: transparent;
-  border: none;
-  color: #007bff;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  transition: background-color 0.2s;
-}
-
-#scanQRButton svg {
-  display: block;
-}
-
-.preview-label {
-  font-weight: 600;
-  color: #495057;
-  display: inline-block;
-  min-width: 80px;
-}
-
-/* start of scanner stuff added by DB */
-.qr-data-preview {
-  font-size: 0.875rem;
-  padding: 12px 15px;
-  word-break: break-all;
-  line-height: 1.5;
-  background-color: #f8f9fa;
-  cursor: default;
-  max-height: 150px;
-  overflow-y: auto;
-  margin-top: 1rem;
-  border-radius: 4px;
-  border: 1px solid #dee2e6;
-  color: #495057;
-}
-
-.preview-label {
-  font-weight: 600;
-  color: #495057;
-  display: inline-block;
-  min-width: 80px;
-}
-
-.qr-data-preview {
-  font-size: 0.875rem;
-  padding: 15px;
-  word-break: break-all;
-  line-height: 1.5;
-  background-color: #f8f9fa;
-  cursor: default;
-  height: auto;
-  max-height: none;
-  overflow: visible;
-  margin-top: 1rem;
-  border-radius: 8px;
-  border: 1px solid #dee2e6;
-  color: #495057;
-  transition: all 0.3s ease;
-  position: relative;
-}
-
-.qr-data-preview.minimized {
-  height: 60px !important;
-  max-height: 60px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  padding: 10px 40px 10px 15px;
-}
-
-.qr-data-preview .preview-content {
-  transition: opacity 0.3s ease;
-}
-
-.qr-data-preview.minimized .preview-content {
-  opacity: 0.8;
-}
-
-.qr-data-toggle {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  width: 24px;
-  height: 24px;
-  background-color: rgba(0, 123, 255, 0.1);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #007bff;
-  transition: background-color 0.2s;
-}
-
-.qr-data-toggle:hover {
-  background-color: rgba(0, 123, 255, 0.2);
-}
-
-.qr-data-toggle::before {
-  content: "−";
-  font-size: 16px;
-  line-height: 1;
-}
-
-.qr-data-preview.minimized .qr-data-toggle::before {
-  content: "+";
-}
-
-#receiveModal .form-group .form-group {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-#receiveModal textarea.form-control {
-  resize: vertical;
-  min-height: 60px;
-  max-height: 120px;
-}
-
-#receiveModal input[type="number"] {
-  -moz-appearance: textfield;
-  appearance: textfield;
-}
-
-#receiveModal input[type="number"]::-webkit-outer-spin-button,
-#receiveModal input[type="number"]::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-#qrOptionsContainer {
-  background-color: #f8f9fa;
-  border-radius: 8px;
-  padding: 15px;
-  margin-top: 10px;
-  border: 1px solid #dee2e6;
-  transition: all 0.3s ease;
-}
-
-#toggleQROptions {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
-  background-color: #f1f3f5;
-  border: 1px solid #dee2e6;
-  color: #495057;
-  font-weight: 500;
-  padding: 10px 15px;
-  border-radius: 8px;
-  cursor: pointer;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-}
-
-#toggleQROptions:hover {
-  background-color: #e9ecef;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
-}
-
-#toggleQROptions.active {
-  background-color: #e7f5ff;
-  border-color: #74c0fc;
-  color: #1971c2;
-}
-
-#toggleQROptionsIcon {
-  transition: transform 0.3s ease;
-  margin-left: 8px;
-  font-size: 12px;
-}
-
-#toggleQROptions.active #toggleQROptionsIcon {
-  transform: rotate(180deg);
-}
-
-#qrcode {
-  margin-top: 1rem;
-  display: flex;
-  justify-content: center;
-  background-color: white;
-  padding: 15px;
-  border-radius: 8px;
-  border: 1px solid #dee2e6;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-}
-
-.qr-data-preview.minimized .preview-content::before {
-  content: attr(data-minimized);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: block;
-}
-
-.qr-data-preview.minimized .preview-content br,
-.qr-data-preview.minimized .preview-content span,
-.qr-data-preview.minimized .preview-content strong {
-  display: none;
-}
-
-/* QR Scanner Styles */
-.qr-scanner-container {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: #000;
-  /* z-index: 1000; */
-  display: flex;
-  flex-direction: column;
-}
-
-#qrVideo {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.scanner-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  pointer-events: none;
-}
-
-.scanner-guide {
-  width: 70%;
-  height: 70%;
-  max-width: 500px;
-  max-height: 500px;
-  border: 2px solid rgba(255, 255, 255, 0.5);
-  border-radius: 20px;
-  box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.5);
-  position: relative;
-}
-
-.scanner-guide::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 20px;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8) inset;
-  animation: scan-animation 2s infinite;
-}
-
-@keyframes scan-animation {
-  0% {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8) inset;
+/* Adjust media query styles */
+@media (max-width: 400px), (max-height: 700px) {
+  #receiveModal .qr-data-preview {
+    font-size: 0.8rem;
+    padding: 8px 12px; /* Adjust padding for single line */
+    min-height: auto; /* Remove min-height */
+    height: auto; /* Ensure height is auto */
   }
-  50% {
-    box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.8) inset;
+
+  #receiveModal #displayAddress {
+    font-size: 0.75rem !important; /* Further decrease font size */
+    padding: 5px 8px !important; /* Further decrease padding */
+    line-height: 1.25 !important;
   }
-  100% {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8) inset;
+
+  #receiveModal .form-group div[style*="display: flex"]:has(#displayAddress) {
+    gap: 6px !important; /* Further reduce gap */
+  }
+
+  #receiveModal #qrcode {
+    margin: 0.5rem auto !important; /* Further reduced margin */
+    padding: 0.5rem; /* Further reduced padding */
+  }
+
+  #receiveModal #qrcode img,
+  #receiveModal #qrcode canvas {
+    width: 140px; /* Further reduced size */
+    height: 140px; /* Further reduced size */
   }
 }
 
-.scanner-controls {
-  position: absolute;
-  bottom: 30px;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: space-around;
-  padding: 0 20px;
-}
-
-.scanner-button {
-  padding: 12px 24px;
-  border-radius: 30px;
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  border: none;
-  font-size: 16px;
-  backdrop-filter: blur(5px);
-  -webkit-backdrop-filter: blur(5px);
-}
-
-.scanner-button:hover {
-  background: rgba(255, 255, 255, 0.3);
-}
-
-/* Ensure the scanner is properly positioned on iOS */
-@supports (-webkit-touch-callout: none) {
-  .qr-scanner-container {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 100vh;
-    /* Fix for iOS 100vh issue */
-    height: -webkit-fill-available;
-  }
-}
-/* end of scanner stuff added by DB */
-
-.modal.fixed-header {
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-.modal.fixed-header .form-container {
-  flex: 1;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* Remove spinner buttons from number inputs */
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* For Firefox */
-input[type="number"] {
-  -moz-appearance: textfield;
-  appearance: textfield;
-}
-
-/* the following qr code scan stuff was added by Omar */
-.scanner-container {
-  position: relative;
-  overflow: hidden;
-  margin-bottom: 20px;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  background-color: #fff;
-  aspect-ratio: 4/3;
-}
-
-#video {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 8px;
-}
-
-.scan-region-highlight {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 200px;
-  height: 200px;
-  border: 2px dashed #3498db;
-  border-radius: 8px;
-  pointer-events: none;
-  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.3);
-}
-
-.scan-highlight {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  /* z-index: 10; */
-  border: 2px solid #3498db;
-  border-radius: 8px;
-  opacity: 0;
-  transition: opacity 0.3s;
-}
-
-.scan-highlight.active {
-  opacity: 1;
-  background-color: rgba(52, 152, 219, 0.3);
-}
-
-#canvas {
-  display: none;
-}
-/* end of additions by Omar */
-
-small {
-  font-size: 0.8rem;
-  color: #6c757d;
-  text-align: left;
-  display: block;
-  padding: 8px;
-  border-radius: 4px;
-  margin-top: 8px;
-}
-
-/* Send Confirmation Modal Styles */
-#sendConfirmationModal .form-container {
-  padding: 16px;
-  width: 100%;
-  max-width: 390px;
-  margin: 0 auto;
-}
-
-#sendConfirmationModal .confirmation-details {
-  margin-bottom: 24px;
-  background-color: rgba(61, 61, 206, 0.08);
-  border-radius: 12px;
-  padding: 16px;
-}
-
-#sendConfirmationModal .form-group {
-  margin-bottom: 16px;
-}
-
-#sendConfirmationModal .form-group:last-child {
-  margin-bottom: 0;
-}
-
-#sendConfirmationModal label {
-  display: block;
-  font-size: var(--font-size-sm);
-  color: var(--secondary-text-color);
-  margin-bottom: 8px;
-  font-weight: var(--font-weight-medium);
-}
-
-#sendConfirmationModal .confirm-value {
-  font-size: var(--font-size-base);
-  color: var(--text-color);
-  padding: 12px 16px;
-  background-color: var(--background-color);
-  border-radius: 8px;
-  word-break: break-all;
-  font-weight: var(--font-weight-medium);
-  border: 1px solid var(--border-color);
-}
-
-#sendConfirmationModal .update-button,
-#sendConfirmationModal .secondary-button {
-  width: calc(100% - 32px);
-  height: 48px;
-  border-radius: 24px;
-  margin: 8px 16px;
-  font-family: var(--font-primary);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-bold);
-  transition: all 0.2s ease;
-}
-
-#sendConfirmationModal .update-button {
-  background-color: var(--primary-color);
-  color: var(--background-color);
-  border: none;
-}
-
-#sendConfirmationModal .update-button:hover {
-  background-color: var(--primary-hover);
-  opacity: 0.9;
-}
-
-#sendConfirmationModal .secondary-button {
-  background-color: var(--danger-color);
-  color: var(--background-color);
-  border: none;
-}
-
-#sendConfirmationModal .secondary-button:hover {
-  background-color: var(--hover-background-dark);
-  opacity: 0.9;
-}
-
-#sendConfirmationModal #confirmAmount {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
-  color: var(--text-color);
-}
-
-#sendConfirmationModal #confirmMemoGroup {
-  opacity: 0.8;
-}
-
-#sendConfirmationModal #confirmMemo {
-  font-style: italic;
-  background-color: rgba(61, 61, 206, 0.04);
-}
-
-.icon-button.edit-icon {
-  width: 30px;
-  height: 40px;
-  padding: 8px;
-  border-radius: 8px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--text-color);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 20px;
-  opacity: 0.7;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7'%3E%3C/path%3E%3Cpath d='M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z'%3E%3C/path%3E%3C/svg%3E");
-}
-
-.icon-button.edit-icon:hover {
-  background-color: var(--hover-background);
-  opacity: 1;
-}
-
-.contact-info-value-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  width: 100%;
-  position: relative;
-}
-
-.contact-info-value-container .contact-info-value {
-  text-align: center;
-}
-
-.contact-info-value-container .icon-button {
-  padding: 4px;
-  opacity: 0.7;
-  transition: opacity 0.2s;
-  position: absolute;
-  left: calc(50% + 50px);
-  top: -16px; /* Move the icon up slightly */
-}
-
-.contact-info-value-container .icon-button:hover {
-  opacity: 1;
-}
-
-/* Send money icon button */
-.icon-button.send-money-icon {
-  width: 30px;
-  height: 40px;
-  padding: 8px;
-  border-radius: 8px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--primary-color);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 20px;
-  opacity: 0.7;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='12' y1='1' x2='12' y2='23'%3E%3C/line%3E%3Cpath d='M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6'%3E%3C/path%3E%3C/svg%3E");
-}
-
-.icon-button.send-money-icon:hover {
-  background-color: var(--hover-background);
-  opacity: 1;
-}
-
-.hidden {
-  display: none;
-}
-
-/* Explicitly prevent background change on :active for iOS quirks */
-#uploadQRButton:hover,
-#scanQRButton:hover {
-  background-color: transparent !important;
-}
+/* ... rest of styles ... */

--- a/styles.css
+++ b/styles.css
@@ -1511,8 +1511,8 @@ input[type="file"].form-control {
 #qrcode img,
 #qrcode canvas {
   display: block;
-  width: 160px;
-  height: 160px;
+  width: 200px;
+  height: 200px;
   max-width: 100%;
 }
 
@@ -2927,6 +2927,31 @@ mark {
   transition: none;
 }
 
+#qrcode {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  background-color: white;
+  padding: 10px;
+  border-radius: 4px;
+  border: 1px solid #dee2e6;
+}
+
+/* QR Code Scan Button */
+#scanQRButton {
+  background-color: transparent;
+  border: none;
+  color: #007bff;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+#scanQRButton svg {
+  display: block;
+}
+
 /* Adjust media query styles */
 @media (max-width: 400px), (max-height: 700px) {
   #receiveModal .qr-data-preview {
@@ -2953,9 +2978,477 @@ mark {
 
   #receiveModal #qrcode img,
   #receiveModal #qrcode canvas {
-    width: 140px;
-    height: 140px;
+    width: 200px;
+    height: 200px;
   }
+
+  
+}
+/* start of scanner stuff added by DB */
+.qr-data-preview {
+  font-size: 0.875rem;
+  padding: 12px 15px;
+  word-break: break-all;
+  line-height: 1.5;
+  background-color: #f8f9fa;
+  cursor: default;
+  max-height: 150px;
+  overflow-y: auto;
+  margin-top: 1rem;
+  border-radius: 4px;
+  border: 1px solid #dee2e6;
+  color: #495057;
+}
+
+.preview-label {
+  font-weight: 600;
+  color: #495057;
+  display: inline-block;
+  min-width: 80px;
+}
+
+.qr-data-preview {
+  font-size: 0.875rem;
+  padding: 15px;
+  word-break: break-all;
+  line-height: 1.5;
+  background-color: #f8f9fa;
+  cursor: default;
+  height: auto;
+  max-height: none;
+  overflow: visible;
+  margin-top: 1rem;
+  border-radius: 8px;
+  border: 1px solid #dee2e6;
+  color: #495057;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.qr-data-preview.minimized {
+  height: 60px !important;
+  max-height: 60px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 10px 40px 10px 15px;
+}
+
+.qr-data-preview .preview-content {
+  transition: opacity 0.3s ease;
+}
+
+.qr-data-preview.minimized .preview-content {
+  opacity: 0.8;
+}
+
+.qr-data-toggle {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 24px;
+  height: 24px;
+  background-color: rgba(0, 123, 255, 0.1);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #007bff;
+  transition: background-color 0.2s;
+}
+
+.qr-data-toggle:hover {
+  background-color: rgba(0, 123, 255, 0.2);
+}
+
+.qr-data-toggle::before {
+  content: "−";
+  font-size: 16px;
+  line-height: 1;
+}
+
+.qr-data-preview.minimized .qr-data-toggle::before {
+  content: "+";
+}
+
+#receiveModal .form-group .form-group {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+#receiveModal textarea.form-control {
+  resize: vertical;
+  min-height: 60px;
+  max-height: 120px;
+}
+
+#receiveModal input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+#receiveModal input[type="number"]::-webkit-outer-spin-button,
+#receiveModal input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+#qrOptionsContainer {
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  padding: 15px;
+  margin-top: 10px;
+  border: 1px solid #dee2e6;
+  transition: all 0.3s ease;
+}
+
+#toggleQROptions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  background-color: #f1f3f5;
+  border: 1px solid #dee2e6;
+  color: #495057;
+  font-weight: 500;
+  padding: 10px 15px;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+#toggleQROptions:hover {
+  background-color: #e9ecef;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
+}
+
+#toggleQROptions.active {
+  background-color: #e7f5ff;
+  border-color: #74c0fc;
+  color: #1971c2;
+}
+
+#toggleQROptionsIcon {
+  transition: transform 0.3s ease;
+  margin-left: 8px;
+  font-size: 12px;
+}
+
+#toggleQROptions.active #toggleQROptionsIcon {
+  transform: rotate(180deg);
+}
+
+#qrcode {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  background-color: white;
+  padding: 15px;
+  border-radius: 8px;
+  border: 1px solid #dee2e6;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.qr-data-preview.minimized .preview-content::before {
+  content: attr(data-minimized);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.qr-data-preview.minimized .preview-content br,
+.qr-data-preview.minimized .preview-content span,
+.qr-data-preview.minimized .preview-content strong {
+  display: none;
+}
+
+/* QR Scanner Styles */
+.qr-scanner-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  /* z-index: 1000; */
+  display: flex;
+  flex-direction: column;
+}
+
+#qrVideo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.scanner-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+}
+
+.scanner-guide {
+  width: 70%;
+  height: 70%;
+  max-width: 500px;
+  max-height: 500px;
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  border-radius: 20px;
+  box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+.scanner-guide::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8) inset;
+  animation: scan-animation 2s infinite;
+}
+
+@keyframes scan-animation {
+  0% {
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8) inset;
+  }
+  50% {
+    box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.8) inset;
+  }
+  100% {
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8) inset;
+  }
+}
+
+.scanner-controls {
+  position: absolute;
+  bottom: 30px;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  padding: 0 20px;
+}
+
+.scanner-button {
+  padding: 12px 24px;
+  border-radius: 30px;
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: none;
+  font-size: 16px;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+}
+
+.scanner-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+/* Ensure the scanner is properly positioned on iOS */
+@supports (-webkit-touch-callout: none) {
+  .qr-scanner-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 100vh;
+    /* Fix for iOS 100vh issue */
+    height: -webkit-fill-available;
+  }
+}
+/* end of scanner stuff added by DB */
+
+.modal.fixed-header {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.modal.fixed-header .form-container {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Remove spinner buttons from number inputs */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* For Firefox */
+input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+/* the following qr code scan stuff was added by Omar */
+.scanner-container {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+  aspect-ratio: 4/3;
+}
+
+#video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.scan-region-highlight {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 200px;
+  height: 200px;
+  border: 2px dashed #3498db;
+  border-radius: 8px;
+  pointer-events: none;
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.3);
+}
+
+.scan-highlight {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  /* z-index: 10; */
+  border: 2px solid #3498db;
+  border-radius: 8px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.scan-highlight.active {
+  opacity: 1;
+  background-color: rgba(52, 152, 219, 0.3);
+}
+
+#canvas {
+  display: none;
+}
+/* end of additions by Omar */
+
+small {
+  font-size: 0.8rem;
+  color: #6c757d;
+  text-align: left;
+  display: block;
+  padding: 8px;
+  border-radius: 4px;
+  margin-top: 8px;
+}
+
+/* Send Confirmation Modal Styles */
+#sendConfirmationModal .form-container {
+  padding: 16px;
+  width: 100%;
+  max-width: 390px;
+  margin: 0 auto;
+}
+
+#sendConfirmationModal .confirmation-details {
+  margin-bottom: 24px;
+  background-color: rgba(61, 61, 206, 0.08);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+#sendConfirmationModal .form-group {
+  margin-bottom: 16px;
+}
+
+#sendConfirmationModal .form-group:last-child {
+  margin-bottom: 0;
+}
+
+#sendConfirmationModal label {
+  display: block;
+  font-size: var(--font-size-sm);
+  color: var(--secondary-text-color);
+  margin-bottom: 8px;
+  font-weight: var(--font-weight-medium);
+}
+
+#sendConfirmationModal .confirm-value {
+  font-size: var(--font-size-base);
+  color: var(--text-color);
+  padding: 12px 16px;
+  background-color: var(--background-color);
+  border-radius: 8px;
+  word-break: break-all;
+  font-weight: var(--font-weight-medium);
+  border: 1px solid var(--border-color);
+}
+
+#sendConfirmationModal .update-button,
+#sendConfirmationModal .secondary-button {
+  width: calc(100% - 32px);
+  height: 48px;
+  border-radius: 24px;
+  margin: 8px 16px;
+  font-family: var(--font-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  transition: all 0.2s ease;
+}
+
+#sendConfirmationModal .update-button {
+  background-color: var(--primary-color);
+  color: var(--background-color);
+  border: none;
+}
+
+#sendConfirmationModal .update-button:hover {
+  background-color: var(--primary-hover);
+  opacity: 0.9;
+}
+
+#sendConfirmationModal .secondary-button {
+  background-color: var(--danger-color);
+  color: var(--background-color);
+  border: none;
+}
+
+#sendConfirmationModal .secondary-button:hover {
+  background-color: var(--hover-background-dark);
+  opacity: 0.9;
+}
+
+#sendConfirmationModal #confirmAmount {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-color);
+}
+
+#sendConfirmationModal #confirmMemoGroup {
+  opacity: 0.8;
+}
+
+#sendConfirmationModal #confirmMemo {
+  font-style: italic;
+  background-color: rgba(61, 61, 206, 0.04);
 }
 
 .icon-button.edit-icon {


### PR DESCRIPTION
This PR refactors the QR code functionality in the "Receive" modal:

1.  **Removes QR Data Preview:** Eliminates the detailed QR data preview and its expand/collapse toggle. The `qrDataPreview` element is now used *only* to display errors if QR generation fails.
2.  **Simplifies Payment Options:** Removes the toggle button for showing/hiding QR payment options (Asset, Amount, Memo); these are now always visible.
3.  **Optimizes QR Data:** Removes timestamp and version fields from the generated QR data to reduce its size.
4.  **Adjusts Styles:** Updates related CSS for the Receive modal, QR display, and removed elements.


![image](https://github.com/user-attachments/assets/0bd65d6e-b104-4f4e-9199-368583f4fb65)
![image](https://github.com/user-attachments/assets/20158411-f82b-47b3-9175-24475086640f)

