### PR TITLE
Make URLs in chat messages clickable links

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,7 +124,7 @@ import { cbc, xchacha20poly1305 } from './external/noble-ciphers.js';
 import { normalizeUsername, generateIdenticon, formatTime, 
     isValidEthereumAddress, 
     normalizeAddress, longAddress, utf82bin, bin2utf8, hex2big, bigxnum2big,
-    big2str, base642bin, bin2base64, hex2bin, bin2hex,
+    big2str, base642bin, bin2base64, hex2bin, bin2hex, linkifyUrls
 } from './lib.js';
 
 // Import database functions
@@ -2070,7 +2070,7 @@ function openChatModal(address) {
     // Display messages and click-to-copy feature
     messagesList.innerHTML = messages.map((msg, index) => `
         <div class="message ${msg.my ? 'sent' : 'received'}" data-message-id="${index}">
-            <div class="message-content">${msg.message}</div>
+            <div class="message-content">${linkifyUrls(msg.message)}</div>
             <div class="message-time">${formatTime(msg.timestamp)}</div>
         </div>
     `).join('');
@@ -2136,7 +2136,7 @@ function appendChatModal(){
         // Add message to UI
         messagesList.insertAdjacentHTML('beforeend', `
             <div class="message ${m.type}">
-                <div class="message-content" style="white-space: pre-wrap">${m.message}</div>
+                <div class="message-content" style="white-space: pre-wrap">${linkifyUrls(m.message)}</div>
                 <div class="message-time">${formatTime(m.timestamp)}</div>
             </div>
         `);

--- a/lib.js
+++ b/lib.js
@@ -97,14 +97,27 @@ export function formatTime(timestamp) {
 // Function to detect URLs and convert them to clickable links
 export function linkifyUrls(text) {
     if (!text) return '';
-    // Regex to find URLs (http, https, www), ensuring capture groups don't break replacement
-    // Match http/https/ftp/file protocols OR www. starting URLs
-    const urlRegex = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])|(\bwww\.[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi;
+
+    // Updated Regex: Only match explicit http:// or https://
+    const urlRegex = /(\b(https?):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi;
+
+    // Allowed protocols check (still good practice, though the regex is stricter)
+    const allowedProtocols = /^https?:\/\//i; 
+
     return text.replace(urlRegex, function(url) {
-        // Prepend http:// if the URL starts with www. and doesn't have a protocol
-        const properUrl = /^www\./i.test(url) ? 'http://' + url : url;
-        // Escape HTML characters in the URL for the text node to prevent XSS if the URL itself contains HTML-like strings
-        const escapedUrl = url.replace(/</g, "&lt;").replace(/>/g, "&gt;"); 
+        // No need to prepend protocol anymore, as the regex ensures it's present.
+        const properUrl = url; 
+
+        // Escape HTML characters in the display text to prevent XSS
+        const escapedUrl = url.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+        // **Safety Check:** Validate the protocol
+        // Should always pass now due to the strict regex, but kept for safety.
+        if (!allowedProtocols.test(properUrl)) {
+             return escapedUrl; 
+        }
+
+        // Create the link
         return `<a href="${properUrl}" target="_blank" rel="noopener noreferrer">${escapedUrl}</a>`;
     });
 }

--- a/lib.js
+++ b/lib.js
@@ -94,6 +94,21 @@ export function formatTime(timestamp) {
     }
 }
 
+// Function to detect URLs and convert them to clickable links
+export function linkifyUrls(text) {
+    if (!text) return '';
+    // Regex to find URLs (http, https, www), ensuring capture groups don't break replacement
+    // Match http/https/ftp/file protocols OR www. starting URLs
+    const urlRegex = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])|(\bwww\.[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi;
+    return text.replace(urlRegex, function(url) {
+        // Prepend http:// if the URL starts with www. and doesn't have a protocol
+        const properUrl = /^www\./i.test(url) ? 'http://' + url : url;
+        // Escape HTML characters in the URL for the text node to prevent XSS if the URL itself contains HTML-like strings
+        const escapedUrl = url.replace(/</g, "&lt;").replace(/>/g, "&gt;"); 
+        return `<a href="${properUrl}" target="_blank" rel="noopener noreferrer">${escapedUrl}</a>`;
+    });
+}
+
 export function ab2base64(buffer) {
     let binary = '';
     const bytes = new Uint8Array(buffer);

--- a/styles.css
+++ b/styles.css
@@ -1144,15 +1144,25 @@ input[type="file"].form-control::file-selector-button {
 .message.sent {
   align-self: flex-end;
   background-color: var(--primary-color);
-  color: var(--background-color);
-  border-bottom-right-radius: 0.25rem;
+  color: white;
+}
+
+/* Make links white in sent messages for contrast */
+.message.sent a {
+  color: white;
+  text-decoration: underline; /* Add underline for better visibility */
+}
+
+/* Optional: Style links in received messages if needed (default blue might be ok) */
+.message.received a {
+  /* color: darkblue; */ /* Example: Make links darker blue */
+  text-decoration: underline;
 }
 
 .message.sent .message-time {
-  font-size: 0.75rem;
-  opacity: 0.7;
-  margin-top: 0.25rem;
-  text-align: right;
+  color: rgba(255, 255, 255, 0.7);
+  align-self: flex-end;
+  margin-top: 2px;
 }
 
 .message-time {


### PR DESCRIPTION
feat: Make URLs in chat messages clickable links

This PR implements the functionality to automatically detect and convert URLs starting with `http://` or `https://` within chat messages into clickable HTML links.

Changes:

- Added a `linkifyUrls` utility function to `lib.js` that identifies URLs **explicitly starting with `http://` or `https://`** and wraps them in `<a>` tags. URLs starting with `ftp://`, `file://`, or `www.` without a protocol prefix are no longer converted.
- Updated `openChatModal` and `appendChatModal` in `app.js` to use `linkifyUrls` when rendering message content.
- Added CSS rules in `styles.css` to style the links for better visibility:
    - Links in sent (blue) messages are now white and underlined.
    - Links in received (grey) messages are now underlined.

Outcome:

URLs sent or received in chat messages that **explicitly begin with `http://` or `https://`** are now interactive links that open in a new tab. Styling ensures links are visible against both sent and received message bubble backgrounds. **URLs without these explicit protocols (e.g., `www.example.com`, `example.com`, `ftp://...`) are not automatically linked.**

![image](https://github.com/user-attachments/assets/aaaa91a5-e3a5-4c45-8f31-d1f907693fe0)

