### PR TITLE
Add Private Key Visibility Toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -1030,6 +1030,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         openSendModal();
     });
 
+    // Add listener for the password visibility toggle
+    const togglePasswordButton = document.getElementById('togglePrivateKeyVisibility');
+    const passwordInput = document.getElementById('newPrivateKey');
+    
+    togglePasswordButton.addEventListener('click', function () {
+        // Toggle the type attribute
+        const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+        passwordInput.setAttribute('type', type);
+
+        // Toggle the visual state class on the button
+        this.classList.toggle('toggled-visible');
+    });
+    
+
     setupAddToHomeScreen()
 });
 

--- a/index.html
+++ b/index.html
@@ -374,12 +374,20 @@
                   style="color: #dc3545; display: none"
                 ></span
               ></label>
-              <input
-                type="text"
-                id="newPrivateKey"
-                class="form-control"
-                placeholder="Optional private key in hex format"
-              />
+              <div style="position: relative">
+                <input
+                  type="password"
+                  id="newPrivateKey"
+                  class="form-control"
+                  placeholder="Optional private key in hex format"
+                />
+                <button
+                  type="button"
+                  id="togglePrivateKeyVisibility"
+                  class="password-toggle-btn"
+                >
+                </button>
+              </div>
               <small>
                 If you want to use an existing private key enter it here.
                 Otherwise you can leave this empty to have a private key

--- a/styles.css
+++ b/styles.css
@@ -3536,3 +3536,48 @@ small {
 #scanQRButton:hover {
   background-color: transparent !important;
 }
+
+/* Add these styles for the password visibility toggle */
+.password-toggle-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  width: 20px; /* SVG width */
+  height: 20px; /* SVG height */
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  /* Default eye icon (stroke: #6c757d) */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%236c757d' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z'%3E%3C/path%3E%3Ccircle cx='12' cy='12' r='3'%3E%3C/circle%3E%3C/svg%3E");
+  z-index: 2;
+}
+
+/* Eye icon hover (stroke: #343a40) */
+.password-toggle-btn:hover {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23343a40' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z'%3E%3C/path%3E%3Ccircle cx='12' cy='12' r='3'%3E%3C/circle%3E%3C/svg%3E");
+}
+
+/* Eye-slash icon when toggled (stroke: #6c757d) */
+.password-toggle-btn.toggled-visible {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%236c757d' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24'%3E%3C/path%3E%3Cline x1='1' y1='1' x2='23' y2='23'%3E%3C/line%3E%3C/svg%3E");
+}
+
+/* Eye-slash icon when toggled and hovered (stroke: #343a40) */
+.password-toggle-btn.toggled-visible:hover {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23343a40' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24'%3E%3C/path%3E%3Cline x1='1' y1='1' x2='23' y2='23'%3E%3C/line%3E%3C/svg%3E");
+}
+
+/* Optional: Adjust input padding if the icon overlaps text */
+#newPrivateKey {
+  padding-right: 40px; /* Add padding to prevent text from going under the icon */
+}
+
+/* Style adjustments for focus or hover if desired */
+.password-toggle-btn:hover {
+  color: #343a40;
+}


### PR DESCRIPTION
**feat: Add Private Key Visibility Toggle**

This PR implements a visibility toggle for the "Private Key" field on the "Create Account" modal.

*   **HTML (`index.html`):** Changed the input type to `password` and added a `<button>` element for the toggle.
*   **CSS (`styles.css`):** Styled the toggle button using URL-encoded SVG background images for eye/eye-slash icons, positioning it within the input field. Handled default, toggled, and hover states. Added right padding to the input field.
*   **JavaScript (`app.js`):** Added a click listener to the toggle button that swaps the input field's `type` between `password` and `text` and toggles a CSS class on the button to update the icon.

![image](https://github.com/user-attachments/assets/94e6c49a-1e78-4be7-8a6d-570e08989e66)
![image](https://github.com/user-attachments/assets/2ac9b71e-2889-428e-92a9-b0cba355f098)
![image](https://github.com/user-attachments/assets/370ac376-e957-46d2-add0-f88f351d5d89)

