### PR TITLE
clear input fields in send modal and QR payment functions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // Check if there is a newer version and load that using a new random url to avoid cache hits
 //   Versions should be YYYY.MM.DD.HH.mm like 2025.01.25.10.05
-const version = 'k'   // Also increment this when you increment version.html
+const version = 'r'
 let myVersion = '0'
 async function checkVersion(){
     myVersion = localStorage.getItem('version') || '0';
@@ -2481,6 +2481,12 @@ async function copyAddress() {
 function openSendModal() {
     const modal = document.getElementById('sendModal');
     modal.classList.add('active');
+
+    // Clear fields when opening the modal
+    document.getElementById('sendToAddress').value = '';
+    document.getElementById('sendAmount').value = '';
+    document.getElementById('sendMemo').value = '';
+
     const usernameInput = document.getElementById('sendToAddress');
     const usernameAvailable = document.getElementById('sendToAddressError');
     const submitButton = document.querySelector('#sendForm button[type="submit"]');
@@ -2578,6 +2584,12 @@ function closeQRScanModal(){
 
 function fillPaymentFromQR(data){
     console.log('in fill', data)
+
+    // Clear existing fields first
+    document.getElementById('sendToAddress').value = '';
+    document.getElementById('sendAmount').value = '';
+    document.getElementById('sendMemo').value = '';
+
     data = data.replace('liberdus://', '')
     const paymentData = JSON.parse(atob(data))
     console.log("Read payment data:", JSON.stringify(paymentData, null, 2));

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // Check if there is a newer version and load that using a new random url to avoid cache hits
 //   Versions should be YYYY.MM.DD.HH.mm like 2025.01.25.10.05
-const version = 'r'
+const version = 'r'   // Also increment this when you increment version.html
 let myVersion = '0'
 async function checkVersion(){
     myVersion = localStorage.getItem('version') || '0';


### PR DESCRIPTION
* Change version from 'k' to 'r' for application updates.
* Clear input fields in the send modal when opened to ensure a fresh state for user input.
* Clear existing fields in the `fillPaymentFromQR` function before populating with new data for better user experience.