### PR TITLE
message input overflow=auto & visually remove scroll bar & update viewport meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content"
     />
     <meta name="theme-color" content="#ffffff" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/styles.css
+++ b/styles.css
@@ -1577,6 +1577,18 @@ input[type="file"].form-control {
   padding-right: 45px;
 }
 
+#sendMemo,
+#receiveMemo {
+  overflow-y: auto; /* Allow scrolling when needed */
+  scrollbar-width: none; /* Hide scrollbar for Firefox */
+  -ms-overflow-style: none; /* Hide scrollbar for IE/Edge (older versions) */
+}
+
+#sendMemo::-webkit-scrollbar,
+#receiveMemo::-webkit-scrollbar {
+  display: none; /* Hide scrollbar for WebKit browsers */
+}
+
 #sendModal textarea.form-control {
   min-height: 100px;
   resize: vertical;
@@ -3596,4 +3608,23 @@ small {
 /* Style adjustments for focus or hover if desired */
 .password-toggle-btn:hover {
   color: #343a40;
+}
+
+#sendMemo,
+#receiveMemo {
+  overflow-y: auto; /* Allow scrolling when needed */
+  scrollbar-width: none; /* Hide scrollbar for Firefox */
+  -ms-overflow-style: none; /* Hide scrollbar for IE/Edge (older versions) */
+}
+
+#sendMemo::-webkit-scrollbar,
+#receiveMemo::-webkit-scrollbar {
+  display: none; /* Hide scrollbar for WebKit browsers */
+}
+
+.error-message {
+  color: #dc3545;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+  display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -1083,6 +1083,11 @@ input[type="file"].form-control::file-selector-button {
   line-height: 24px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  scrollbar-width: none; /* Hide scrollbar for Firefox */
+}
+
+.message-input::-webkit-scrollbar {
+  display: none; /* Hide scrollbar for WebKit browsers */
 }
 
 .message-input:focus {

--- a/styles.css
+++ b/styles.css
@@ -1081,7 +1081,8 @@ input[type="file"].form-control::file-selector-button {
   height: 48px;
   min-height: unset;
   line-height: 24px;
-  overflow-y: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .message-input:focus {


### PR DESCRIPTION
**Summary:**

This PR updates the styling for several text input areas (`.message-input`, `#sendMemo`, `#receiveMemo`) to visually hide their scrollbars across different browsers while ensuring they remain scrollable when the content overflows. It also adjusts the viewport meta tag for better behavior with interactive widgets on mobile android devices.

**Changes:**

*   **index.html:**
    *   Added `interactive-widget=resizes-content` to the `viewport` meta tag to ensure the layout resizes correctly when virtual keyboards or other interactive widgets appear for android devices
*   **styles.css:**
    *   Updated `.message-input`:
        *   Changed `overflow-y` from `hidden` to `auto`.
        *   Added `-webkit-overflow-scrolling: touch` for mobile scrolling behavior.
        *   Added `scrollbar-width: none` to hide scrollbars in Firefox.
    *   Added `.message-input::-webkit-scrollbar` rule with `display: none` to hide scrollbars in WebKit browsers.
    *   Added new rules targeting `#sendMemo` and `#receiveMemo` to apply `overflow-y: auto`, `scrollbar-width: none`, and `-ms-overflow-style: none`.
    *   Added corresponding `#sendMemo::-webkit-scrollbar` and `#receiveMemo::-webkit-scrollbar` rules with `display: none`.
    *   (Note: Duplicate rules for `#sendMemo`/`#receiveMemo` and a new `.error-message` rule were also added at the end of the file).
