### PR TITLE
Modify Search Result Highlighting Logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -5033,7 +5033,7 @@ function searchMessages(searchText) {
                 const messageText = message.message;
                 const highlightedText = messageText.replace(
                     new RegExp(searchText, 'gi'),
-                    match => `<mark>${match}</mark>`
+                    match => `${match}`
                 );
                 
                 results.push({
@@ -5042,8 +5042,8 @@ function searchMessages(searchText) {
                     messageId: index,
                     message: message,  // Pass the entire message object
                     timestamp: message.timestamp,
-                    preview: truncateMessage(highlightedText, 100),
-                    my: message.my  // Include the my property
+                    preview: truncateMessage(highlightedText, 100), // Store plain truncated text
+                    my: message.my // Include the my property
                 });
             }
         });
@@ -5067,7 +5067,7 @@ function displaySearchResults(results) {
         
         // Format message preview with "You:" prefix if it's a sent message
         // make this textContent?
-        const messagePreview = result.my ? `You: ${result.preview}` : result.preview;
+        const messagePreview = result.my ? `You: <mark>${escapeHtml(result.preview)}</mark>` : `<mark>${escapeHtml(result.preview)}</mark>`;
         
         resultElement.innerHTML = `
             <div class="chat-avatar">
@@ -5079,7 +5079,7 @@ function displaySearchResults(results) {
                     <div class="chat-time">${formatTime(result.timestamp)}</div>
                 </div>
                 <div class="chat-message">
-                    ${linkifyUrls(messagePreview)}
+                    ${messagePreview}
                 </div>
             </div>
         `;

--- a/app.js
+++ b/app.js
@@ -5042,8 +5042,8 @@ function searchMessages(searchText) {
                     messageId: index,
                     message: message,  // Pass the entire message object
                     timestamp: message.timestamp,
-                    preview: truncateMessage(highlightedText, 100), // Store plain truncated text
-                    my: message.my // Include the my property
+                    preview: truncateMessage(highlightedText, 100),
+                    my: message.my  // Include the my property
                 });
             }
         });


### PR DESCRIPTION
**Summary:**

*   Updates the message search functionality to highlight the entire message preview in the results list, rather than just the specific search term occurrences.
*   Removes the step that added `<mark>` tags around specific matches within the `searchMessages` function.
*   Modifies `displaySearchResults` to wrap the complete, HTML-escaped message preview string in `<mark>` tags before rendering.
*   Removes the `linkifyUrls` call from the search result message preview display.
![image](https://github.com/user-attachments/assets/4b163ec2-ec40-489d-95dd-eacec3b90bb4)
![image](https://github.com/user-attachments/assets/80ad7839-da28-4bb2-9046-1f92c0122a01)
![image](https://github.com/user-attachments/assets/3c76934f-d270-4cf3-bc26-8957bf1c3e8c)
BEFORE:
![image](https://github.com/user-attachments/assets/4fcd49a4-b601-4886-b2e5-bc3a61f3b82c)
![image](https://github.com/user-attachments/assets/23e351e2-8bca-4f7d-ab91-ee2ce7f74ece)
