### PR TITLE
Feat: Add notification dot to Wallet History button for new transactions

### DIFF
--- a/app.js
+++ b/app.js
@@ -3419,6 +3419,11 @@ console.log(JSON.stringify(data,null,4))
 }
 
 function openHistoryModal() {
+    // remove notification from wallet-action-button if it is active
+    if (document.getElementById('openHistoryModal').classList.contains('has-notification')) {
+        document.getElementById('openHistoryModal').classList.remove('has-notification');
+    }
+
     const modal = document.getElementById('historyModal');
     modal.classList.add('active');
     
@@ -3878,6 +3883,9 @@ async function processChats(chats, keys) {
                 if (!document.getElementById('walletScreen').classList.contains('active')) {
                     walletButton.classList.add('has-notification');
                 }
+                // Add notification to openHistoryModal wallet-action-button
+                const historyButton = document.getElementById('openHistoryModal');
+                historyButton.classList.add('has-notification');
             }
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -1293,6 +1293,27 @@ input[type="file"].form-control::file-selector-button {
   cursor: pointer;
   border-radius: 8px;
   transition: all 0.2s ease;
+  position: relative; /* Added for notification dot */
+}
+
+/* Notification indicator for wallet action buttons */
+.wallet-action-button::after {
+  content: "";
+  position: absolute;
+  top: 4px; /* Adjust vertical position if needed */
+  right: 10px; /* Adjust horizontal position if needed */
+  width: 8px;
+  height: 8px;
+  background-color: #3d3dce; /* Same blue color as nav buttons */
+  border-radius: 50%;
+  opacity: 0; /* Hidden by default */
+  transition: opacity 0.2s ease;
+  pointer-events: none; /* Prevent the dot interfering with clicks */
+}
+
+/* Show notification for wallet action button */
+.wallet-action-button.has-notification::after {
+  opacity: 1;
 }
 
 .wallet-action-button:hover {


### PR DESCRIPTION
**Summary:**

*   **Wallet History Notification:**
    *   Added a visual notification dot (using CSS `::after` pseudo-element) to the "History" button on the Wallet screen (`#openHistoryModal`).
    *   The dot appears when a new transaction notification is received via WebSocket while the user is not on the Wallet tab.
    *   The notification dot is automatically removed when the user clicks the "History" button to open the transaction history modal.
*   **CSS:**
    *   Added `position: relative` to `.wallet-action-button` to allow absolute positioning of the notification dot.
    *   Added new CSS rules for `.wallet-action-button::after` to define the dot's appearance (hidden by default).
    *   Added `.wallet-action-button.has-notification::after` rule to make the dot visible when the class is present.


![image](https://github.com/user-attachments/assets/610d0772-ee2a-4559-a736-f8f85b52a86e)
