### PR TITLE
Refactor sound playback logic in processChats function

### DIFF
--- a/app.js
+++ b/app.js
@@ -3943,10 +3943,8 @@ async function processChats(chats, keys) {
                     if (historyModalActive) {
                         updateTransactionHistory();
                     }
-                    // if historyModal and walletScreen are not active, play transfer sound
-                    if (!walletScreenActive && !historyModalActive){
-                        playTransferSound(true);
-                    }
+                    // Always play transfer sound for new transfers
+                    playTransferSound(true);
                 }
             }
             // If messages were added to contact.messages, update myData.chats


### PR DESCRIPTION
Feature: Always Play Transfer Sound

Changes:
- Modified the transfer sound behavior to play for all incoming transfers
- Removed conditional check that prevented sound from playing when wallet screen or history modal was active
- Ensures users are notified of incoming transfers regardless of which screen they're viewing