### PR TITLE
Feature: Integrate Payments into chatModal

### DIFF
--- a/app.js
+++ b/app.js
@@ -2957,7 +2957,7 @@ console.log('payload is', payload)
         const inActiveChatWithRecipient = appendChatModal.address === toAddress && chatModalActive;
 
         if (inActiveChatWithRecipient) {
-            appendChatModal(true); // Re-render the chat modal and highlight the new item
+            appendChatModal(); // Re-render the chat modal and highlight the new item
         }
 
         closeSendModal();

--- a/app.js
+++ b/app.js
@@ -2212,8 +2212,9 @@ function appendChatModal(highlightNewMessage = false) {
 
             // --- Render Payment Transaction ---
             const directionText = item.my ? '-' : '+';
+            const messageClass = item.my ? 'sent' : 'received';
             messageHTML = `
-                <div class="message sent payment-info" ${timestampAttribute}> 
+                <div class="message ${messageClass} payment-info" ${timestampAttribute}> 
                     <div class="payment-header">
                         <span class="payment-direction">${directionText}</span>
                         <span class="payment-amount">${amountDisplay}</span>

--- a/app.js
+++ b/app.js
@@ -2961,7 +2961,7 @@ console.log('payload is', payload)
             my: true, // Sent transfer
             message: memo, // Use the memo as the message content
             amount: amount, // Use the BigInt amount
-            symbol: '???', // Using '??' as in processChats for now
+            symbol: 'LIB', // TODO: Use the asset symbol
         };
         // Insert the transfer message into the contact's message list, maintaining sort order
         insertSorted(myData.contacts[toAddress].messages, transferMessage, 'timestamp');
@@ -4073,7 +4073,7 @@ async function processChats(chats, keys) {
                         my: false, // Received transfer
                         message: payload.message, // Use the memo as the message content
                         amount: parse(stringify(tx.amount)), // Ensure amount is stored as BigInt
-                        symbol: '???', // TODO: get the symbol from the asset
+                        symbol: 'LIB', // TODO: get the symbol from the asset
                     };
                     // Insert the transfer message into the contact's message list, maintaining sort order
                     insertSorted(contact.messages, transferMessage, 'timestamp');

--- a/app.js
+++ b/app.js
@@ -2179,8 +2179,7 @@ function appendChatModal(highlightNewMessage = false) {
             console.log('No contact or messages found for address:', appendChatModal.address);
             return;
     }
-    // Ensure messages array exists and is sorted descending (newest first)
-    const messages = contact?.messages || [];
+    const messages = contact.messages; // Already sorted descending
 
     const modal = document.getElementById('chatModal');
     if (!modal) return;

--- a/app.js
+++ b/app.js
@@ -1364,7 +1364,7 @@ async function updateChatList(force, retry = 0) {
 
         // Find the latest message/activity for this contact (which is the first in the messages array)
         const latestActivity = contact.messages[0]; // Assumes messages array includes transfers and is sorted descending
-        if (!message){ return '' }
+        if (!latestActivity){ return '' }
 
         let latestItemTimestamp = 0;
         let previewHTML = '<span class="empty-preview">No recent activity</span>'; // Default

--- a/app.js
+++ b/app.js
@@ -2209,33 +2209,19 @@ function appendChatModal(highlightNewMessage = false) {
             const amountDisplay = `${amountStr.slice(0, 6)} ${item.symbol || 'LIB'}`; // Use item.symbol or fallback
 
             // Check item.my for sent/received
-            if (item.my) { // item is sent
-                // --- Render SENT Payment Transaction (like a sent message) ---
-                const directionText = '-';
-                messageHTML = `
-                    <div class="message sent payment-info" ${timestampAttribute}> 
-                        <div class="payment-header">
-                            <span class="payment-direction">${directionText}</span>
-                            <span class="payment-amount">${amountDisplay}</span>
-                        </div>
-                        ${itemMemo ? `<div class="payment-memo">${linkifyUrls(itemMemo)}</div>` : ''}
-                        <div class="message-time">${timeString}</div>
+
+            // --- Render Payment Transaction ---
+            const directionText = item.my ? '-' : '+';
+            messageHTML = `
+                <div class="message sent payment-info" ${timestampAttribute}> 
+                    <div class="payment-header">
+                        <span class="payment-direction">${directionText}</span>
+                        <span class="payment-amount">${amountDisplay}</span>
                     </div>
-                `;
-            } else { // item.my is false (received)
-                // --- Render RECEIVED Payment Transaction (like a received message) ---
-                const directionText = '+';
-                messageHTML = `
-                    <div class="message received payment-info" ${timestampAttribute}>
-                        <div class="payment-header">
-                            <span class="payment-direction">${directionText}</span>
-                            <span class="payment-amount">${amountDisplay}</span>
-                        </div>
-                        ${itemMemo ? `<div class="payment-memo">${linkifyUrls(itemMemo)}</div>` : ''}
-                        <div class="message-time">${timeString}</div>
-                    </div>
-                `;
-            }
+                    ${itemMemo ? `<div class="payment-memo">${linkifyUrls(itemMemo)}</div>` : ''}
+                    <div class="message-time">${timeString}</div>
+                </div>
+            `;
         } else {
             // --- Render Chat Message ---
             const messageClass = item.my ? 'sent' : 'received'; // Use item.my directly

--- a/app.js
+++ b/app.js
@@ -1381,7 +1381,7 @@ async function updateChatList(force, retry = 0) {
                 previewHTML = `<span class="payment-preview">${directionText} ${amountDisplay}</span>`;
                  // Optionally add memo preview
                  if (latestActivity.message) { // Memo is stored in the 'message' field for transfers
-                     previewHTML += ` <span class="memo-preview">(${truncateMessage(escapeHtml(latestActivity.message), 25)})</span>`;
+                     previewHTML += ` <span class="memo-preview"> | ${truncateMessage(escapeHtml(latestActivity.message), 25)}</span>`;
                  }
             } else {
                 // Latest item is a regular message
@@ -2253,26 +2253,20 @@ function appendChatModal(highlightNewMessage = false) {
         // 4. Append the constructed HTML
         // Insert at the end of the list to maintain correct chronological order
         messagesList.insertAdjacentHTML('beforeend', messageHTML);
-
-        // 5. Remove the incorrect tracking logic from the loop
         // The newest received element will be found after the loop completes
     }
 
-    console.log('appendChatModal: After loop, rendering complete.');
-
-    // --- 6. Find the corresponding DOM element after rendering ---
+    // --- 5. Find the corresponding DOM element after rendering ---
     // This happens inside the setTimeout to ensure elements are in the DOM
 
-    // 7. Delayed Scrolling & Highlighting Logic (after loop)
+    // 6. Delayed Scrolling & Highlighting Logic (after loop)
     setTimeout(() => {
-        console.log('appendChatModal: Inside setTimeout, attempting to find and highlight.');
         const messageContainer = messagesList.parentElement; 
 
         // Find the DOM element for the actual newest received item using its timestamp
         // Only proceed if newestReceivedItem was found and highlightNewMessage is true
         if (newestReceivedItem && highlightNewMessage) {
             const newestReceivedElementDOM = messagesList.querySelector(`[data-message-timestamp="${newestReceivedItem.timestamp}"]`);
-            console.log('appendChatModal: Found newestReceivedElementDOM:', newestReceivedElementDOM);
 
             if (newestReceivedElementDOM) {
                 // Found the element, scroll to and highlight it
@@ -2287,7 +2281,7 @@ function appendChatModal(highlightNewMessage = false) {
                      if (newestReceivedElementDOM && newestReceivedElementDOM.parentNode) {
                         newestReceivedElementDOM.classList.remove('highlighted'); 
                      }
-                }, 2000); 
+                }, 3000); 
             } else {
                  console.warn('appendChatModal: Could not find DOM element for newestReceivedItem with timestamp:', newestReceivedItem.timestamp);
                  // If element not found, just scroll to bottom
@@ -4073,15 +4067,13 @@ async function processChats(chats, keys) {
                     hasNewTransfer = true
 
                     // --- Create and Insert Transfer Message into contact.messages ---
-                    console.log('Processing received transfer for chat:', from);
-                    console.log('Transfer details - tx.amount:', tx.amount, 'payload.message:', payload.message, 'payload.sent_timestamp:', payload.sent_timestamp);
                     const transferMessage = {
                         timestamp: payload.sent_timestamp,
                         sent_timestamp: payload.sent_timestamp,
                         my: false, // Received transfer
                         message: payload.message, // Use the memo as the message content
                         amount: parse(stringify(tx.amount)), // Ensure amount is stored as BigInt
-                        symbol: '???', // Assuming LIB for now
+                        symbol: '???', // TODO: get the symbol from the asset
                     };
                     // Insert the transfer message into the contact's message list, maintaining sort order
                     insertSorted(contact.messages, transferMessage, 'timestamp');

--- a/app.js
+++ b/app.js
@@ -2188,10 +2188,6 @@ function appendChatModal(highlightNewMessage = false) {
     const newestReceivedItem = messages.find(item => !item.my);
     console.log('appendChatModal: Identified newestReceivedItem data:', newestReceivedItem);
 
-    // --- Tracking Variable for the newest received message's DOM element ---
-    // This will now be found *after* rendering
-    let newestReceivedElementDOM = null;
-
     // 2. Clear the entire list
     messagesList.innerHTML = '';
 

--- a/app.js
+++ b/app.js
@@ -2175,6 +2175,10 @@ function appendChatModal(highlightNewMessage = false) {
     if (!currentAddress) { return; }
 
     const contact = myData.contacts[currentAddress];
+    if (!contact || !contact.messages) {
+            console.log('No contact or messages found for address:', appendChatModal.address);
+            return;
+    }
     // Ensure messages array exists and is sorted descending (newest first)
     const messages = contact?.messages || [];
 

--- a/app.js
+++ b/app.js
@@ -4079,6 +4079,8 @@ async function processChats(chats, keys) {
                     insertSorted(contact.messages, transferMessage, 'timestamp');
                     // --------------------------------------------------------------
 
+                    added += 1;
+
                     const walletScreenActive = document.getElementById("walletScreen")?.classList.contains("active");
                     const historyModalActive = document.getElementById("historyModal")?.classList.contains("active");
                     // Update wallet view if it's active

--- a/app.js
+++ b/app.js
@@ -4079,8 +4079,6 @@ async function processChats(chats, keys) {
                     insertSorted(contact.messages, transferMessage, 'timestamp');
                     // --------------------------------------------------------------
 
-                    added += 1;
-
                     const walletScreenActive = document.getElementById("walletScreen")?.classList.contains("active");
                     const historyModalActive = document.getElementById("historyModal")?.classList.contains("active");
                     // Update wallet view if it's active

--- a/app.js
+++ b/app.js
@@ -1366,36 +1366,29 @@ async function updateChatList(force, retry = 0) {
         const latestActivity = contact.messages[0]; // Assumes messages array includes transfers and is sorted descending
         if (!latestActivity){ return '' }
 
-        let latestItemTimestamp = 0;
-        let previewHTML = '<span class="empty-preview">No recent activity</span>'; // Default
+        let previewHTML = ''; // Default
 
-        if (latestActivity) {
-            latestItemTimestamp = latestActivity.timestamp;
+        
+        const latestItemTimestamp = latestActivity.timestamp;
 
-            // Check if the latest activity is a payment/transfer message
-            if (typeof latestActivity.amount === 'bigint') {
-                // Latest item is a payment/transfer
-                const amountStr = big2str(latestActivity.amount, 18);
-                const amountDisplay = `${amountStr.slice(0, 6)} ${latestActivity.symbol || 'LIB'}`;
-                const directionText = latestActivity.my ? '-' : '+';
-                // Create payment preview text
-                previewHTML = `<span class="payment-preview">${directionText} ${amountDisplay}</span>`;
-                 // Optionally add memo preview
-                 if (latestActivity.message) { // Memo is stored in the 'message' field for transfers
-                     previewHTML += ` <span class="memo-preview"> | ${truncateMessage(escapeHtml(latestActivity.message), 25)}</span>`;
-                 }
-            } else {
-                // Latest item is a regular message
-                const messageText = escapeHtml(latestActivity.message);
-                // Add "You:" prefix for sent messages
-                const prefix = latestActivity.my ? 'You: ' : '';
-                previewHTML = `${prefix}${truncateMessage(messageText, 50)}`; // Truncate for preview
-            }
-        }
-
-        // If no messages or payments found, timestamp will be 0. Use current time as a fallback.
-        if (latestItemTimestamp === 0) {
-           latestItemTimestamp = Date.now();
+        // Check if the latest activity is a payment/transfer message
+        if (typeof latestActivity.amount === 'bigint') {
+            // Latest item is a payment/transfer
+            const amountStr = big2str(latestActivity.amount, 18);
+            const amountDisplay = `${amountStr.slice(0, 6)} ${latestActivity.symbol || 'LIB'}`;
+            const directionText = latestActivity.my ? '-' : '+';
+            // Create payment preview text
+            previewHTML = `<span class="payment-preview">${directionText} ${amountDisplay}</span>`;
+                // Optionally add memo preview
+                if (latestActivity.message) { // Memo is stored in the 'message' field for transfers
+                    previewHTML += ` <span class="memo-preview"> | ${truncateMessage(escapeHtml(latestActivity.message), 25)}</span>`;
+                }
+        } else {
+            // Latest item is a regular message
+            const messageText = escapeHtml(latestActivity.message);
+            // Add "You:" prefix for sent messages
+            const prefix = latestActivity.my ? 'You: ' : '';
+            previewHTML = `${prefix}${truncateMessage(messageText, 50)}`; // Truncate for preview
         }
 
         // Use the determined latest timestamp for display

--- a/app.js
+++ b/app.js
@@ -1363,7 +1363,8 @@ async function updateChatList(force, retry = 0) {
         if (!contact) return ''; // Safety check
 
         // Find the latest message/activity for this contact (which is the first in the messages array)
-        const latestActivity = contact.messages?.[0]; // Assumes messages array includes transfers and is sorted descending
+        const latestActivity = contact.messages[0]; // Assumes messages array includes transfers and is sorted descending
+        if (!message){ return '' }
 
         let latestItemTimestamp = 0;
         let previewHTML = '<span class="empty-preview">No recent activity</span>'; // Default

--- a/network.js
+++ b/network.js
@@ -1,6 +1,6 @@
 const network = {
   "netid": "fd1b56b08fd1e5035aa19eb631f7f1ad0395175c5d3dfc49411dfa528e6af7c3",
-  "name": "Testnet",
+  "name": "Devnet",
   "gateways": [
     {
       "protocol": "http",

--- a/network.js
+++ b/network.js
@@ -1,20 +1,20 @@
 const network = {
-  "netid": "2f4b9f72089bbfce9f89d3d8e76086daab6ae6f416887c809aab26abb6e5703b",
-  "name": "Testnet",
+  "netid": "fd1b56b08fd1e5035aa19eb631f7f1ad0395175c5d3dfc49411dfa528e6af7c3",
+  "name": "Devnet",
   "gateways": [
     {
-      "protocol": "http",
-      "host": "localhost",
+      "protocol": "https",
+      "host": "dev.liberdus.com",
       "port": 3030    
     },
   ],
   "monitor": {
-    "url": "https://test.liberdus.com/monitor"
+    "url": "https://dev.liberdus.com/monitor"
   },
   "explorer": {
-    "url": "https://test.liberdus.com/explorer"
+    "url": "https://dev.liberdus.com/explorer"
   },
   websocket: {
-    url: "ws://localhost:3031",
+    url: "wss://dev.liberdus.com:3031",
   }
 }

--- a/network.js
+++ b/network.js
@@ -1,20 +1,20 @@
 const network = {
   "netid": "fd1b56b08fd1e5035aa19eb631f7f1ad0395175c5d3dfc49411dfa528e6af7c3",
-  "name": "Devnet",
+  "name": "Testnet",
   "gateways": [
     {
-      "protocol": "https",
-      "host": "dev.liberdus.com",
+      "protocol": "http",
+      "host": "localhost",
       "port": 3030    
     },
   ],
   "monitor": {
-    "url": "https://dev.liberdus.com/monitor"
+    "url": "https://test.liberdus.com/monitor"
   },
   "explorer": {
-    "url": "https://dev.liberdus.com/explorer"
+    "url": "https://test.liberdus.com/explorer"
   },
   websocket: {
-    url: "wss://dev.liberdus.com:3031",
+    url: "ws://localhost:3031",
   }
 }

--- a/network.js_web
+++ b/network.js_web
@@ -1,20 +1,20 @@
 const network = {
-  "netid": "2f4b9f72089bbfce9f89d3d8e76086daab6ae6f416887c809aab26abb6e5703b",
-  "name": "Testnet",
+  "netid": "fd1b56b08fd1e5035aa19eb631f7f1ad0395175c5d3dfc49411dfa528e6af7c3",
+  "name": "Devnet",
   "gateways": [
     {
       "protocol": "https",
-      "host": "test.liberdus.com",
+      "host": "dev.liberdus.com",
       "port": 3030    
     },
   ],
   "monitor": {
-    "url": "https://test.liberdus.com/monitor"
+    "url": "https://dev.liberdus.com/monitor"
   },
   "explorer": {
-    "url": "https://test.liberdus.com/explorer"
+    "url": "https://dev.liberdus.com/explorer"
   },
   websocket: {
-    url: "wss://test.liberdus.com:3031",
+    url: "wss://dev.liberdus.com:3031",
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -3774,10 +3774,10 @@ small {
 /* Styles for Payment Previews in Chat List */
 .chat-item .chat-message .payment-preview {
   font-weight: var(--font-weight-bold);
-  color: var(--primary-color); /* Or a distinct color */
+  /* color: var(--text-color); */ /* Or a distinct color */
 }
 
 .chat-item .chat-message .memo-preview {
   font-style: italic;
-  color: var(--secondary-text-color); /* Or a muted color */
+  /* color: var(--secondary-text-color); */ /* Or a muted color */
 }

--- a/styles.css
+++ b/styles.css
@@ -3690,10 +3690,18 @@ small {
   align-items: baseline;
   gap: 10px;
   margin-bottom: 8px;
-  padding: 25px 0; /* User adjusted */
-  font-family: var(--font-monospace);
-  font-size: var(--font-size-sm);
+  padding: 30px 0; /* User adjusted */
+  font-family: Georgia, serif; /* Changed font family */
+  font-size: var(--font-size-sm); /* Base size for header */
   text-align: center;
+}
+
+/* Styles for the direction/amount spans within the header */
+.payment-amount,
+.payment-direction {
+  font-weight: var(--font-weight-bold); /* Keep bold */
+  font-size: var(--font-size-base); /* Keep large */
+  /* Font family inherited from .payment-header */
 }
 
 /* Base styles for payment memo (italic, top border) */
@@ -3722,6 +3730,9 @@ small {
 .message.received.payment-info {
   padding: 0.75rem 1rem;
   /* Bubble background/color/border inherited from .message.sent/.received */
+  max-width: 85%; /* Set maximum width (adjust percentage if needed) */
+  width: 85%; /* Force width to max */
+  box-sizing: border-box; /* Include padding/border in width */
 }
 
 /* --- Styling for elements INSIDE SENT payments --- */
@@ -3758,4 +3769,15 @@ small {
 .message.received.payment-info .message-time {
   color: var(--secondary-text-color);
   opacity: 0.7;
+}
+
+/* Styles for Payment Previews in Chat List */
+.chat-item .chat-message .payment-preview {
+  font-weight: var(--font-weight-bold);
+  color: var(--primary-color); /* Or a distinct color */
+}
+
+.chat-item .chat-message .memo-preview {
+  font-style: italic;
+  color: var(--secondary-text-color); /* Or a muted color */
 }

--- a/styles.css
+++ b/styles.css
@@ -3680,3 +3680,82 @@ small {
   text-align: left;
   letter-spacing: 0.5px;
 }
+
+/* Styles for Payment Messages in Chat */
+
+/* Base styles for payment header (center, monospace, gap) */
+.payment-header {
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 8px;
+  padding: 25px 0; /* User adjusted */
+  font-family: var(--font-monospace);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
+/* Base styles for payment memo (italic, top border) */
+.payment-memo {
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  opacity: 0.9;
+  margin-top: 4px;
+  border-top: 1px solid rgba(0, 0, 0, 0.1); /* User changed to solid */
+  padding-top: 4px;
+  white-space: normal;
+  overflow: hidden;
+  word-wrap: break-word;
+  word-break: break-all;
+}
+
+/* Make direction and amount stand out */
+.payment-amount,
+.payment-direction {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-base);
+}
+
+/* Common bubble padding */
+.message.sent.payment-info,
+.message.received.payment-info {
+  padding: 0.75rem 1rem;
+  /* Bubble background/color/border inherited from .message.sent/.received */
+}
+
+/* --- Styling for elements INSIDE SENT payments --- */
+.message.sent.payment-info .payment-header {
+  color: white;
+  /* No bottom border needed */
+}
+.message.sent.payment-info .payment-memo {
+  color: rgba(255, 255, 255, 0.9);
+  border-top-color: rgba(255, 255, 255, 0.2);
+}
+.message.sent.payment-info .payment-memo a {
+  color: white;
+  text-decoration: underline;
+}
+.message.sent.payment-info .message-time {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* --- Styling for elements INSIDE RECEIVED payments --- */
+.message.received.payment-info .payment-header {
+  color: var(--text-color);
+  width: 100%; /* Keep full width */
+  /* No bottom border needed (user removed) */
+}
+.message.received.payment-info .payment-memo {
+  color: var(--secondary-text-color);
+  border-top-color: rgba(0, 0, 0, 0.15);
+}
+.message.received.payment-info .payment-memo a {
+  color: var(--primary-color);
+  text-decoration: underline;
+}
+.message.received.payment-info .message-time {
+  color: var(--secondary-text-color);
+  opacity: 0.7;
+}


### PR DESCRIPTION
*   **Problem:** Chat list previews only displayed text messages, and payment transactions were not explicitly styled or handled differently from regular messages in the chat view. The mechanism for highlighting the newest received message in the chat modal was potentially fragile. Network configurations were set to localhost.
*   **Changes:**
    *   Updated `updateChatList` to display a specific format for payment previews in the main chat list, including direction, amount, symbol, and an optional truncated memo.
    *   Refactored `appendChatModal` to explicitly render and style payment transactions differently from chat messages within the chat modal, using dedicated CSS classes for payment details (direction, amount, memo).
    *   Improved the newest received message highlighting logic in `appendChatModal` to reliably find and scroll to the correct message DOM element using timestamps after rendering.
    *   Enhanced `processChats` to handle incoming payment transfers, add them to wallet history, and integrate them into the chat view, triggering appropriate UI updates and notifications (including a distinct transfer sound and wallet/history notifications).

![image](https://github.com/user-attachments/assets/ffd87162-7686-49c5-975e-bd497246d053)
![image](https://github.com/user-attachments/assets/e73638b8-1981-4994-9917-b86dea466612)
![image](https://github.com/user-attachments/assets/087dd17b-2a85-42c9-937c-735f8a87e28c)

