### PR TITLE
fix(app): Update sign-in modal behavior to improve user experience by disabling the submit button until an account is selected and enhancing the account selection prompt.

### DIFF
--- a/app.js
+++ b/app.js
@@ -262,7 +262,7 @@ function openSignInModal() {
     const usernameSelect = document.getElementById('username');
     // Populate select with usernames
     usernameSelect.innerHTML = `
-        <option value="">Select an account</option>
+        <option value="" disabled selected hidden>Select an account</option>
         ${usernames.map(username => `<option value="${username}">${username}</option>`).join('')}
     `;
 
@@ -279,7 +279,7 @@ function openSignInModal() {
     const removeButton = document.getElementById('removeAccountButton');
     const notFoundMessage = document.getElementById('usernameNotFound');
 
-    submitButton.disabled = false;
+    submitButton.disabled = true;  // Keep button disabled until an account is selected
     submitButton.textContent = 'Sign In';
     submitButton.style.display = 'inline';
     removeButton.style.display = 'none';


### PR DESCRIPTION
# Improve Account Selection UX in Sign-In Modal

## Changes Made
- Modified the account dropdown in the sign-in modal to have better UX:
  - Made the "Select an account" prompt option disabled and hidden
  - Set the submit button to be disabled by default
  - Button only becomes enabled when a valid account is selected

## Impact
- Prevents users from submitting the form without selecting an account
- Eliminates the browser's default validation message
- Provides clearer visual feedback about the required action
- Maintains existing functionality for single-account scenarios

## Testing Steps
1. Open the sign-in modal with multiple accounts
2. Verify the submit button is disabled by default
3. Select an account and verify the button becomes enabled
4. Verify the single-account case still works automatically
5. Verify the "Recreate" functionality still works as expected