### PR TITLE
Ensure initial transfers appear in chatList if sender/receiver has never sent payment to user

### DIFF
--- a/app.js
+++ b/app.js
@@ -2958,6 +2958,25 @@ console.log('payload is', payload)
         insertSorted(myData.contacts[toAddress].messages, transferMessage, 'timestamp');
         // --------------------------------------------------------------
 
+        // --- Update myData.chats to reflect the new message ---
+        const existingChatIndex = myData.chats.findIndex(chat => chat.address === toAddress);
+        if (existingChatIndex !== -1) {
+            myData.chats.splice(existingChatIndex, 1); // Remove existing entry
+        }
+        // Create the new chat entry
+        const chatUpdate = {
+            address: toAddress,
+            timestamp: currentTime,
+        };
+        // Find insertion point to maintain timestamp order (newest first)
+        const insertIndex = myData.chats.findIndex(chat => chat.timestamp < chatUpdate.timestamp);
+        if (insertIndex === -1) {
+            myData.chats.push(chatUpdate); // Append if newest or list is empty
+        } else {
+            myData.chats.splice(insertIndex, 0, chatUpdate); // Insert at correct position
+        }
+        // --- End Update myData.chats ---
+
         // Update the chat modal to show the newly sent transfer message
         // Check if the chat modal for this recipient is currently active
         const chatModalActive = document.getElementById('chatModal')?.classList.contains('active');

--- a/app.js
+++ b/app.js
@@ -4088,6 +4088,8 @@ async function processChats(chats, keys) {
                     insertSorted(contact.messages, transferMessage, 'timestamp');
                     // --------------------------------------------------------------
 
+                    added += 1
+
                     const walletScreenActive = document.getElementById("walletScreen")?.classList.contains("active");
                     const historyModalActive = document.getElementById("historyModal")?.classList.contains("active");
                     // Update wallet view if it's active
@@ -4145,8 +4147,8 @@ async function processChats(chats, keys) {
                 }
                 
                 // Show toast notification for new messages
-                // Only suppress notification if we're ACTIVELY viewing this chat
-                if (!inActiveChatWithSender) {
+                // Only suppress notification if we're ACTIVELY viewing this chat and if not a transfer
+                if (!inActiveChatWithSender && !hasNewTransfer) {
                     // Get name of sender
                     const senderName = contact.name || contact.username || `${from.slice(0,8)}...`
                     

--- a/app.js
+++ b/app.js
@@ -2969,12 +2969,7 @@ console.log('payload is', payload)
             timestamp: currentTime,
         };
         // Find insertion point to maintain timestamp order (newest first)
-        const insertIndex = myData.chats.findIndex(chat => chat.timestamp < chatUpdate.timestamp);
-        if (insertIndex === -1) {
-            myData.chats.push(chatUpdate); // Append if newest or list is empty
-        } else {
-            myData.chats.splice(insertIndex, 0, chatUpdate); // Insert at correct position
-        }
+        insertSorted(myData.chats, chatUpdate, 'timestamp');
         // --- End Update myData.chats ---
 
         // Update the chat modal to show the newly sent transfer message


### PR DESCRIPTION
*   **Immediate Chat List Update for Sent Transfers:** Update `myData.chats` immediately after sending a transfer to ensure the chat appears at the top of the list.
*   **Correctly Count Incoming Transfers:** Increment the `added` counter when processing incoming transfer messages in `processChats`.
*   **Suppress Transfer Notifications:** Prevent toast notifications for incoming transfers if the user is not actively viewing that specific chat.
