### PR TITLE
refactor(openEditContactModal): Simplify modal activation by storing reference to the edit contact modal element and adding a focus handler for improved user experience during transitions.

### DIFF
--- a/app.js
+++ b/app.js
@@ -3152,6 +3152,8 @@ class ContactInfoModalManager {
 }
 
 async function openEditContactModal() {
+    const editContactModal = document.getElementById('editContactModal');
+    
     // Get the avatar section elements
     const avatarSection = document.querySelector('#editContactModal .contact-avatar-section');
     const avatarDiv = avatarSection.querySelector('.avatar');
@@ -3182,7 +3184,7 @@ async function openEditContactModal() {
     nameInput.parentElement.querySelector('.field-action-button').className = 'field-action-button clear';
 
     // Show the edit contact modal
-    document.getElementById('editContactModal').classList.add('active');
+    editContactModal.classList.add('active');
     
     // Get the current contact info from the contact info modal
     const currentContactAddress = contactInfoModal.currentContactAddress;
@@ -3194,9 +3196,14 @@ async function openEditContactModal() {
     // Create display info object using the same format as contactInfoModal
     const displayInfo = createDisplayInfo(myData.contacts[currentContactAddress]);
 
-    setTimeout(() => {
+    // Create a handler function to focus the input after the modal transition
+    const editContactFocusHandler = () => {
         nameInput.focus();
-    }, 1000);
+        editContactModal.removeEventListener('transitionend', editContactFocusHandler);
+    };
+
+    // Add the event listener
+    editContactModal.addEventListener('transitionend', editContactFocusHandler);
 }
 
 openEditContactModal.originalName = ''


### PR DESCRIPTION
# Replace setTimeout with One-Time Event Listener in Edit Contact Modal

## Changes Made
- Replaced the 1-second `setTimeout` in `openEditContactModal` with a one-time `transitionend` event listener
- This ensures the focus is applied after the modal's transition completes, rather than after an arbitrary delay

## Why This Change?
- More reliable timing - focuses the input field exactly when the modal is ready
- Better user experience - no artificial delay
- More robust - works regardless of system performance or animation timing
- Follows best practices for handling transitions and focus management

## Testing
- Verified that the input field receives focus after the modal transition completes
- Confirmed that the focus behavior is consistent across different devices and performance conditions
- Tested modal opening and closing to ensure no regressions

## Notes
- This change improves the reliability of the focus behavior while maintaining the same user experience
- The one-time event listener automatically cleans itself up after execution