### PR TITLE
Fix closeHistoryModal function to remove notification classes from history modal triggers, enhancing UI feedback on modal closure.

### DIFF
--- a/app.js
+++ b/app.js
@@ -3613,6 +3613,8 @@ function openHistoryModal() {
 
 function closeHistoryModal() {
     document.getElementById('historyModal').classList.remove('active');
+    document.getElementById('openHistoryModal').classList.remove('has-notification');
+    document.getElementById('switchToWallet').classList.remove('has-notification');
 }
 
 function updateHistoryAddresses() {         // TODO get rid of this function after changing all refrences 


### PR DESCRIPTION
# Clear Notification Bubbles When Closing Transaction History Modal

## Changes Made
- Added automatic clearing of notification bubbles in `closeHistoryModal` function
- Clears notifications from both the History button and Wallet tab button when modal is closed

## Why This Change?
- Improves user experience by automatically clearing notifications after viewing transactions
- Eliminates the need for users to manually click buttons to clear notifications they've already seen
- Makes the notification system more intuitive - if a user has viewed the transaction in the modal, they shouldn't need to take additional action to clear the notifications

## Testing
- Verified that notification bubbles are cleared when:
  - Closing the modal after viewing a new transaction
  - Closing the modal normally
  - Opening and closing the modal multiple times
- Confirmed that notifications still appear correctly for new transactions
- Checked that the modal's core functionality remains unchanged

## Notes
- This change only affects the behavior when closing the modal
- No changes to how notifications are added or displayed