### PR TITLE
validator staking menu item and modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,6 +235,7 @@
           <li class="menu-item" id="openAccountForm">Account</li>
           <li class="menu-item" id="openExportForm">Backup</li>
           <li class="menu-item" id="openNetwork">Gateway</li>
+          <li class="menu-item" id="openValidator">Validator</li>
           <!--                <li class="menu-item" id="openSettings">Settings</li> -->
           <li class="menu-item" id="openExplorer">Explorer</li>
           <li class="menu-item" id="openMonitor">Network</li>
@@ -1084,6 +1085,101 @@
               <div class="contact-info-value" id="editContactX"></div>
             </div>
           </div>
+        </div>
+      </div>
+
+      <!-- Validator Modal -->
+      <div class="modal" id="validatorModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeValidatorModal"></button>
+          <div class="modal-title">Validator Options</div>
+        </div>
+        <div class="modal-content">
+          <p>Manage your validator stake:</p>
+
+          <div class="action-item">
+            <button id="openStakeModal" class="button full-width">Stake</button>
+            <p class="action-description">
+              Delegate LIB to a validator node to earn rewards.
+            </p>
+          </div>
+
+          <div class="action-item">
+            <button
+              id="openUnstakeModal"
+              class="button full-width secondary-button"
+            >
+              Unstake
+            </button>
+            <p class="action-description">
+              Withdraw your delegated LIB from a validator node.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Stake Modal -->
+      <div class="modal fixed-header" id="stakeModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeStakeModal"></button>
+          <div class="modal-title">Stake Validator</div>
+        </div>
+        <div class="form-container">
+          <form id="stakeForm">
+            <div class="form-group">
+              <label for="stakeNodeAddress">Validator Node Address</label>
+              <input
+                type="text"
+                id="stakeNodeAddress"
+                class="form-control"
+                required
+                placeholder="Enter node address"
+              />
+            </div>
+            <div class="form-group">
+              <label for="stakeAmount">Stake Amount</label>
+              <input
+                type="number"
+                id="stakeAmount"
+                class="form-control"
+                required
+                placeholder="Enter amount to stake"
+                min="0"
+                step="any"
+              />
+              <!-- Add potential balance display/validation message area if needed -->
+            </div>
+            <button type="submit" id="submitStake" class="button full-width">
+              Submit Stake
+            </button>
+            <!-- Add potential error/success message area -->
+          </form>
+        </div>
+      </div>
+
+      <!-- Unstake Modal -->
+      <div class="modal fixed-header" id="unstakeModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeUnstakeModal"></button>
+          <div class="modal-title">Unstake Validator</div>
+        </div>
+        <div class="form-container">
+          <form id="unstakeForm">
+            <div class="form-group">
+              <label for="unstakeNodeAddress">Validator Node Address</label>
+              <input
+                type="text"
+                id="unstakeNodeAddress"
+                class="form-control"
+                required
+                placeholder="Enter node address"
+              />
+            </div>
+            <button type="submit" id="submitUnstake" class="button full-width">
+              Submit Unstake
+            </button>
+            <!-- Add potential error/success message area -->
+          </form>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -3794,3 +3794,104 @@ small {
 .ws-status-indicator.ws-red    { background: #d32f2f; }
 .ws-status-indicator.ws-yellow { background: #fbc02d; color: #222; }
 .ws-status-indicator.ws-green  { background: #388e3c; }
+
+/* --- Validator Modal --- */
+#validatorModal .modal-content {
+  padding: 16px;
+  padding-top: 24px; /* Add more top padding */
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* Center items */
+  gap: 24px; /* Increase space between action items */
+}
+
+#validatorModal .modal-content p {
+  text-align: center; /* Center the text */
+  color: var(--secondary-text-color);
+  margin-bottom: 8px; /* Reduced space below main paragraph */
+  font-size: var(--font-size-base);
+}
+
+#validatorModal .action-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%; /* Take full width */
+  gap: 8px; /* Space between button and its description */
+}
+
+#validatorModal .action-description {
+  font-size: var(--font-size-sm); /* Smaller font */
+  color: var(--secondary-text-color);
+  text-align: center;
+  margin: 0 16px; /* Horizontal margin */
+  line-height: 1.4;
+  max-width: 360px; /* Limit width */
+}
+
+#validatorModal .button.full-width {
+  width: calc(100% - 32px); /* Match update-button width */
+  max-width: 360px; /* Max width for larger screens */
+  height: 48px;
+  border-radius: 24px; /* Rounded corners like update-button */
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  margin: 0; /* Remove margin as it's handled by action-item */
+  /* Inherit background/color from .button and .secondary-button */
+}
+
+/* Ensure primary button style */
+#validatorModal #openStakeModal {
+  background-color: var(--primary-color);
+  color: var(--background-color);
+  border: none;
+}
+#validatorModal #openStakeModal:hover {
+  background-color: var(--primary-hover);
+}
+
+/* Ensure secondary button style (now danger) */
+#validatorModal #openUnstakeModal {
+  /* Styles inherited from .button, .full-width, .secondary-button */
+  background-color: var(--danger-color);
+  color: var(--background-color);
+  border: none; /* Ensure no border from secondary */
+}
+
+#validatorModal #openUnstakeModal:hover {
+  opacity: 0.9; /* Standard hover effect */
+  /* Consider a slightly darker red on hover if needed */
+  /* background-color: #c82333; */ /* Example darker red */
+}
+
+/* Style submit buttons like primary action buttons */
+#stakeModal #submitStake,
+#unstakeModal #submitUnstake {
+  /* Apply primary button styling */
+  background-color: var(--primary-color);
+  color: var(--background-color);
+  border: none;
+  width: calc(100% - 32px); /* Match update-button */
+  max-width: 360px;
+  height: 48px;
+  border-radius: 24px;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  margin: 1rem auto; /* Center button */
+  display: block; /* Needed for margin: auto */
+  cursor: pointer;
+}
+
+#stakeModal #submitStake:hover {
+  background-color: var(--primary-hover);
+  opacity: 0.9;
+}
+
+/* submit unstake will use red button */
+#unstakeModal #submitUnstake {
+  background-color: var(--danger-color);
+}
+
+#unstakeModal #submitUnstake:hover {
+  opacity: 0.9;
+}


### PR DESCRIPTION
Summary:

*   Adds 'Validator' option to the main menu (`#menuModal` in `index.html`).
*   Creates 'Validator Options' modal (`#validatorModal`) accessible from the menu:
    *   Includes styled 'Stake' (primary) and 'Unstake' (danger) buttons.
    *   Adds concise descriptions below each button.
*   Creates 'Stake Validator' modal (`#stakeModal`) opened from `#validatorModal`:
    *   Contains a form (`#stakeForm`) with 'Validator Node Address' (`#stakeNodeAddress`) and 'Stake Amount' (`#stakeAmount`) inputs.
    *   Includes a primary-styled 'Submit Stake' button (`#submitStake`).
*   Creates 'Unstake Validator' modal (`#unstakeModal`) opened from `#validatorModal`:
    *   Contains a form (`#unstakeForm`) with 'Validator Node Address' (`#unstakeNodeAddress`) input.
    *   Includes a danger-styled 'Submit Unstake' button (`#submitUnstake`).
*   Adds CSS (`styles.css`) for the new modals, buttons, descriptions, and forms to ensure visual consistency.
*   Implements JavaScript logic (`app.js`) for:
    *   Opening and closing the new modals sequentially.
    *   Handling form submissions (`handleStakeSubmit`, `handleUnstakeSubmit`).
    *   Performing basic validation in submit handlers (checking for empty fields, validating stake amount is positive using `bigxnum2big`). **Note:** Address format validation is currently commented out.
    *   Disabling submit buttons during the transaction submission process.
    *   Clearing form fields on *successful* stake submission (clearing on modal close is noted as TODO).
    *   Constructing transaction objects:
        *   `postStake`: Creates `{ type: "stake", from: longAddress(nodeAddress), stake: amount }`. **Note:** Uses the *validator's* address in the `from` field via `longAddress()` instead of the user's address. Passes the user's `keys` object as the third argument.
        *   `postUnstake`: Creates `{ type: "unstake", from: myAccount?.keys?.address, stake: amount }`. **Note:** Uses the user's address but incorrectly includes a `stake: amount` field.
    *   Calling `injectTx` with the constructed transaction object and keys (for `postStake`). Adds a debug log within `injectTx`.
    *   Displaying user feedback via toast notifications (loading, success/error). **Note:** Success/error handling based on the response in `handle*Submit` functions is partially commented out.
