### PR TITLE
Fix: Standardize Node Address Handling in Staking Operations

### DIFF
--- a/app.js
+++ b/app.js
@@ -6543,7 +6543,7 @@ async function handleUnstakeSubmit(event) {
     const stakeTx = {
         type: "deposit_stake",
         nominator: longAddress(myAccount.keys.address),
-        nominee: longAddress(nodeAddress),
+        nominee: nodeAddress,
         stake: amount,
         timestamp: getCorrectedTimestamp(),
     };
@@ -6557,7 +6557,7 @@ async function handleUnstakeSubmit(event) {
     const unstakeTx = {
         type: "withdraw_stake",
         nominator: longAddress(myAccount?.keys?.address),
-        nominee: longAddress(nodeAddress),
+        nominee: nodeAddress,
         force: false,
         timestamp: getCorrectedTimestamp(),
     };


### PR DESCRIPTION
• Removes `longAddress()` wrapper from `nodeAddress` in stake/unstake transactions
• Affects two locations in `app.js`:
  - Deposit stake transaction
  - Withdraw stake transaction
• Rationale: Node addresses should be used in their original format without padding

Note: This change appears to fix an issue where node addresses were being incorrectly padded with zeros, which would cause validation errors for 64-character addresses that don't follow the expected 40+24 zeros pattern.
