### PR TITLE
 Feat: Add Balance Display and Validation to Stake Modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1002,9 +1002,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         handleOpenSendModalInput(e);
     });
 
+    const debounceValidateStakeInputs = debounce(validateStakeInputs, 300);
     // Add input listeners for stake modal validation
-    document.getElementById('stakeNodeAddress').addEventListener('input', validateStakeInputs);
-    document.getElementById('stakeAmount').addEventListener('input', validateStakeInputs);
+    document.getElementById('stakeNodeAddress').addEventListener('input', debounceValidateStakeInputs);
+    document.getElementById('stakeAmount').addEventListener('input', debounceValidateStakeInputs);
 
     setupAddToHomeScreen()
 });
@@ -6002,9 +6003,12 @@ async function openValidatorModal() {
         const marketPriceValue = document.getElementById('validator-market-price');
         const marketStakeUsdValue = document.getElementById('validator-market-stake-usd');
 
+        // set stakeForm dataset.minStake to big2str(stakeAmountLibBaseUnits, 18) for 
+        document.getElementById('stakeForm').dataset.minStake = big2str(stakeAmountLibBaseUnits, 18);
+
         // Format Network Info unconditionally
         const displayNetworkStakeUsd = stakeRequiredUsdBaseUnits ? '$' + big2str(BigInt('0x' + stakeRequiredUsdBaseUnits), 18).slice(0, 6) : 'N/A';
-        const displayNetworkStakeLib = stakeAmountLibBaseUnits ? big2str(stakeAmountLibBaseUnits, 18).slice(0, 6) : 'N/A';
+        const displayNetworkStakeLib = stakeAmountLibBaseUnits ? big2str(stakeAmountLibBaseUnits, 18).slice(0, 7) : 'N/A';
         const displayStabilityFactor = stabilityFactor ? stabilityFactor.toFixed(4) : 'N/A';
         const displayMarketPrice = marketPrice ? '$' + marketPrice.toFixed(4) : 'N/A';
         const displayMarketStakeUsd = marketStakeUsdBaseUnits ? '$' + big2str(marketStakeUsdBaseUnits, 18).slice(0, 6) : 'N/A';
@@ -6110,8 +6114,7 @@ async function getMarketPrice() {
 // Stake Modal
 function openStakeModal() {
     document.getElementById('stakeModal').classList.add('active');
-    const stakeForm = document.getElementById('stakeForm'); // Get the form element
-
+    
     // Display Available Balance
     const balanceDisplay = document.getElementById('stakeAvailableBalanceDisplay');
     const libAsset = myData.wallet.assets.find(asset => asset.symbol === 'LIB'); // Assuming LIB is index 0 or find by symbol
@@ -6125,21 +6128,13 @@ function openStakeModal() {
 
     // fill amount with with the min stake amount
     const amountInput = document.getElementById('stakeAmount');
-    // get min stake amount from #validator-network-stake-lib in validatorModal
-    const validatorModal = document.getElementById('validatorModal');
-    const minStakeAmountElement = validatorModal.querySelector('#validator-network-stake-lib');
-    const minStakeAmount = minStakeAmountElement ? minStakeAmountElement.textContent : '0'; // Default to 0 if not found
+    // get min stake amount from document.getElementById('stakeForm').dataset
+    const minStakeAmountValue = document.getElementById('stakeForm').dataset.minStake;
+    const minStakeAmount = minStakeAmountValue ? minStakeAmountValue : '0'; // Default to 0 if not found
     if (amountInput && minStakeAmount) amountInput.value = minStakeAmount;
-
-    // Store minStakeAmount on the form for validation access
-    if (stakeForm) {
-        stakeForm.dataset.minStake = minStakeAmount;
-    }
 
     // Call initial validation
     validateStakeInputs();
-
-    // TODO: input validation and focus on node address input
 }
 
 function closeStakeModal() {
@@ -6812,17 +6807,20 @@ function validateStakeInputs() {
     const nodeAddressInput = document.getElementById('stakeNodeAddress');
     const amountInput = document.getElementById('stakeAmount');
     const stakeForm = document.getElementById('stakeForm');
-    const warningElement = document.getElementById('stakeAmountWarning');
+    const amountWarningElement = document.getElementById('stakeAmountWarning'); // Renamed for clarity
+    const nodeAddressWarningElement = document.getElementById('stakeNodeAddressWarning'); // New warning element
     const submitButton = document.getElementById('submitStake');
 
     const nodeAddress = nodeAddressInput.value.trim();
     const amountStr = amountInput.value.trim();
     const minStakeAmountStr = stakeForm.dataset.minStake || '0';
 
-    // Default state: button disabled, warning hidden
+    // Default state: button disabled, warnings hidden
     submitButton.disabled = true;
-    warningElement.style.display = 'none';
-    warningElement.textContent = '';
+    amountWarningElement.style.display = 'none';
+    amountWarningElement.textContent = '';
+    nodeAddressWarningElement.style.display = 'none'; // Hide address warning too
+    nodeAddressWarningElement.textContent = '';
 
     // Check 1: Empty Fields
     if ( !amountStr || !nodeAddress) {
@@ -6830,39 +6828,55 @@ function validateStakeInputs() {
         return;
     }
 
+    // Check 1.5: Node Address Format (64 hex chars)
+    const addressRegex = /^[0-9a-fA-F]{64}$/;
+    if (!addressRegex.test(nodeAddress)) {
+        nodeAddressWarningElement.textContent = 'Invalid node address format (must be 64 hex characters).';
+        nodeAddressWarningElement.style.display = 'block';
+        amountWarningElement.style.display = 'none'; // Hide amount warning if address is bad
+        amountWarningElement.textContent = '';
+        return; // Keep button disabled
+    } else {
+        // Ensure address warning is hidden if format is now valid
+        nodeAddressWarningElement.style.display = 'none';
+        nodeAddressWarningElement.textContent = '';
+    }
+
+    // --- Amount Checks --- 
     let amountWei;
     let minStakeWei;
     try {
         amountWei = bigxnum2big(wei, amountStr);
         minStakeWei = bigxnum2big(wei, minStakeAmountStr);
         if (amountWei <= 0n) {
-             warningElement.textContent = 'Amount must be positive.';
-             warningElement.style.display = 'block';
+             amountWarningElement.textContent = 'Amount must be positive.';
+             amountWarningElement.style.display = 'block';
              return; // Keep button disabled
         }
     } catch (error) {
-        warningElement.textContent = 'Invalid amount format.';
-        warningElement.style.display = 'block';
+        amountWarningElement.textContent = 'Invalid amount format.';
+        amountWarningElement.style.display = 'block';
         return; // Keep button disabled
     }
 
     // Check 2: Minimum Stake Amount
     if (amountWei < minStakeWei) {
         const minStakeFormatted = big2str(minStakeWei, 18).slice(0, -16); // Example formatting
-        warningElement.textContent = `Amount must be at least ${minStakeFormatted} LIB.`;
-        warningElement.style.display = 'block';
+        amountWarningElement.textContent = `Amount must be at least ${minStakeFormatted} LIB.`;
+        amountWarningElement.style.display = 'block';
         return; // Keep button disabled
     }
 
     // Check 3: Sufficient Balance (using existing function)
     // Assuming LIB is asset index 0 since after creation of wallet, LIB is the first asset
-    const hasInsufficientBalance = validateBalance(amountStr, 0, warningElement);
+    const hasInsufficientBalance = validateBalance(amountStr, 0, amountWarningElement);
     if (hasInsufficientBalance) {
-        // validateBalance already shows the warning
+        // validateBalance already shows the warning in amountWarningElement
         return; // Keep button disabled
     }
 
     // All checks passed: Enable button
     submitButton.disabled = false;
-    warningElement.style.display = 'none'; // Ensure warning is hidden if balance is sufficient
+    amountWarningElement.style.display = 'none'; // Ensure warning is hidden if balance is sufficient
+    nodeAddressWarningElement.style.display = 'none'; // Ensure address warning is also hidden
 }

--- a/index.html
+++ b/index.html
@@ -1212,6 +1212,11 @@
                 required
                 placeholder="Enter long node address"
               />
+              <div
+                id="stakeNodeAddressWarning"
+                class="validation-warning"
+                style="display: none"
+              ></div>
             </div>
             <div class="form-group">
               <label for="stakeAmount">Stake Amount</label>

--- a/index.html
+++ b/index.html
@@ -970,10 +970,10 @@
         <div class="form-container">
           <div style="padding: 1rem">
             <p>
-              Before removing your account, please export your account data to ensure
-              you have a backup. This action only removes the account from this
-              device and not from the network. You can use the account again
-              after restoring it from the backup file.
+              Before removing your account, please export your account data to
+              ensure you have a backup. This action only removes the account
+              from this device and not from the network. You can use the account
+              again after restoring it from the backup file.
             </p>
             <button
               id="confirmRemoveAccount"
@@ -1210,11 +1210,15 @@
                 id="stakeNodeAddress"
                 class="form-control"
                 required
-                placeholder="Enter node address"
+                placeholder="Enter long node address"
               />
             </div>
             <div class="form-group">
               <label for="stakeAmount">Stake Amount</label>
+              <div
+                id="stakeAvailableBalanceDisplay"
+                class="available-balance-display"
+              ></div>
               <input
                 type="number"
                 id="stakeAmount"
@@ -1224,15 +1228,19 @@
                 min="0"
                 step="any"
               />
-              <!-- Add potential balance display/validation message area if needed -->
+              <div
+                id="stakeAmountWarning"
+                class="validation-warning"
+                style="display: none"
+              ></div>
             </div>
             <button type="submit" id="submitStake" class="button full-width">
               Submit Stake
             </button>
-            <!-- Add potential error/success message area -->
           </form>
         </div>
       </div>
+    </div>
     <!-- Audio element for notification sounds -->
     <audio
       id="notificationSound"

--- a/lib.js
+++ b/lib.js
@@ -386,6 +386,12 @@ export function bigxnum2big_old(bigIntNum, floatNum) {
     return result;
 }
 
+/**
+ * Convert a string number to a BigInt number
+ * @param {BigInt} bigIntNum - The base BigInt number
+ * @param {string} stringNum - The string number to convert
+ * @returns {BigInt} The converted BigInt number
+ */
 export function bigxnum2big(bigIntNum, stringNum) {
     stringNum = stringNum.trim().replace(/\.0*$/, '')
     // Find decimal point position if it exists
@@ -435,6 +441,12 @@ export function bigxnum2num(bigIntNum, floatNum) {
     return result;
 }
 
+/**
+ * Convert a BigInt number to a string number with decimals
+ * @param {BigInt} amount - The amount to convert
+ * @param {number} decimals - The number of decimals
+ * @returns {string} The converted string number
+ */
 export function big2str(amount, decimals) {
     let amountString = amount.toString();
     // Pad with zeros if needed

--- a/styles.css
+++ b/styles.css
@@ -1658,7 +1658,9 @@ input[type="file"].form-control {
 }
 
 .balance-warning,
-#stakeAmountWarning {
+#stakeAmountWarning,
+#stakeNodeAddressWarning {
+  /* Added new ID */
   font-size: 0.8em;
   color: var(--danger-color);
   display: none;

--- a/styles.css
+++ b/styles.css
@@ -1657,7 +1657,8 @@ input[type="file"].form-control {
   color: var(--secondary-text-color);
 }
 
-.balance-warning {
+.balance-warning,
+#stakeAmountWarning {
   font-size: 0.8em;
   color: var(--danger-color);
   display: none;
@@ -3792,9 +3793,16 @@ small {
   transition: background 0.3s;
   margin-left: 10px; /* adjust as needed */
 }
-.ws-status-indicator.ws-red    { background: #d32f2f; }
-.ws-status-indicator.ws-yellow { background: #fbc02d; color: #222; }
-.ws-status-indicator.ws-green  { background: #388e3c; }
+.ws-status-indicator.ws-red {
+  background: #d32f2f;
+}
+.ws-status-indicator.ws-yellow {
+  background: #fbc02d;
+  color: #222;
+}
+.ws-status-indicator.ws-green {
+  background: #388e3c;
+}
 
 /* --- Validator Modal --- */
 #validatorModal .modal-content {
@@ -3884,7 +3892,7 @@ small {
   cursor: pointer;
 }
 
-#stakeModal #submitStake:hover {
+#stakeModal #submitStake:hover:not(:disabled) {
   background-color: var(--primary-hover);
   opacity: 0.9;
 }
@@ -3986,4 +3994,12 @@ small {
   100% {
     transform: rotate(360deg);
   }
+}
+
+#stakeAvailableBalanceDisplay {
+  font-family: var(--font-primary);
+  font-size: var(--font-size-sm);
+  color: var(--secondary-text-color) !important;
+  margin-bottom: 0.5rem;
+  text-align: left;
 }


### PR DESCRIPTION
This PR enhances the "Stake Validator" modal by adding available balance display and comprehensive input validation.

**`app.js`**

*   Applied debounce (300ms) to `input` listeners for `stakeNodeAddress` and `stakeAmount` fields in the stake modal, calling `validateStakeInputs`.
*   Refactored `openValidatorModal` to store the calculated minimum stake amount (formatted string) in `stakeForm.dataset.minStake`.
*   Updated `openStakeModal`:
    *   Displays the user's available LIB balance in the new `#stakeAvailableBalanceDisplay` element.
    *   Reads the minimum stake amount from `stakeForm.dataset.minStake` (set by `openValidatorModal`) to pre-fill the amount input.
    *   Calls `validateStakeInputs` on open for initial state.
*   Created `validateStakeInputs` function:
    *   Gets necessary elements, including new `#stakeNodeAddressWarning`.
    *   Disables submit button and hides warnings by default.
    *   Validates `stakeNodeAddress` is not empty and matches the 64-hex-character format, showing errors in `#stakeNodeAddressWarning`.
    *   Validates `stakeAmount` is not empty, is positive, and meets the minimum stake requirement (read from `stakeForm.dataset.minStake`), showing errors in `#stakeAmountWarning`.
    *   Reuses `validateBalance` to check for sufficient funds (including fee), showing errors in `#stakeAmountWarning`.
    *   Enables the submit button only if all validations pass.

**`index.html`**

*   Added `div#stakeAvailableBalanceDisplay` within the amount form group to show available balance.
*   Added `div#stakeNodeAddressWarning` below the address input for address-specific validation errors.
*   Added `div#stakeAmountWarning` below the amount input for amount-specific validation errors (was previously a comment).
*   Updated `stakeNodeAddress` placeholder text.

**`lib.js`**

*   Added JSDoc comments to `bigxnum2big` and `big2str` utility functions.

**`styles.css`**

*   Added CSS rule for `#stakeAvailableBalanceDisplay` to match styling of similar elements.
*   Added `#stakeNodeAddressWarning` to the existing `.balance-warning` / `#stakeAmountWarning` selector group to apply consistent warning styles.
*   Refined hover state for the stake modal submit button (`:hover:not(:disabled)`).