### PR TITLE
Feat: Add QR Code Scanning for Stake Validator Address

### DIFF
--- a/app.js
+++ b/app.js
@@ -2132,31 +2132,6 @@ function closeReceiveModal() {
     modal.classList.remove('active');
 }
 
-// Show preview of QR data
-function previewQRData(paymentData) {
-    const previewElement = document.getElementById('qrDataPreview');
-    const previewContent = previewElement.querySelector('.preview-content');
-    
-    // Create minimized version (single line)
-    let minimizedPreview = `${paymentData.u} • ${paymentData.s}`;
-    if (paymentData.a) {
-        minimizedPreview += ` • ${paymentData.a} ${paymentData.s}`;
-    }
-    if (paymentData.m) {
-        const shortMemo = paymentData.m.length > 20 ? 
-            paymentData.m.substring(0, 20) + '...' : 
-            paymentData.m;
-        minimizedPreview += ` • Memo: ${shortMemo}`;
-    }
-    
-    // SET minimizedPreview directly as innerHTML
-    previewContent.innerHTML = minimizedPreview;
-    
-    // Ensure consistent height and style for the single line preview
-    previewElement.style.height = 'auto'; // Let content determine height initially
-    previewElement.classList.remove('minimized'); // Ensure minimized class is not present
-}
-
 function updateReceiveAddresses() {
     // Update display address
     updateDisplayAddress();

--- a/index.html
+++ b/index.html
@@ -840,21 +840,6 @@
         </div>
       </div>
 
-      <!-- QR Scan Modal -->
-      <div class="modal fixed-header" id="qrScanModal">
-        <div class="modal-header">
-          <button class="back-button" id="closeQRScanModal"></button>
-          <div class="modal-title">Scan QR</div>
-        </div>
-        <div class="scanner-container">
-          <p id="scan-waiting" class="status"></p>
-          <video id="video"></video>
-          <div class="scan-region-highlight"></div>
-          <div class="scan-highlight" id="scan-highlight"></div>
-          <canvas id="canvas"></canvas>
-        </div>
-      </div>
-
       <!-- History Modal -->
       <div class="modal fixed-header" id="historyModal">
         <div class="modal-header">
@@ -1264,6 +1249,21 @@
               Submit Stake
             </button>
           </form>
+        </div>
+      </div>
+
+      <!-- QR Scan Modal -->
+      <div class="modal fixed-header" id="qrScanModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeQRScanModal"></button>
+          <div class="modal-title">Scan QR</div>
+        </div>
+        <div class="scanner-container">
+          <p id="scan-waiting" class="status"></p>
+          <video id="video"></video>
+          <div class="scan-region-highlight"></div>
+          <div class="scan-highlight" id="scan-highlight"></div>
+          <canvas id="canvas"></canvas>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1205,13 +1205,34 @@
           <form id="stakeForm">
             <div class="form-group">
               <label for="stakeNodeAddress">Validator Node Address</label>
-              <input
-                type="text"
-                id="stakeNodeAddress"
-                class="form-control"
-                required
-                placeholder="Enter long node address"
-              />
+              <div style="display: flex; align-items: center; gap: 0.5rem">
+                <input
+                  type="text"
+                  id="stakeNodeAddress"
+                  class="form-control"
+                  required
+                  placeholder="Enter long node address"
+                  style="flex: 1"
+                />
+                <button
+                  type="button"
+                  id="scanStakeQRButton"
+                  class="icon-button"
+                  title="Scan Validator Address QR"
+                  style="flex-shrink: 0"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="24"
+                    height="24"
+                    style="fill: #007bff"
+                  >
+                    <path
+                      d="M3,3 L10,3 L10,10 L3,10 Z M5,5 L5,8 L8,8 L8,5 Z M14,3 L21,3 L21,10 L14,10 Z M16,5 L16,8 L19,8 L19,5 Z M3,14 L10,14 L10,21 L3,21 Z M5,16 L5,19 L8,19 L8,16 Z M14,14 L21,14 L21,21 L14,21 Z M16,16 L16,19 L19,19 L19,16 Z M11,3 L13,3 L13,10 L11,10 Z M11,14 L13,14 L13,21 L11,21 Z M3,11 L10,11 L10,13 L3,13 Z M14,11 L21,11 L21,13 L14,13 Z"
+                    />
+                  </svg>
+                </button>
+              </div>
               <div
                 id="stakeNodeAddressWarning"
                 class="validation-warning"


### PR DESCRIPTION
**`app.js`**

*   Added new handler function `fillStakeAddressFromQR` to populate the stake address field with scanned QR data (expects plain text address).
*   Refactored `handleSuccessfulScan` to remove generic prefix check and delegate format validation to context-specific `fill...` functions.
*   Enhanced `fillPaymentFromQR` to include explicit `liberdus://` prefix validation and improved error handling.
*   Updated `openStakeModal` to set `openQRScanModal.fill = fillStakeAddressFromQR` when the modal opens.
*   Simplified the event listener for `#scanStakeQRButton` in `DOMContentLoaded` to directly call `openQRScanModal`.

**`index.html`**

*   Added a scan button (`#scanStakeQRButton`) next to the "Validator Node Address" input field within the `#stakeModal`.
*   Wrapped the address input and scan button in a flex `div` for proper alignment.
*   Relocated the `#qrScanModal` element to be a direct child of the main `.container` div to resolve mobile horizontal scrolling issues and manage stacking order.
