### PR TITLE
Fix Small Amount Validation and Prevent Zero Amount Sends

### DIFF
--- a/app.js
+++ b/app.js
@@ -6978,20 +6978,32 @@ function validateStakeInputs() {
     let amountWei;
     let minStakeWei;
     try {
+        // Try converting the input string
         amountWei = bigxnum2big(wei, amountStr);
-        minStakeWei = bigxnum2big(wei, minStakeAmountStr);
-        if (amountWei <= 0n) {
-             amountWarningElement.textContent = 'Amount must be positive.';
-             amountWarningElement.style.display = 'block';
-             return; // Keep button disabled
+
+        // Check if the resulting amount is zero
+        if (amountWei === 0n) {
+            if (amountStr === '0') {
+                amountWarningElement.textContent = "Amount cannot be zero.";
+            } else {
+                // Input was non-zero but became 0n (e.g., "1e-19")
+                amountWarningElement.textContent = "Amount too small (min 1 wei).";
+            }
+            amountWarningElement.style.display = 'block';
+            return; // Keep button disabled
         }
+        
+        // If amount > 0n, proceed to convert min stake and compare
+        minStakeWei = bigxnum2big(wei, minStakeAmountStr);
+
     } catch (error) {
+        // This catch is for errors during bigxnum2big conversion itself (e.g., invalid characters)
         amountWarningElement.textContent = 'Invalid amount format.';
         amountWarningElement.style.display = 'block';
         return; // Keep button disabled
     }
 
-    // Check 2: Minimum Stake Amount
+    // Check 2: Minimum Stake Amount (only if amountWei > 0n)
     if (amountWei < minStakeWei) {
         const minStakeFormatted = big2str(minStakeWei, 18).slice(0, -16); // Example formatting
         amountWarningElement.textContent = `Amount must be at least ${minStakeFormatted} LIB.`;


### PR DESCRIPTION
**Summary:**

This PR addresses issues related to sending or staking very small cryptocurrency amounts:

*   **Problem:** Sending/staking amounts less than 1 wei (e.g., 1e-19 LIB) incorrectly triggered validation errors ("Insufficient balance" or "Amount must be positive"), and the UI allowed attempting transactions with exactly 0 wei, which the network rejects. Additionally, small transfer amounts were displayed with incorrect precision (as "0.0000") in the chat modal.
*   **Solution:**
    *   Modified `updateAvailableBalance` (for sending) and `validateStakeInputs` (for staking) to provide immediate feedback and disable submitting if the input amount is empty, exactly "0", or converts to 0 wei due to being too small (< 1 wei). Specific warning messages ("Amount cannot be zero", "Amount too small") are now shown.
    *   Added a final validation check in `handleSendAsset` to prevent submitting send transactions if the final calculated amount is <= 0 wei, showing an appropriate alert.
    *   Corrected the balance validation logic in `handleSendAsset` to use the original string input, preventing the original "Insufficient balance" bug for amounts >= 1 wei.
    *   Removed precision slicing (`.slice(0, 6)`) in `appendChatModal` and `updateChatList` to ensure transfer amounts (including very small ones) are displayed correctly in the chat UI.
    *   Improved error handling in `handleSendAsset` to re-enable buttons and close the confirmation modal on failure.
    *   Ensured minimum stake amount and balance checks in `validateStakeInputs` are only performed if the input amount is valid and greater than 0 wei.
