### PR TITLE
Prevent Self-Interaction (sendAsset)

### DIFF
--- a/app.js
+++ b/app.js
@@ -2395,7 +2395,12 @@ function handleOpenSendModalInput(e){
             usernameAvailable.style.color = '#28a745';
             usernameAvailable.style.display = 'inline';
             submitButton.disabled = false;
-        } else if ((taken == 'available') || (taken == 'mine')) {
+        } else if((taken == 'mine')) {
+            usernameAvailable.textContent = 'mine';
+            usernameAvailable.style.color = '#dc3545';
+            usernameAvailable.style.display = 'inline';
+            submitButton.disabled = true;
+        } else if ((taken == 'available')) {
             usernameAvailable.textContent = 'not found';
             usernameAvailable.style.color = '#dc3545';
             usernameAvailable.style.display = 'inline';
@@ -2583,6 +2588,14 @@ async function handleSendAsset(event) {
     event.preventDefault();
     const confirmButton = document.getElementById('confirmSendButton');
     const cancelButton = document.getElementById('cancelSendButton');
+    const username = normalizeUsername(document.getElementById('sendToAddress').value);
+
+    // if it's your own username disable the send button
+    if (username == myAccount.username) {
+        confirmButton.disabled = true;
+        showToast('You cannot send assets to yourself', 3000, 'error');
+        return;
+    }
 
     if ((getCorrectedTimestamp() - handleSendAsset.timestamp) < 2000 || confirmButton.disabled) {
         return;
@@ -2594,9 +2607,7 @@ async function handleSendAsset(event) {
     handleSendAsset.timestamp = getCorrectedTimestamp()
     const wallet = myData.wallet;
     const assetIndex = document.getElementById('sendAsset').value;  // TODO include the asset id and symbol in the tx
-    const fromAddress = myAccount.keys.address;
     const amount = bigxnum2big(wei, document.getElementById('sendAmount').value);
-    const username = normalizeUsername(document.getElementById('sendToAddress').value);
     const memoIn = document.getElementById('sendMemo').value || '';
     const memo = memoIn.trim()
     const keys = myAccount.keys;

--- a/app.js
+++ b/app.js
@@ -1731,7 +1731,7 @@ function handleUsernameInput(e) {
             usernameAvailable.style.color = '#28a745';
             usernameAvailable.style.display = 'inline';
             submitButton.disabled = false;
-        } else if ((taken == 'available') || (taken == 'mine')) {
+        } else if ((taken == 'mine') || (taken == 'available')) {
             usernameAvailable.textContent = 'not found';
             usernameAvailable.style.color = '#dc3545';
             usernameAvailable.style.display = 'inline';
@@ -3146,6 +3146,11 @@ async function handleSendMessage() {
         */
         const currentAddress = appendChatModal.address
         if (!currentAddress) return;
+
+        // Check if trying to message self
+        if (currentAddress === myAccount.address) {
+            return;
+        }
 
         // Get sender's keys from wallet
         const keys = myAccount.keys;

--- a/index.html
+++ b/index.html
@@ -763,7 +763,6 @@
                     >Fee: <span id="transactionFee">0.00</span> LIB</span
                   >
                 </div>
-                <div id="balanceWarning" class="balance-warning"></div>
               </div>
               <input
                 type="number"
@@ -773,6 +772,7 @@
                 min="0.000000000000000001"
                 required
               />
+              <div id="balanceWarning" class="balance-warning"></div>
             </div>
             <div class="form-group">
               <label for="sendMemo">Memo (Optional)</label>


### PR DESCRIPTION
Update username availability check and prevent self-sending of assets

* Adjust the order of username availability checks to improve logic flow.
* Disable the send button and show a toast notification if the user attempts to send assets to their own account.
* Reposition balance warning display in the send asset form to show up underneath the input for consistent UI