### PR TITLE
Failed Message Handling with Pop-up Dialog

### DIFF
--- a/app.js
+++ b/app.js
@@ -1863,6 +1863,9 @@ function openChatModal(address) {
     const contact = myData.contacts[address]
     // Set user info
     modalTitle.textContent = contact.name || contact.senderInfo?.name || contact.username || `${contact.address.slice(0,8)}...${contact.address.slice(-6)}`;
+
+    // clear hidden txid input
+    document.getElementById('retryOfTxId').value = '';
     
     // Add data attributes to store the username and address
     const sendMoneyButton = document.getElementById('chatSendMoneyButton');

--- a/app.js
+++ b/app.js
@@ -1007,6 +1007,26 @@ document.addEventListener('DOMContentLoaded', async () => {
         event.target.setCustomValidity('');
     });
 
+
+    // Event Listeners for FailedMessageModal (using named functions)
+    const failedMessageModal = document.getElementById('failedMessageModal');
+    const failedMessageRetryButton = failedMessageModal.querySelector('.retry-button');
+    const failedMessageDeleteButton = failedMessageModal.querySelector('.delete-button');
+    const failedMessageHeaderCloseButton = document.getElementById('closeFailedMessageModal');
+
+    if (failedMessageRetryButton) {
+        failedMessageRetryButton.addEventListener('click', handleFailedMessageRetry);
+    }
+    if (failedMessageDeleteButton) {
+        failedMessageDeleteButton.addEventListener('click', handleFailedMessageDelete);
+    }
+    if (failedMessageHeaderCloseButton) {
+        failedMessageHeaderCloseButton.addEventListener('click', closeFailedMessageModalAndClearState);
+    }
+    failedMessageModal.addEventListener('click', handleFailedMessageBackdropClick);
+    
+    
+
     // call checkPendingTransactions every 5 seconds
     setInterval(checkPendingTransactions, 5000);
 
@@ -3273,12 +3293,18 @@ async function handleClickToCopy(e) {
     const messageEl = e.target.closest('.message');
     if (!messageEl) return;
 
-    // Prevent copying if the message has failed
-    if (messageEl.classList.contains('status-failed')) {
+    // Prevent copying if the message has failed and not `payment-info`
+    if (messageEl.dataset.status === 'failed') {
         console.log('Copy prevented for failed message.');
-        // create a standalone function that'll give user option to retry sending the message or delete it (delete from all data stores)
-        // if user decides to retry we'll fill the input field with the message content and fill a hidden input with the txid
-          // then when user clicks send that invokes handleSendMessage() we'll use txid to remove the message from all data stores
+
+        // If the message is not a payment message, show the failed message modal
+        if (!messageEl.classList.contains('payment-info')) {
+            handleFailedMessageClick(messageEl)
+        }
+
+        // TODO: if message is a payment open sendModal and fill with information in the payment message?
+
+        return;
     }
 
     let textToCopy = null;
@@ -3323,6 +3349,117 @@ async function handleClickToCopy(e) {
         showToast('Memo is empty', 2000, 'info');
     }
      // No need for an else here, cases with no element are handled above
+}
+
+/**
+ * Invoked when the user clicks on a failed message
+ * Will show failed message modal with retry, delete (delete from all data stores), and close buttons
+ * It will also store the message content and txid in the handleSendMessage object containing the handleFailedMessage and txid properties
+ */
+function handleFailedMessageClick(messageEl) {
+    const modal = document.getElementById('failedMessageModal');
+
+    // Get the message content and txid from the original failed message element
+    const messageContent = messageEl.querySelector('.message-content').textContent;
+    const originalTxid = messageEl.dataset.txid;
+
+    // Store content and txid in properties of handleSendMessage
+    handleSendMessage.handleFailedMessage = messageContent;
+    handleSendMessage.txid = originalTxid;
+
+    // Show the modal
+    if (modal) {
+        modal.classList.add('active');
+    }
+}
+handleSendMessage.handleFailedMessage = '';
+handleSendMessage.txid = '';
+
+/**
+ * Invoked when the user clicks the retry button in the failed message modal
+ * It will fill the chat modal with the message content and txid of the failed message and focus the message input
+ */
+function handleFailedMessageRetry() {
+    const failedMessageModal = document.getElementById('failedMessageModal');
+    const mainChatInput = document.querySelector('#chatModal .message-input');
+    const retryTxIdInput = document.getElementById('retryOfTxId');
+
+    // Use the values stored when handleFailedMessage was called
+    const messageToRetry = handleSendMessage.handleFailedMessage;
+    const originalTxid = handleSendMessage.txid;
+
+    if (mainChatInput && retryTxIdInput && typeof messageToRetry === 'string' && typeof originalTxid === 'string') {
+        mainChatInput.value = messageToRetry;
+        retryTxIdInput.value = originalTxid;
+        
+        if (failedMessageModal) {
+            failedMessageModal.classList.remove('active');
+        }
+        mainChatInput.focus();
+        
+        // Clear the stored values after use
+        handleSendMessage.handleFailedMessage = '';
+        handleSendMessage.txid = ''; 
+    } else {
+        console.error('Error preparing message retry: Necessary elements or data missing.');
+        if (failedMessageModal) {
+            failedMessageModal.classList.remove('active'); 
+        }
+    }
+}
+
+/**
+ * Invoked when the user clicks the delete button in the failed message modal
+ * It will delete the message from all data stores
+ */
+function handleFailedMessageDelete() {
+    const failedMessageModal = document.getElementById('failedMessageModal');
+    const originalTxid = handleSendMessage.txid;
+
+    if (typeof originalTxid === 'string' && originalTxid) {
+        // Assuming handleDeleteMessage is defined and handles UI update
+        //TODO: invoke removeFailedTx
+        removeFailedTx(originalTxid)
+        if (failedMessageModal) {
+            failedMessageModal.classList.remove('active');
+        }
+        
+        // Clear the stored values
+        handleSendMessage.handleFailedMessage = '';
+        handleSendMessage.txid = ''; 
+        // refresh current chatModal
+        appendChatModal();
+    } else {
+        console.error('Error deleting message: TXID not found.');
+        if (failedMessageModal) {
+            failedMessageModal.classList.remove('active'); 
+        }
+    }
+}
+
+/**
+ * Invoked when the user clicks the close button in the failed message modal
+ * It will close the modal and clear the stored values
+ */
+function closeFailedMessageModalAndClearState() {
+    const failedMessageModal = document.getElementById('failedMessageModal');
+    if (failedMessageModal) {
+        failedMessageModal.classList.remove('active');
+    }
+    // Clear the stored values when modal is closed
+    handleSendMessage.handleFailedMessage = '';
+    handleSendMessage.txid = ''; 
+}
+
+/**
+ * Invoked when the user clicks the backdrop in the failed message modal
+ * It will close the modal and clear the stored values
+ */
+function handleFailedMessageBackdropClick(event) {
+    const failedMessageModal = document.getElementById('failedMessageModal');
+    if (event.target === failedMessageModal) {
+        closeFailedMessageModalAndClearState();
+    }
 }
 
 // Update wallet view; refresh wallet
@@ -3502,6 +3639,7 @@ function handleHistoryItemClick(event) {
     const item = event.target.closest('.transaction-item');
 
     if (item.dataset.status === 'failed') {
+        //TODO: open sendModal with the message content and txid of the failed message?
         return;
     }
 
@@ -6904,16 +7042,30 @@ function validateStakeInputs() {
 // Standalone function to remove a failed/timed-out transaction from all relevant data stores
 function removeFailedTx(txid) {
     console.log(`DEBUG: Removing failed/timed-out txid ${txid} from all stores`);
+    
+    const index = myData.pending.findIndex(tx => tx.txid === txid);
+    console.log(`DEBUG: index of txid ${txid} in pending to be used in splice: ${index}`);
+
+    if (index === -1) {
+        console.log(`DEBUG: txid ${txid} not found in pending, skipping removal`);
+        return;
+    }
+
+    const type = myData.pending[index].type;
+    
+
     // Remove from pending array
-    myData.pending = myData.pending.filter(tx => tx.txid !== txid);
+    myData.pending.splice(index, 1);
     
     // Remove from contacts messages
     for (const contact of Object.values(myData.contacts)) {
         contact.messages = contact.messages.filter(msg => msg.txid !== txid);
     }
     
-    // Remove from wallet history (Corrected: walletData.history)
-    walletData.history = walletData.history.filter(item => item.txid !== txid);
+    // Remove from wallet history
+    if (type === 'transfer') {
+        myData.wallet.history = myData.wallet.history.filter(item => item.txid !== txid);
+    }
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -514,6 +514,7 @@
             placeholder="Type a message..."
             maxlength="2000"
           ></textarea>
+          <input type="hidden" id="retryOfTxId" />
           <button class="send-button" id="handleSendMessage">
             <svg viewBox="0 0 24 24">
               <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
@@ -1293,6 +1294,26 @@
           <div class="scan-region-highlight"></div>
           <div class="scan-highlight" id="scan-highlight"></div>
           <canvas id="canvas"></canvas>
+        </div>
+      </div>
+
+      <!-- Failed Message Modal -->
+      <div class="modal modal-dialog" id="failedMessageModal">
+        <div class="dialog-box-content">
+          <div class="modal-header">
+            <button class="back-button" id="closeFailedMessageModal"></button>
+            <div class="modal-title">Failed Message</div>
+          </div>
+          <div class="form-container">
+            <div class="modal-actions">
+              <button type="button" class="secondary-button delete-button">
+                Delete
+              </button>
+              <button type="button" class="update-button retry-button">
+                Retry
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -4087,3 +4087,146 @@ small {
   font-weight: bold;
   line-height: 1;
 }
+
+#stakeAvailableBalanceDisplay {
+  font-size: 0.85em;
+  color: var(--secondary-text-color);
+  margin-bottom: 8px;
+  text-align: left;
+}
+
+/* Styles for the failed message pop-up dialog */
+.modal-dialog .modal-header {
+  /* Assuming .modal-header already has flex and alignment for title and back button */
+  /* We might want to ensure it fits the smaller dialog width */
+  padding: 12px 16px; /* Adjust padding if needed */
+}
+
+.modal-dialog .form-container {
+  background-color: var(--background-color);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  width: auto; /* Let content dictate width up to max-width */
+  max-width: 400px; /* Max width of the dialog */
+  margin: 0 auto; /* Center the form-container if .modal-dialog is flex centering */
+  display: flex;
+  flex-direction: column;
+  gap: 16px; /* Space between form groups */
+}
+
+/* Ensure the base .modal.active for .modal-dialog still provides the backdrop */
+.modal.modal-dialog.active {
+  /* display: flex; /* This is usually on .modal.active already */
+  /* justify-content: center; /* This is usually on .modal.active already */
+  /* align-items: center; /* This is usually on .modal.active already */
+  /* The above are likely inherited. If not, uncomment them. */
+  /* The backdrop color comes from .modal's background-color */
+}
+
+.modal-dialog #failedMessageContent {
+  min-height: 60px; /* Give it some initial height */
+  resize: vertical; /* Allow vertical resize if needed */
+}
+
+.modal-dialog .modal-actions {
+  display: flex;
+  flex-direction: column; /* Stack buttons vertically */
+  align-items: center; /* Center buttons horizontally in the column */
+  gap: 10px; /* Space between buttons vertically */
+}
+
+.modal-dialog .modal-actions .update-button,
+.modal-dialog .modal-actions .secondary-button,
+.modal-dialog .modal-actions .tertiary-button {
+  padding: 8px 16px; /* Adjust button padding for a more compact look */
+  font-size: var(--font-size-sm);
+  width: 300px; /* Override general button widths */
+  height: 48px; /* Let padding and content determine height */
+  margin: 0; /* Reset margin, rely on flex gap */
+}
+
+/* Adjust tertiary button specifically if needed */
+.modal-dialog .modal-actions .tertiary-button {
+  background-color: transparent;
+  color: var(--secondary-text-color);
+  border: 1px solid var(--border-color);
+}
+
+.modal-dialog .modal-actions .tertiary-button:hover {
+  background-color: var(--hover-background);
+}
+
+.transaction-item[data-status="failed"] {
+  border-left: 4px solid var(--danger-color);
+  padding-left: 10px; /* Add some padding so content doesn't touch the border */
+}
+
+/* Styles for the failed message pop-up dialog */
+
+/* Base for the dialog overlay/backdrop */
+.modal.modal-dialog {
+  display: none; /* Hidden by default */
+  position: fixed; /* Fixed position to overlay everything */
+  top: 0;
+  left: 0; /* Start from left, no slide-in */
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent backdrop */
+  justify-content: center; /* Center direct child (dialog-box-content) horizontally */
+  align-items: center; /* Center direct child (dialog-box-content) vertically */
+  z-index: 1001; /* Ensure it's on top */
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  /* Override general .modal transition if it interferes */
+  transform: none !important; /* Prevent slide-in */
+}
+
+.modal.modal-dialog.active {
+  display: flex; /* Show and use flex for centering */
+  opacity: 1;
+  transform: none !important; /* Ensure no slide-in even when active */
+}
+
+/* The actual dialog box appearance */
+.modal-dialog .dialog-box-content {
+  background-color: var(--background-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  width: auto;
+  max-width: 400px; /* Max width of the dialog */
+  display: flex;
+  flex-direction: column; /* Stack header and form-container */
+  overflow: hidden; /* Clip children to border-radius */
+}
+
+.modal-dialog .modal-header {
+  padding: 12px 16px;
+  /* display: flex, align-items: center are inherited or default */
+  /* Ensure its width is not 100% of screen if it was before */
+  width: 100%;
+}
+
+.modal-dialog .form-container {
+  /* Remove properties now on dialog-box-content */
+  /* background-color, border-radius, box-shadow, max-width, margin: 0 auto are removed */
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%; /* Take full width of parent dialog-box-content */
+}
+
+.modal-dialog #failedMessageContent {
+  min-height: 60px; /* Give it some initial height */
+  resize: vertical; /* Allow vertical resize if needed */
+}
+
+/* Style the Delete button in the dialog to be red and pill-shaped */
+.modal-dialog .modal-actions .delete-button {
+  background-color: var(--danger-color);
+  color: var(--background-color);
+  border-radius: 24px; /* Match update-button pill shape */
+  border: none; /* Ensure no border */
+  /* Padding and font-size are inherited from the common rule for dialog action buttons */
+}


### PR DESCRIPTION
**Overview:**

This pull request refactors the handling of failed messages by introducing a new pop-up dialog modal. This provides users with clear options to retry or delete a failed message, improving user experience and error recovery. The changes also include a bug fix for message removal and cleaner event listener management for the new modal.

**Key Changes:**

*   **New Failed Message Modal (`failedMessageModal`):**
    *   **HTML (`index.html`):** A new modal structure (`failedMessageModal` with class `modal-dialog`) has been added to display options for failed messages.
    *   **CSS (`styles.css`):**
        *   The `failedMessageModal` is styled as a compact, centered pop-up dialog box with a backdrop, distinct from the existing full-screen modals.
        *   The "Retry" and "Delete" buttons within this modal are now stacked vertically (Delete on top) and styled for consistency (pill-shaped, with Delete being red).
    *   **JavaScript (`app.js`):**
        *   A new function `handleFailedMessageClick(messageEl)` is introduced. When a failed message is clicked, this function captures its content and `txid`, stores them in `handleSendMessage.handleFailedMessage` and `handleSendMessage.txid` respectively, and then displays the `failedMessageModal`.
        *   Event listeners for the `failedMessageModal` (Retry, Delete, header Close button, and backdrop click) are now managed centrally within `DOMContentLoaded`. These listeners utilize new standalone named functions (`handleFailedMessageRetry`, `handleFailedMessageDelete`, `closeFailedMessageModalAndClearState`, `handleFailedMessageBackdropClick`) for better organization and to prevent multiple listener attachments.

*   **Retry Functionality:**
    *   The "Retry" button in the `failedMessageModal` now populates the main chat input (`#chatModal .message-input`) with the content of the failed message.
    *   The `txid` of the failed message is stored in a new hidden input field (`<input type="hidden" id="retryOfTxId">`) added to the `chatModal`'s message input container in `index.html`. This allows `handleSendMessage` (in a future step) to identify a retry attempt.

*   **Delete Functionality:**
    *   The "Delete" button in the `failedMessageModal` now calls `handleFailedMessageDelete()`, which in turn invokes `removeFailedTx(originalTxid)` to remove the message from data stores.
    *   The UI (current chat modal) is refreshed by calling `appendChatModal()` after deletion.

*   **Click Handling for Failed Messages (`handleClickToCopy` in `app.js`):**
    *   Updated to call `handleFailedMessageClick(messageEl)` when a non-payment message with `data-status="failed"` is clicked, thereby showing the new options dialog instead of attempting to copy the message content.
    *   A TODO comment has been added to consider specific handling for failed *payment* messages.

*   **Bug Fix in Message Removal (`removeFailedTx` in `app.js`):**
    *   The `removeFailedTx` function has been made more robust. It now checks if a `txid` is actually found in the `myData.pending` array before attempting to access its `type` property or splice it. This prevents the "Cannot read properties of undefined (reading 'type')" error.
    *   More detailed console logging has been added for debugging purposes during message removal.

**Impact:**

*   **Improved User Experience:** Users now have a clear and intuitive way to address failed messages directly from the chat interface.
*   **Enhanced Error Recovery:** The retry mechanism allows users to easily resend messages that didn't go through.
*   **More Robust Code:** The bug fix in `removeFailedTx` prevents potential runtime errors. Centralized event listener management for the new modal improves code clarity and reduces the risk of issues related to listener duplication.
