### PR TITLE
Enhance Failed Message Handling: "Edit & Resend" and Cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -3214,6 +3214,12 @@ async function handleSendMessage() {
         const chatMessageObj = createChatMessage(currentAddress, payload, 1, keys);
         const txid = await signObj(chatMessageObj, keys)
 
+        // if there a hidden txid input, get the value to be used to delete that txid from relevant data stores
+        const retryTxId = document.getElementById('retryOfTxId').value;
+        if (retryTxId) {
+            removeFailedTx(retryTxId);
+        }
+
         // --- Optimistic UI Update ---
         // Create new message object for local display immediately
         const newMessage = {
@@ -3255,35 +3261,11 @@ async function handleSendMessage() {
         //console.log('payload is', payload)
         // Send the message transaction using createChatMessage with default toll of 1
         const response = await injectTx(chatMessageObj, txid)
-
-        // Find the message we just added optimistically
-/*         const optimisticallyAddedMessage = chatsData.contacts[currentAddress].messages.find(
-            msg => msg.sent_timestamp === newMessage.sent_timestamp && msg.my === true && msg.status === 'sending'
-        ); */
         
-        //TODO: UI update to show sent message was sent or failed
         // will have to delete message from the places we added it to
         if (!response || !response.result || !response.result.success) {
             console.log('message failed to send', response)
-/*              // Handle failure: Update message status
-            if (optimisticallyAddedMessage) {
-                optimisticallyAddedMessage.status = 'failed';
-                // Optionally add error reason: optimisticallyAddedMessage.error = response.result?.reason || 'Unknown error';
-            }
-            // Update the UI again to show the failure state
-            appendChatModal();
-            alert('Message failed to send: ' + (response.result?.reason || 'Unknown error'));
-            // Note: Button is re-enabled in finally block, which is correct.
-            return; // Stop further processing on failure */
         }
-
-        // --- Update message status on successful send ---
-/*         if (optimisticallyAddedMessage) {
-            optimisticallyAddedMessage.status = 'sent'; // Or 'delivered' if you get confirmation
-            // Update the UI to reflect the 'sent' status if needed (e.g., remove 'sending' indicator)
-             appendChatModal(); // Refresh UI to potentially change message style based on 'sent' status
-        } */
-        // --- End Status Update ---
     } catch (error) {
         console.error('Message error:', error);
         alert('Failed to send message. Please try again.');
@@ -7105,6 +7087,7 @@ async function checkPendingTransactions() {
 
             if (res?.transaction?.success === true) {
                 console.log(`DEBUG: txid ${txid} is successful, removing from pending only`);
+                // comment out to test the pending txs removal logic
                 myData.pending.splice(i, 1);
             } 
             else if (res?.transaction?.success === false) {

--- a/app.js
+++ b/app.js
@@ -3262,7 +3262,6 @@ async function handleSendMessage() {
         // Send the message transaction using createChatMessage with default toll of 1
         const response = await injectTx(chatMessageObj, txid)
         
-        // will have to delete message from the places we added it to
         if (!response || !response.result || !response.result.success) {
             console.log('message failed to send', response)
         }

--- a/index.html
+++ b/index.html
@@ -1310,7 +1310,7 @@
                 Delete
               </button>
               <button type="button" class="update-button retry-button">
-                Retry
+                Edit & Resend
               </button>
             </div>
           </div>


### PR DESCRIPTION
**PR Summary:**

This pull request significantly improves the user experience for handling failed messages and ensures proper cleanup of data when resending.

*   **Updated "Retry" Functionality and Wording:**
    *   **`index.html`:** The button in the `failedMessageModal` previously labeled "Retry" has been renamed to **"Edit & Resend"** to more accurately reflect its behavior (populating the main chat input for user review/editing before resending).
*   **Resending Failed Messages - Data Cleanup:**
    *   **`app.js` (`handleSendMessage`)**:
        *   When a message is sent, the function now checks the hidden input `retryOfTxId` (populated when "Edit & Resend" is used).
        *   If `retryOfTxId` contains a transaction ID, `removeFailedTx()` is called with this ID. This ensures that the original failed message entry is removed from all relevant data stores (`myData.pending`, `contact.messages`, `myData.wallet.history`) before the new send attempt is processed. This prevents duplicate or orphaned failed message entries.
        *   Removed legacy commented-out code related to older optimistic UI update logic for message send status.
*   **Testing/Debugging Note:**
    *   **`app.js` (`checkPendingTransactions`)**: A temporary comment (`// comment out to test the pending txs removal logic`) has been added before the line that removes successful transactions from the `myData.pending` array. This should be reviewed and removed before final merge if it's for debugging purposes only.
