### PR TITLE
Feature: Failed Transaction Handling Modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1014,32 +1014,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     const failedMessageDeleteButton = failedMessageModal.querySelector('.delete-button');
     const failedMessageHeaderCloseButton = document.getElementById('closeFailedMessageModal');
 
-    if (failedMessageRetryButton) {
-        failedMessageRetryButton.addEventListener('click', handleFailedMessageRetry);
-    }
-    if (failedMessageDeleteButton) {
-        failedMessageDeleteButton.addEventListener('click', handleFailedMessageDelete);
-    }
-    if (failedMessageHeaderCloseButton) {
-        failedMessageHeaderCloseButton.addEventListener('click', closeFailedMessageModalAndClearState);
-    }
+    
+    failedMessageRetryButton.addEventListener('click', handleFailedMessageRetry);
+    failedMessageDeleteButton.addEventListener('click', handleFailedMessageDelete);
+    failedMessageHeaderCloseButton.addEventListener('click', closeFailedMessageModalAndClearState);
     failedMessageModal.addEventListener('click', handleFailedMessageBackdropClick);
 
+    
     // Event Listerns for FailedHistoryItemModal
     const failedHistoryItemModal = document.getElementById('failedHistoryItemModal');
     const failedHistoryItemRetryButton = failedHistoryItemModal.querySelector('.retry-button');
     const failedHistoryItemDeleteButton = failedHistoryItemModal.querySelector('.delete-button');
     const failedHistoryItemHeaderCloseButton = document.getElementById('closeFailedHistoryItemModal');
 
-    if (failedHistoryItemRetryButton) {
-        failedHistoryItemRetryButton.addEventListener('click', handleFailedHistoryItemRetry);
-    }
-    if (failedHistoryItemDeleteButton) {
-        failedHistoryItemDeleteButton.addEventListener('click', handleFailedHistoryItemDelete);
-    } 
-    if (failedHistoryItemHeaderCloseButton) {
-        failedHistoryItemHeaderCloseButton.addEventListener('click', closeFailedHistoryItemModalAndClearState);
-    }
+    failedHistoryItemRetryButton.addEventListener('click', handleFailedHistoryItemRetry);
+    failedHistoryItemDeleteButton.addEventListener('click', handleFailedHistoryItemDelete);
+    failedHistoryItemHeaderCloseButton.addEventListener('click', closeFailedHistoryItemModalAndClearState);
     failedHistoryItemModal.addEventListener('click', handleFailedHistoryItemBackdropClick);
     
     
@@ -3752,7 +3742,7 @@ function handleHistoryItemClick(event) {
 
     if (item.dataset.status === 'failed') {
         console.log(`Not opening chatModal for failed transaction`)
-        
+
         if (event.target.closest('.transaction-item')){
             handleFailedHistoryItemClick(item.dataset.txid, item);
         }

--- a/app.js
+++ b/app.js
@@ -1021,16 +1021,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     failedMessageModal.addEventListener('click', handleFailedMessageBackdropClick);
 
 
-    // Event Listerns for FailedPaymentItemModal
-    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
-    const failedPaymentItemRetryButton = failedPaymentItemModal.querySelector('.retry-button');
-    const failedPaymentItemDeleteButton = failedPaymentItemModal.querySelector('.delete-button');
-    const failedPaymentItemHeaderCloseButton = document.getElementById('closeFailedPaymentItemModal');
+    // Event Listerns for FailedPaymentModal
+    const failedPaymentModal = document.getElementById('failedPaymentModal');
+    const failedPaymentRetryButton = failedPaymentModal.querySelector('.retry-button');
+    const failedPaymentDeleteButton = failedPaymentModal.querySelector('.delete-button');
+    const failedPaymentHeaderCloseButton = document.getElementById('closeFailedPaymentModal');
 
-    failedPaymentItemRetryButton.addEventListener('click', handleFailedPaymentItemRetry);
-    failedPaymentItemDeleteButton.addEventListener('click', handleFailedPaymentItemDelete);
-    failedPaymentItemHeaderCloseButton.addEventListener('click', closeFailedPaymentItemModalAndClearState);
-    failedPaymentItemModal.addEventListener('click', handleFailedPaymentItemBackdropClick);
+    failedPaymentRetryButton.addEventListener('click', handleFailedPaymentRetry);
+    failedPaymentDeleteButton.addEventListener('click', handleFailedPaymentDelete);
+    failedPaymentHeaderCloseButton.addEventListener('click', closeFailedPaymentModalAndClearState);
+    failedPaymentModal.addEventListener('click', handleFailedPaymentBackdropClick);
     
     
     
@@ -3321,7 +3321,7 @@ async function handleClickToCopy(e) {
 
         // If the message is a payment message, show the failed history item modal
         if (messageEl.classList.contains('payment-info')) {
-            handleFailedPaymentItemClick(messageEl.dataset.txid, messageEl)
+            handleFailedPaymentClick(messageEl.dataset.txid, messageEl)
         }
 
         // TODO: if message is a payment open sendModal and fill with information in the payment message?
@@ -3397,33 +3397,33 @@ function handleFailedMessageClick(messageEl) {
 handleFailedMessageClick.handleFailedMessage = '';
 handleFailedMessageClick.txid = '';
 
-function handleFailedPaymentItemClick(txid, element) {
-    console.log('handleFailedPaymentItemClick', txid)
-    const modal = document.getElementById('failedPaymentItemModal');
+function handleFailedPaymentClick(txid, element) {
+    console.log('handleFailedPaymentClick', txid)
+    const modal = document.getElementById('failedPaymentModal');
 
     // Get the address and memo from the original failed transfer element
     const address = element?.dataset?.address || appendChatModal?.address;
     const memo = element?.querySelector('.transaction-memo')?.textContent || element?.querySelector('.payment-memo')?.textContent;
     const assetID = element?.dataset?.assetID || ''; // TODO: need to add assetID to `message sent payment-info` class for when we implement retry
 
-    // Store the address and memo in properties of handleFailedPaymentItemClick
-    handleFailedPaymentItemClick.address = address;
-    handleFailedPaymentItemClick.memo = memo;
-    handleFailedPaymentItemClick.txid = txid;
-    handleFailedPaymentItemClick.assetID = assetID;
+    // Store the address and memo in properties of handleFailedPaymentClick
+    handleFailedPaymentClick.address = address;
+    handleFailedPaymentClick.memo = memo;
+    handleFailedPaymentClick.txid = txid;
+    handleFailedPaymentClick.assetID = assetID;
 
-    console.log(`handleFailedPaymentItemClick.address: ${handleFailedPaymentItemClick.address}`)
-    console.log(`handleFailedPaymentItemClick.memo: ${handleFailedPaymentItemClick.memo}`)
-    console.log(`handleFailedPaymentItemClick.txid: ${handleFailedPaymentItemClick.txid}`)
-    console.log(`handleFailedPaymentItemClick.assetID: ${handleFailedPaymentItemClick.assetID}`)
+    console.log(`handleFailedPaymentClick.address: ${handleFailedPaymentClick.address}`)
+    console.log(`handleFailedPaymentClick.memo: ${handleFailedPaymentClick.memo}`)
+    console.log(`handleFailedPaymentClick.txid: ${handleFailedPaymentClick.txid}`)
+    console.log(`handleFailedPaymentClick.assetID: ${handleFailedPaymentClick.assetID}`)
     if (modal) {
         modal.classList.add('active');
     }
 }
-handleFailedPaymentItemClick.txid = '';
-handleFailedPaymentItemClick.address = '';
-handleFailedPaymentItemClick.memo = '';
-handleFailedPaymentItemClick.assetID = '';
+handleFailedPaymentClick.txid = '';
+handleFailedPaymentClick.address = '';
+handleFailedPaymentClick.memo = '';
+handleFailedPaymentClick.assetID = '';
 
 /**
  * Invoked when the user clicks the retry button in the failed message modal
@@ -3458,8 +3458,8 @@ function handleFailedMessageRetry() {
     }
 }
 
-function handleFailedPaymentItemRetry() {
-    console.log('handleFailedPaymentItemRetry')
+function handleFailedPaymentRetry() {
+    console.log('handleFailedPaymentRetry')
 }
 
 /**
@@ -3493,30 +3493,30 @@ function handleFailedMessageDelete() {
 
 
 
-function handleFailedPaymentItemDelete() {
-    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
-    const originalTxid = handleFailedPaymentItemClick.txid;
+function handleFailedPaymentDelete() {
+    const failedPaymentModal = document.getElementById('failedPaymentModal');
+    const originalTxid = handleFailedPaymentClick.txid;
 
     if (typeof originalTxid === 'string' && originalTxid) {
-        const currentAddress = handleFailedPaymentItemClick.address;
+        const currentAddress = handleFailedPaymentClick.address;
         removeFailedTx(originalTxid, currentAddress);
         
-        if (failedPaymentItemModal) {
-            failedPaymentItemModal.classList.remove('active');
+        if (failedPaymentModal) {
+            failedPaymentModal.classList.remove('active');
         }
         
         // Clear the stored values
-        handleFailedPaymentItemClick.txid = '';
-        handleFailedPaymentItemClick.address = '';
-        handleFailedPaymentItemClick.memo = '';
-        handleFailedPaymentItemClick.assetID = '';
+        handleFailedPaymentClick.txid = '';
+        handleFailedPaymentClick.address = '';
+        handleFailedPaymentClick.memo = '';
+        handleFailedPaymentClick.assetID = '';
 
         // refresh current view
         refreshCurrentView();
     } else {
         console.error('Error deleting message: TXID not found.');
-        if (failedPaymentItemModal) {
-            failedPaymentItemModal.classList.remove('active');
+        if (failedPaymentModal) {
+            failedPaymentModal.classList.remove('active');
         }
     }
 }
@@ -3535,16 +3535,16 @@ function closeFailedMessageModalAndClearState() {
     handleFailedMessageClick.txid = ''; 
 }
 
-function closeFailedPaymentItemModalAndClearState() {
-    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
-    if (failedPaymentItemModal) {
-        failedPaymentItemModal.classList.remove('active');
+function closeFailedPaymentModalAndClearState() {
+    const failedPaymentModal = document.getElementById('failedPaymentModal');
+    if (failedPaymentModal) {
+        failedPaymentModal.classList.remove('active');
     }
     // Clear the stored values when modal is closed
-    handleFailedPaymentItemClick.txid = '';
-    handleFailedPaymentItemClick.address = '';
-    handleFailedPaymentItemClick.memo = '';
-    handleFailedPaymentItemClick.assetID = '';
+    handleFailedPaymentClick.txid = '';
+    handleFailedPaymentClick.address = '';
+    handleFailedPaymentClick.memo = '';
+    handleFailedPaymentClick.assetID = '';
 }
 
 /**
@@ -3558,10 +3558,10 @@ function handleFailedMessageBackdropClick(event) {
     }
 }
 
-function handleFailedPaymentItemBackdropClick(event) {
-    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
-    if (event.target === failedPaymentItemModal) {
-        closeFailedPaymentItemModalAndClearState();
+function handleFailedPaymentBackdropClick(event) {
+    const failedPaymentModal = document.getElementById('failedPaymentModal');
+    if (event.target === failedPaymentModal) {
+        closeFailedPaymentModalAndClearState();
     }
 }
 
@@ -3745,7 +3745,7 @@ function handleHistoryItemClick(event) {
         console.log(`Not opening chatModal for failed transaction`)
 
         if (event.target.closest('.transaction-item')){
-            handleFailedPaymentItemClick(item.dataset.txid, item);
+            handleFailedPaymentClick(item.dataset.txid, item);
         }
         
         return;

--- a/app.js
+++ b/app.js
@@ -1321,14 +1321,20 @@ async function updateChatList() {
 
     console.log('updateChatList chats.length', JSON.stringify(chats.length))
     
-    const chatItems = await Promise.all(chats.map(async chat => {
+    // Clear existing chat items before adding new ones
+    chatList.innerHTML = ''; 
+
+    const chatElements = await Promise.all(chats.map(async chat => {
         const identicon = await generateIdenticon(chat.address);
         const contact = contacts[chat.address];
-        if (!contact) return ''; // Safety check
-
-        // Find the latest message/activity for this contact (which is the first in the messages array)
-        const latestActivity = contact.messages[0]; // Assumes messages array includes transfers and is sorted descending
-        if (!latestActivity){ return '' }
+        
+        // If contact doesn't exist, skip this chat item
+        if (!contact) return null; 
+        
+        const latestActivity = contact.messages && contact.messages.length > 0 ? contact.messages[0] : null;
+        
+        // If there's no latest activity (no messages), skip this chat item
+        if (!latestActivity) return null;
 
         let previewHTML = ''; // Default
         const latestItemTimestamp = latestActivity.timestamp;
@@ -1357,31 +1363,38 @@ async function updateChatList() {
         const timeDisplay = formatTime(latestItemTimestamp);
         const contactName = contact.name || contact.senderInfo?.name || contact.username || `${contact.address.slice(0,8)}...${contact.address.slice(-6)}`;
 
-        return `
-            <li class="chat-item">
-                <div class="chat-avatar">${identicon}</div>
-                <div class="chat-content">
-                    <div class="chat-header">
-                        <div class="chat-name">${contactName}</div>
-                        <div class="chat-time">${timeDisplay} <span class="chat-time-chevron"></span></div>
-                    </div>
-                    <div class="chat-message">
-                        ${previewHTML}
-                        ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : ''}
-                    </div>
+        // Create the list item element
+        const li = document.createElement('li');
+        li.classList.add('chat-item');
+        
+        // Set its inner HTML
+        li.innerHTML = `
+            <div class="chat-avatar">${identicon}</div>
+            <div class="chat-content">
+                <div class="chat-header">
+                    <div class="chat-name">${escapeHtml(contactName)}</div>
+                    <div class="chat-time">${timeDisplay} <span class="chat-time-chevron"></span></div>
                 </div>
-            </li>
+                <div class="chat-message">
+                    ${previewHTML}
+                    ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : ''}
+                </div>
+            </div>
         `;
+        
+        // Add the onclick handler directly to the element
+        li.onclick = () => openChatModal(chat.address);
+        
+        return li; // Return the created DOM element
     }));
     
-    chatList.innerHTML = chatItems.join('');
-    
-    // Add click handlers to chat items
-    document.querySelectorAll('.chat-item').forEach((item, index) => {
-        item.onclick = () => openChatModal(chats[index].address);
+    // Append the created (and non-null) list item elements to the chatList
+    chatElements.forEach(element => {
+        if (element) { // Only append if the element is not null
+            chatList.appendChild(element);
+        }
     });
 }
-
 // refresh wallet balance
 async function updateWalletBalances() {
     if (!myAccount || !myData || !myData.wallet || !myData.wallet.assets) {
@@ -3504,15 +3517,15 @@ function handleFailedPaymentDelete() {
         if (failedPaymentModal) {
             failedPaymentModal.classList.remove('active');
         }
+
+        // refresh current view
+        refreshCurrentView(handleFailedPaymentClick.txid);
         
         // Clear the stored values
         handleFailedPaymentClick.txid = '';
         handleFailedPaymentClick.address = '';
         handleFailedPaymentClick.memo = '';
         handleFailedPaymentClick.assetID = '';
-
-        // refresh current view
-        refreshCurrentView();
     } else {
         console.error('Error deleting message: TXID not found.');
         if (failedPaymentModal) {
@@ -7246,19 +7259,13 @@ function refreshCurrentView(txid) { // contactAddress is kept for potential futu
     const historyModal = document.getElementById('historyModal');
     const messagesList = chatModal ? chatModal.querySelector('.messages-list') : null;
 
-    // 1. Refresh Chat List if active
-    // This is checked first as it's a common background view.
-    if (chatsScreen && chatsScreen.classList.contains('active')) {
-        console.log("DEBUG: Refreshing chat list view due to transaction failure.");
-        updateChatList();
-    }
-    // 2. Refresh History Modal if active
-    else if (historyModal && historyModal.classList.contains('active')) {
+    // 1. Refresh History Modal if active
+    if (historyModal && historyModal.classList.contains('active')) {
         console.log("DEBUG: Refreshing transaction history modal due to transaction failure.");
         updateTransactionHistory();
     }
-    // 3. Refresh Chat Modal if active AND the failed txid's message is currently rendered
-    else if (chatModal && chatModal.classList.contains('active') && txid && messagesList) {
+    // 2. Refresh Chat Modal if active AND the failed txid's message is currently rendered
+    if (chatModal && chatModal.classList.contains('active') && txid && messagesList) {
         // Check if an element with the specific data-txid exists within the message list
         const messageElement = messagesList.querySelector(`[data-txid="${txid}"]`);
 
@@ -7270,6 +7277,11 @@ function refreshCurrentView(txid) { // contactAddress is kept for potential futu
             // The failed txid doesn't correspond to a visible message in the *currently open* chat modal. No UI refresh needed for the modal itself.
             console.log(`DEBUG: Skipping chat modal refresh. Failed txid ${txid} not found in the active modal's message list.`);
         }
+    } 
+    // 3. Refresh Chat List if active
+    if (chatsScreen && chatsScreen.classList.contains('active')) {
+        console.log("DEBUG: Refreshing chat list view due to transaction failure.");
+        updateChatList();
     }
     // No other active view to refresh in this context
 }

--- a/app.js
+++ b/app.js
@@ -1020,7 +1020,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     failedMessageHeaderCloseButton.addEventListener('click', closeFailedMessageModalAndClearState);
     failedMessageModal.addEventListener('click', handleFailedMessageBackdropClick);
 
-    
+
     // Event Listerns for FailedHistoryItemModal
     const failedHistoryItemModal = document.getElementById('failedHistoryItemModal');
     const failedHistoryItemRetryButton = failedHistoryItemModal.querySelector('.retry-button');
@@ -3423,6 +3423,7 @@ function handleFailedHistoryItemClick(txid, element) {
 handleFailedHistoryItemClick.txid = '';
 handleFailedHistoryItemClick.address = '';
 handleFailedHistoryItemClick.memo = '';
+handleFailedHistoryItemClick.assetID = '';
 
 /**
  * Invoked when the user clicks the retry button in the failed message modal

--- a/app.js
+++ b/app.js
@@ -1021,16 +1021,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     failedMessageModal.addEventListener('click', handleFailedMessageBackdropClick);
 
 
-    // Event Listerns for FailedHistoryItemModal
-    const failedHistoryItemModal = document.getElementById('failedHistoryItemModal');
-    const failedHistoryItemRetryButton = failedHistoryItemModal.querySelector('.retry-button');
-    const failedHistoryItemDeleteButton = failedHistoryItemModal.querySelector('.delete-button');
-    const failedHistoryItemHeaderCloseButton = document.getElementById('closeFailedHistoryItemModal');
+    // Event Listerns for FailedPaymentItemModal
+    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
+    const failedPaymentItemRetryButton = failedPaymentItemModal.querySelector('.retry-button');
+    const failedPaymentItemDeleteButton = failedPaymentItemModal.querySelector('.delete-button');
+    const failedPaymentItemHeaderCloseButton = document.getElementById('closeFailedPaymentItemModal');
 
-    failedHistoryItemRetryButton.addEventListener('click', handleFailedHistoryItemRetry);
-    failedHistoryItemDeleteButton.addEventListener('click', handleFailedHistoryItemDelete);
-    failedHistoryItemHeaderCloseButton.addEventListener('click', closeFailedHistoryItemModalAndClearState);
-    failedHistoryItemModal.addEventListener('click', handleFailedHistoryItemBackdropClick);
+    failedPaymentItemRetryButton.addEventListener('click', handleFailedPaymentItemRetry);
+    failedPaymentItemDeleteButton.addEventListener('click', handleFailedPaymentItemDelete);
+    failedPaymentItemHeaderCloseButton.addEventListener('click', closeFailedPaymentItemModalAndClearState);
+    failedPaymentItemModal.addEventListener('click', handleFailedPaymentItemBackdropClick);
     
     
     
@@ -3321,7 +3321,7 @@ async function handleClickToCopy(e) {
 
         // If the message is a payment message, show the failed history item modal
         if (messageEl.classList.contains('payment-info')) {
-            handleFailedHistoryItemClick(messageEl.dataset.txid, messageEl)
+            handleFailedPaymentItemClick(messageEl.dataset.txid, messageEl)
         }
 
         // TODO: if message is a payment open sendModal and fill with information in the payment message?
@@ -3397,33 +3397,33 @@ function handleFailedMessageClick(messageEl) {
 handleFailedMessageClick.handleFailedMessage = '';
 handleFailedMessageClick.txid = '';
 
-function handleFailedHistoryItemClick(txid, element) {
-    console.log('handleFailedHistoryItemClick', txid)
-    const modal = document.getElementById('failedHistoryItemModal');
+function handleFailedPaymentItemClick(txid, element) {
+    console.log('handleFailedPaymentItemClick', txid)
+    const modal = document.getElementById('failedPaymentItemModal');
 
     // Get the address and memo from the original failed transfer element
     const address = element?.dataset?.address || appendChatModal?.address;
     const memo = element?.querySelector('.transaction-memo')?.textContent || element?.querySelector('.payment-memo')?.textContent;
     const assetID = element?.dataset?.assetID || ''; // TODO: need to add assetID to `message sent payment-info` class for when we implement retry
 
-    // Store the address and memo in properties of handleFailedHistoryItemClick
-    handleFailedHistoryItemClick.address = address;
-    handleFailedHistoryItemClick.memo = memo;
-    handleFailedHistoryItemClick.txid = txid;
-    handleFailedHistoryItemClick.assetID = assetID;
+    // Store the address and memo in properties of handleFailedPaymentItemClick
+    handleFailedPaymentItemClick.address = address;
+    handleFailedPaymentItemClick.memo = memo;
+    handleFailedPaymentItemClick.txid = txid;
+    handleFailedPaymentItemClick.assetID = assetID;
 
-    console.log(`handleFailedHistoryItemClick.address: ${handleFailedHistoryItemClick.address}`)
-    console.log(`handleFailedHistoryItemClick.memo: ${handleFailedHistoryItemClick.memo}`)
-    console.log(`handleFailedHistoryItemClick.txid: ${handleFailedHistoryItemClick.txid}`)
-    console.log(`handleFailedHistoryItemClick.assetID: ${handleFailedHistoryItemClick.assetID}`)
+    console.log(`handleFailedPaymentItemClick.address: ${handleFailedPaymentItemClick.address}`)
+    console.log(`handleFailedPaymentItemClick.memo: ${handleFailedPaymentItemClick.memo}`)
+    console.log(`handleFailedPaymentItemClick.txid: ${handleFailedPaymentItemClick.txid}`)
+    console.log(`handleFailedPaymentItemClick.assetID: ${handleFailedPaymentItemClick.assetID}`)
     if (modal) {
         modal.classList.add('active');
     }
 }
-handleFailedHistoryItemClick.txid = '';
-handleFailedHistoryItemClick.address = '';
-handleFailedHistoryItemClick.memo = '';
-handleFailedHistoryItemClick.assetID = '';
+handleFailedPaymentItemClick.txid = '';
+handleFailedPaymentItemClick.address = '';
+handleFailedPaymentItemClick.memo = '';
+handleFailedPaymentItemClick.assetID = '';
 
 /**
  * Invoked when the user clicks the retry button in the failed message modal
@@ -3458,8 +3458,8 @@ function handleFailedMessageRetry() {
     }
 }
 
-function handleFailedHistoryItemRetry() {
-    console.log('handleFailedHistoryItemRetry')
+function handleFailedPaymentItemRetry() {
+    console.log('handleFailedPaymentItemRetry')
 }
 
 /**
@@ -3493,30 +3493,30 @@ function handleFailedMessageDelete() {
 
 
 
-function handleFailedHistoryItemDelete() {
-    const failedHistoryItemModal = document.getElementById('failedHistoryItemModal');
-    const originalTxid = handleFailedHistoryItemClick.txid;
+function handleFailedPaymentItemDelete() {
+    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
+    const originalTxid = handleFailedPaymentItemClick.txid;
 
     if (typeof originalTxid === 'string' && originalTxid) {
-        const currentAddress = handleFailedHistoryItemClick.address;
+        const currentAddress = handleFailedPaymentItemClick.address;
         removeFailedTx(originalTxid, currentAddress);
         
-        if (failedHistoryItemModal) {
-            failedHistoryItemModal.classList.remove('active');
+        if (failedPaymentItemModal) {
+            failedPaymentItemModal.classList.remove('active');
         }
         
         // Clear the stored values
-        handleFailedHistoryItemClick.txid = '';
-        handleFailedHistoryItemClick.address = '';
-        handleFailedHistoryItemClick.memo = '';
-        handleFailedHistoryItemClick.assetID = '';
+        handleFailedPaymentItemClick.txid = '';
+        handleFailedPaymentItemClick.address = '';
+        handleFailedPaymentItemClick.memo = '';
+        handleFailedPaymentItemClick.assetID = '';
 
         // refresh current view
         refreshCurrentView();
     } else {
         console.error('Error deleting message: TXID not found.');
-        if (failedHistoryItemModal) {
-            failedHistoryItemModal.classList.remove('active');
+        if (failedPaymentItemModal) {
+            failedPaymentItemModal.classList.remove('active');
         }
     }
 }
@@ -3535,16 +3535,16 @@ function closeFailedMessageModalAndClearState() {
     handleFailedMessageClick.txid = ''; 
 }
 
-function closeFailedHistoryItemModalAndClearState() {
-    const failedHistoryItemModal = document.getElementById('failedHistoryItemModal');
-    if (failedHistoryItemModal) {
-        failedHistoryItemModal.classList.remove('active');
+function closeFailedPaymentItemModalAndClearState() {
+    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
+    if (failedPaymentItemModal) {
+        failedPaymentItemModal.classList.remove('active');
     }
     // Clear the stored values when modal is closed
-    handleFailedHistoryItemClick.txid = '';
-    handleFailedHistoryItemClick.address = '';
-    handleFailedHistoryItemClick.memo = '';
-    handleFailedHistoryItemClick.assetID = '';
+    handleFailedPaymentItemClick.txid = '';
+    handleFailedPaymentItemClick.address = '';
+    handleFailedPaymentItemClick.memo = '';
+    handleFailedPaymentItemClick.assetID = '';
 }
 
 /**
@@ -3558,10 +3558,10 @@ function handleFailedMessageBackdropClick(event) {
     }
 }
 
-function handleFailedHistoryItemBackdropClick(event) {
-    const failedHistoryItemModal = document.getElementById('failedHistoryItemModal');
-    if (event.target === failedHistoryItemModal) {
-        closeFailedHistoryItemModalAndClearState();
+function handleFailedPaymentItemBackdropClick(event) {
+    const failedPaymentItemModal = document.getElementById('failedPaymentItemModal');
+    if (event.target === failedPaymentItemModal) {
+        closeFailedPaymentItemModalAndClearState();
     }
 }
 
@@ -3745,7 +3745,7 @@ function handleHistoryItemClick(event) {
         console.log(`Not opening chatModal for failed transaction`)
 
         if (event.target.closest('.transaction-item')){
-            handleFailedHistoryItemClick(item.dataset.txid, item);
+            handleFailedPaymentItemClick(item.dataset.txid, item);
         }
         
         return;

--- a/index.html
+++ b/index.html
@@ -1317,13 +1317,13 @@
         </div>
       </div>
 
-      <!-- Failed Payment Item Modal -->
-      <div class="modal modal-dialog" id="failedPaymentItemModal">
+      <!-- Failed Payment Modal -->
+      <div class="modal modal-dialog" id="failedPaymentModal">
         <div class="dialog-box-content">
           <div class="modal-header">
             <button
               class="back-button"
-              id="closeFailedPaymentItemModal"
+              id="closeFailedPaymentModal"
             ></button>
             <div class="modal-title">Failed Transaction</div>
           </div>

--- a/index.html
+++ b/index.html
@@ -1317,13 +1317,13 @@
         </div>
       </div>
 
-      <!-- Failed History Item Modal -->
-      <div class="modal modal-dialog" id="failedHistoryItemModal">
+      <!-- Failed Payment Item Modal -->
+      <div class="modal modal-dialog" id="failedPaymentItemModal">
         <div class="dialog-box-content">
           <div class="modal-header">
             <button
               class="back-button"
-              id="closeFailedHistoryItemModal"
+              id="closeFailedPaymentItemModal"
             ></button>
             <div class="modal-title">Failed Transaction</div>
           </div>

--- a/index.html
+++ b/index.html
@@ -1316,6 +1316,29 @@
           </div>
         </div>
       </div>
+
+      <!-- Failed History Item Modal -->
+      <div class="modal modal-dialog" id="failedHistoryItemModal">
+        <div class="dialog-box-content">
+          <div class="modal-header">
+            <button
+              class="back-button"
+              id="closeFailedHistoryItemModal"
+            ></button>
+            <div class="modal-title">Failed Transaction</div>
+          </div>
+          <div class="form-container">
+            <div class="modal-actions">
+              <button type="button" class="secondary-button delete-button">
+                Delete
+              </button>
+              <button type="button" class="update-button retry-button">
+                Edit & Resend
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <!-- Audio element for notification sounds -->
     <audio


### PR DESCRIPTION
**`app.js`**

*   **New Modal for Failed Payment Items:**
    *   Added event listeners for a new modal `failedPaymentModal`. This includes listeners for retry, delete, and close buttons, as well as a backdrop click. (Previously `failedHistoryModal`)
    *   `handleFailedPaymentClick(txid, element)`: This new function is triggered when a failed transaction item is clicked. It retrieves transaction details (address, memo, assetID) from the clicked element or existing modal data and stores them. It then displays the `failedPaymentModal`. (Previously `handleFailedHistoryClick`)
    *   `handleFailedPaymentRetry()`: A new placeholder function for handling the retry logic for a failed transaction. (Previously `handleFailedHistoryRetry`)
    *   `handleFailedPaymentDelete()`: This new function handles the deletion of a failed transaction. It uses the stored `txid` and `address` to call `removeFailedTx`, closes the modal, clears stored transaction data, and refreshes the current view. (Previously `handleFailedHistoryDelete`)
    *   `closeFailedPaymentModalAndClearState()`: This new function closes the `failedPaymentModal` and clears any stored transaction data associated with it. (Previously `closeFailedHistoryModalAndClearState`)
    *   `handleFailedPaymentBackdropClick(event)`: This new function closes the `failedPaymentModal` if the click occurs on the modal backdrop. (Previously `handleFailedHistoryBackdropClick`)
*   **Integration with Existing Click Handlers:**
    *   In `handleClickToCopy(e)`, if a clicked message element has the class `payment-info` (indicating a payment message), it now calls `handleFailedPaymentClick` to show the new modal for failed items. (Previously `handleFailedHistoryClick`)
    *   In `handleHistoryClick(event)`, if a clicked history item has a status of `failed`, it now calls `handleFailedPaymenClick`. (Previously `handleFailedHistoryClick`)
*   **Minor code adjustment:** Removed unnecessary `if` checks before adding event listeners for `failedMessageModal` buttons, as the buttons are expected to exist.

**`index.html`**

*   **New Modal HTML Structure:**
    *   Added the HTML structure for `failedPaymentModal`. (Previously `failedHistoryModal`)
    *   The modal ID is now `failedPaymentModal` and the close button ID is `closeFailedPaymentModal`.
    *   This modal includes a header with a close button and the title "Failed Transaction".
    *   It contains two action buttons: "Delete" (secondary-button delete-button) and "Edit & Resend" (update-button retry-button).
