### PR TITLE
Feat: Implement Retry Failed Payment Functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -2325,6 +2325,7 @@ async function openSendModal() {
     document.getElementById('sendToAddress').value = '';
     document.getElementById('sendAmount').value = '';
     document.getElementById('sendMemo').value = '';
+    document.getElementById('retryOfTxId').value = '';
 
     const usernameAvailable = document.getElementById('sendToAddressError');
     const submitButton = document.querySelector('#sendForm button[type="submit"]');
@@ -2690,6 +2691,18 @@ async function handleSendAsset(event) {
     let encMemo = ''
     if (memo){
         encMemo = encryptChacha(dhkey, memo)
+    }
+
+    // hidden input field retryOfTxId is present delete it from myData and clear the field
+    if (document.getElementById('retryOfTxId')) {
+        // remove from myData 
+        removeFailedTx(handleFailedPaymentClick.txid, handleFailedPaymentClick.address)
+
+        // clear the field
+        handleFailedPaymentClick.txid = '';
+        handleFailedPaymentClick.address = '';
+        handleFailedPaymentClick.memo = '';
+        document.getElementById('retryOfTxId').value = '';
     }
 
     // Create sender info object
@@ -3417,18 +3430,18 @@ function handleFailedPaymentClick(txid, element) {
     // Get the address and memo from the original failed transfer element
     const address = element?.dataset?.address || appendChatModal?.address;
     const memo = element?.querySelector('.transaction-memo')?.textContent || element?.querySelector('.payment-memo')?.textContent;
-    const assetID = element?.dataset?.assetID || ''; // TODO: need to add assetID to `message sent payment-info` class for when we implement retry
+    //const assetID = element?.dataset?.assetID || ''; // TODO: need to add assetID to `myData.wallet.history` for when we have multiple assets
 
     // Store the address and memo in properties of handleFailedPaymentClick
     handleFailedPaymentClick.address = address;
     handleFailedPaymentClick.memo = memo;
     handleFailedPaymentClick.txid = txid;
-    handleFailedPaymentClick.assetID = assetID;
+    //handleFailedPaymentClick.assetID = assetID;
 
     console.log(`handleFailedPaymentClick.address: ${handleFailedPaymentClick.address}`)
     console.log(`handleFailedPaymentClick.memo: ${handleFailedPaymentClick.memo}`)
     console.log(`handleFailedPaymentClick.txid: ${handleFailedPaymentClick.txid}`)
-    console.log(`handleFailedPaymentClick.assetID: ${handleFailedPaymentClick.assetID}`)
+    //console.log(`handleFailedPaymentClick.assetID: ${handleFailedPaymentClick.assetID}`)
     if (modal) {
         modal.classList.add('active');
     }
@@ -3436,7 +3449,7 @@ function handleFailedPaymentClick(txid, element) {
 handleFailedPaymentClick.txid = '';
 handleFailedPaymentClick.address = '';
 handleFailedPaymentClick.memo = '';
-handleFailedPaymentClick.assetID = '';
+//handleFailedPaymentClick.assetID = '';
 
 /**
  * Invoked when the user clicks the retry button in the failed message modal
@@ -3471,8 +3484,42 @@ function handleFailedMessageRetry() {
     }
 }
 
+/**
+ * Invoked when the user clicks the retry button in the failed payment modal
+ * It will fill the sendModal with the payment content and txid of the failed payment in a hidden input field in the sendModal
+ */
 function handleFailedPaymentRetry() {
-    console.log('handleFailedPaymentRetry')
+    const sendModal = document.getElementById('sendModal');
+    const retryOfTxId = document.getElementById('retryOfTxId');
+
+    // close the failed payment modal
+    const failedPaymentModal = document.getElementById('failedPaymentModal');
+    if (failedPaymentModal) {
+        failedPaymentModal.classList.remove('active');
+    }
+
+    if (sendModal && retryOfTxId) {
+        sendModal.classList.add('active');
+
+        // 1. fill in hidden retryOfTxId input
+        retryOfTxId.value = handleFailedPaymentClick.txid;
+
+        // 2. fill in the memo input
+        sendModal.querySelector('#sendMemo').value = handleFailedPaymentClick.memo;
+
+        // 3. fill in the to address input
+        // find username in myData.contacts[handleFailedPaymentClick.address].senderInfo.username
+        // enter as an input to invoke the oninput event
+        sendModal.querySelector('#sendToAddress').value = myData.contacts[handleFailedPaymentClick.address]?.senderInfo?.username || handleFailedPaymentClick.address || '';
+        sendModal.querySelector('#sendToAddress').dispatchEvent(new Event('input', { bubbles: true }));
+
+        // 4. fill in the amount input
+        // get the amount from myData.wallet.history since we need to the bigint value
+        const amount = myData.wallet.history.find(tx => tx.txid === handleFailedPaymentClick.txid)?.amount;
+        // convert bigint to string
+        const amountStr = big2str(amount, 18);
+        sendModal.querySelector('#sendAmount').value = amountStr;
+    }
 }
 
 /**
@@ -3525,7 +3572,7 @@ function handleFailedPaymentDelete() {
         handleFailedPaymentClick.txid = '';
         handleFailedPaymentClick.address = '';
         handleFailedPaymentClick.memo = '';
-        handleFailedPaymentClick.assetID = '';
+        //handleFailedPaymentClick.assetID = '';
     } else {
         console.error('Error deleting message: TXID not found.');
         if (failedPaymentModal) {
@@ -3557,7 +3604,7 @@ function closeFailedPaymentModalAndClearState() {
     handleFailedPaymentClick.txid = '';
     handleFailedPaymentClick.address = '';
     handleFailedPaymentClick.memo = '';
-    handleFailedPaymentClick.assetID = '';
+    //handleFailedPaymentClick.assetID = '';
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -2693,8 +2693,8 @@ async function handleSendAsset(event) {
         encMemo = encryptChacha(dhkey, memo)
     }
 
-    // hidden input field retryOfTxId is present delete it from myData and clear the field
-    if (document.getElementById('retryOfTxId')) {
+    // hidden input field retryOfTxId value is present delete it from myData and clear the field
+    if (document.getElementById('retryOfTxId').value) {
         // remove from myData 
         removeFailedTx(handleFailedPaymentClick.txid, handleFailedPaymentClick.address)
 
@@ -3499,7 +3499,7 @@ function handleFailedPaymentRetry() {
     }
 
     if (sendModal && retryOfTxId) {
-        sendModal.classList.add('active');
+        openSendModal();
 
         // 1. fill in hidden retryOfTxId input
         retryOfTxId.value = handleFailedPaymentClick.txid;

--- a/app.js
+++ b/app.js
@@ -2695,8 +2695,8 @@ async function handleSendAsset(event) {
 
     // hidden input field retryOfTxId value is not an empty string
     if (document.getElementById('retryOfPaymentTxId').value) {
-        // remove from myData 
-        removeFailedTx(handleFailedPaymentClick.txid, handleFailedPaymentClick.address)
+        // remove from myData use txid from hidden field retryOfPaymentTxId
+        removeFailedTx(document.getElementById('retryOfPaymentTxId').value, toAddress)
 
         // clear the field
         handleFailedPaymentClick.txid = '';

--- a/app.js
+++ b/app.js
@@ -3254,6 +3254,7 @@ async function handleSendMessage() {
         const retryTxId = document.getElementById('retryOfTxId').value;
         if (retryTxId) {
             removeFailedTx(retryTxId, currentAddress);
+            document.getElementById('retryOfTxId').value = '';
         }
 
         // --- Optimistic UI Update ---

--- a/app.js
+++ b/app.js
@@ -2325,7 +2325,7 @@ async function openSendModal() {
     document.getElementById('sendToAddress').value = '';
     document.getElementById('sendAmount').value = '';
     document.getElementById('sendMemo').value = '';
-    document.getElementById('retryOfTxId').value = '';
+    document.getElementById('retryOfPaymentTxId').value = '';
 
     const usernameAvailable = document.getElementById('sendToAddressError');
     const submitButton = document.querySelector('#sendForm button[type="submit"]');
@@ -2694,7 +2694,7 @@ async function handleSendAsset(event) {
     }
 
     // hidden input field retryOfTxId value is not an empty string
-    if (document.getElementById('retryOfTxId').value !== '') {
+    if (document.getElementById('retryOfPaymentTxId').value) {
         // remove from myData 
         removeFailedTx(handleFailedPaymentClick.txid, handleFailedPaymentClick.address)
 
@@ -2702,7 +2702,7 @@ async function handleSendAsset(event) {
         handleFailedPaymentClick.txid = '';
         handleFailedPaymentClick.address = '';
         handleFailedPaymentClick.memo = '';
-        document.getElementById('retryOfTxId').value = '';
+        document.getElementById('retryOfPaymentTxId').value = '';
     }
 
     // Create sender info object
@@ -3490,7 +3490,7 @@ function handleFailedMessageRetry() {
  */
 function handleFailedPaymentRetry() {
     const sendModal = document.getElementById('sendModal');
-    const retryOfTxId = document.getElementById('retryOfTxId');
+    const retryOfPaymentTxId = document.getElementById('retryOfPaymentTxId');
 
     // close the failed payment modal
     const failedPaymentModal = document.getElementById('failedPaymentModal');
@@ -3498,11 +3498,11 @@ function handleFailedPaymentRetry() {
         failedPaymentModal.classList.remove('active');
     }
 
-    if (sendModal && retryOfTxId) {
+    if (sendModal && retryOfPaymentTxId) {
         openSendModal();
 
-        // 1. fill in hidden retryOfTxId input
-        retryOfTxId.value = handleFailedPaymentClick.txid;
+        // 1. fill in hidden retryOfPaymentTxId input
+        retryOfPaymentTxId.value = handleFailedPaymentClick.txid;
 
         // 2. fill in the memo input
         sendModal.querySelector('#sendMemo').value = handleFailedPaymentClick.memo;

--- a/app.js
+++ b/app.js
@@ -3255,6 +3255,8 @@ async function handleSendMessage() {
         if (retryTxId) {
             removeFailedTx(retryTxId, currentAddress);
             document.getElementById('retryOfTxId').value = '';
+            handleFailedMessageClick.txid = '';
+            handleFailedMessageClick.handleFailedMessage = '';
         }
 
         // --- Optimistic UI Update ---

--- a/app.js
+++ b/app.js
@@ -2693,8 +2693,8 @@ async function handleSendAsset(event) {
         encMemo = encryptChacha(dhkey, memo)
     }
 
-    // hidden input field retryOfTxId value is present delete it from myData and clear the field
-    if (document.getElementById('retryOfTxId').value) {
+    // hidden input field retryOfTxId value is not an empty string
+    if (document.getElementById('retryOfTxId').value !== '') {
         // remove from myData 
         removeFailedTx(handleFailedPaymentClick.txid, handleFailedPaymentClick.address)
 

--- a/index.html
+++ b/index.html
@@ -783,7 +783,7 @@
                 maxlength="2000"
               ></textarea>
             </div>
-            <input type="hidden" id="retryOfTxId" />
+            <input type="hidden" id="retryOfPaymentTxId" />
             <button type="submit" class="update-button">Send</button>
           </form>
 

--- a/index.html
+++ b/index.html
@@ -783,6 +783,7 @@
                 maxlength="2000"
               ></textarea>
             </div>
+            <input type="hidden" id="retryOfTxId" />
             <button type="submit" class="update-button">Send</button>
           </form>
 

--- a/index.html
+++ b/index.html
@@ -671,6 +671,23 @@
         </div>
       </div>
 
+      <!-- History Modal -->
+      <div class="modal fixed-header" id="historyModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeHistoryModal"></button>
+          <div class="modal-title">Transaction History</div>
+        </div>
+        <div class="form-container">
+          <div class="form-group">
+            <label for="historyAsset">Asset</label>
+            <select id="historyAsset" class="form-control"></select>
+          </div>
+          <div class="transaction-list" id="transactionList">
+            <!-- Transactions will be populated here -->
+          </div>
+        </div>
+      </div>
+
       <!-- Send Modal -->
       <div class="modal fixed-header" id="sendModal">
         <div class="modal-header">
@@ -836,23 +853,6 @@
             Confirm Send
           </button>
           <button id="cancelSendButton" class="secondary-button">Cancel</button>
-        </div>
-      </div>
-
-      <!-- History Modal -->
-      <div class="modal fixed-header" id="historyModal">
-        <div class="modal-header">
-          <button class="back-button" id="closeHistoryModal"></button>
-          <div class="modal-title">Transaction History</div>
-        </div>
-        <div class="form-container">
-          <div class="form-group">
-            <label for="historyAsset">Asset</label>
-            <select id="historyAsset" class="form-control"></select>
-          </div>
-          <div class="transaction-list" id="transactionList">
-            <!-- Transactions will be populated here -->
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
**Summary:**

*   **Introduced Retry Mechanism for Failed Payments:**
    *   Added a new hidden input field `retryOfTxId` to the send modal (`index.html`) to store the transaction ID of a payment being retried.
    *   Implemented a new function `handleFailedPaymentRetry()` in `app.js`:
        *   This function is invoked when a user opts to retry a failed payment.
        *   It closes the "failed payment" modal.
        *   It opens the "send" modal and pre-fills the recipient address, amount, and memo from the original failed transaction.
        *   The `txid` of the failed payment is stored in the `retryOfTxId` hidden field.
*   **Updated Send Modal and Transaction Handling:**
    *   `openSendModal()` in `app.js` now clears the `retryOfTxId` field.
    *   `handleSendAsset()` in `app.js` now checks if `retryOfTxId` is populated:
        *   If it is (indicating a retry), the original failed transaction is removed from local data (`myData`) using `removeFailedTx()`.
        *   The global state related to the failed payment (`handleFailedPaymentClick` object) and the `retryOfTxId` field are cleared after processing.
*   **State Management for Failed Payments:**
    *   The `handleFailedPaymentClick()` function in `app.js` now stores the `txid`, `address`, and `memo` of the clicked failed payment into the global `handleFailedPaymentClick` object, making these details available for the retry process.
    *   References to `assetID` in `handleFailedPaymentClick`, `handleFailedPaymentDelete`, and `closeFailedPaymentModalAndClearState` have been commented out, suggesting a potential deferral or change in handling multi-asset scenarios for retries.
