### PR TITLE
Enhance error handling and user feedback for pending stake/unstake transactions in validator modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -7367,7 +7367,13 @@ async function checkPendingTransactions() {
                 console.log(`DEBUG: failure reason: ${failureReason}`);
                 
                 // Show toast notification with the failure reason
-                showToast(failureReason, 5000, "error");
+                if (type !== 'deposit_stake' && type !== 'withdraw_stake') {
+                    showToast(failureReason, 5000, "error");
+                } else if (type === 'withdraw_stake') {
+                    showToast(`Unstake failed: ${failureReason}`, 5000, "error");
+                } else {
+                    showToast(`Stake failed: ${failureReason}`, 5000, "error");
+                }
                 
                 // Remove from pending array
                 myData.pending.splice(i, 1);
@@ -7375,6 +7381,15 @@ async function checkPendingTransactions() {
                 updateTransactionStatus(txid, toAddress, 'failed', type);
                 // Then we'll want to refresh the current view
                 refreshCurrentView(txid);
+
+                // refresh the validator modal if this is a withdraw_stake and validator modal is open
+                if ((type === 'withdraw_stake' || type === 'deposit_stake') && document.getElementById('validatorModal').classList.contains('active')) {
+                    //remove from wallet history
+                    myData.wallet.history = myData.wallet.history.filter(tx => tx.txid !== txid);
+                    // refresh the validator modal
+                    closeValidatorModal();
+                    openValidatorModal();
+                }
             }
             else {
                 console.log(`DEBUG: tx ${txid} status unknown, waiting for receipt`);

--- a/app.js
+++ b/app.js
@@ -6158,6 +6158,7 @@ async function openValidatorModal() {
     if (userStakeUsdItem) userStakeUsdItem.style.display = 'flex';
     // Disable unstake button initially while loading/checking
     if (unstakeButton) unstakeButton.disabled = true;
+    if (stakeButton) stakeButton.disabled = false;
 
 
     if (validatorModal) validatorModal.classList.add('active'); // Open modal immediately
@@ -6608,7 +6609,7 @@ async function handleStakeSubmit(event) {
             openValidatorModal();
         } else {
             const reason = response?.result?.reason || 'Unknown error';
-            showToast(`Stake failed: ${reason}`, 5000, 'error');
+            //showToast(`Stake failed: ${reason}`, 5000, 'error');
             // after toast shown, stays in stakeModal
         }
     } catch (error) {

--- a/app.js
+++ b/app.js
@@ -7381,14 +7381,17 @@ async function checkPendingTransactions() {
                 updateTransactionStatus(txid, toAddress, 'failed', type);
                 // Then we'll want to refresh the current view
                 refreshCurrentView(txid);
-
+                
                 // refresh the validator modal if this is a withdraw_stake/deposit_stake and validator modal is open
-                if ((type === 'withdraw_stake' || type === 'deposit_stake') && document.getElementById('validatorModal').classList.contains('active')) {
-                    //remove from wallet history
+                if (type === 'withdraw_stake' || type === 'deposit_stake') {
+                    // remove from wallet history
                     myData.wallet.history = myData.wallet.history.filter(tx => tx.txid !== txid);
-                    // refresh the validator modal
-                    closeValidatorModal();
-                    openValidatorModal();
+
+                    if (document.getElementById('validatorModal').classList.contains('active')) {
+                        // refresh the validator modal
+                        closeValidatorModal();
+                        openValidatorModal();
+                    }
                 }
             }
             else {

--- a/app.js
+++ b/app.js
@@ -7382,7 +7382,7 @@ async function checkPendingTransactions() {
                 // Then we'll want to refresh the current view
                 refreshCurrentView(txid);
 
-                // refresh the validator modal if this is a withdraw_stake and validator modal is open
+                // refresh the validator modal if this is a withdraw_stake/deposit_stake and validator modal is open
                 if ((type === 'withdraw_stake' || type === 'deposit_stake') && document.getElementById('validatorModal').classList.contains('active')) {
                     //remove from wallet history
                     myData.wallet.history = myData.wallet.history.filter(tx => tx.txid !== txid);

--- a/app.js
+++ b/app.js
@@ -7371,7 +7371,7 @@ async function checkPendingTransactions() {
                     showToast(failureReason, 5000, "error");
                 } else if (type === 'withdraw_stake') {
                     showToast(`Unstake failed: ${failureReason}`, 5000, "error");
-                } else {
+                } else if (type === 'deposit_stake') {
                     showToast(`Stake failed: ${failureReason}`, 5000, "error");
                 }
                 


### PR DESCRIPTION
Enhance error handling and user feedback for pending transactions in validator modal

* Update toast notifications to provide specific failure messages for stake and unstake transactions, improving clarity for users.
* Implement logic to refresh the validator modal when a stake or unstake stake transaction fails, ensuring accurate wallet history display.
* Clean up code for better readability and maintainability.