### PR TITLE
Fix username input handling in account creation modal to normalize input values before checking the length, improving consistency and user experience during account setup.

### DIFF
--- a/app.js
+++ b/app.js
@@ -337,7 +337,7 @@ function openCreateAccountModal() {
 // Check availability on input changes
 let createAccountCheckTimeout;
 function handleCreateAccountInput(e) {
-    const username = e.target.value;
+    const username = normalizeUsername(e.target.value);
     const usernameAvailable = document.getElementById('newUsernameAvailable');
     const submitButton = document.querySelector('#createAccountForm button[type="submit"]');
     


### PR DESCRIPTION
Fix to normalize username before checking if it's too short.

More could be done to let the user know what the normalized username is, if they have characters that will be ignored.