### PR TITLE
checkPendingTransactions query for old receipts after tx is 20 seconds old

### DIFF
--- a/app.js
+++ b/app.js
@@ -7393,7 +7393,7 @@ async function checkPendingTransactions() {
     console.log(`checking pending transactions (${myData.pending.length})`);
     const now = getCorrectedTimestamp();
     const eightSecondsAgo = now - 8000;
-
+    const twentySecondsAgo = now - 20000;
     // Process each transaction in reverse to safely remove items
     for (let i = myData.pending.length - 1; i >= 0; i--) {
         const pendingTxInfo = myData.pending[i];
@@ -7402,12 +7402,13 @@ async function checkPendingTransactions() {
         if (submittedts < eightSecondsAgo) {
             console.log(`DEBUG: txid ${txid} is older than 8 seconds, checking receipt`);
 
-            // is submittedts> 15000 use new endpoint (/old_receipt/<tx_hash_without_0x_prefix>) to check for older receipts since other endpoint may not contain the receipt anymore
-            // if (now - submittedts > 15000) {
-            //     const res = await queryNetwork(`/old_receipt/${txid}`);
-            // } else {
-            const res = await queryNetwork(`/transaction/${txid}`);
-            // }
+            let endpointPath;
+        if (submittedts < twentySecondsAgo) {
+            endpointPath = `/old_receipt/${txid}`;
+        } else {
+            endpointPath = `/transaction/${txid}`;
+        }
+        const res = await queryNetwork(endpointPath);
 
             if (res?.transaction?.success === true) {
                 // comment out to test the pending txs removal logic

--- a/app.js
+++ b/app.js
@@ -7404,18 +7404,19 @@ async function checkPendingTransactions() {
             console.log(`DEBUG: txid ${txid} is older than 8 seconds, checking receipt`);
 
             let endpointPath = `/transaction/${txid}`;
-            if (submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo) {
+            /* if (submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo) {
                 endpointPath = `/old_receipt/${txid}`;
-            }
-
+            } */
+            //console.log(`DEBUG: txid ${txid} endpointPath: ${endpointPath}`);
             const res = await queryNetwork(endpointPath);
+            //console.log(`DEBUG: txid ${txid} res: ${JSON.stringify(res)}`);
 
-            if (submittedts < thirtySecondsAgo && res.transaction === null) {
+            /* if (submittedts < thirtySecondsAgo && res.transaction === null) {
                 console.error(`DEBUG: txid ${txid} timed out, removing completely`);
                 // remove the pending tx from the pending array
                 myData.pending.splice(i, 1);
                 continue;
-            }
+            } */
 
             if (res?.transaction?.success === true) {
                 // comment out to test the pending txs removal logic
@@ -7450,9 +7451,6 @@ async function checkPendingTransactions() {
                         openValidatorModal();
                     }
                 }
-
-                // remove the pending tx from the pending array
-                myData.pending.splice(i, 1);
             }
             else if (res?.transaction?.success === false) {
                 console.log(`DEBUG: txid ${txid} failed, removing completely`);


### PR DESCRIPTION
**Summary:**

*   Introduced a `thirtySecondsAgo` constant to define a new timeout threshold.
*   **Modified API endpoint selection:**
    *   The endpoint path is initialized to `/transaction/<txid>`.
    *   It's updated to `/old_receipt/<txid>` if `submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo`.
        *   *Note: The condition `submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo` simplifies to `submittedts < twentySecondsAgo` because if a timestamp is less than `thirtySecondsAgo`, it will inherently be less than `twentySecondsAgo`.*
*   **Implemented transaction timeout and removal:**
    *   If a transaction is older than 30 seconds (`submittedts < thirtySecondsAgo`) AND the network query result (`res.transaction`) is `null`, the transaction is considered timed out.
    *   Timed-out transactions are logged with an error message and removed directly from the `myData.pending` array using `splice()`.
    *   A `continue` statement is used to skip further processing for removed transactions within the loop.
*   Removed previous `TODO` comments related to timeout logic, as a new implementation has been added.
*   The `twentySecondsAgo` constant remains defined outside the loop for efficiency.
