### PR TITLE
feat(history-click): Add memo check for stake/unstake transactions in handleHistoryItemClick function

### DIFF
--- a/app.js
+++ b/app.js
@@ -3855,6 +3855,13 @@ function handleHistoryItemClick(event) {
     } */
 
     if (item) {
+        // Check if this is a stake/unstake transaction by looking at the memo
+        const memo = item.querySelector('.transaction-memo')?.textContent;
+        if (memo === 'stake' || memo === 'unstake') {
+            openValidatorModal();
+            return;
+        }
+
         // Get the address from the data-address attribute
         const address = item.dataset.address;
         if (address && myData.contacts[address]) {


### PR DESCRIPTION
Note that regular transactions may also have 'stake/unstake' as memo and these will open validator modal as well.