### PR TITLE
Hide Private Key Input Behind Checkbox in Create Account Modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -797,6 +797,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('closeCreateAccountModal').addEventListener('click', closeCreateAccountModal);
     document.getElementById('createAccountForm').addEventListener('submit', handleCreateAccount);
 
+    // Event listener for the private key toggle checkbox
+    const togglePrivateKeyInput = document.getElementById('togglePrivateKeyInput');
+    togglePrivateKeyInput.addEventListener('change', handleTogglePrivateKeyInput);
+
     // Account Form Modal
     myProfileModal.load()
 
@@ -7662,3 +7666,17 @@ const pendingPromiseService = (() => {
 
     return { register, resolve, reject };
   })();
+
+function handleTogglePrivateKeyInput() {
+    const privateKeySection = document.getElementById('privateKeySection');
+    const newPrivateKeyInput = document.getElementById('newPrivateKey');
+
+    // clear the newPrivateKeyInput
+    newPrivateKeyInput.value = '';
+
+    if (togglePrivateKeyInput.checked) {
+        privateKeySection.style.display = 'block';
+    } else {
+        privateKeySection.style.display = 'none';
+    }
+}

--- a/index.html
+++ b/index.html
@@ -381,31 +381,41 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="newPrivateKey"
-                >Private Key
-                <span
-                  id="newPrivateKeyError"
-                  style="color: #dc3545; display: none"
-                ></span
-              ></label>
-              <div style="position: relative">
-                <input
-                  type="password"
-                  id="newPrivateKey"
-                  class="form-control"
-                  placeholder="Optional private key in hex format"
-                />
-                <button
-                  type="button"
-                  id="togglePrivateKeyVisibility"
-                  class="password-toggle-btn"
-                ></button>
+              <input type="checkbox" id="togglePrivateKeyInput" />
+              <label
+                for="togglePrivateKeyInput"
+                style="display: inline; margin-left: 5px"
+                >Use my own private key (Advanced)</label
+              >
+            </div>
+            <div id="privateKeySection" style="display: none">
+              <div class="form-group">
+                <label for="newPrivateKey"
+                  >Private Key
+                  <span
+                    id="newPrivateKeyError"
+                    style="color: #dc3545; display: none"
+                  ></span
+                ></label>
+                <div style="position: relative">
+                  <input
+                    type="password"
+                    id="newPrivateKey"
+                    class="form-control"
+                    placeholder="Optional private key in hex format"
+                  />
+                  <button
+                    type="button"
+                    id="togglePrivateKeyVisibility"
+                    class="password-toggle-btn"
+                  ></button>
+                </div>
+                <small>
+                  If you want to use an existing private key enter it here.
+                  Otherwise you can leave this empty to have a private key
+                  automatically generated.
+                </small>
               </div>
-              <small>
-                If you want to use an existing private key enter it here.
-                Otherwise you can leave this empty to have a private key
-                automatically generated.
-              </small>
             </div>
             <button type="submit" class="update-button" disabled>
               Create Account
@@ -1111,33 +1121,33 @@
           >
             <div class="info-section">
               <h4>Your Stake Info</h4>
-                              <!-- New Skeleton Bars for Pending Nominee Info -->
-                              <div
-                              class="skeleton-item"
-                              id="pending-nominee-skeleton-1"
-                              style="
-                                display: none;
-                                height: 22px;
-                                width: 100%;
-                                margin-top: 4px;
-                                margin-bottom: 8px;
-                                background-color: #e0e0e0;
-                                padding: 0 5px;
-                                box-sizing: border-box;
-                              "
-                            >
-                              <span
-                                id="pending-tx-text-in-bar"
-                                style="
-                                  display: none;
-                                  font-size: 0.75em;
-                                  color: #333;
-                                  line-height: 22px;
-                                  width: 100%;
-                                  text-align: center;
-                                "
-                              ></span>
-                            </div>
+              <!-- New Skeleton Bars for Pending Nominee Info -->
+              <div
+                class="skeleton-item"
+                id="pending-nominee-skeleton-1"
+                style="
+                  display: none;
+                  height: 22px;
+                  width: 100%;
+                  margin-top: 4px;
+                  margin-bottom: 8px;
+                  background-color: #e0e0e0;
+                  padding: 0 5px;
+                  box-sizing: border-box;
+                "
+              >
+                <span
+                  id="pending-tx-text-in-bar"
+                  style="
+                    display: none;
+                    font-size: 0.75em;
+                    color: #333;
+                    line-height: 22px;
+                    width: 100%;
+                    text-align: center;
+                  "
+                ></span>
+              </div>
               <div class="info-item vertical-layout">
                 <span class="info-label" id="validator-nominee-label"
                   >Nominated Validator:</span
@@ -1349,10 +1359,7 @@
       <div class="modal modal-dialog" id="failedPaymentModal">
         <div class="dialog-box-content">
           <div class="modal-header">
-            <button
-              class="back-button"
-              id="closeFailedPaymentModal"
-            ></button>
+            <button class="back-button" id="closeFailedPaymentModal"></button>
             <div class="modal-title">Failed Transaction</div>
           </div>
           <div class="form-container">


### PR DESCRIPTION

**PR Summary: Hide Private Key Input Behind Checkbox in Create Account Modal**

- **UI/UX Improvement:**  
  - The "Private Key" input on the Create Account modal is now hidden by default.
  - Added a checkbox labeled **"Use my own private key (Advanced)"**.  
  - When checked, the private key input field and its description are revealed.

- **JavaScript Logic:**  
  - Added a `handleTogglePrivateKeyInput` function in `app.js` to toggle the visibility of the private key section and clear its value when hidden.
  - Registered the checkbox change event in the DOMContentLoaded block for proper initialization.

- **User Guidance:**  
  - Reduces confusion for new users by hiding advanced options unless explicitly requested.

---

This change makes the account creation process simpler and less error-prone for most users, while still allowing advanced users to enter their own private key if needed.

![image](https://github.com/user-attachments/assets/a3b4b03f-750e-47af-84b4-df367dc093a6)
![image](https://github.com/user-attachments/assets/3441d738-52f0-49f8-90f3-16eb070e4a4a)

