### PR TITLE
Add toggle functionality for LIB/USD balance in send modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1086,6 +1086,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     failedPaymentHeaderCloseButton.addEventListener('click', closeFailedPaymentModalAndClearState);
     failedPaymentModal.addEventListener('click', handleFailedPaymentBackdropClick);
 
+    // add event listener for toggle LIB/USD button
+    document.getElementById('toggleBalance').addEventListener('click', handleToggleBalance);
+
     setupAddToHomeScreen()
 });
 
@@ -2415,6 +2418,36 @@ async function openSendModal() {
 }
 
 openSendModal.username = null
+
+/*
+* This function is called when the user clicks the toggle LIB/USD button.
+* Updates the balance symbol and the send amount to the equivalent value in USD/LIB
+*/
+async function handleToggleBalance(e) {
+    e.preventDefault();
+    const balanceSymbol = document.getElementById('balanceSymbol');
+    balanceSymbol.textContent = balanceSymbol.textContent === 'LIB' ? 'USD' : 'LIB';
+    const sendAmount = document.getElementById('sendAmount');
+    const balanceAmount = document.getElementById('balanceAmount');
+    const transactionFee = document.getElementById('transactionFee');
+
+    // check the context value of the button to determine if it's LIB or USD
+    const isLib = balanceSymbol.textContent === 'LIB';
+
+    // get the current price of LIB in USD
+    const marketPrice = await getMarketPrice();
+
+    // if isLib is false, convert the sendAmount to USD
+    if (!isLib) {
+        sendAmount.value = (sendAmount.value * marketPrice);
+        balanceAmount.textContent = (balanceAmount.textContent * marketPrice);
+        transactionFee.textContent = (transactionFee.textContent * marketPrice);
+    } else {
+        sendAmount.value = (sendAmount.value / marketPrice);
+        balanceAmount.textContent = (balanceAmount.textContent / marketPrice);
+        transactionFee.textContent = (transactionFee.textContent / marketPrice);
+    }
+}
 
 let sendModalCheckTimeout;
 function handleOpenSendModalInput(e){
@@ -6065,18 +6098,26 @@ class WSManager {
 let wsManager = new WSManager()        // this is set to new WSManager() for convience
 
 // New functions for send confirmation flow
-function handleSendFormSubmit(event) {
+async function handleSendFormSubmit(event) {
     event.preventDefault();
 
     // Get form values
     const assetSelect = document.getElementById('sendAsset');
     const assetSymbol = assetSelect.options[assetSelect.selectedIndex].text;
     const recipient = document.getElementById('sendToAddress').value;
-    const amount = document.getElementById('sendAmount').value;
+    const balanceSymbol = document.getElementById('balanceSymbol');
+    let amount = document.getElementById('sendAmount').value;
     const memo = document.getElementById('sendMemo').value;
-
     const confirmButton = document.getElementById('confirmSendButton');
     const cancelButton = document.getElementById('cancelSendButton');
+    
+    const marketPrice = await getMarketPrice();
+
+    // need to convert to LIB if USD is selected
+    const isLib = balanceSymbol.textContent === 'LIB';
+    if (!isLib) {
+        amount = (amount / marketPrice);
+    }
 
     // Update confirmation modal with values
     document.getElementById('confirmRecipient').textContent = recipient;

--- a/index.html
+++ b/index.html
@@ -781,6 +781,21 @@
             </div>
             <div class="form-group">
               <label for="sendAmount">Amount</label>
+              <div class="amount-container">
+                <input
+                  type="number"
+                  id="sendAmount"
+                  class="form-control"
+                  step="any"
+                  min="0.000000000000000001"
+                  required
+                />
+                <!-- add button to toggle between LIB and USD -->
+                <button id="toggleBalance" class="toggle-balance">
+                  <span id="balanceSymbol">LIB</span>
+                </button>
+              </div>
+              <div id="balanceWarning" class="balance-warning"></div>
               <div id="availableBalance" class="available-balance">
                 <div class="balance-info">
                   <span
@@ -792,15 +807,6 @@
                   >
                 </div>
               </div>
-              <input
-                type="number"
-                id="sendAmount"
-                class="form-control"
-                step="any"
-                min="0.000000000000000001"
-                required
-              />
-              <div id="balanceWarning" class="balance-warning"></div>
             </div>
             <div class="form-group">
               <label for="sendMemo">Memo (Optional)</label>

--- a/styles.css
+++ b/styles.css
@@ -4269,12 +4269,60 @@ small {
 
 @keyframes pulse {
   0% {
-      background-color: #e0e0e0; /* Initial color */
+    background-color: #e0e0e0; /* Initial color */
   }
   50% {
-      background-color: #d0d0d0; /* Slightly darker or different shade for pulse effect */
+    background-color: #d0d0d0; /* Slightly darker or different shade for pulse effect */
   }
   100% {
-      background-color: #e0e0e0; /* Return to initial color */
+    background-color: #e0e0e0; /* Return to initial color */
   }
+}
+
+.amount-container {
+  display: flex;
+  align-items: center;
+}
+
+/* Added to make the input field flexible and adjust its right-side appearance */
+.amount-container .form-control {
+  flex: 1; /* Allows the input to take available space */
+  min-width: 0; /* Important for flex item shrinkage */
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none; /* Remove the input's right border to join with the button */
+  /* width: auto; /* Overrides the default form-control width: 100% */
+}
+
+/* Styles for the toggle button */
+.toggle-balance {
+  height: 56px; /* Match the form-control height */
+  padding: 0 16px; /* Horizontal padding */
+  background-color: var(--button-background);
+  color: var(--button-text);
+  border: 1px solid var(--border-color);
+  border-left: none; /* Remove left border to seamlessly join with the input */
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 12px; /* Match form-control's border radius */
+  border-bottom-right-radius: 12px; /* Match form-control's border radius */
+  font-family: var(--font-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap; /* Prevent text like "USD" from wrapping */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#sendAmount {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+  text-align: right;
+}
+
+.toggle-balance:hover {
+  background-color: var(--button-hover-background);
 }


### PR DESCRIPTION
* Introduced a button to toggle between LIB and USD for the send amount, enhancing user experience by allowing users to view and send amounts in their preferred currency.
* Implemented the `handleToggleBalance` function to update the balance symbol and convert amounts based on the selected currency.
* Updated the send form submission logic to account for the selected currency, ensuring accurate transaction amounts are processed.
* Enhanced the UI with new styles for the toggle button and input field layout for better usability.

![image](https://github.com/user-attachments/assets/95520e87-4517-45f9-af98-3ee049c98b68)
