### PR TITLE
Do not allow tab while on last item to prevent switching pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -883,6 +883,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         button.addEventListener('keydown', ignoreShiftTabKey);
     });
 
+    // add event listener for unused button
+    document.querySelectorAll('.last-item').forEach(item => {
+        item.addEventListener('keydown', ignoreTabKey);
+    });
+
     // Add message click-to-copy handler
     document.querySelector('.messages-list')?.addEventListener('click', handleClickToCopy);
 
@@ -1571,6 +1576,13 @@ async function switchView(view) {
                 if (wsManager && !wsManager.isSubscribed()) {
                     pollChatInterval(pollIntervalNormal);
                 }
+            }
+
+            // focus onto last-item in the footer
+            const footer = document.getElementById('footer');
+            const lastItem = footer.querySelector('.last-item');
+            if (lastItem) {
+                lastItem.focus();
             }
         } else if (view === 'contacts') {
             await updateContactsList();
@@ -7736,16 +7748,24 @@ function handleTogglePrivateKeyInput() {
     }
 }
 
-// use this so buttons don't get focused when tabbing through the page
+/*
+* Used to prevent tab from working.
+* @param {Event} e - The event object.
+*/
 function ignoreTabKey(e) {
+    //console.log('DEBUG: ignoring tab key');
     // allow shift+tab to work
     if (e.key === 'Tab' && !e.shiftKey) {
         e.preventDefault();
     }
 }
 
-// use this so buttons don't get focused when shift+tabbing through the page
+/*
+* Used to prevent shift+tab from working.
+* @param {Event} e - The event object.
+*/
 function ignoreShiftTabKey(e) {
+    //console.log('DEBUG: ignoring shift+tab key');
     // if key is tab and key.shiftKey is true, prevent default
     if (e.key === 'Tab' && e.shiftKey) {
         e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -1404,7 +1404,6 @@
               </button>
             </div>
           </div>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
       <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>

--- a/index.html
+++ b/index.html
@@ -118,6 +118,8 @@
         <div style="font-size: 0.8rem; margin-top: 10px; text-align: center">
           Version <span id="versionDisplay"></span>
         </div>
+        <!-- Add a unused anchor tag with nothing in it and add a class to it so can't shift and end up on another modal. Should still be displayed but will just show nothing -->
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <div class="app-screen" id="chatsScreen">
@@ -195,6 +197,8 @@
           <button class="nav-button" id="switchToContacts">Contacts</button>
           <button class="nav-button" id="switchToWallet">Wallet</button>
         </div>
+        <!-- set focus on last-item in the footer -->
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </footer>
 
       <!-- New Chat Modal -->
@@ -222,6 +226,7 @@
             </div>
             <button type="submit" class="update-button">Continue</button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -239,13 +244,12 @@
           <!--                <li class="menu-item" id="openSettings">Settings</li> -->
           <li class="menu-item" id="openExplorer">Explorer</li>
           <li class="menu-item" id="openMonitor">Network</li>
-          <!--
-                <li class="menu-item" id="openImportFormMenu">Import</li>
--->
+          <!--<li class="menu-item" id="openImportFormMenu">Import</li>-->
           <li class="menu-item" id="openRemoveAccount">Remove</li>
           <li class="menu-item" id="openAbout">About</li>
           <li class="menu-item" id="handleSignOut">Sign Out</li>
         </ul>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- About Modal -->
@@ -318,6 +322,7 @@
             </p>
           </div>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Sign In Modal -->
@@ -350,6 +355,7 @@
               Remove
             </button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -421,6 +427,7 @@
               Create Account
             </button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -457,6 +464,7 @@
             </div>
             <button type="submit" class="update-button">Update Profile</button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -489,6 +497,7 @@
             </div>
             <button type="submit" class="update-button">Load Account</button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -531,6 +540,7 @@
             </svg>
           </button>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Contact Info Modal -->
@@ -605,6 +615,7 @@
             </div>
           </div>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Receive Modal -->
@@ -679,6 +690,7 @@
             ></textarea>
           </div>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- History Modal -->
@@ -696,6 +708,7 @@
             <!-- Transactions will be populated here -->
           </div>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Send Modal -->
@@ -838,6 +851,7 @@
             </div>
           </div>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Send Confirmation Modal -->
@@ -870,6 +884,7 @@
           </button>
           <button id="cancelSendButton" class="secondary-button">Cancel</button>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Export Modal -->
@@ -891,6 +906,7 @@
             </div>
             <button type="submit" class="update-button">Download Data</button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -907,6 +923,7 @@
           <button id="addGatewayButton" class="update-button">
             Add Gateway
           </button>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -958,6 +975,7 @@
             </div>
             <button type="submit" class="update-button">Save</button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -983,6 +1001,7 @@
               Remove
             </button>
           </div>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -1007,6 +1026,7 @@
           <div id="searchResults" class="chat-list">
             <!-- Results will be populated here -->
           </div>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -1031,6 +1051,7 @@
           <div id="contactSearchResults" class="chat-list">
             <!-- Contact search results will be populated here -->
           </div>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -1085,6 +1106,7 @@
               <div class="contact-info-value" id="editContactX"></div>
             </div>
           </div>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -1220,6 +1242,7 @@
             </p>
           </div>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Stake Modal -->
@@ -1323,6 +1346,7 @@
               Submit Stake
             </button>
           </form>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
 
@@ -1339,6 +1363,7 @@
           <div class="scan-highlight" id="scan-highlight"></div>
           <canvas id="canvas"></canvas>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Failed Message Modal -->
@@ -1359,6 +1384,7 @@
             </div>
           </div>
         </div>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
       </div>
 
       <!-- Failed Payment Modal -->
@@ -1378,8 +1404,10 @@
               </button>
             </div>
           </div>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
         </div>
       </div>
+      <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
     </div>
     <!-- Audio element for notification sounds -->
     <audio

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
           Version <span id="versionDisplay"></span>
         </div>
         <!-- Add a unused anchor tag with nothing in it and add a class to it so can't shift and end up on another modal. Should still be displayed but will just show nothing -->
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <div class="app-screen" id="chatsScreen">
@@ -198,7 +198,7 @@
           <button class="nav-button" id="switchToWallet">Wallet</button>
         </div>
         <!-- set focus on last-item in the footer -->
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </footer>
 
       <!-- New Chat Modal -->
@@ -226,7 +226,7 @@
             </div>
             <button type="submit" class="update-button">Continue</button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -249,7 +249,7 @@
           <li class="menu-item" id="openAbout">About</li>
           <li class="menu-item" id="handleSignOut">Sign Out</li>
         </ul>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- About Modal -->
@@ -322,7 +322,7 @@
             </p>
           </div>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Sign In Modal -->
@@ -355,7 +355,7 @@
               Remove
             </button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -427,7 +427,7 @@
               Create Account
             </button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -464,7 +464,7 @@
             </div>
             <button type="submit" class="update-button">Update Profile</button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -497,7 +497,7 @@
             </div>
             <button type="submit" class="update-button">Load Account</button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -540,7 +540,7 @@
             </svg>
           </button>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Contact Info Modal -->
@@ -615,7 +615,7 @@
             </div>
           </div>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Receive Modal -->
@@ -690,7 +690,7 @@
             ></textarea>
           </div>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- History Modal -->
@@ -708,7 +708,7 @@
             <!-- Transactions will be populated here -->
           </div>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Send Modal -->
@@ -851,7 +851,7 @@
             </div>
           </div>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Send Confirmation Modal -->
@@ -884,7 +884,7 @@
           </button>
           <button id="cancelSendButton" class="secondary-button">Cancel</button>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Export Modal -->
@@ -906,7 +906,7 @@
             </div>
             <button type="submit" class="update-button">Download Data</button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -923,7 +923,7 @@
           <button id="addGatewayButton" class="update-button">
             Add Gateway
           </button>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -975,7 +975,7 @@
             </div>
             <button type="submit" class="update-button">Save</button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -1001,7 +1001,7 @@
               Remove
             </button>
           </div>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -1026,7 +1026,7 @@
           <div id="searchResults" class="chat-list">
             <!-- Results will be populated here -->
           </div>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -1051,7 +1051,7 @@
           <div id="contactSearchResults" class="chat-list">
             <!-- Contact search results will be populated here -->
           </div>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -1106,7 +1106,7 @@
               <div class="contact-info-value" id="editContactX"></div>
             </div>
           </div>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -1242,7 +1242,7 @@
             </p>
           </div>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Stake Modal -->
@@ -1346,7 +1346,7 @@
               Submit Stake
             </button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
 
@@ -1363,7 +1363,7 @@
           <div class="scan-highlight" id="scan-highlight"></div>
           <canvas id="canvas"></canvas>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Failed Message Modal -->
@@ -1384,7 +1384,7 @@
             </div>
           </div>
         </div>
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
       </div>
 
       <!-- Failed Payment Modal -->
@@ -1404,10 +1404,10 @@
               </button>
             </div>
           </div>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
         </div>
       </div>
-      <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="unusedAnchor"> </a>
+      <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
     </div>
     <!-- Audio element for notification sounds -->
     <audio


### PR DESCRIPTION
* Added event listeners for the newly introduced 'last-item' anchor tags to handle tab key navigation, improving accessibility.
* Updated the app.js file to focus on the last-item in the footer when switching view to chatsScreen, enhancing user experience.
* Refactored the `ignoreTabKey` and `ignoreShiftTabKey` functions to include detailed comments for clarity on their purpose.
* Modified index.html to include multiple 'last-item' anchor tags for better navigation control in various modals.