### PR TITLE
Prevent shift-tab on welcome screen when first loaded

### DIFF
--- a/app.js
+++ b/app.js
@@ -1101,6 +1101,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // add event listener for toggle LIB/USD button
     document.getElementById('toggleBalance').addEventListener('click', handleToggleBalance);
 
+    const lastItem = document.getElementById('welcomeScreenLastItem');
+    lastItem.focus();
+          
     setupAddToHomeScreen()
 });
 

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
           Version <span id="versionDisplay"></span>
         </div>
         <!-- Add a unused anchor tag with nothing in it and add a class to it so can't shift and end up on another modal. Should still be displayed but will just show nothing -->
-        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
+        <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="welcomeScreenLastItem"> </a>
       </div>
 
       <div class="app-screen" id="chatsScreen">


### PR DESCRIPTION
* Updated app.js to set focus on the last-item anchor tag upon DOM content load, to prevent shift-tab from switching pages.
* Modified index.html to assign an ID to the last-item anchor tag to have unique ID for focusing