### PR TITLE
Prevent shift-tab on signInModal and on tabbed headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -269,6 +269,12 @@ function openSignInModal() {
     removeButton.style.display = 'none';
     notFoundMessage.style.display = 'none';
 
+    const signInModalLastItem = document.getElementById('signInModalLastItem');
+    // set timeout to focus on the last item so shift+tab and tab prevention works
+    setTimeout(() => {
+        signInModalLastItem.focus();
+    }, 100);
+
 }
 
 async function handleRemoveAccountButton() {
@@ -875,17 +881,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('closeChatModal').addEventListener('click', closeChatModal);
     document.getElementById('closeContactInfoModal').addEventListener('click', () => contactInfoModal.close());
     document.getElementById('handleSendMessage').addEventListener('click', handleSendMessage);
+
     // add event listener for tab key
     document.getElementById('handleSendMessage').addEventListener('keydown', ignoreTabKey);
-
-    // for back-button presses don't allow shift+tab to work for all back-button classes use ignoreShiftTabKey
+    // add event listener for back-button presses to prevent shift+tab
     document.querySelectorAll('.back-button').forEach(button => {
         button.addEventListener('keydown', ignoreShiftTabKey);
     });
-
-    // add event listener for unused button
+    // add event listener for last-item to prevent tab
     document.querySelectorAll('.last-item').forEach(item => {
         item.addEventListener('keydown', ignoreTabKey);
+    });
+    // add event listener for first-item to prevent shift+tab
+    document.querySelectorAll('.first-item').forEach(item => {
+        item.addEventListener('keydown', ignoreShiftTabKey);
     });
 
     // Add message click-to-copy handler
@@ -1101,8 +1110,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     // add event listener for toggle LIB/USD button
     document.getElementById('toggleBalance').addEventListener('click', handleToggleBalance);
 
-    const lastItem = document.getElementById('welcomeScreenLastItem');
-    lastItem.focus();
+    const welcomeScreenLastItem = document.getElementById('welcomeScreenLastItem');
+    welcomeScreenLastItem.focus();
           
     setupAddToHomeScreen()
 });
@@ -7768,7 +7777,7 @@ function ignoreTabKey(e) {
 * @param {Event} e - The event object.
 */
 function ignoreShiftTabKey(e) {
-    //console.log('DEBUG: ignoring shift+tab key');
+    console.log('DEBUG: ignoring shift+tab key');
     // if key is tab and key.shiftKey is true, prevent default
     if (e.key === 'Tab' && e.shiftKey) {
         e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             href="https://liberdus.com"
             target="_blank"
             title="Visit Liberdus website"
-            class="logo-link"
+            class="logo-link first-item"
             ><img src="./media/liberdus_logo_50.png"
           /></a>
         </div>
@@ -355,7 +355,7 @@
               Remove
             </button>
           </form>
-          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;"> </a>
+          <a class="last-item" href="#" style="display: block; width: 0; height: 0; border: none; background: none;" id="signInModalLastItem"> </a>
         </div>
       </div>
 


### PR DESCRIPTION
* Added functionality to focus on the last item in the sign-in modal after opening, to prevent shift-tab opening another page problem
* Updated event listeners to prevent tabbing behavior for first and last items, ensuring better control during navigation.
* Refactored comments in app.js for clarity on the purpose of key event handlers.
* Modified index.html to assign an ID to the last-item anchor tag in the sign-in modal for improved accessibility.