### PR TITLE
Consolidate to use just logo-link class for shift-tab preventation 

### DIFF
--- a/app.js
+++ b/app.js
@@ -893,11 +893,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         item.addEventListener('keydown', ignoreTabKey);
     });
     // add event listener for first-item to prevent shift+tab
-    document.querySelectorAll('.first-item').forEach(item => {
+    document.querySelectorAll('.logo-link').forEach(item => {
         item.addEventListener('keydown', ignoreShiftTabKey);
     });
-    // add event listener for logo link to prevent tab
-    document.getElementById('welcomeScreenLogoLink').addEventListener('keydown', ignoreShiftTabKey);
 
     // Add message click-to-copy handler
     document.querySelector('.messages-list')?.addEventListener('click', handleClickToCopy);
@@ -6287,7 +6285,7 @@ function getCorrectedTimestamp() {
 function updateWebSocketIndicator() {
     // added this so that we don't miss messages on phones, since phones drop the ws if not used periodically
     if (getCorrectedTimestamp() - updateWebSocketIndicator.lastSubscribed > 31000){
-        wsManager.subscribe()
+        /* wsManager.subscribe() */
         updateWebSocketIndicator.lastSubscribed = getCorrectedTimestamp()
     }
     const indicator = document.getElementById('wsStatusIndicator');

--- a/app.js
+++ b/app.js
@@ -6285,7 +6285,7 @@ function getCorrectedTimestamp() {
 function updateWebSocketIndicator() {
     // added this so that we don't miss messages on phones, since phones drop the ws if not used periodically
     if (getCorrectedTimestamp() - updateWebSocketIndicator.lastSubscribed > 31000){
-        /* wsManager.subscribe() */
+        wsManager.subscribe()
         updateWebSocketIndicator.lastSubscribed = getCorrectedTimestamp()
     }
     const indicator = document.getElementById('wsStatusIndicator');

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             href="https://liberdus.com"
             target="_blank"
             title="Visit Liberdus website"
-            class="logo-link first-item"
+            class="logo-link"
             ><img src="./media/liberdus_logo_50.png"
           /></a>
         </div>
@@ -87,7 +87,6 @@
           target="_blank"
           title="Visit Liberdus website"
           class="logo-link"
-          id="welcomeScreenLogoLink"
         >
           <img
             src="./media/liberdus_logo_250.png"


### PR DESCRIPTION
* Changed event listener from '.first-item' to '.logo-link' to consolidate to already implemented unique class.
* Removed redundant ID from the logo link in index.html to streamline the code.