### PR TITLE
Remove vibration feedback that was causing silent error for unsupported browsers

### DIFF
--- a/app.js
+++ b/app.js
@@ -4154,7 +4154,6 @@ function playChatSound(shouldPlay) {
             notificationAudio.play().catch(error => {
                 console.warn("Notification sound playback failed:", error);
             });
-            navigator.vibrate(100);
         }
     }
 }
@@ -4166,7 +4165,6 @@ function playTransferSound(shouldPlay) {
             notificationAudio.play().catch(error => {
                 console.warn("Notification sound playback failed:", error);
             });
-            navigator.vibrate(100);
         }
     }
 }


### PR DESCRIPTION
Remove vibration feedback from playChatSound and playTransferSound functions to prevent silent errors causing problems with updateChatList