### PR TITLE
Update TollModal to display `currentTollValue` based on toggled USD or LIB

### DIFF
--- a/app.js
+++ b/app.js
@@ -7334,7 +7334,8 @@ class TollModal {
         this.modal.classList.add('active');
         // set currentTollValue to the toll value in wei
         const toll = big2str(myData.settings.toll, 18)
-        document.getElementById('currentTollValue').textContent = toll == 0 ? '0' : toll
+        const tollValue = toll == 0 ? '0' : toll
+        document.getElementById('currentTollValue').textContent = tollValue + ' LIB'
         this.currentCurrency = 'LIB'; // Reset currency state
         document.getElementById('tollCurrencySymbol').textContent = this.currentCurrency;
         document.getElementById('newTollAmountInput').value = ''; // Clear input field
@@ -7358,6 +7359,11 @@ class TollModal {
             const convertedValue = this.currentCurrency === 'USD' ? currentValue * marketPrice : currentValue / marketPrice;
             newTollAmountInput.value = convertedValue.toFixed(6);
         }
+
+        // convert `currentTollValue`
+        const currentTollValue = big2str(myData.settings.toll, 18);
+        const convertedValue = this.currentCurrency === 'USD' ? currentTollValue * marketPrice : currentTollValue;
+        document.getElementById('currentTollValue').textContent = this.currentCurrency === 'USD' ? `$${convertedValue}` : `${convertedValue} LIB`;
     }
 
     async saveAndPostNewToll(event) {


### PR DESCRIPTION
- Modified the display of the current toll value to include the currency symbol (LIB) when the toll is set.
- Refactored the conversion logic for the toll value based on the selected currency, ensuring accurate representation in both LIB and USD formats.
- Enhanced user feedback by updating the toll display dynamically based on currency selection.