### PR TITLE
fix: Update endpoint path for old receipts in checkPendingTransactions function

### DIFF
--- a/app.js
+++ b/app.js
@@ -7734,7 +7734,7 @@ async function checkPendingTransactions() {
 
             let endpointPath = `/transaction/${txid}`;
             if (submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo) {
-                endpointPath = `/old_receipt/${txid}`;
+                endpointPath = `collector/api/transaction?appReceiptId=${txid}`;
             }
             //console.log(`DEBUG: txid ${txid} endpointPath: ${endpointPath}`);
             const res = await queryNetwork(endpointPath);

--- a/app.js
+++ b/app.js
@@ -7734,7 +7734,7 @@ async function checkPendingTransactions() {
 
             let endpointPath = `/transaction/${txid}`;
             if (submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo) {
-                endpointPath = `collector/api/transaction?appReceiptId=${txid}`;
+                endpointPath = `/collector/api/transaction?appReceiptId=${txid}`;
             }
             //console.log(`DEBUG: txid ${txid} endpointPath: ${endpointPath}`);
             const res = await queryNetwork(endpointPath);


### PR DESCRIPTION
- Changed the endpoint path for old receipts from `/old_receipt/${txid}` to `collector/api/transaction?appReceiptId=${txid}` to align with new API structure.