### PR TITLE
Feat: openChatModal to retrieve and save contact's fee

### DIFF
--- a/app.js
+++ b/app.js
@@ -1967,8 +1967,7 @@ function createNewContact(addr, username){
     c.unread = 0
 }
 
-
-function openChatModal(address) {
+async function openChatModal(address) {
     const modal = document.getElementById('chatModal');
     const modalAvatar = modal.querySelector('.modal-avatar');
     const modalTitle = modal.querySelector('.modal-title');
@@ -2015,6 +2014,11 @@ function openChatModal(address) {
         }
     };
 
+    // query for the contact account data to retrieve the contact's fee
+    const contactAccountData = await queryNetwork(`/account/${longAddress(address)}`);
+    openChatModal.toll = contactAccountData?.account?.data?.toll; // type bigint
+    //console.log(`DEBUG: openChatModal.fee: ${JSON.stringify(big2str(openChatModal.fee * wei, 18), null, 2)}`);
+
     // Show modal
     modal.classList.add('active');
 
@@ -2035,6 +2039,7 @@ function openChatModal(address) {
         }
     }
 }
+openChatModal.toll = null;
 
 function appendChatModal(highlightNewMessage = false) {
     const currentAddress = appendChatModal.address; // Use a local constant

--- a/app.js
+++ b/app.js
@@ -7729,7 +7729,7 @@ async function checkPendingTransactions() {
 
             let endpointPath = `/transaction/${txid}`;
             if (submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo) {
-                endpointPath = `/old_receipt/${txid}`;
+                endpointPath = `collector/api/transaction?appReceiptId=${txid}`;
             }
             //console.log(`DEBUG: txid ${txid} endpointPath: ${endpointPath}`);
             const res = await queryNetwork(endpointPath);

--- a/app.js
+++ b/app.js
@@ -7729,7 +7729,7 @@ async function checkPendingTransactions() {
 
             let endpointPath = `/transaction/${txid}`;
             if (submittedts < twentySecondsAgo || submittedts < thirtySecondsAgo) {
-                endpointPath = `collector/api/transaction?appReceiptId=${txid}`;
+                endpointPath = `/collector/api/transaction?appReceiptId=${txid}`;
             }
             //console.log(`DEBUG: txid ${txid} endpointPath: ${endpointPath}`);
             const res = await queryNetwork(endpointPath);


### PR DESCRIPTION
refactor: Update openChatModal to support asynchronous contact data retrieval

- Changed openChatModal function to be asynchronous, allowing for the retrieval of contact account data before displaying the modal.
- Added logic to query the network for the contact's fee and store it in openChatModal.toll.
- Initialized openChatModal.toll to null for clarity.