### PR TITLE
fix: Update handleSendAsset to use validated amount directly in wei

### DIFF
--- a/app.js
+++ b/app.js
@@ -2777,16 +2777,13 @@ async function handleSendAsset(event) {
     let toAddress;
 
     // Validate amount including transaction fee
-    if (validateBalance(amount, assetIndex)) {
+    if (await validateBalance(amount, assetIndex)) {
         await getNetworkParams();
         const txFeeInLIB = (parameters.current.transactionFee || 1n);
-        const amountInWei = bigxnum2big(wei, amount.toString());
         const balance = BigInt(wallet.assets[assetIndex].balance);
-
-        const amountStr = big2str(amountInWei, 18).slice(0, -16);
+        const amountStr = big2str(amount, 18).slice(0, -16);
         const feeStr = big2str(txFeeInLIB, 18).slice(0, -16);
         const balanceStr = big2str(balance, 18).slice(0, -16);
-
         alert(`Insufficient balance: ${amountStr} + ${feeStr} (fee) > ${balanceStr} LIB`);
         return;
     }


### PR DESCRIPTION
- Changed the handleSendAsset function to await validateBalance for accurate balance validation.
- Simplified amount handling by using the already converted 'amount' in wei, removing unnecessary conversions for clarity and efficiency.