### PR TITLE
fix: Prevent state saving on visibility change if no account is present

### DIFF
--- a/app.js
+++ b/app.js
@@ -1181,6 +1181,10 @@ console.log('stop back button')
 // This is for installed apps where we can't stop the back button; just save the state
 async function handleVisibilityChange(e) {
     console.log('in handleVisibilityChange', document.visibilityState);
+    if (!myAccount) {
+        return;
+    }
+
     if (document.visibilityState === 'hidden') {
         saveState();
         if (handleSignOut.exit) {


### PR DESCRIPTION
- Added a check in the handleVisibilityChange function to return early if myAccount is not defined, preventing unnecessary state saving when the user is not logged in.