### PR TITLE
Fix default new account default toll value

### DIFF
--- a/app.js
+++ b/app.js
@@ -711,7 +711,7 @@ function newDataRecord(myAccount){
         },
         settings: {
             encrypt: true,
-            toll: 0n
+            toll: parameters.current.defaultToll,
         }
     }
 


### PR DESCRIPTION
Update default toll value in `newDataRecord` function in app.js to use `parameters.current.defaultToll` for network default toll amount which is currently big int value of 1