### PR TITLE
Implement Chat Read Receipts and Fix Friend Status Handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -6943,6 +6943,7 @@ class ChatModal {
         this.sendMoneyButton = document.getElementById('chatSendMoneyButton');
         this.retryOfTxId = document.getElementById('retryOfTxId');
         this.messageInput = document.querySelector('.message-input');
+        this.newestReceivedMessage = null;
         
         
         // used by updateTollValue and updateTollRequired
@@ -7068,6 +7069,7 @@ class ChatModal {
      * @returns {void}
      */
     close() {
+        this.sendReadTransaction(this.address);
         this.modal.classList.remove('active');
         if (document.getElementById('chatsScreen').classList.contains('active')) {
             updateChatList()
@@ -7083,6 +7085,42 @@ class ChatModal {
                 pollChatInterval(pollIntervalNormal) // back to polling at slower rate
             }
         }
+    }
+
+    /**
+     * Sends a read transaction to the contact if the contact's timestamp is less than the newest received message's timestamp
+     * @param {string} contactAddress - The address of the contact
+     * @returns {void}
+     */
+    async sendReadTransaction(contactAddress) {
+        const contact = myData.contacts[contactAddress];
+        const latestMessage = this.newestReceivedMessage;
+        if (contact.timestamp < latestMessage.timestamp) {
+            const readTransaction = await this.createReadTransaction(contactAddress);
+            const txid = await signObj(readTransaction, myAccount.keys)
+            const response = await injectTx(readTransaction, txid)
+            if (!response || !response.result || !response.result.success) {
+                console.warn('read transaction failed to send', response)
+            } else {
+                contact.timestamp = readTransaction.timestamp;
+            }
+        }
+    }
+
+    /**
+     * Creates a read transaction object for the given contact address
+     * @param {string} contactAddress - The address of the contact
+     * @returns {Object} The read transaction object
+     */
+    async createReadTransaction(contactAddress) {
+        const readTransaction = {
+            type: 'read',
+            from: longAddress(myAccount.address),
+            to: longAddress(contactAddress),
+            chatId: hashBytes([longAddress(myAccount.address), longAddress(contactAddress)].sort().join``),
+            timestamp: getCorrectedTimestamp(),
+        }
+        return readTransaction;
     }
 
     /**
@@ -7335,6 +7373,7 @@ class ChatModal {
         // Since messages are sorted descending (newest first), the first item with my: false is the newest received.
         const newestReceivedItem = messages.find(item => !item.my);
         console.log('appendChatModal: Identified newestReceivedItem data:', newestReceivedItem);
+        this.newestReceivedMessage = newestReceivedItem;
     
         // 2. Clear the entire list
         this.messagesList.innerHTML = '';
@@ -7981,7 +8020,6 @@ class SendModal {
         this.sendForm.reset();
         this.username = null
     }
-    
 
     /**
      * Invoked when the user types in the username input

--- a/app.js
+++ b/app.js
@@ -2657,7 +2657,7 @@ class FriendModal {
         if (!selectedStatus) return;
 
         // send transaction to update chat toll
-        const res = await this.postUpdateTollRequired(this.currentContactAddress, contact.friend)
+        const res = await this.postUpdateTollRequired(this.currentContactAddress, Number(selectedStatus))
         if (res?.transaction?.success === false) {
             console.log(`[handleFriendSubmit] update_chat_toll transaction failed: ${res?.transaction?.reason}. Did not update contact status.`);
             return;
@@ -7115,9 +7115,9 @@ class ChatModal {
     async createReadTransaction(contactAddress) {
         const readTransaction = {
             type: 'read',
-            from: longAddress(myAccount.address),
+            from: longAddress(myData.account.keys.address),
             to: longAddress(contactAddress),
-            chatId: hashBytes([longAddress(myAccount.address), longAddress(contactAddress)].sort().join``),
+            chatId: hashBytes([longAddress(myData.account.keys.address), longAddress(contactAddress)].sort().join``),
             timestamp: getCorrectedTimestamp(),
         }
         return readTransaction;


### PR DESCRIPTION
### Key Changes:
• **Fix friend status submission** - Convert selected status to number when calling `postUpdateTollRequired()`
• **Add read transaction on chat close** - Automatically send read receipt when closing chat modal if there are unread messages
• **Track newest received messages** - Store reference to most recent received message in `ChatModal.newestReceivedMessage`
• **Implement read transaction logic** - Add `sendReadTransaction()` and `createReadTransaction()` methods to handle read receipt functionality
• **Update contact timestamps** - Mark messages as read by updating contact timestamp after successful read transaction
• **Minor code cleanup** - Remove unnecessary blank line in SendModal

### Technical Details:
- Read transactions only sent if contact's timestamp is older than newest received message
- Read receipts use `type: 'read'` transaction with chat participants' addresses
- Includes error handling for failed read transactions with console warnings
