### PR TITLE
Iphone safe area inset bottom addition to ChatModal and remove border on footer buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -704,7 +704,6 @@ button:disabled {
   width: 100%;
   padding: 4px 0;
   background-color: white;
-  border-top: 1px solid #dee2e6;
   position: fixed;
   bottom: 0;
   left: 0;
@@ -1101,6 +1100,7 @@ input[type="file"].form-control::file-selector-button {
 .message-input-container {
   min-height: 80px;
   padding: 16px;
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px));
   background: white;
   display: flex;
   gap: 12px;


### PR DESCRIPTION
Update styles.css to remove redundant border from disabled buttons and adjust padding in message input container for better layout on devices with safe area insets.
BEFORE
![image](https://github.com/user-attachments/assets/8ba81865-aea1-4cdc-bb1a-a094708b7f1e)
![image](https://github.com/user-attachments/assets/6dc3c286-b7ec-4d84-8907-bd030f53aba5)

AFTER
![image](https://github.com/user-attachments/assets/d78c33b1-699d-48eb-941e-fda08c914f84)
![image](https://github.com/user-attachments/assets/e176b3c4-62fb-4dbf-b399-074f174bb939)
