### PR TITLE
Adjust padding in message input container 

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1100,7 +1100,7 @@ input[type="file"].form-control::file-selector-button {
 .message-input-container {
   min-height: 80px;
   padding: 16px;
-  padding-bottom: calc(env(safe-area-inset-bottom, 0px));
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 18px);
   background: white;
   display: flex;
   gap: 12px;


### PR DESCRIPTION
- improve layout on FireFox with safe area insets while also improving Iphone display as well. Firefox and Iphone screenshots below

Firefox
![image](https://github.com/user-attachments/assets/5504b50d-c38d-40cc-b3a7-fecac3509c54)

Iphone
![image](https://github.com/user-attachments/assets/c101ae4f-fdc4-446d-bb67-e5d4bf94a6d8)

