### PR TITLE
Fix: Only send read messages for message types and not transfers in the chatModal

### DIFF
--- a/app.js
+++ b/app.js
@@ -7120,8 +7120,8 @@ class ChatModal {
      * @returns {void}
      */
     close() {
-        if (this.newestReceivedMessage) {
-            console.log(`[close] invoking sendReadTransaction`)
+        // if newestRecevied message does not have an amount property, then send a read transaction
+        if (this.newestReceivedMessage && !this?.newestReceivedMessage?.amount) {
             this.sendReadTransaction(this.address);
         }
 


### PR DESCRIPTION
Update read transaction logic in ChatModal class to check for amount property before sending

- Modified the close method to ensure a read transaction is only sent if the newest received message does not have an amount property, improving transaction handling and preventing unnecessary calls.