### PR TITLE
Add user response tracking and update read transaction logic in ChatModal class

### DIFF
--- a/app.js
+++ b/app.js
@@ -7154,12 +7154,16 @@ class ChatModal {
      * @returns {Promise<boolean>} - True if the last message is from us and not a payment message, false otherwise
      */
     async hasUserResponded() {
-        // using from messagelist because new messages won't be added to myData until we do saveState()
-        const lastMessage = this.messagesList.lastElementChild;
+        // actually can grab from myData and newest message is first in array
+        const contact = myData.contacts[this.address];
+        if (!contact) {
+            return false;
+        }
+        const lastMessage = contact.messages[0];
         if (!lastMessage) {
             return false;
         }
-        return lastMessage.classList.contains('sent') && !lastMessage.classList.contains('payment-into');
+        return lastMessage?.my && !lastMessage.amount;
     }
 
     /**

--- a/app.js
+++ b/app.js
@@ -7154,7 +7154,7 @@ class ChatModal {
      * @returns {Promise<boolean>} - True if the last message is from us and not a payment message, false otherwise
      */
     async hasUserResponded() {
-        // actually can grab from myData and newest message is first in array
+        // get newest message from first message in myData.contacts[this.address] 
         const contact = myData.contacts[this.address];
         if (!contact) {
             return false;

--- a/app.js
+++ b/app.js
@@ -7121,7 +7121,7 @@ class ChatModal {
      */
     close() {
         const userResponded = this.hasUserResponded();
-
+        console.log(`[close] userResponded: ${userResponded}`)
         // if newestRecevied message does not have an amount property and user has not responded, then send a read transaction
         if (this?.newestReceivedMessage && !this?.newestReceivedMessage?.amount && !userResponded) {
             this.sendReadTransaction(this.address);
@@ -7150,7 +7150,7 @@ class ChatModal {
      * Checks if the last message is from us and not a payment message
      * @returns {Promise<boolean>} - True if the last message is from us and not a payment message, false otherwise
      */
-    async hasUserResponded() {
+    hasUserResponded() {
         // get newest message from first message in myData.contacts[this.address] 
         const contact = myData.contacts[this.address];
         if (!contact) {
@@ -7234,6 +7234,7 @@ class ChatModal {
      * @returns {void}
      */
     async sendReadTransaction(contactAddress) {
+        console.log(`[sendReadTransaction] entering function`)
         const contact = myData.contacts[contactAddress];
         const latestMessage = this.newestReceivedMessage;
         // if the other party is not required to pay toll, then don't send a read transaction.

--- a/app.js
+++ b/app.js
@@ -7123,7 +7123,7 @@ class ChatModal {
         const userResponded = this.hasUserResponded();
 
         // if newestRecevied message does not have an amount property and user has not responded, then send a read transaction
-        if (this?.newestReceivedMessage && !this?.newestReceivedMessage?.amount && userResponded) {
+        if (this?.newestReceivedMessage && !this?.newestReceivedMessage?.amount && !userResponded) {
             this.sendReadTransaction(this.address);
         }
 

--- a/app.js
+++ b/app.js
@@ -6995,7 +6995,6 @@ class ChatModal {
         this.messageInput = document.querySelector('.message-input');
         this.newestReceivedMessage = null;
         this.newestSentMessage = null;
-        this.userResponded = false;
         
         
         // used by updateTollValue and updateTollRequired
@@ -7043,7 +7042,6 @@ class ChatModal {
      * @returns {void}
      */
     async open(address) {
-        this.userResponded = false;
         friendModal.setAddress(address);
         document.getElementById('newChatButton').classList.remove('visible');
         const contact = myData.contacts[address]
@@ -7122,11 +7120,10 @@ class ChatModal {
      * @returns {void}
      */
     close() {
-        this.userResponded = this.hasUserResponded();
+        const userResponded = this.hasUserResponded();
 
         // if newestRecevied message does not have an amount property and user has not responded, then send a read transaction
-        if (this?.newestReceivedMessage && !this?.newestReceivedMessage?.amount && !this?.userResponded) {
-            this.hasResponded = false;
+        if (this?.newestReceivedMessage && !this?.newestReceivedMessage?.amount && userResponded) {
             this.sendReadTransaction(this.address);
         }
 

--- a/app.js
+++ b/app.js
@@ -6995,6 +6995,7 @@ class ChatModal {
         this.messageInput = document.querySelector('.message-input');
         this.newestReceivedMessage = null;
         this.newestSentMessage = null;
+        this.userResponded = false;
         
         
         // used by updateTollValue and updateTollRequired
@@ -7042,6 +7043,7 @@ class ChatModal {
      * @returns {void}
      */
     async open(address) {
+        this.userResponded = false;
         friendModal.setAddress(address);
         document.getElementById('newChatButton').classList.remove('visible');
         const contact = myData.contacts[address]
@@ -7120,8 +7122,11 @@ class ChatModal {
      * @returns {void}
      */
     close() {
-        // if newestRecevied message does not have an amount property, then send a read transaction
-        if (this.newestReceivedMessage && !this?.newestReceivedMessage?.amount) {
+        this.userResponded = this.hasUserResponded();
+
+        // if newestRecevied message does not have an amount property and user has not responded, then send a read transaction
+        if (this?.newestReceivedMessage && !this?.newestReceivedMessage?.amount && !this?.userResponded) {
+            this.hasResponded = false;
             this.sendReadTransaction(this.address);
         }
 
@@ -7142,6 +7147,19 @@ class ChatModal {
                 pollChatInterval(pollIntervalNormal) // back to polling at slower rate
             }
         }
+    }
+
+    /**
+     * Checks if the last message is from us and not a payment message
+     * @returns {Promise<boolean>} - True if the last message is from us and not a payment message, false otherwise
+     */
+    async hasUserResponded() {
+        // using from messagelist because new messages won't be added to myData until we do saveState()
+        const lastMessage = this.messagesList.lastElementChild;
+        if (!lastMessage) {
+            return false;
+        }
+        return lastMessage.classList.contains('sent') && !lastMessage.classList.contains('payment-into');
     }
 
     /**

--- a/app.js
+++ b/app.js
@@ -7156,11 +7156,11 @@ class ChatModal {
         if (!contact) {
             return false;
         }
-        const lastMessage = contact.messages[0];
+        const lastMessage = contact?.messages?.[0];
         if (!lastMessage) {
             return false;
         }
-        return lastMessage?.my && !lastMessage.amount;
+        return lastMessage?.my && !lastMessage?.amount;
     }
 
     /**


### PR DESCRIPTION
# Chat Modal Improvements

## Changes
- Added user response tracking to prevent unnecessary read transactions
- Improved read transaction logic to only trigger when:
  - There is a newest received message
  - The message doesn't have an amount property
  - The user hasn't responded to the message
- Added `hasUserResponded()` method to check if the last message is from the user and not a payment message

## Technical Details
- Added `userResponded` flag to track user interaction state
- Reset `userResponded` flag when opening chat modal
- Enhanced `close()` method to check user response before sending read transaction
- Added message list validation to determine if user has responded

## Impact
- Reduces unnecessary read transactions
- Improves user experience by better handling message read states
- More accurate tracking of user interactions with messages