### PR TITLE
Rename Send Modal to Send Asset Form Modal for Clarity

### DIFF
--- a/app.js
+++ b/app.js
@@ -950,10 +950,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   // New Chat Modal
   newChatModal.load();
 
-  // Send Modal
+  // Send Asset Modal
   sendAssetFormModal.load();
 
-  // Add event listeners for send confirmation modal
+  // Add event listeners for send asset confirmation modal
   document
     .getElementById('closeSendAssetConfirmModal')
     .addEventListener('click', closeSendAssetConfirmModal);
@@ -8466,7 +8466,7 @@ class NewChatModal {
 
 const newChatModal = new NewChatModal();
 
-// Send Modal
+// Send Asset Form Modal
 class SendAssetFormModal {
   constructor() {
     this.modal = document.getElementById('sendAssetFormModal');
@@ -8488,7 +8488,7 @@ class SendAssetFormModal {
   }
 
   /**
-   * Loads the send modal event listeners
+   * Loads the send asset form modal event listeners
    * @returns {void}
    */
   load() {
@@ -8525,7 +8525,7 @@ class SendAssetFormModal {
   }
 
   /**
-   * Opens the send modal
+   * Opens the send asset modal
    * @returns {void}
    */
   async open() {
@@ -8562,7 +8562,7 @@ class SendAssetFormModal {
   }
 
   /**
-   * Closes the send modal
+   * Closes the send asset modal
    * @returns {void}
    */
   async close() {
@@ -8661,7 +8661,7 @@ class SendAssetFormModal {
       memoGroup.style.display = 'none';
     }
 
-    // Hide send modal and show confirmation modal
+    // Hide send asset modal and show confirmation modal
     this.modal.classList.remove('active');
 
     confirmButton.disabled = false;
@@ -8684,7 +8684,7 @@ class SendAssetFormModal {
   }
 
   /**
-   * Updates the available balance in the send modal based on the asset
+   * Updates the available balance in the send asset modal based on the asset
    * @returns {void}
    */
   async updateAvailableBalance() {
@@ -8706,7 +8706,7 @@ class SendAssetFormModal {
   }
 
   /**
-   * Updates the balance display in the send modal based on the asset
+   * Updates the balance display in the send asset modal based on the asset
    * @param {object} asset - The asset to update the balance display for
    * @returns {void}
    */

--- a/app.js
+++ b/app.js
@@ -5619,7 +5619,7 @@ class WSManager {
 let wsManager = new WSManager(); // this is set to new WSManager() for convience
 
 function closeSendConfirmationModal() {
-  document.getElementById('sendConfirmationModal').classList.remove('active');
+  document.getElementById('sendAssetConfirmModal').classList.remove('active');
   document.getElementById('sendAssetFormModal').classList.add('active');
 }
 
@@ -8666,7 +8666,7 @@ class SendAssetFormModal {
 
     confirmButton.disabled = false;
     cancelButton.disabled = false;
-    document.getElementById('sendConfirmationModal').classList.add('active');
+    document.getElementById('sendAssetConfirmModal').classList.add('active');
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -951,7 +951,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   newChatModal.load();
 
   // Send Modal
-  sendModal.load();
+  sendAssetFormModal.load();
 
   // Add event listeners for send confirmation modal
   document
@@ -1119,15 +1119,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('contactInfoSendButton').addEventListener('click', () => {
     const contactUsername = document.getElementById('contactInfoUsername');
     if (contactUsername) {
-      sendModal.username = contactUsername.textContent;
+      sendAssetFormModal.username = contactUsername.textContent;
     }
-    sendModal.open();
+    sendAssetFormModal.open();
   });
 
   document.getElementById('chatSendMoneyButton').addEventListener('click', (event) => {
     const button = event.currentTarget;
-    sendModal.username = button.dataset.username;
-    sendModal.open();
+    sendAssetFormModal.username = button.dataset.username;
+    sendAssetFormModal.open();
   });
 
   // Add listener for the password visibility toggle
@@ -2592,7 +2592,7 @@ async function handleSendAsset(event) {
       chatModal.appendChatModal(); // Re-render the chat modal and highlight the new item
     }
 
-    sendModal.close();
+    sendAssetFormModal.close();
     closeSendConfirmationModal();
     document.getElementById('sendToAddress').value = '';
     document.getElementById('sendAmount').value = '';
@@ -3104,10 +3104,10 @@ handleFailedPaymentClick.memo = '';
 
 /**
  * Invoked when the user clicks the retry button in the failed payment modal
- * It will fill the sendModal with the payment content and txid of the failed payment in a hidden input field in the sendModal
+ * It will fill the sendAssetFormModal with the payment content and txid of the failed payment in a hidden input field in the sendAssetFormModal
  */
 function handleFailedPaymentRetry() {
-  const retryOfPaymentTxId = sendModal.retryTxIdInput;
+  const retryOfPaymentTxId = sendAssetFormModal.retryTxIdInput;
 
   // close the failed payment modal
   const failedPaymentModal = document.getElementById('failedPaymentModal');
@@ -3115,23 +3115,23 @@ function handleFailedPaymentRetry() {
     failedPaymentModal.classList.remove('active');
   }
 
-  if (sendModal.modal && retryOfPaymentTxId) {
-    sendModal.open();
+  if (sendAssetFormModal.modal && retryOfPaymentTxId) {
+    sendAssetFormModal.open();
 
     // 1. fill in hidden retryOfPaymentTxId input
     retryOfPaymentTxId.value = handleFailedPaymentClick.txid;
 
     // 2. fill in the memo input
-    sendModal.querySelector('#sendMemo').value = handleFailedPaymentClick.memo;
+    sendAssetFormModal.querySelector('#sendMemo').value = handleFailedPaymentClick.memo;
 
     // 3. fill in the to address input
     // find username in myData.contacts[handleFailedPaymentClick.address].senderInfo.username
     // enter as an input to invoke the oninput event
-    sendModal.usernameInput.value =
+    sendAssetFormModal.usernameInput.value =
       myData.contacts[handleFailedPaymentClick.address]?.senderInfo?.username ||
       handleFailedPaymentClick.address ||
       '';
-    sendModal.usernameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    sendAssetFormModal.usernameInput.dispatchEvent(new Event('input', { bubbles: true }));
 
     // 4. fill in the amount input
     // get the amount from myData.wallet.history since we need to the bigint value
@@ -3140,7 +3140,7 @@ function handleFailedPaymentRetry() {
     )?.amount;
     // convert bigint to string
     const amountStr = big2str(amount, 18);
-    sendModal.amountInput.value = amountStr;
+    sendAssetFormModal.amountInput.value = amountStr;
   }
 }
 
@@ -4703,7 +4703,7 @@ function markConnectivityDependentElements() {
     '#chatSendMoneyButton',
 
     // Wallet related
-    '#openSendModal',
+    '#openSendAssetFormModal',
     '#refreshBalance',
     '#sendForm button[type="submit"]',
 
@@ -5620,7 +5620,7 @@ let wsManager = new WSManager(); // this is set to new WSManager() for convience
 
 function closeSendConfirmationModal() {
   document.getElementById('sendConfirmationModal').classList.remove('active');
-  document.getElementById('sendModal').classList.add('active');
+  document.getElementById('sendAssetFormModal').classList.add('active');
 }
 
 /**
@@ -8006,7 +8006,7 @@ class ChatModal {
         failedMessageModal.handleFailedPaymentClick(messageEl.dataset.txid, messageEl);
       }
 
-      // TODO: if message is a payment open sendModal and fill with information in the payment message?
+      // TODO: if message is a payment open sendAssetFormModal and fill with information in the payment message?
 
       return;
     }
@@ -8467,11 +8467,11 @@ class NewChatModal {
 const newChatModal = new NewChatModal();
 
 // Send Modal
-class SendModal {
+class SendAssetFormModal {
   constructor() {
-    this.modal = document.getElementById('sendModal');
-    this.openSendModalButton = document.getElementById('openSendModal');
-    this.closeSendModalButton = document.getElementById('closeSendModal');
+    this.modal = document.getElementById('sendAssetFormModal');
+    this.openSendAssetFormModalButton = document.getElementById('openSendAssetFormModal');
+    this.closeSendAssetFormModalButton = document.getElementById('closeSendAssetFormModal');
     this.sendForm = document.getElementById('sendForm');
     this.username = null;
     this.usernameInput = document.getElementById('sendToAddress');
@@ -8481,7 +8481,7 @@ class SendModal {
     this.usernameAvailable = document.getElementById('sendToAddressError');
     this.submitButton = document.querySelector('#sendForm button[type="submit"]');
     this.assetSelectDropdown = document.getElementById('sendAsset');
-    this.sendModalCheckTimeout = null;
+    this.sendAssetFormModalCheckTimeout = null;
     this.balanceSymbol = document.getElementById('balanceSymbol');
     this.availableBalance = document.getElementById('availableBalance');
     this.toggleBalanceButton = document.getElementById('toggleBalance');
@@ -8493,8 +8493,8 @@ class SendModal {
    */
   load() {
     // TODO add comment about which send form this is for chat or assets
-    this.openSendModalButton.addEventListener('click', this.open.bind(this));
-    this.closeSendModalButton.addEventListener('click', this.close.bind(this));
+    this.openSendAssetFormModalButton.addEventListener('click', this.open.bind(this));
+    this.closeSendAssetFormModalButton.addEventListener('click', this.close.bind(this));
     this.sendForm.addEventListener('submit', this.handleSendFormSubmit.bind(this));
     // TODO: need to add check that it's not a back/delete key
     this.usernameInput.addEventListener('input', async (e) => {
@@ -8584,8 +8584,8 @@ class SendModal {
     const usernameAvailable = this.usernameAvailable;
 
     // Clear previous timeout
-    if (this.sendModalCheckTimeout) {
-      clearTimeout(this.sendModalCheckTimeout);
+    if (this.sendAssetFormModalCheckTimeout) {
+      clearTimeout(this.sendAssetFormModalCheckTimeout);
     }
 
     // Check if username is too short
@@ -8598,7 +8598,7 @@ class SendModal {
     }
 
     // Check network availability
-    this.sendModalCheckTimeout = setTimeout(async () => {
+    this.sendAssetFormModalCheckTimeout = setTimeout(async () => {
       const taken = await checkUsernameAvailability(username, myAccount.keys.address);
       if (taken == 'taken') {
         usernameAvailable.textContent = 'found';
@@ -8857,7 +8857,7 @@ class SendModal {
   }
 }
 
-const sendModal = new SendModal();
+const sendAssetFormModal = new SendAssetFormModal();
 
 /**
  * Remove failed transaction from the contacts messages, pending, and wallet history

--- a/app.js
+++ b/app.js
@@ -955,10 +955,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Add event listeners for send confirmation modal
   document
-    .getElementById('closeSendConfirmationModal')
-    .addEventListener('click', closeSendConfirmationModal);
+    .getElementById('closeSendAssetConfirmModal')
+    .addEventListener('click', closeSendAssetConfirmModal);
   document.getElementById('confirmSendButton').addEventListener('click', handleSendAsset);
-  document.getElementById('cancelSendButton').addEventListener('click', closeSendConfirmationModal);
+  document.getElementById('cancelSendButton').addEventListener('click', closeSendAssetConfirmModal);
 
   document.getElementById('openReceiveModal').addEventListener('click', openReceiveModal);
   document.getElementById('closeReceiveModal').addEventListener('click', closeReceiveModal);
@@ -2593,7 +2593,7 @@ async function handleSendAsset(event) {
     }
 
     sendAssetFormModal.close();
-    closeSendConfirmationModal();
+    closeSendAssetConfirmModal();
     document.getElementById('sendToAddress').value = '';
     document.getElementById('sendAmount').value = '';
     document.getElementById('sendMemo').value = '';
@@ -5618,7 +5618,7 @@ class WSManager {
 
 let wsManager = new WSManager(); // this is set to new WSManager() for convience
 
-function closeSendConfirmationModal() {
+function closeSendAssetConfirmModal() {
   document.getElementById('sendAssetConfirmModal').classList.remove('active');
   document.getElementById('sendAssetFormModal').classList.add('active');
 }

--- a/data_structures_flow/offline-fliw.md
+++ b/data_structures_flow/offline-fliw.md
@@ -174,7 +174,7 @@ function markConnectivityDependentElements() {
     "#newChatButton",
 
     // Wallet related
-    "#openSendModal",
+    "#openSendAssetFormModal",
     "#refreshBalance",
     '#sendForm button[type="submit"]',
 

--- a/data_structures_flow/qr-code-flow.md
+++ b/data_structures_flow/qr-code-flow.md
@@ -42,7 +42,7 @@ sequenceDiagram
 
     %% QR Code Scanning Flow
     User->>SendScreen: Opens Send screen
-    Note over SendScreen: openSendModal()
+    Note over SendScreen: openSendAssetFormModal()
 
     alt Camera Scanning
         User->>QRScanner: Initiates QR scan

--- a/index.html
+++ b/index.html
@@ -817,7 +817,7 @@
         </a>
       </div>
 
-      <!-- Send Modal -->
+      <!-- Send Asset Form Modal -->
       <div class="modal fixed-header" id="sendAssetFormModal">
         <div class="modal-header">
           <button class="back-button" id="closeSendAssetFormModal"></button>
@@ -941,7 +941,7 @@
         </a>
       </div>
 
-      <!-- Send Confirmation Modal -->
+      <!-- Send Asset Confirmation Modal -->
       <div class="modal fixed-header" id="sendAssetConfirmModal">
         <div class="modal-header">
           <button class="back-button" id="closeSendAssetConfirmModal"></button>

--- a/index.html
+++ b/index.html
@@ -944,7 +944,7 @@
       <!-- Send Confirmation Modal -->
       <div class="modal fixed-header" id="sendAssetConfirmModal">
         <div class="modal-header">
-          <button class="back-button" id="closeSendConfirmationModal"></button>
+          <button class="back-button" id="closeSendAssetConfirmModal"></button>
           <div class="modal-title">Confirm Transaction</div>
         </div>
         <div class="form-container">

--- a/index.html
+++ b/index.html
@@ -942,7 +942,7 @@
       </div>
 
       <!-- Send Confirmation Modal -->
-      <div class="modal fixed-header" id="sendConfirmationModal">
+      <div class="modal fixed-header" id="sendAssetConfirmModal">
         <div class="modal-header">
           <button class="back-button" id="closeSendConfirmationModal"></button>
           <div class="modal-title">Confirm Transaction</div>

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
           </div>
         </div>
         <div class="wallet-actions">
-          <button class="wallet-action-button" id="openSendModal">
+          <button class="wallet-action-button" id="openSendAssetFormModal">
             <span class="action-icon"></span>
             <span class="action-label">Send</span>
           </button>
@@ -818,9 +818,9 @@
       </div>
 
       <!-- Send Modal -->
-      <div class="modal fixed-header" id="sendModal">
+      <div class="modal fixed-header" id="sendAssetFormModal">
         <div class="modal-header">
-          <button class="back-button" id="closeSendModal"></button>
+          <button class="back-button" id="closeSendAssetFormModal"></button>
           <div class="modal-title">Send</div>
         </div>
         <div class="form-container">

--- a/styles.css
+++ b/styles.css
@@ -1402,7 +1402,7 @@ input[type='file'].form-control::file-selector-button {
 }
 
 /* Send icon (up chevron) */
-#openSendModal .action-icon {
+#openSendAssetFormModal .action-icon {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='18 15 12 9 6 15'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
@@ -1664,12 +1664,12 @@ input[type='file'].form-control {
   padding: 0 16px;
 }
 
-#sendModal .form-group {
+#sendAssetFormModal .form-group {
   margin-bottom: 1.5rem;
   width: 100%;
 }
 
-#sendModal .form-control {
+#sendAssetFormModal .form-control {
   width: 100%;
   height: 56px;
   padding: 15px;
@@ -1679,7 +1679,7 @@ input[type='file'].form-control {
   background-color: #fff;
 }
 
-#sendModal select.form-control {
+#sendAssetFormModal select.form-control {
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23333' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
@@ -1700,7 +1700,7 @@ input[type='file'].form-control {
   display: none; /* Hide scrollbar for WebKit browsers */
 }
 
-#sendModal textarea.form-control {
+#sendAssetFormModal textarea.form-control {
   min-height: 100px;
   resize: vertical;
 }
@@ -1743,13 +1743,13 @@ input[type='file'].form-control {
 }
 
 /* Number input specific styles */
-#sendModal input[type='number'] {
+#sendAssetFormModal input[type='number'] {
   appearance: textfield;
   -moz-appearance: textfield;
 }
 
-#sendModal input[type='number']::-webkit-outer-spin-button,
-#sendModal input[type='number']::-webkit-inner-spin-button {
+#sendAssetFormModal input[type='number']::-webkit-outer-spin-button,
+#sendAssetFormModal input[type='number']::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -3551,29 +3551,29 @@ small {
 }
 
 /* Send Confirmation Modal Styles */
-#sendConfirmationModal .form-container {
+#sendAssetConfirmModal .form-container {
   padding: 16px;
   width: 100%;
   max-width: 390px;
   margin: 0 auto;
 }
 
-#sendConfirmationModal .confirmation-details {
+#sendAssetConfirmModal .confirmation-details {
   margin-bottom: 24px;
   background-color: rgba(61, 61, 206, 0.08);
   border-radius: 12px;
   padding: 16px;
 }
 
-#sendConfirmationModal .form-group {
+#sendAssetConfirmModal .form-group {
   margin-bottom: 16px;
 }
 
-#sendConfirmationModal .form-group:last-child {
+#sendAssetConfirmModal .form-group:last-child {
   margin-bottom: 0;
 }
 
-#sendConfirmationModal label {
+#sendAssetConfirmModal label {
   display: block;
   font-size: var(--font-size-sm);
   color: var(--secondary-text-color);
@@ -3581,7 +3581,7 @@ small {
   font-weight: var(--font-weight-medium);
 }
 
-#sendConfirmationModal .confirm-value {
+#sendAssetConfirmModal .confirm-value {
   font-size: var(--font-size-base);
   color: var(--text-color);
   padding: 12px 16px;
@@ -3592,8 +3592,8 @@ small {
   border: 1px solid var(--border-color);
 }
 
-#sendConfirmationModal .update-button,
-#sendConfirmationModal .secondary-button {
+#sendAssetConfirmModal .update-button,
+#sendAssetConfirmModal .secondary-button {
   width: calc(100% - 32px);
   height: 48px;
   border-radius: 24px;
@@ -3604,39 +3604,39 @@ small {
   transition: all 0.2s ease;
 }
 
-#sendConfirmationModal .update-button {
+#sendAssetConfirmModal .update-button {
   background-color: var(--primary-color);
   color: var(--background-color);
   border: none;
 }
 
-#sendConfirmationModal .update-button:hover {
+#sendAssetConfirmModal .update-button:hover {
   background-color: var(--primary-hover);
   opacity: 0.9;
 }
 
-#sendConfirmationModal .secondary-button {
+#sendAssetConfirmModal .secondary-button {
   background-color: var(--danger-color);
   color: var(--background-color);
   border: none;
 }
 
-#sendConfirmationModal .secondary-button:hover {
+#sendAssetConfirmModal .secondary-button:hover {
   background-color: var(--hover-background-dark);
   opacity: 0.9;
 }
 
-#sendConfirmationModal #confirmAmount {
+#sendAssetConfirmModal #confirmAmount {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
   color: var(--text-color);
 }
 
-#sendConfirmationModal #confirmMemoGroup {
+#sendAssetConfirmModal #confirmMemoGroup {
   opacity: 0.8;
 }
 
-#sendConfirmationModal #confirmMemo {
+#sendAssetConfirmModal #confirmMemo {
   font-style: italic;
   background-color: rgba(61, 61, 206, 0.04);
 }


### PR DESCRIPTION
### Summary of Changes

- **Class and Variable Renaming**
  - Renamed `SendModal` class to `SendAssetFormModal`
  - Renamed `sendModal` instance to `sendAssetFormModal`
  - Updated all related variable names and comments for consistency

- **HTML Element Updates**
  - Renamed modal IDs:
    - `sendModal` → `sendAssetFormModal`
    - `sendConfirmationModal` → `sendAssetConfirmModal`
  - Updated button IDs:
    - `openSendModal` → `openSendAssetFormModal`
    - `closeSendModal` → `closeSendAssetFormModal`
    - `closeSendConfirmationModal` → `closeSendAssetConfirmModal`

- **CSS Updates**
  - Updated all CSS selectors to match new modal IDs
  - Maintained all existing styles and functionality

- **Documentation Updates**
  - Updated comments in code to reflect new naming
  - Updated flow documentation in `qr-code-flow.md`

---

**Technical Notes:**
- This is a pure rename refactor with no functional changes
- All references to the send modal have been updated for consistency
- The change improves clarity by explicitly indicating this is for sending assets