### PR TITLE
Fix: Refresh tollModal value display when pending failed and when toll modal is active

### DIFF
--- a/app.js
+++ b/app.js
@@ -9010,6 +9010,12 @@ async function checkPendingTransactions() {
             );
             // revert the local myData.settings.toll to the old value
             tollModal.editMyDataToll(tollModal.oldToll);
+            // check if the toll modal is open
+            if (document.getElementById('tollModal').classList.contains('active')) {
+              // change the tollAmountLIB and tollAmountUSD to the old value
+              tollModal.tollAmountLIB = tollModal.oldToll;
+              tollModal.tollAmountUSD = tollModal.oldToll;
+            }
           } else if (type === 'update_toll_required') {
             showToast(
               `Update contact status failed: ${failureReason}. Reverting contact to old status.`,

--- a/app.js
+++ b/app.js
@@ -9010,7 +9010,7 @@ async function checkPendingTransactions() {
             );
             // revert the local myData.settings.toll to the old value
             tollModal.editMyDataToll(tollModal.oldToll);
-            // need to refresh the toll modal
+            // refresh to show fallback old toll
             tollModal.close();
             tollModal.open();
           } else if (type === 'update_toll_required') {

--- a/app.js
+++ b/app.js
@@ -9010,6 +9010,9 @@ async function checkPendingTransactions() {
             );
             // revert the local myData.settings.toll to the old value
             tollModal.editMyDataToll(tollModal.oldToll);
+            // need to refresh the toll modal
+            tollModal.close();
+            tollModal.open();
           } else if (type === 'update_toll_required') {
             showToast(
               `Update contact status failed: ${failureReason}. Reverting contact to old status.`,

--- a/app.js
+++ b/app.js
@@ -9011,7 +9011,7 @@ async function checkPendingTransactions() {
             // revert the local myData.settings.toll to the old value
             tollModal.editMyDataToll(tollModal.oldToll);
             // check if the toll modal is open
-            if (document.getElementById('tollModal').classList.contains('active')) {
+            if (tollModal.modal.classList.contains('active')) {
               // change the tollAmountLIB and tollAmountUSD to the old value
               tollModal.tollAmountLIB = tollModal.oldToll;
               tollModal.tollAmountUSD = tollModal.oldToll;

--- a/app.js
+++ b/app.js
@@ -9010,9 +9010,6 @@ async function checkPendingTransactions() {
             );
             // revert the local myData.settings.toll to the old value
             tollModal.editMyDataToll(tollModal.oldToll);
-            // refresh to show fallback old toll
-            tollModal.close();
-            tollModal.open();
           } else if (type === 'update_toll_required') {
             showToast(
               `Update contact status failed: ${failureReason}. Reverting contact to old status.`,


### PR DESCRIPTION
- Implemented a check to update `tollAmountLIB` and `tollAmountUSD` to the old value if the toll modal is currently active, ensuring accurate display of toll values after reverting changes.
- Enhanced user experience by maintaining consistency in toll value representation during transaction checks.
