### PR TITLE
Fix Address Normalization in Pending Transaction Storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -4027,7 +4027,7 @@ async function injectTx(tx, txid) {
         tx.type === 'deposit_stake' ||
         tx.type === 'withdraw_stake'
       ) {
-        pendingTxData.to = tx.to;
+        pendingTxData.to = normalizeAddress(tx.to);
       }
       myData.pending.push(pendingTxData);
     } else {


### PR DESCRIPTION
### Reason for PR
Ensures consistent address formatting for pending transactions by normalizing addresses before local storage, preventing issues with address comparison and lookup operations.

### Changes Made
• **Fixed pending transaction address storage** - Modified `injectTx()` function in `app.js` to normalize the `to` address using `normalizeAddress()` before storing in `myData.pending` array for stake-related transactions
• **Improved data consistency** - Addresses stored locally now match the normalized format used by network operations, preventing potential mismatches during transaction processing

**Location**: ```4030:4030:app.js```
```javascript
pendingTxData.to = normalizeAddress(tx.to);
```

This change ensures that when deposit_stake and withdraw_stake transactions are processed, the recipient address is properly normalized before being stored in the pending transactions array, maintaining consistency with how addresses are handled throughout the rest of the application.