### PR TITLE
Refactor sendReclaimTollTransaction in ChatModal to improve timestamp validation logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -7638,16 +7638,13 @@ class ChatModal {
    */
   async sendReclaimTollTransaction(contactAddress) {
     console.log(`[sendReclaimTollTransaction] entering function`);
-    const sevenDaysAgo = getCorrectedTimestamp() - 7 * 24 * 60 * 60 * 1000;
-    console.log(`this.newestSentMessage: ${!!this.newestSentMessage}`);
-    console.log(`this.newestSentMessage?.timestamp: ${this.newestSentMessage?.timestamp}`);
-    console.log(`sevenDaysAgo: ${sevenDaysAgo}`);
-    console.log(
-      `this.newestSentMessage?.timestamp > sevenDaysAgo: ${this.newestSentMessage?.timestamp < sevenDaysAgo}`
-    );
-    if (!this.newestSentMessage || this.newestSentMessage?.timestamp > sevenDaysAgo) {
+    await getNetworkParams();
+    const currentTime = getCorrectedTimestamp();
+    const networkTollTimeoutInMs = parameters.current.tollTimeout; 
+    const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
+    if (!this.newestSentMessage || timeSinceNewestSentMessage < networkTollTimeoutInMs) {
       console.log(
-        `[sendReclaimTollTransaction] newestSentMessage is null or timestamp is less than 7 days ago, skipping reclaim toll transaction`
+        `[sendReclaimTollTransaction] timeSinceNewestSentMessage ${timeSinceNewestSentMessage}ms is less than networkTollTimeoutInMs ${networkTollTimeoutInMs}ms, skipping reclaim toll transaction`
       );
       return;
     }


### PR DESCRIPTION
- Updated the function to use the current network toll timeout for validating the timestamp of the newest sent message, enhancing accuracy in determining whether to skip the reclaim toll transaction.
- Removed outdated console logs and replaced them with more relevant logging for better clarity on the validation process.