### PR TITLE
Deprecate setupAddToHomeScreen functionality to avoid user confusion regarding local storage on iOS. Commented out related code in app.js and index.html for clarity.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1184,7 +1184,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const welcomeScreenLastItem = document.getElementById('welcomeScreenLastItem');
   welcomeScreenLastItem.focus();
 
-  setupAddToHomeScreen();
+  // Deprecated - do not want to encourage or confuse users with this feature since on IOS uses seperate local storage
+  //setupAddToHomeScreen();
 });
 
 function handleUnload() {
@@ -1255,7 +1256,7 @@ function saveState() {
   }
 }
 
-function setupAddToHomeScreen() {
+/* function setupAddToHomeScreen() {
   // Add to home screen functionality
   let deferredInstallPrompt;
   let addToHomeScreenButton = document.getElementById('addToHomeScreenButton');
@@ -1446,7 +1447,7 @@ function setupAddToHomeScreen() {
       updateButtonVisibility();
     });
   }
-}
+} */
 
 async function updateChatData() {
   let gotChats = 0;

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
           <button id="signInButton" class="secondary-button hidden">Sign In</button>
           <button id="createAccountButton" class="secondary-button hidden">Create Account</button>
           <button id="importAccountButton" class="secondary-button hidden">Restore Account</button>
-          <button id="addToHomeScreenButton" class="secondary-button hidden">Install</button>
+          <!-- <button id="addToHomeScreenButton" class="secondary-button hidden">Install</button> -->
         </div>
         <div style="font-size: 0.8rem; margin-top: 10px; text-align: center">
           Version <span id="versionDisplay"></span>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7b1a1389-2f7f-4e6d-924c-df764ce60645)
