### PR TITLE
Add system notice fetching logic to check file existence and modification timestamp

### DIFF
--- a/app.js
+++ b/app.js
@@ -9474,6 +9474,23 @@ getNetworkParams.timestamp = 0;
 
 async function getSystemNotice() {
   try {
+    // First, do a HEAD request to check if the file exists and get its timestamp
+    const headResponse = await fetch(`./notice.html?${Math.random()}`, { method: 'HEAD' });
+    if (!headResponse.ok) {
+      return;
+    }
+
+    // Get the Last-Modified header timestamp
+    const lastModified = headResponse.headers.get('Last-Modified');
+    const fileTimestamp = lastModified ? new Date(lastModified).getTime() : null;
+    
+    // Check if we need to show the notice based on file modification time
+    // If no Last-Modified header, we'll check the content timestamp instead
+    if (fileTimestamp && myData.settings.noticets && myData.settings.noticets >= fileTimestamp) {
+      return; // File hasn't changed, no need to download
+    }
+
+    // Download the file content
     const response = await fetch(`./notice.html?${Math.random()}`);
     if (!response.ok) {
       return;


### PR DESCRIPTION
- Implemented a HEAD request to verify if the notice.html file exists and retrieve its Last-Modified timestamp.
- Added logic to determine if the notice should be displayed based on the file's modification time compared to the current settings.
- Enhanced user experience by preventing unnecessary downloads of unchanged content.