### PR TITLE
Recreate fix by clearing signInModal on .close()

### DIFF
--- a/app.js
+++ b/app.js
@@ -2291,6 +2291,14 @@ class SignInModal {
   }
 
   close() {
+    // clear signInModal input fields
+    this.usernameSelect.value = '';
+    this.submitButton.disabled = true;
+    this.submitButton.textContent = 'Sign In';
+    this.submitButton.style.display = 'inline';
+    this.removeButton.style.display = 'none';
+    this.notFoundMessage.style.display = 'none';
+    
     this.modal.classList.remove('active');
     this.preselectedUsername = null;
   }


### PR DESCRIPTION
Enhance SignInModal close method in app.js to clear input fields and reset button states. This improves user experience by ensuring a clean state when the modal is closed.