### PR TITLE
Add Provided Name field to contact info display in UI and update contact name retrieval logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -2488,6 +2488,7 @@ class ContactInfoModal {
     const fields = {
       Username: 'contactInfoUsername',
       Name: 'contactInfoName',
+      ProvidedName: 'contactInfoProvidedName',
       Email: 'contactInfoEmail',
       Phone: 'contactInfoPhone',
       LinkedIn: 'contactInfoLinkedin',
@@ -4371,7 +4372,8 @@ function createDisplayInfo(contact) {
       contact.senderInfo?.username ||
       contact.username ||
       contact.address.slice(0, 8) + '...' + contact.address.slice(-6),
-    name: contact.name || contact.senderInfo?.name || 'Not provided',
+    name: contact.name || 'Not provided',
+    providedname: contact.senderInfo?.name || 'Not provided',
     email: contact.senderInfo?.email || 'Not provided',
     phone: contact.senderInfo?.phone || 'Not provided',
     linkedin: contact.senderInfo?.linkedin || 'Not provided',

--- a/index.html
+++ b/index.html
@@ -515,6 +515,10 @@
               </div>
             </div>
             <div class="contact-info-item">
+              <div class="contact-info-label">Provided Name</div>
+              <div class="contact-info-value" id="contactInfoProvidedName"></div>
+            </div>
+            <div class="contact-info-item">
               <div class="contact-info-label">Email</div>
               <div class="contact-info-value" id="contactInfoEmail"></div>
             </div>


### PR DESCRIPTION
- Introduced a new field for Provided Name in the contact info modal to enhance user visibility of contact details.
- Updated the logic in app.js to ensure consistent retrieval of contact names, defaulting to 'Not provided' when necessary.