### PR TITLE
Handle timestamp out of range error in tx injection 

### DIFF
--- a/app.js
+++ b/app.js
@@ -3945,6 +3945,13 @@ async function injectTx(tx, txid) {
     } else {
       showToast('Error injecting transaction: ' + data?.result?.reason, 0, 'error');
       console.error('Error injecting transaction:', data?.result?.reason);
+      if (data?.result?.reason?.includes('timestamp out of range')) {
+        console.error('Timestamp out of range, updating timestamp');
+        // recalculate time skew
+        timeDifference()
+
+        showToast('Try again.', 0, 'error');
+      }
     }
 
     return data;

--- a/app.js
+++ b/app.js
@@ -3947,9 +3947,7 @@ async function injectTx(tx, txid) {
       console.error('Error injecting transaction:', data?.result?.reason);
       if (data?.result?.reason?.includes('timestamp out of range')) {
         console.error('Timestamp out of range, updating timestamp');
-        // recalculate time skew
         timeDifference()
-
         showToast('Try again.', 0, 'error');
       }
     }


### PR DESCRIPTION
Recalculate time skew and prompting user to try again. 