### PR TITLE
Add memo byte size validation in SendAssetFormModal

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,8 +749,11 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="sendMemo">Memo (Optional)</label>
-              <textarea id="sendMemo" class="form-control" maxlength="2000"></textarea>
+              <label for="sendMemo">
+                Memo (Optional)
+                <span class="memo-byte-counter" style="font-size: 12px; margin-left: 8px; font-weight: normal; display: none;"></span>
+              </label>
+              <textarea id="sendMemo" class="form-control"></textarea>
               <div class="toll-container" id="memoTollContainer">
                 <span class="toll-memo" id="tollMemo"></span>
               </div>


### PR DESCRIPTION
* Introduce constants for maximum memo and chat message byte sizes.
* Implement memo size validation logic and update UI to display remaining bytes.
* Modify the SendAssetFormModal to include memo byte counter and validation checks before submission.