### PR TITLE
Add clickable links for Email, LinkedIn, and X-Twitter in contact info modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -2179,8 +2179,27 @@ class ContactInfoModal {
       const element = document.getElementById(elementId);
       if (element) {
         const value = displayInfo[field.toLowerCase()] || 'Not provided';
-        element.textContent = value;
-        element.parentElement.style.display = value === 'Not provided' ? 'none' : 'block';
+        
+        if (field === 'Email' && value !== 'Not provided') {
+          // Handle email link
+          element.textContent = value;
+          element.href = `mailto:${value}`;
+          element.parentElement.parentElement.style.display = 'block';
+        } else if (field === 'LinkedIn' && value !== 'Not provided') {
+          // Handle LinkedIn link
+          element.textContent = value;
+          element.href = `https://linkedin.com/in/${value}`;
+          element.parentElement.parentElement.style.display = 'block';
+        } else if (field === 'X' && value !== 'Not provided') {
+          // Handle X-Twitter link
+          element.textContent = value;
+          element.href = `https://x.com/${value}`;
+          element.parentElement.parentElement.style.display = 'block';
+        } else {
+          // Handle other fields as before
+          element.textContent = value;
+          element.parentElement.style.display = value === 'Not provided' ? 'none' : 'block';
+        }
       }
     });
   }

--- a/index.html
+++ b/index.html
@@ -523,7 +523,9 @@
             </div>
             <div class="contact-info-item" style="display: none">
               <div class="contact-info-label">Email</div>
-              <div class="contact-info-value" id="contactInfoEmail"></div>
+              <div class="contact-info-value">
+                <a href="#" id="contactInfoEmail" class="contact-info-link" target="_blank" rel="noopener noreferrer"></a>
+              </div>
             </div>
             <div class="contact-info-item" style="display: none">
               <div class="contact-info-label">Phone</div>
@@ -531,11 +533,15 @@
             </div>
             <div class="contact-info-item" style="display: none">
               <div class="contact-info-label">LinkedIn</div>
-              <div class="contact-info-value" id="contactInfoLinkedin"></div>
+              <div class="contact-info-value">
+                <a href="#" id="contactInfoLinkedin" class="contact-info-link" target="_blank" rel="noopener noreferrer"></a>
+              </div>
             </div>
             <div class="contact-info-item" style="display: none">
               <div class="contact-info-label">X-Twitter</div>
-              <div class="contact-info-value" id="contactInfoX"></div>
+              <div class="contact-info-value">
+                <a href="#" id="contactInfoX" class="contact-info-link" target="_blank" rel="noopener noreferrer"></a>
+              </div>
             </div>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1974,6 +1974,24 @@ input[type='file'].form-control {
   padding: 1rem;
 }
 
+/* Contact Info Link Styles */
+.contact-info-link {
+  display: inline-block;
+  color: var(--primary-color);
+  text-decoration: none;
+  font-family: var(--font-primary);
+  font-size: var(--font-size-base);
+  transition: opacity 0.2s ease;
+}
+
+.contact-info-link:hover {
+  opacity: 0.7;
+}
+
+.contact-info-link:visited {
+  color: var(--primary-color);
+}
+
 /* Contact Avatar Section */
 .contact-avatar-section {
   display: flex;


### PR DESCRIPTION
## PR Summary
- **Reason**: Enhance user experience by making contact information fields clickable and actionable
- **Changes Made**:
  - **HTML**: Converted Email, LinkedIn, and X-Twitter fields from static `<div>` elements to clickable `<a>` elements with proper security attributes (`target="_blank"`, `rel="noopener noreferrer"`)
  - **CSS**: Added `.contact-info-link` styling class that matches the existing `.about-link` design pattern for consistent visual appearance
  - **JavaScript**: Updated `updateContactInfo()` method to set appropriate URLs:
    - Email: `mailto:` protocol to open default email client
    - LinkedIn: `https://linkedin.com/in/{username}` to open profile in new tab
    - X-Twitter: `https://x.com/{username}` to open profile in new tab
  - **UX Improvement**: Users can now directly interact with contact information to send emails or view social media profiles without manual URL construction