### PR TITLE
Fix HistoryModal asset check to validate wallet history instead of assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -2638,7 +2638,7 @@ class HistoryModal {
     const walletData = myData.wallet;
     const assetIndex = this.assetSelect.value;
     
-    if (!walletData.assets || walletData.assets.length === 0) {
+    if (!walletData.history || walletData.history.length === 0) {
       this.showEmptyState();
       return;
     }


### PR DESCRIPTION
Now will render `showEmptyState()` when no tx history present
![image](https://github.com/user-attachments/assets/04edb08e-e384-4d6d-8e25-9f76bd3a7bef)
