### PR TITLE
Fix Chat Modal Title Overflow and Improve Text Wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -876,7 +876,24 @@ button:disabled {
   display: flex;
   align-items: center;
   margin-left: 48px;
+  margin-right: 140px; /* Reserve space for header actions */
   gap: 12px;
+  cursor: pointer;
+  flex: 1;
+  min-width: 180px; /* Minimum width for the container */
+  max-width: calc(100vw - 200px); /* Responsive max width */
+}
+
+/* Responsive adjustments for smaller screens */
+@media (max-width: 480px) {
+  .chat-user-info {
+    min-width: 120px; /* Smaller minimum on mobile */
+    margin-right: 100px; /* Less margin on smaller screens */
+  }
+}
+
+.chat-user-info:hover {
+  opacity: 0.8;
 }
 
 .modal-avatar {
@@ -903,6 +920,11 @@ button:disabled {
   font-weight: var(--font-weight-semibold);
   color: var(--text-color);
   margin: 0 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0; /* Allow flex item to shrink below content size */
+  max-width: 100%; /* Allow full width when possible */
 }
 
 .menu-list {
@@ -1241,14 +1263,6 @@ input[type='file'].form-control::file-selector-button {
   word-wrap: break-word;
   word-break: break-word;
   hyphens: auto;
-}
-
-.chat-user-info {
-  cursor: pointer;
-}
-
-.chat-user-info:hover {
-  opacity: 0.8;
 }
 
 /* Wrapper for the send button and the toll information */
@@ -2062,14 +2076,6 @@ input[type='file'].form-control {
   word-break: break-word;
   overflow-wrap: break-word;
   max-width: 100%;
-}
-
-.chat-user-info {
-  cursor: pointer;
-}
-
-.chat-user-info:hover {
-  opacity: 0.8;
 }
 
 /* Logs Modal Styles */

--- a/styles.css
+++ b/styles.css
@@ -2041,6 +2041,9 @@ input[type='file'].form-control {
   font-weight: var(--font-weight-semibold);
   color: var(--text-color);
   margin-bottom: 0.25rem;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  max-width: 100%;
 }
 
 .contact-avatar-section .subtitle {


### PR DESCRIPTION
### **Reason for PR:**
- Chat modal titles with long names/usernames were overflowing and overlapping with header action buttons
- Contact names in the contact info section needed better text wrapping for long names

### **Changes Made:**
- **Added text truncation to modal titles** with ellipsis for long names
- **Made chat user info container responsive** with proper spacing for header actions
- **Added responsive breakpoints** for mobile devices (min-width adjustments)
- **Improved contact name text wrapping** with word-break properties
- **Removed duplicate CSS rules** for `.chat-user-info` hover states

The changes ensure that long contact names are properly handled in both the chat modal header and contact info sections, preventing layout overflow while maintaining readability across different screen sizes.