### PR TITLE
Refactor QR Scan buttons into classes

### DIFF
--- a/app.js
+++ b/app.js
@@ -5813,7 +5813,7 @@ class StakeValidatorModal {
     this.modal.classList.add('active');
 
     // Set the correct fill function for the staking context
-    scanQRModal.fillFunction = fillStakeAddressFromQR;
+    scanQRModal.fillFunction = stakeValidatorModal.fillFromQR;
 
     // Display Available Balance
     const libAsset = myData.wallet.assets.find((asset) => asset.symbol === 'LIB');
@@ -7751,7 +7751,7 @@ class SendAssetFormModal {
 
     this.usernameAvailable.style.display = 'none';
     this.submitButton.disabled = true;
-    scanQRModal.fillFunction = fillPaymentFromQR; // set function to handle filling the payment form from QR data
+    scanQRModal.fillFunction = sendAssetFormModal.fillFromQR; // set function to handle filling the payment form from QR data
 
     if (this.username) {
       this.usernameInput.value = this.username;


### PR DESCRIPTION
- Moved QRScan and Upload buttons their modal classes
- Moved `handleQRFileSelect` function into SendAssetFormModal class
- added `resetForm`, and `fillFromQR` to `SendAssetFormModal` and `StakeValidator` classes 
- changed `handleQRFileSelect` to accept a modal instead of a fillFunction. Now it calls resetForm and FillFromQR for the given modal