### PR TITLE
Refactor Modal Initialization: Move DOM Element References to load() Methods

### DIFF
--- a/app.js
+++ b/app.js
@@ -4817,21 +4817,25 @@ const restoreAccountModal = new RestoreAccountModal();
 
 class TollModal {
   constructor() {
-    this.modal = document.getElementById('tollModal');
     this.currentCurrency = 'LIB'; // Initialize currency state
     this.oldToll = null;
     this.minToll = null; // Will be set from network account
+  }
+
+  load() {
+    this.modal = document.getElementById('tollModal');
     this.minTollDisplay = document.getElementById('minTollDisplay');
     this.newTollAmountInputElement = document.getElementById('newTollAmountInput');
     this.toggleTollCurrencyElement = document.getElementById('toggleTollCurrency');
     this.warningMessageElement = document.getElementById('tollWarningMessage');
     this.saveButton = document.getElementById('saveNewTollButton');
-  }
-
-  load() {
-    document.getElementById('closeTollModal').addEventListener('click', () => this.close());
+    this.closeButton = document.getElementById('closeTollModal');
+    this.tollForm = document.getElementById('tollForm');
+    this.tollCurrencySymbol = document.getElementById('tollCurrencySymbol');
+    
+    this.tollForm.addEventListener('submit', (event) => this.saveAndPostNewToll(event));
+    this.closeButton.addEventListener('click', () => this.close());
     this.toggleTollCurrencyElement.addEventListener('click', (event) => this.handleToggleTollCurrency(event));
-    document.getElementById('tollForm').addEventListener('submit', (event) => this.saveAndPostNewToll(event));
     this.newTollAmountInputElement.addEventListener('input', () => this.newTollAmountInputElement.value = normalizeUnsignedFloat(this.newTollAmountInputElement.value));
     this.newTollAmountInputElement.addEventListener('input', () => this.updateSaveButtonState());
   }
@@ -4848,7 +4852,7 @@ class TollModal {
     this.updateTollDisplay(toll, tollUnit);
 
     this.currentCurrency = tollUnit;
-    document.getElementById('tollCurrencySymbol').textContent = this.currentCurrency;
+    this.tollCurrencySymbol.textContent = this.currentCurrency;
     this.newTollAmountInputElement.value = ''; // Clear input field
     this.warningMessageElement.textContent = '';
     this.warningMessageElement.style.display = 'none';
@@ -4870,18 +4874,16 @@ class TollModal {
    */
   async handleToggleTollCurrency(event) {
     event.preventDefault();
-    const newTollAmountInput = document.getElementById('newTollAmountInput');
-    const tollCurrencySymbol = document.getElementById('tollCurrencySymbol');
 
     this.currentCurrency = this.currentCurrency === 'LIB' ? 'USD' : 'LIB';
-    tollCurrencySymbol.textContent = this.currentCurrency;
+    this.tollCurrencySymbol.textContent = this.currentCurrency;
 
     const scalabilityFactor = parameters.current.stabilityScaleMul / parameters.current.stabilityScaleDiv;
-    if (newTollAmountInput.value !== '') {
-      const currentValue = parseFloat(newTollAmountInput.value);
+    if (this.newTollAmountInputElement.value !== '') {
+      const currentValue = parseFloat(this.newTollAmountInputElement.value);
       const convertedValue =
         this.currentCurrency === 'USD' ? currentValue * scalabilityFactor : currentValue / scalabilityFactor;
-      newTollAmountInput.value = convertedValue.toString();
+      this.newTollAmountInputElement.value = convertedValue.toString();
     }
 
     // Update min toll display with converted value
@@ -4901,8 +4903,7 @@ class TollModal {
    */
   async saveAndPostNewToll(event) {
     event.preventDefault();
-    const newTollAmountInput = document.getElementById('newTollAmountInput');
-    let newTollValue = parseFloat(newTollAmountInput.value);
+    let newTollValue = parseFloat(this.newTollAmountInputElement.value);
 
     // disable submit button
     this.saveButton.disabled = true;
@@ -4912,7 +4913,7 @@ class TollModal {
       return;
     }
 
-    const newToll = bigxnum2big(wei, newTollAmountInput.value);
+    const newToll = bigxnum2big(wei, this.newTollAmountInputElement.value);
 
     // Check if the toll is non-zero but less than minimum
     if (newToll > 0n) {

--- a/app.js
+++ b/app.js
@@ -425,6 +425,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Failed Transaction Modal
   failedTransactionModal.load();
+  
+  // Friend Modal
+  friendModal.load();
 
   // add event listener for back-button presses to prevent shift+tab
   document.querySelectorAll('.back-button').forEach((button) => {
@@ -2095,10 +2098,9 @@ class FriendModal {
   constructor() {
     this.currentContactAddress = null;
     this.needsContactListUpdate = false; // track if we need to update the contact list
-    this.setupEventListeners();
   }
 
-  setupEventListeners() {
+  load() {
     this.modal = document.getElementById('friendModal');
     this.friendForm = document.getElementById('friendForm');
 

--- a/app.js
+++ b/app.js
@@ -6968,6 +6968,12 @@ class ChatModal {
 
 const chatModal = new ChatModal();
 
+/**
+ * Failed Message Modal Class
+ * @class
+ * @description Handles the failed message modal
+ * @returns {void}
+ */
 class FailedMessageModal {
   constructor() {
     this.handleFailedMessageData = {
@@ -7089,15 +7095,14 @@ class FailedMessageModal {
 
 const failedMessageModal = new FailedMessageModal();
 
-// new chat modal
+/**
+ * New Chat Modal Class
+ * @class
+ * @description Handles the new chat modal
+ * @returns {void}
+ */
 class NewChatModal {
   constructor() {
-    this.modal = document.getElementById('newChatModal');
-    this.closeNewChatModalButton = document.getElementById('closeNewChatModal');
-    this.newChatForm = document.getElementById('newChatForm');
-    this.usernameAvailable = document.getElementById('chatRecipientError');
-    this.recipientInput = document.getElementById('chatRecipient');
-    this.submitButton = document.querySelector('#newChatForm button[type="submit"]');
     this.usernameInputCheckTimeout = null;
   }
 
@@ -7106,6 +7111,13 @@ class NewChatModal {
    * @returns {void}
    */
   load() {
+    this.modal = document.getElementById('newChatModal');
+    this.closeNewChatModalButton = document.getElementById('closeNewChatModal');
+    this.newChatForm = document.getElementById('newChatForm');
+    this.usernameAvailable = document.getElementById('chatRecipientError');
+    this.recipientInput = document.getElementById('chatRecipient');
+    this.submitButton = document.querySelector('#newChatForm button[type="submit"]');
+
     this.closeNewChatModalButton.addEventListener('click', this.closeNewChatModal.bind(this));
     this.newChatForm.addEventListener('submit', this.handleNewChat.bind(this));
     this.recipientInput.addEventListener('input', debounce(this.handleUsernameInput.bind(this), 300));

--- a/app.js
+++ b/app.js
@@ -1973,7 +1973,7 @@ class ContactInfoModal {
     // Add add friend button handler
     this.addFriendButton.addEventListener('click', () => {
       if (!this.currentContactAddress) return;
-      friendModal.openFriendModal();
+      friendModal.open();
     });
   }
 
@@ -2093,18 +2093,14 @@ const contactInfoModal = new ContactInfoModal();
  */
 class FriendModal {
   constructor() {
-    this.modal = document.getElementById('friendModal');
-    this.friendForm = document.getElementById('friendForm');
     this.currentContactAddress = null;
     this.needsContactListUpdate = false; // track if we need to update the contact list
     this.setupEventListeners();
   }
 
   setupEventListeners() {
-    document.getElementById('addFriendButtonChat').addEventListener('click', () => {
-      if (!this.currentContactAddress) return;
-      this.openFriendModal();
-    });
+    this.modal = document.getElementById('friendModal');
+    this.friendForm = document.getElementById('friendForm');
 
     // Friend modal form submission
     this.friendForm.addEventListener('submit', (event) => this.handleFriendSubmit(event));
@@ -2114,7 +2110,7 @@ class FriendModal {
   }
 
   // Open the friend modal
-  openFriendModal() {
+  open() {
     const contact = myData.contacts[this.currentContactAddress];
     if (!contact) return;
 
@@ -2230,6 +2226,11 @@ class FriendModal {
     button.classList.remove('status-0', 'status-1', 'status-2', 'status-3');
     // Add the current status class
     button.classList.add(`status-${contact.friend}`);
+  }
+
+  // get the current contact address
+  getCurrentContactAddress() {
+    return this.currentContactAddress || false;
   }
 }
 
@@ -6044,6 +6045,7 @@ class ChatModal {
     this.chatSendMoneyButton = document.getElementById('chatSendMoneyButton');
     this.messageByteCounter = document.querySelector('.message-byte-counter');
     this.messagesContainer = document.querySelector('.messages-container');
+    this.addFriendButtonChat = document.getElementById('addFriendButtonChat');
 
     // Add message click-to-copy handler
     this.messagesList.addEventListener('click', this.handleClickToCopy.bind(this));
@@ -6087,6 +6089,11 @@ class ChatModal {
     this.chatSendMoneyButton.addEventListener('click', () => {
       sendAssetFormModal.username = this.chatSendMoneyButton.dataset.username;
       sendAssetFormModal.open();
+    });
+
+    this.addFriendButtonChat.addEventListener('click', () => {
+      if (!friendModal.getCurrentContactAddress()) return;
+      friendModal.open();
     });
   }
 

--- a/app.js
+++ b/app.js
@@ -333,6 +333,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   window.addEventListener('beforeunload', handleBeforeUnload);
   document.addEventListener('visibilitychange', handleVisibilityChange); // Keep as document
 
+  // Sign In Modal
+  signInModal.load();
+
   // Welcome Screen
   welcomeScreen.load()
 
@@ -1320,7 +1323,6 @@ class WalletScreen {
 
 const walletScreen = new WalletScreen();
 
-// create new contact
 /**
  * createNewContact
  * @param {string} addr - the address of the contact
@@ -1702,6 +1704,10 @@ async function validateBalance(amount, assetIndex = 0, balanceWarning = null) {
 // Sign In Modal Management
 class SignInModal {
   constructor() {
+    this.preselectedUsername = null;
+  }
+
+  load () {
     this.modal = document.getElementById('signInModal');
     this.usernameSelect = document.getElementById('username');
     this.submitButton = document.querySelector('#signInForm button[type="submit"]');
@@ -1709,11 +1715,7 @@ class SignInModal {
     this.notFoundMessage = document.getElementById('usernameNotFound');
     this.signInModalLastItem = document.getElementById('signInModalLastItem');
     this.backButton = document.getElementById('closeSignInModal');
-    this.setupEventListeners();
-    this.preselectedUsername = null;
-  }
 
-  setupEventListeners() {
     // Sign in form submission
     document.getElementById('signInForm').addEventListener('submit', (event) => this.handleSignIn(event));
     

--- a/app.js
+++ b/app.js
@@ -7650,34 +7650,19 @@ class CreateAccountModal {
 // Initialize the create account modal
 const createAccountModal = new CreateAccountModal();
 
-// Send Asset Form Modal
+/**
+ * Send Asset Form Modal Class
+ * @class
+ * @description Handles the send asset form modal
+ * @returns {void}
+ */
 class SendAssetFormModal {
   constructor() {
-    this.modal = document.getElementById('sendAssetFormModal');
-    this.closeSendAssetFormModalButton = document.getElementById('closeSendAssetFormModal');
-    this.sendForm = document.getElementById('sendForm');
     this.username = null;
-    this.usernameInput = document.getElementById('sendToAddress');
-    this.amountInput = document.getElementById('sendAmount');
-    this.memoInput = document.getElementById('sendMemo');
-    this.retryTxIdInput = document.getElementById('retryOfPaymentTxId');
-    this.usernameAvailable = document.getElementById('sendToAddressError');
-    this.submitButton = document.querySelector('#sendForm button[type="submit"]');
-    this.assetSelectDropdown = document.getElementById('sendAsset');
     this.sendAssetFormModalCheckTimeout = null;
-    this.balanceSymbol = document.getElementById('balanceSymbol');
-    this.availableBalance = document.getElementById('availableBalance');
-    this.toggleBalanceButton = document.getElementById('toggleBalance');
     this.foundAddressObject = { address: null };
     this.needTollInfo = false;
     this.tollInfo = {};
-    this.tollMemoSpan = document.getElementById('tollMemo');
-    // Add balance element references
-    this.balanceAmount = document.getElementById('balanceAmount');
-    this.transactionFee = document.getElementById('transactionFee');
-    this.balanceWarning = document.getElementById('balanceWarning');
-    this.memoLabel = document.querySelector('label[for="sendMemo"]');
-    this.memoByteCounter = document.querySelector('.memo-byte-counter');
     this.memoValidation = {}
   }
 
@@ -7686,6 +7671,27 @@ class SendAssetFormModal {
    * @returns {void}
    */
   load() {
+    this.modal = document.getElementById('sendAssetFormModal');
+    this.closeSendAssetFormModalButton = document.getElementById('closeSendAssetFormModal');
+    this.sendForm = document.getElementById('sendForm');
+    this.usernameInput = document.getElementById('sendToAddress');
+    this.amountInput = document.getElementById('sendAmount');
+    this.memoInput = document.getElementById('sendMemo');
+    this.retryTxIdInput = document.getElementById('retryOfPaymentTxId');
+    this.usernameAvailable = document.getElementById('sendToAddressError');
+    this.submitButton = document.querySelector('#sendForm button[type="submit"]');
+    this.assetSelectDropdown = document.getElementById('sendAsset');
+    this.balanceSymbol = document.getElementById('balanceSymbol');
+    this.availableBalance = document.getElementById('availableBalance');
+    this.toggleBalanceButton = document.getElementById('toggleBalance');
+    this.tollMemoSpan = document.getElementById('tollMemo');
+    // Add balance element references
+    this.balanceAmount = document.getElementById('balanceAmount');
+    this.transactionFee = document.getElementById('transactionFee');
+    this.balanceWarning = document.getElementById('balanceWarning');
+    this.memoLabel = document.querySelector('label[for="sendMemo"]');
+    this.memoByteCounter = document.querySelector('.memo-byte-counter');
+
     // TODO add comment about which send form this is for chat or assets
     this.closeSendAssetFormModalButton.addEventListener('click', this.close.bind(this));
     this.sendForm.addEventListener('submit', this.handleSendFormSubmit.bind(this));

--- a/app.js
+++ b/app.js
@@ -6970,11 +6970,6 @@ const chatModal = new ChatModal();
 
 class FailedMessageModal {
   constructor() {
-    this.modal = document.getElementById('failedMessageModal');
-    this.retryButton = this.modal.querySelector('.retry-button');
-    this.deleteButton = this.modal.querySelector('.delete-button');
-    this.closeButton = document.getElementById('closeFailedMessageModal');
-    // used by handleFailedMessageClick
     this.handleFailedMessageData = {
       handleFailedMessage: '',
       txid: '',
@@ -6986,6 +6981,11 @@ class FailedMessageModal {
    * @returns {void}
    */
   load() {
+    this.modal = document.getElementById('failedMessageModal');
+    this.retryButton = this.modal.querySelector('.retry-button');
+    this.deleteButton = this.modal.querySelector('.delete-button');
+    this.closeButton = document.getElementById('closeFailedMessageModal');
+
     this.retryButton.addEventListener('click', this.handleFailedMessageRetry.bind(this));
     this.deleteButton.addEventListener('click', this.handleFailedMessageDelete.bind(this));
     this.closeButton.addEventListener('click', this.closeFailedMessageModalAndClearState.bind(this));

--- a/app.js
+++ b/app.js
@@ -4832,7 +4832,7 @@ class TollModal {
     this.closeButton = document.getElementById('closeTollModal');
     this.tollForm = document.getElementById('tollForm');
     this.tollCurrencySymbol = document.getElementById('tollCurrencySymbol');
-    
+
     this.tollForm.addEventListener('submit', (event) => this.saveAndPostNewToll(event));
     this.closeButton.addEventListener('click', () => this.close());
     this.toggleTollCurrencyElement.addEventListener('click', (event) => this.handleToggleTollCurrency(event));
@@ -5111,19 +5111,20 @@ const tollModal = new TollModal();
 
 // Invite Modal
 class InviteModal {
-  constructor() {
+  constructor() {}
+
+  load() {
     this.modal = document.getElementById('inviteModal');
     this.inviteEmailInput = document.getElementById('inviteEmail');
     this.invitePhoneInput = document.getElementById('invitePhone');
     this.submitButton = document.querySelector('#inviteForm button[type="submit"]');
-  }
+    this.closeButton = document.getElementById('closeInviteModal');
+    this.inviteForm = document.getElementById('inviteForm');
 
-  load() {
-    // Set up event listeners
-    document.getElementById('closeInviteModal').addEventListener('click', () => this.close());
-    document.getElementById('inviteForm').addEventListener('submit', (event) => this.handleSubmit(event));
+    this.closeButton.addEventListener('click', () => this.close());
+    this.inviteForm.addEventListener('submit', (event) => this.handleSubmit(event));
 
-    // Add input event listeners for email and phone fields
+    // input event listeners for email and phone fields
     this.inviteEmailInput.addEventListener('input', () => this.inviteEmailInput.value = normalizeEmail(this.inviteEmailInput.value));
     this.inviteEmailInput.addEventListener('input', () => this.validateInputs());
     this.invitePhoneInput.addEventListener('input', () => this.invitePhoneInput.value = normalizePhone(this.invitePhoneInput.value));

--- a/app.js
+++ b/app.js
@@ -5196,18 +5196,22 @@ class InviteModal {
 const inviteModal = new InviteModal();
 
 class AboutModal {
-  constructor() {
-    this.modal = document.getElementById('aboutModal');
-  }
+  constructor() {}
 
   load() {
+    this.modal = document.getElementById('aboutModal');
+    this.closeButton = document.getElementById('closeAboutModal');
+    this.versionDisplay = document.getElementById('versionDisplayAbout');
+    this.networkName = document.getElementById('networkNameAbout');
+    this.netId = document.getElementById('netIdAbout');
+
     // Set up event listeners
-    document.getElementById('closeAboutModal').addEventListener('click', () => this.close());
+    this.closeButton.addEventListener('click', () => this.close());
 
     // Set version and network information once during initialization
-    document.getElementById('versionDisplayAbout').textContent = myVersion + ' ' + version;
-    document.getElementById('networkNameAbout').textContent = network.name;
-    document.getElementById('netIdAbout').textContent = network.netid;
+    this.versionDisplay.textContent = myVersion + ' ' + version;
+    this.networkName.textContent = network.name;
+    this.netId.textContent = network.netid;
   }
 
   open() {
@@ -5222,13 +5226,15 @@ class AboutModal {
 const aboutModal = new AboutModal();
 
 class ContactModal {
-  constructor() {
-    this.modal = document.getElementById('contactModal');
-  }
+  constructor() {}
 
   load() {
-    document.getElementById('closeContactModal').addEventListener('click', () => this.close());
-    document.getElementById('submitFeedback').addEventListener('click', () => {
+    this.modal = document.getElementById('contactModal');
+    this.closeButton = document.getElementById('closeContactModal');
+    this.submitFeedbackButton = document.getElementById('submitFeedback');
+
+    this.closeButton.addEventListener('click', () => this.close());
+    this.submitFeedbackButton.addEventListener('click', () => {
       window.open('https://github.com/liberdus/web-client-v2/issues', '_blank');
     });
   }
@@ -5244,21 +5250,23 @@ class ContactModal {
 const contactModal = new ContactModal();
 
 class MyProfileModal {
-  constructor() {
-    this.name = document.getElementById('name');
-    this.email = document.getElementById('email');
-    this.phone = document.getElementById('phone');
-    this.linkedin = document.getElementById('linkedin');
-    this.x = document.getElementById('x');
-  }
+  constructor() {}
 
   load() {
     // called when the DOM is loaded; can setup event handlers here
     this.modal = document.getElementById('accountModal');
     this.closeButton = document.getElementById('closeAccountForm');
-    this.closeButton.addEventListener('click', () => this.close());
-    document.getElementById('accountForm').addEventListener('submit', (event) => this.handleSubmit(event));
+    this.name = document.getElementById('name');
+    this.email = document.getElementById('email');
+    this.phone = document.getElementById('phone');
+    this.linkedin = document.getElementById('linkedin');
+    this.x = document.getElementById('x');
+    this.accountForm = document.getElementById('accountForm');
     this.submitButton = document.querySelector('#accountForm .update-button');
+
+    this.closeButton.addEventListener('click', () => this.close());
+    this.accountForm.addEventListener('submit', (event) => this.handleSubmit(event));
+    
 
     // Add input event listeners for validation
     this.name.addEventListener('input', (e) => this.handleNameInput(e));

--- a/app.js
+++ b/app.js
@@ -5381,7 +5381,9 @@ class MyProfileModal {
 const myProfileModal = new MyProfileModal();
 
 class ValidatorStakingModal {
-  constructor() {
+  constructor() {}
+
+  load() {
     // Modal and main buttons
     this.modal = document.getElementById('validatorModal');
     this.stakeButton = document.getElementById('openStakeModal');
@@ -5412,14 +5414,9 @@ class ValidatorStakingModal {
     this.marketPriceValue = document.getElementById('validator-market-price');
     this.marketStakeUsdValue = document.getElementById('validator-market-stake-usd');
     this.stakeForm = document.getElementById('stakeForm');
-  }
 
-  load() {
-    // Setup event listeners when DOM is loaded
-    // stakeButton handling is in the StakeValidatorModal
+
     this.unstakeButton.addEventListener('click', () => this.handleUnstake());
-
-    // Add listeners for opening and closing the modal
     this.backButton.addEventListener('click', () => this.close());
   }
 


### PR DESCRIPTION
## PR Summary

**Reason for PR:**
• Standardizes modal initialization pattern across all modal classes
• Improves code maintainability by centralizing DOM element references in load() methods
• Ensures consistent event listener setup timing

**Changes Made:**
• **SignInModal**: Moved DOM element references from constructor to `load()` method and added `preselectedUsername` property
• **FriendModal**: Refactored to store DOM elements in `load()` method and renamed `openFriendModal()` to `open()`
• **TollModal**: Moved all DOM element references and event listeners to `load()` method
• **InviteModal**: Restructured to initialize DOM elements in `load()` method
• **AboutModal**: Moved DOM element references from constructor to `load()` method
• **ContactModal**: Refactored to store DOM elements in `load()` method
• **MyProfileModal**: Moved DOM element initialization to `load()` method
• **ValidatorStakingModal**: Restructured to initialize DOM elements in `load()` method
• **FailedMessageModal**: Moved DOM element references to `load()` method and added proper JSDoc comments
• **NewChatModal**: Moved DOM element initialization to `load()` method
• **SendAssetFormModal**: Moved DOM element references and properties to `load()` method
• **ChatModal**: Added friend button event listener and `getCurrentContactAddress()` method
• **ContactInfoModal**: Updated to use new `friendModal.open()` method
• **DOM Loading**: Added `signInModal.load()` and `friendModal.load()` calls to main initialization sequence

This refactoring ensures all modals follow a consistent pattern where DOM elements are referenced after the DOM is fully loaded, preventing potential null reference errors and improving code organization.