### PR TITLE
Enhance desktop styles in styles.css for header and button elements

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -345,6 +345,10 @@ body {
 }
 
 .header.active {
+  /* only want margin-top on desktop */
+  @media (min-width: 769px) {
+    margin-top: 16px;
+  }
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -861,6 +865,10 @@ button:disabled {
   display: flex;
   align-items: center;
   padding-top: calc(env(safe-area-inset-top));
+  /* only want + 16px on desktop */
+  @media (min-width: 769px) {
+    padding-top: calc(env(safe-area-inset-top) + 16px);
+  }
   background-color: var(--background-color);
   /* z-index: 1002; */
   position: relative;
@@ -1918,13 +1926,6 @@ input[type='file'].form-control {
 }
 
 /* About Modal Content Styles */
-#aboutModal .modal-header {
-  /* Inherited from .modal-header */
-  padding-top: calc(env(safe-area-inset-top, 0px));
-  position: sticky;
-  top: 0;
-}
-
 #aboutModal #netIdAbout {
   word-wrap: break-word;
 }


### PR DESCRIPTION
- Added media queries to apply margin-top and padding-top adjustments specifically for desktop viewports (min-width: 769px).
- Removed unnecessary top padding from the about modal header to streamline layout.