### PR TITLE
Fix: Password unlock now needed for restore modal when app is locked

### DIFF
--- a/app.js
+++ b/app.js
@@ -667,23 +667,9 @@ class WelcomeScreen {
     this.versionDisplay.textContent = myVersion + ' ' + version;
     this.networkNameDisplay.textContent = network.name;
     
-    this.signInButton.addEventListener('click', () => {
-      if (localStorage.lock && unlockModal.isLocked()) {
-        unlockModal.openButtonElementUsed = this.signInButton;
-        unlockModal.open();
-      } else {
-        signInModal.open();
-      }
-    });
-    this.createAccountButton.addEventListener('click', () => {
-      if (localStorage.lock && unlockModal.isLocked()) {
-        unlockModal.openButtonElementUsed = this.createAccountButton;
-        unlockModal.open();
-      } else {
-        createAccountModal.openWithReset();
-      }
-    });
-    this.importAccountButton.addEventListener('click', () => restoreAccountModal.open());
+    this.handleButtonWithLock(this.signInButton, () => signInModal.open());
+    this.handleButtonWithLock(this.createAccountButton, () => createAccountModal.openWithReset());
+    this.handleButtonWithLock(this.importAccountButton, () => restoreAccountModal.open());
 
     this.orderButtons();
   }
@@ -698,6 +684,22 @@ class WelcomeScreen {
 
   isActive() {
     return this.screen.style.display === 'flex';
+  }
+
+  /**
+   * Handle button click with lock check
+   * @param {HTMLElement} button - The button element to handle
+   * @param {Function} modalOpenFn - The function to call when the modal is opened
+   */
+  handleButtonWithLock(button, modalOpenFn) {
+    button.addEventListener('click', () => {
+      if (localStorage.lock && unlockModal.isLocked()) {
+        unlockModal.openButtonElementUsed = button;
+        unlockModal.open();
+      } else {
+        modalOpenFn();
+      }
+    });
   }
 
   orderButtons() {

--- a/app.js
+++ b/app.js
@@ -667,9 +667,31 @@ class WelcomeScreen {
     this.versionDisplay.textContent = myVersion + ' ' + version;
     this.networkNameDisplay.textContent = network.name;
     
-    this.handleButtonWithLock(this.signInButton, () => signInModal.open());
-    this.handleButtonWithLock(this.createAccountButton, () => createAccountModal.openWithReset());
-    this.handleButtonWithLock(this.importAccountButton, () => restoreAccountModal.open());
+    this.signInButton.addEventListener('click', () => {
+      if (localStorage.lock && unlockModal.isLocked()) {
+        unlockModal.openButtonElementUsed = this.signInButton;
+        unlockModal.open();
+      } else {
+        signInModal.open();
+      }
+    });
+    this.createAccountButton.addEventListener('click', () => {
+      if (localStorage.lock && unlockModal.isLocked()) {
+        unlockModal.openButtonElementUsed = this.createAccountButton;
+        unlockModal.open();
+      } else {
+        createAccountModal.openWithReset();
+      }
+    });
+
+    this.importAccountButton.addEventListener('click', () => {
+      if (localStorage.lock && unlockModal.isLocked()) {
+        unlockModal.openButtonElementUsed = this.importAccountButton;
+        unlockModal.open();
+      } else {
+        restoreAccountModal.open();
+      }
+    });
 
     this.orderButtons();
   }
@@ -684,22 +706,6 @@ class WelcomeScreen {
 
   isActive() {
     return this.screen.style.display === 'flex';
-  }
-
-  /**
-   * Handle button click with lock check
-   * @param {HTMLElement} button - The button element to handle
-   * @param {Function} modalOpenFn - The function to call when the modal is opened
-   */
-  handleButtonWithLock(button, modalOpenFn) {
-    button.addEventListener('click', () => {
-      if (localStorage.lock && unlockModal.isLocked()) {
-        unlockModal.openButtonElementUsed = button;
-        unlockModal.open();
-      } else {
-        modalOpenFn();
-      }
-    });
   }
 
   orderButtons() {
@@ -9612,6 +9618,8 @@ class UnlockModal {
       this.close();
       if (this.openButtonElementUsed === welcomeScreen.createAccountButton) {
         createAccountModal.openWithReset();
+      } else if (this.openButtonElementUsed === welcomeScreen.importAccountButton) {
+        restoreAccountModal.open();
       } else {
         signInModal.open();
       }


### PR DESCRIPTION
- **Reason for PR:**  
  Previously, when the app was locked and the user clicked "Import Account," user did not sign in causing problem when importing. This was due to missing logic in the unlock flow to handle the import account button.

- **Changes Made:**  
  - Updated the event handler for `importAccountButton` to check for lock status and open the unlock modal if needed, mirroring the logic for other account actions.
  - Enhanced the `UnlockModal` logic to track which button triggered the unlock modal. After a successful unlock, it now correctly opens the Restore Account modal if the import account button was used.
  - No changes to network.js are included in this summary.