### PR TITLE
Update balance warning display style and improve user feedback in asset transfer forms

### DIFF
--- a/app.js
+++ b/app.js
@@ -1820,7 +1820,7 @@ async function validateBalance(amount, assetIndex = 0, balanceWarning = null) {
   if (balanceWarning) balanceWarning.style.display = 'none';
   // not checking for 0 since we allow 0 amount for messages when toll is not required
   if (amount < 0n) {
-    if (balanceWarning) balanceWarning.style.display = 'block';
+    if (balanceWarning) balanceWarning.style.display = 'inline';
     balanceWarning.textContent = 'Amount cannot be negative';
     return false;
   }
@@ -1834,7 +1834,7 @@ async function validateBalance(amount, assetIndex = 0, balanceWarning = null) {
   if (balanceWarning) {
     if (hasInsufficientBalance) {
       balanceWarning.textContent = `Insufficient balance (including ${big2str(feeInWei, 18).slice(0, -16)} LIB fee)`;
-      balanceWarning.style.display = 'block';
+      balanceWarning.style.display = 'inline';
     } else {
       balanceWarning.style.display = 'none';
     }
@@ -8217,8 +8217,8 @@ class SendAssetFormModal {
           `toll > amount  ${big2str(tollInLIB, 8)} > ${big2str(amountInLIB, 8)} : ${tollInLIB > amountInLIB}`
         );
         if (tollInLIB > amountInLIB) {
-          this.balanceWarning.textContent = 'Amount is less than toll for memo.';
-          this.balanceWarning.style.display = 'block';
+          this.balanceWarning.textContent = 'less than toll for memo';
+          this.balanceWarning.style.display = 'inline';
           return false;
         }
       }

--- a/index.html
+++ b/index.html
@@ -826,7 +826,9 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="sendAmount">Amount</label>
+              <label for="sendAmount">
+                Amount <span id="balanceWarning" class="balance-warning"></span>
+              </label>
               <div class="amount-container">
                 <input
                   type="text"
@@ -839,7 +841,6 @@
                   <span id="balanceSymbol">LIB</span>
                 </button>
               </div>
-              <div id="balanceWarning" class="balance-warning"></div>
               <div id="availableBalance" class="available-balance">
                 <div class="balance-info">
                   <span>Available: <span id="balanceAmount">0.00 LIB</span></span>

--- a/styles.css
+++ b/styles.css
@@ -1851,7 +1851,12 @@ input[type='file'].form-control {
   color: var(--secondary-text-color);
 }
 
-.balance-warning,
+.balance-warning {
+  font-size: 0.8em;
+  color: var(--danger-color);
+  display: none;
+}
+
 #stakeAmountWarning,
 #stakeNodeAddressWarning {
   /* Added new ID */
@@ -4674,7 +4679,6 @@ small {
   font-weight: 500;
   color: var(--secondary-text-color);
   display: inline-block; /* Ensure consistent layout */
-  min-height: 1.3em; /* Match parent's line-height */
 }
 
 .last-item {


### PR DESCRIPTION
- Changed balance warning display style from 'block' to 'inline' for better integration with the UI.
- Updated HTML structure to include balance warning directly within the label for the amount input.
- Adjusted CSS for balance warning to ensure consistent styling and visibility.