### PR TITLE
Fix filename generation in BackupAccountModal to use default method without username since myData not present

### DIFF
--- a/app.js
+++ b/app.js
@@ -4471,7 +4471,7 @@ class BackupAccountModal {
       // Create and trigger download
       const blob = new Blob([finalData], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
-      const filename = this.generateBackupFilename(myAccount.username);
+      const filename = this.generateBackupFilename();
       // Detect if running inside React Native WebView
       if (window.ReactNativeWebView?.postMessage) {
         // ✅ React Native WebView: Send base64 via postMessage


### PR DESCRIPTION
Fixes this error `app.js:4502 Encryption failed: TypeError: Cannot read properties of null (reading 'username')`
