### PR TITLE
Encrypt attachment with webworker

### DIFF
--- a/app.js
+++ b/app.js
@@ -7025,7 +7025,7 @@ console.warn('in send message', txid)
       event.target.value = ''; // Reset file input
       return;
     }
-    
+
     // Validate file type
     const allowedTypePrefixes = ['image/', 'audio/', 'video/'];
     const allowedExplicitTypes = [
@@ -7074,6 +7074,7 @@ console.warn('in send message', txid)
         hideToast(loadingToastId);
         showToast(`File encryption failed: ${err.message}`, 3000, 'error');
         this.isEncrypting = false;
+        this.submitButton.disabled = false; // Re-enable send button
         worker.terminate();
       };
       

--- a/app.js
+++ b/app.js
@@ -7025,28 +7025,16 @@ console.warn('in send message', txid)
       event.target.value = ''; // Reset file input
       return;
     }
-
-    // Optional: File type validation
-    // add video file types
-    const allowedTypes = [
-      // images
-      'image/jpeg', 'image/png', 'image/gif', 'image/webp',
-
-      // video
-      'video/mp4', 'video/quicktime', 'video/webm', 'video/ogg',
-      'video/x-msvideo', 'video/x-ms-wmv', 'video/x-flv', 'video/x-matroska',
-
-      // audio
-      'audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/webm',
-      'audio/x-m4a', 'audio/aac', 'audio/flac',
-
-      // docs
-      'application/pdf', 'text/plain',
-      'application/msword',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-    ];
     
-    if (!allowedTypes.includes(file.type)) {
+    // Validate file type
+    const allowedTypePrefixes = ['image/', 'audio/', 'video/'];
+    const allowedExplicitTypes = [
+      'application/pdf', // PDF
+      'text/plain',      // TXT
+      'application/msword', // DOC
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document' // DOCX
+    ];
+    if (!(allowedTypePrefixes.some(prefix => file.type.startsWith(prefix)) || allowedExplicitTypes.includes(file.type))) {
       showToast('File type not supported.', 3000, 'error');
       event.target.value = ''; // Reset file input
       return;

--- a/app.js
+++ b/app.js
@@ -7029,10 +7029,21 @@ console.warn('in send message', txid)
     // Optional: File type validation
     // add video file types
     const allowedTypes = [
+      // images
       'image/jpeg', 'image/png', 'image/gif', 'image/webp',
-      'application/pdf', 'text/plain', 'application/msword',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'video/mp4', 'video/quicktime', 'video/webm', 'video/ogg', 'video/mov', 'video/avi', 'video/wmv', 'video/flv', 'video/mkv'
+
+      // video
+      'video/mp4', 'video/quicktime', 'video/webm', 'video/ogg',
+      'video/x-msvideo', 'video/x-ms-wmv', 'video/x-flv', 'video/x-matroska',
+
+      // audio
+      'audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/webm',
+      'audio/x-m4a', 'audio/aac', 'audio/flac',
+
+      // docs
+      'application/pdf', 'text/plain',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     ];
     
     if (!allowedTypes.includes(file.type)) {
@@ -7044,7 +7055,7 @@ console.warn('in send message', txid)
     try {
       this.isEncrypting = true;
       this.sendButton.disabled = true; // Disable send button during encryption
-      const loadingToastId = showToast(`Encrypting ${file.name}...`, 0, 'loading');
+      const loadingToastId = showToast(`Encrypting file...`, 0, 'loading');
       const { dhkey, cipherText: pqEncSharedKey } = await this.getRecipientDhKey(this.address);
 
       const worker = new Worker('encryption.worker.js', { type: 'module' });

--- a/app.js
+++ b/app.js
@@ -7044,7 +7044,7 @@ console.warn('in send message', txid)
     try {
       this.isEncrypting = true;
       this.sendButton.disabled = true; // Disable send button during encryption
-      const loadingToastId = showToast(`Encrypting ${file.name}...`, 1000, 'loading');
+      const loadingToastId = showToast(`Encrypting ${file.name}...`, 0, 'loading');
       const { dhkey, cipherText: pqEncSharedKey } = await this.getRecipientDhKey(this.address);
 
       const worker = new Worker('encryption.worker.js', { type: 'module' });
@@ -7056,8 +7056,9 @@ console.warn('in send message', txid)
           this.sendButton.disabled = false; // Re-enable send button
         } else {
           // Encryption successful
+          // upload to get url here 
           this.fileAttachments.push({
-            encryptedBuffer: e.data.encryptedFileBuffer,
+            file: file,
             name: file.name,
             size: file.size,
             type: file.type,

--- a/app.js
+++ b/app.js
@@ -7052,7 +7052,7 @@ console.warn('in send message', txid)
         hideToast(loadingToastId);
         this.isEncrypting = false;
         if (e.data.error) {
-          showToast(`File encryption failed: ${e.data.error}`, 3000, 'error');
+          showToast(e.data.error, 3000, 'error');
           this.sendButton.disabled = false; // Re-enable send button
         } else {
           // Encryption successful

--- a/crypto.js
+++ b/crypto.js
@@ -36,7 +36,7 @@ const myHashKey = hex2bin('69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96
 
 // Core encryption functions
 export function encryptChacha(key, data) {
-    const nonce = window.crypto.getRandomValues(new Uint8Array(24))
+    const nonce = globalThis.crypto.getRandomValues(new Uint8Array(24))
     const cipher = xchacha20poly1305(key, nonce);
     const encrypted = cipher.encrypt(utf82bin(data));
 

--- a/encryption.worker.js
+++ b/encryption.worker.js
@@ -1,0 +1,22 @@
+import { encryptChacha } from './crypto.js?';
+import { bin2base64 } from './lib.js?';
+
+self.onmessage = async (event) => {
+  const { fileBuffer, dhkey } = event.data;
+
+  try {
+    const bytes = new Uint8Array(fileBuffer);
+    const b64Plain = bin2base64(bytes);
+
+    const cipherB64 = encryptChacha(dhkey, b64Plain);
+
+    if (!cipherB64) {
+      throw new Error("Encryption returned null or undefined.");
+    }
+
+    self.postMessage({ encryptedFileBuffer: cipherB64 });;
+
+  } catch (error) {
+    self.postMessage({ error: `Encryption failed: ${error.message}` });
+  }
+};

--- a/index.html
+++ b/index.html
@@ -562,9 +562,9 @@
             <input type="hidden" id="retryOfTxId" />
             <!-- Add hidden file input for chat attachments -->
             <input type="file" id="chatFileInput"
-            accept=".jpg,.jpeg,.png,.gif,.webp,
-            .mp4,.mov,.webm,.ogg,.ogv,.avi,.wmv,.flv,.mkv,
-            .mp3,.wav,.ogg,.m4a,.aac,.flac,
+            accept="image/*,video/*,audio/*,video/mp4,video/x-m4v,
+            .jpg,.jpeg,.png,.gif,.webp,.mp4,.mov,.webm,.ogg,.ogv,
+            .avi,.wmv,.flv,.mkv,.mp3,.wav,.ogg,.m4a,.aac,.flac,
             .pdf,.txt,.doc,.docx"
             style="display:none;">
             <button class="send-button" id="handleSendMessage">

--- a/index.html
+++ b/index.html
@@ -561,7 +561,12 @@
             </div>
             <input type="hidden" id="retryOfTxId" />
             <!-- Add hidden file input for chat attachments -->
-            <input type="file" id="chatFileInput" accept="image/*,.pdf,.txt,.doc,.docx" style="display: none;" />
+            <input type="file" id="chatFileInput"
+            accept=".jpg,.jpeg,.png,.gif,.webp,
+            .mp4,.mov,.webm,.ogg,.ogv,.avi,.wmv,.flv,.mkv,
+            .mp3,.wav,.ogg,.m4a,.aac,.flac,
+            .pdf,.txt,.doc,.docx"
+            style="display:none;">
             <button class="send-button" id="handleSendMessage">
               <svg viewBox="0 0 24 24">
                 <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />


### PR DESCRIPTION
- when a file is selected it is encrypted via a web worker
- change to crypto.js use globalThis instead of window since window is [not available to workers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#description) 
- nothing happens with the encrypted file yet, next step will be to upload and get a url to download