### PR TITLE
Decrypt Encrypted File Attachments (`xattach`) in Chat Messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,6 +121,7 @@ import {
   generateAddress,
   passwordToKey,
   dhkeyCombined,
+  decryptChacha,
 } from './crypto.js?';
 
 // Put standalone conversion function in lib.js
@@ -3017,6 +3018,20 @@ if (mine) console.warn('txid in processChats is', txidHex)
               }
             }
             payload.public = senderPublic;
+          }
+          if (payload.xattach && typeof payload.xattach === 'string') {
+            try {
+              // if mine, use selfKey to get dhkey
+              // if not mine, use public key and pqEncSharedKey to get dhkey
+              const dhkey = mine 
+                ? hex2bin(decryptData(payload.selfKey, keys.secret + keys.pqSeed, true))
+                : dhkeyCombined(keys.secret, payload.public, keys.pqSeed, payload.pqEncSharedKey).dhkey;
+              const decryptedAttachData = decryptChacha(dhkey, payload.xattach);
+              payload.xattach = parse(decryptedAttachData);
+            } catch (error) {
+              console.error('Failed to decrypt xattach:', error);
+              delete payload.xattach;
+            }
           }
           //console.log("payload", payload)
           decryptMessage(payload, keys, mine); // modifies the payload object


### PR DESCRIPTION
### PR Summary

**Reason for PR:**
- To ensure that file attachments sent in chat messages (the `xattach` field) are properly decrypted on the frontend, matching the security and privacy of the main message content.

**Key Changes:**
- **xattach Decryption Logic:**  
  - Added logic to `processChats` to decrypt the `xattach` field for both sent and received messages.
  - For your own messages (`mine`), the decryption uses the `selfKey` (mirroring how the main message is decrypted).
  - For received messages, the decryption uses the sender's public key and the post-quantum encrypted shared key, matching the encryption logic used when sending.
- **Cleaner, More Concise Code:**  
  - Uses a ternary operator to select the correct key derivation method based on message ownership.
  - Handles errors gracefully, removing the `xattach` field if decryption fails.
- **Import Update:**  
  - Ensures `decryptChacha` is imported from the crypto module.

**Impact:**
- File attachments are now decrypted and available for display in the chat UI, just like the main message text.
- The code is concise, readable, and robust against malformed or missing data.

---

**Result:**  
This change brings attachment decryption in line with message decryption, ensuring a seamless and secure user experience for file sharing in chats.