### PR TITLE
Add Launch URL Modal for ReactNativeWebView Integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -585,6 +585,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Lock Modal
   lockModal.load();
 
+  // Launch Modal
+  launchModal.load();
+
   // add event listener for back-button presses to prevent shift+tab
   document.querySelectorAll('.back-button').forEach((button) => {
     button.addEventListener('keydown', ignoreShiftTabKey);
@@ -1319,9 +1322,14 @@ class MenuModal {
     this.backupButton.addEventListener('click', () => backupAccountModal.open());
     this.bridgeButton = document.getElementById('openBridge');
     this.bridgeButton.addEventListener('click', () => bridgeModal.open());
+    this.launchButton = document.getElementById('openLaunchUrl');
+    this.launchButton.addEventListener('click', () => launchModal.open());
   }
 
   open() {
+    if (window.ReactNativeWebView) {
+      this.launchButton.style.display = 'block';
+    }
     this.modal.classList.add('active');
     enterFullscreen();
   }
@@ -10487,6 +10495,51 @@ class UnlockModal {
   }
 }
 const unlockModal = new UnlockModal();
+
+class LaunchModal {
+  constructor() {
+
+  }
+
+  load() {
+    this.modal = document.getElementById('launchModal');
+    this.closeButton = document.getElementById('closeLaunchModal');
+    this.launchForm = document.getElementById('launchForm');
+    this.urlInput = this.modal.querySelector('#url');
+    this.launchButton = this.modal.querySelector('button[type="submit"]');
+    this.closeButton.addEventListener('click', () => this.close());
+    this.launchForm.addEventListener('submit', (event) => this.handleSubmit(event));
+    this.urlInput.addEventListener('input', () => this.updateButtonState());
+  }
+
+  open() {
+    this.modal.classList.add('active');
+  }
+
+  close() {
+    this.urlInput.value = '';
+    this.modal.classList.remove('active');
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    const url = this.urlInput.value;
+    if (!url) {
+      showToast('Please enter a URL', 0, 'error');
+      return;
+    }
+    // open the url in the app
+    window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'launch', url }));
+    this.close();
+  }
+
+  updateButtonState() {
+    const url = this.urlInput.value;
+    this.launchButton.disabled = url.length === 0;
+  }
+}
+
+const launchModal = new LaunchModal();
 
 /**
  * Remove failed transaction from the contacts messages, pending, and wallet history

--- a/index.html
+++ b/index.html
@@ -228,6 +228,8 @@
           <li class="menu-item" id="openRemoveAccount" data-icon="trash-2">Remove</li>
           <li class="menu-item" id="openHelp" data-icon="github">Help</li>
           <li class="menu-item" id="openAbout" data-icon="info">About</li>
+          <!-- launch url that open a launchModal that only shows up when `window.ReactNativeWebView` is defined -->
+          <li class="menu-item" id="openLaunchUrl" data-icon="globe" style="display: none;">Launch</li>
           <li class="menu-item" id="handleSignOut" data-icon="log-out">Sign Out</li>
         </ul>
         <a class="last-item" href="#"> </a>
@@ -293,6 +295,24 @@
               <a class="about-link" href="./external/qr.js" target="_blank">qr.js</a>
             </div>
           </div>
+        </div>
+        <a class="last-item" href="#"> </a>
+      </div>
+
+      <!-- Launch Modal -->
+      <div class="modal" id="launchModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeLaunchModal"></button>
+          <div class="modal-title">Launch</div>
+        </div>
+        <div class="form-container">
+          <form id="launchForm">
+            <div class="form-group">
+              <label for="url">URL</label>
+              <input type="url" id="url" class="form-control" required />
+            </div>
+            <button type="submit" class="update-button" disabled>Launch</button>
+          </form>
         </div>
         <a class="last-item" href="#"> </a>
       </div>


### PR DESCRIPTION
### PR Summary

**Reason for PR:**
- To enable users to launch external URLs from within the app, specifically when running inside a ReactNativeWebView environment.
- To improve UX by conditionally showing the "Launch" menu item and modal only when the app is running in a compatible environment.

**Changes Made:**
- **Launch Modal Implementation:**
  - Added a new `LaunchModal` class in `app.js` to handle the modal's logic, including form validation, open/close behavior, and message posting to ReactNativeWebView.
  - Added initialization and event binding for the LaunchModal in the main app startup sequence.
- **Menu Integration:**
  - Added a new menu item ("Launch") in `index.html` with `id="openLaunchUrl"` and set its default style to `display: none;`.
  - In `MenuModal.open()`, the "Launch" menu item is shown (`display: block`) only if `window.ReactNativeWebView` is defined.
  - Clicking the menu item opens the LaunchModal.
- **Modal HTML:**
  - Added the Launch Modal HTML structure to `index.html`, including a form for entering a URL and a submit button.
  - Ensured all modal and form tags are properly closed to avoid DOM issues.
- **General:**
  - No changes to network.js, .gitignore, or settings.json (per instructions).
  - All new features are gated to only appear in the appropriate environment, preserving the experience for web users.

---

**This PR enables a new, environment-aware feature for launching URLs, with robust modal and menu integration, and ensures no impact on users outside the ReactNativeWebView context.**