### PR TITLE
Send empty array for unsubscribed addresses

### DIFF
--- a/app.js
+++ b/app.js
@@ -426,11 +426,9 @@ async function handleNativeAppUnsubscribe() {
 
   if (remainingAddresses.length === 0) {
     // This is the only account. Unsubscribe the device completely.
-    const DUMMY_ADDRESS = '0'.repeat(64);
     payload = {
       deviceToken,
-      addresses: [DUMMY_ADDRESS],
-      // no expoPushToken
+      addresses: [],
     };
   } else {
     // Other accounts remain. Update the subscription to only include them.


### PR DESCRIPTION
Replace the use of a dummy address with an empty array when unsubscribing.

[notification service now accepts an empty array to remove subscriptions](https://github.com/Liberdus/liberdus-notifcation-service/commit/4105c663311222db1aeee5fff064b79527f22965)