### PR TITLE
Validate URL Before Sending to RN in Launch Modal*

### DIFF
--- a/app.js
+++ b/app.js
@@ -10588,9 +10588,32 @@ class LaunchModal {
       showToast('Please enter a URL', 0, 'error');
       return;
     }
-    // open the url in the app
-    window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'launch', url }));
-    this.close();
+    
+    // Disable button and show loading state
+    this.launchButton.disabled = true;
+    this.launchButton.textContent = 'Checking URL...';
+    
+    // Validate URL by fetching it
+    fetch(url, { 
+      method: 'HEAD', 
+      mode: 'no-cors',
+      signal: AbortSignal.timeout(10000) // 10 second timeout
+    })
+      .then(() => {
+        // URL is reachable, proceed with launching
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'launch', url }));
+        this.close();
+      })
+      .catch((error) => {
+        // URL is not reachable or timed out
+        showToast('URL is not reachable. Please check the address and try again.', 0, 'error');
+        console.error('URL validation failed:', error);
+      })
+      .finally(() => {
+        // Reset button state
+        this.launchButton.disabled = false;
+        this.launchButton.textContent = 'Launch';
+      });
   }
 
   updateButtonState() {


### PR DESCRIPTION
### PR Summary

**Reason for PR:**
- Prevents users from launching invalid or unreachable URLs in the app, improving user experience and reducing errors.

**Changes Made:**
- Added URL validation in the `LaunchModal`:
  - When the user submits a URL, the app now attempts to fetch the URL using a `HEAD` request before sending it to the native app.
  - The launch button is disabled and shows a loading state ("Checking URL...") during validation.
  - If the URL is unreachable or times out, an error toast is shown and the user can try again.
  - If the URL is valid, the original launch action proceeds as before.
  - Button state is reset after the check, regardless of outcome.
- Error handling and user feedback are improved for a smoother experience.