### PR TITLE
Refine Reclaim Toll Error Handling to not show when toll pool is empty

### DIFF
--- a/app.js
+++ b/app.js
@@ -10939,7 +10939,9 @@ async function checkPendingTransactions() {
             // revert the local myData.contacts[toAddress].timestamp to the old value
             myData.contacts[pendingTxInfo.to].timestamp = pendingTxInfo.oldContactTimestamp;
           } else if (type === 'reclaim_toll') {
-            showToast(`Reclaim toll failed: ${failureReason}`, 0, 'error');
+            if (failureReason !== 'user is trying to reclaim toll but the toll pool is empty') {
+              showToast(`Reclaim toll failed: ${failureReason}`, 0, 'error');
+            }
           } else {
             // for messages, transfer etc.
             showToast(failureReason, 0, 'error');


### PR DESCRIPTION
### PR Summary

#### **Reason for PR**
- Refine reclaim toll error handling to avoid unnecessary error toasts when the toll pool is already empty.

#### **Changes Made**
- **Reclaim Toll Error Handling:**  
  - Updated logic so that if a reclaim toll transaction fails with the reason `"user is trying to reclaim toll but the toll pool is empty"`, no error toast is shown. This prevents unnecessary alerts for a benign, expected condition.

---

#### **Summary of Affected Areas**
- Reclaim toll transaction error handling in chat logic.