### PR TITLE
Update error handling for file download attempts by logging failed new tab openings instead of showing a toast notification.

### DIFF
--- a/app.js
+++ b/app.js
@@ -7616,7 +7616,7 @@ console.warn('in send message', txid)
             if (newTab) {
               console.log('opened in new tab');
             } else {
-              showToast('Popup blocked. File downloaded instead.', 3000, 'warning');
+              console.log('failed to open in new tab');
             }
           } else {
             // Non-viewable files: download only


### PR DESCRIPTION
Problem: On mobile when downloading an attachment, a pop up blocked toast appears. It opens a dialog to either view or download, the popup blocked toast shows regardless of option picked.

Solution: Toast is removed and logging instead. Do not need to let user know opening in tab did not work.