### PR TITLE
Add word-break to toast so long file names wrap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2873,6 +2873,7 @@ mark {
   -webkit-perspective: 1000;
   perspective: 1000;
   will-change: transform, opacity;
+  word-break: break-all;
 }
 
 /* Toast type styles */


### PR DESCRIPTION
add word break to toast so that long unbroken file names wrap instead of overflowing off the screen

<img width="453" height="275" alt="image" src="https://github.com/user-attachments/assets/7a9feab0-d0d4-4edb-92fc-1f6c4afc3f59" />
