### PR TITLE
Add "Check for Updates" Button to About Modal for Native App Users

### DIFF
--- a/app.js
+++ b/app.js
@@ -5458,9 +5458,18 @@ class AboutModal {
     this.versionDisplay = document.getElementById('versionDisplayAbout');
     this.networkName = document.getElementById('networkNameAbout');
     this.netId = document.getElementById('netIdAbout');
+    this.checkForUpdatesBtn = document.getElementById('checkForUpdatesBtn');
 
     // Set up event listeners
     this.closeButton.addEventListener('click', () => this.close());
+
+    // Only show "Check for Updates" button if user is in React Native app
+    if (window.ReactNativeWebView) {
+      this.checkForUpdatesBtn.style.display = 'inline-block';
+      this.checkForUpdatesBtn.addEventListener('click', () => this.openStore());
+    } else {
+      this.checkForUpdatesBtn.style.display = 'none';
+    }
 
     // Set version and network information once during initialization
     this.versionDisplay.textContent = myVersion + ' ' + version;
@@ -5475,6 +5484,23 @@ class AboutModal {
 
   close() {
     this.modal.classList.remove('active');
+  }
+
+  openStore() {
+    // This method only runs when user is in React Native app
+    const userAgent = navigator.userAgent.toLowerCase();
+    let storeUrl;
+
+    if (userAgent.includes('android')) {
+      storeUrl = 'https://play.google.com/store/apps/details?id=com.jairaj.liberdus';
+    } else if (userAgent.includes('iphone') || userAgent.includes('ipad') || userAgent.includes('ios')) {
+      storeUrl = 'https://testflight.apple.com/join/zSRCWyxy';
+    } else {
+      storeUrl = 'https://play.google.com/store/apps/details?id=com.jairaj.liberdus';
+    }
+
+    // Open store URL in new tab (same as explorer/network buttons and Chris is having handler to have alert happen before going to new tab)
+    window.open(storeUrl, '_blank');
   }
 }
 const aboutModal = new AboutModal();

--- a/app.js
+++ b/app.js
@@ -5499,7 +5499,7 @@ class AboutModal {
       storeUrl = 'https://play.google.com/store/apps/details?id=com.jairaj.liberdus';
     }
 
-    // Open store URL in new tab (same as explorer/network buttons and Chris is having handler to have alert happen before going to new tab)
+    // Open store URL in new tab (same as explorer/network buttons)
     window.open(storeUrl, '_blank');
   }
 }

--- a/index.html
+++ b/index.html
@@ -273,6 +273,7 @@
             <div class="about-links-section">
               <a class="about-link" href="https://liberdus.com" target="_blank">Liberdus.com</a>
               <a class="about-link" href="https://github.com/Liberdus/web-client-v2" target="_blank">GitHub Repo</a>
+              <button class="about-link" id="checkForUpdatesBtn">Check for Updates</button>
             </div>
 
             <div class="about-source-links">

--- a/styles.css
+++ b/styles.css
@@ -2140,6 +2140,17 @@ input[type='file'].form-control {
   color: var(--primary-color);
 }
 
+button.about-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+#checkForUpdatesBtn {
+  display: none; /* Hidden by default, shown only in React Native app */
+}
+
 /* Contact Info Modal Styles */
 .contact-info-list {
   padding: 1rem;


### PR DESCRIPTION
### PR Summary

**Reason for PR:**
- To provide a clear way for users of the React Native app to check for updates by opening the appropriate app store page.
- To ensure the "Check for Updates" button is only shown to users running the app inside the React Native WebView, not to web browser users.

**Changes Made:**
- **About Modal:**
  - Added a "Check for Updates" button to the About modal's links section in `index.html`.
  - The button is hidden by default via CSS and only shown if `window.ReactNativeWebView` is present (i.e., running inside the native app).
  - When clicked, the button opens the correct store page (Google Play for Android, TestFlight for iOS) in a new tab, using the same `window.open(..., '_blank')` pattern as other external links in the app.
- **JavaScript:**
  - Refactored the AboutModal logic to only add the event listener and show the button for React Native app users.
  - Simplified the update logic: no message passing, just a direct link open.
- **Styling:**
  - Ensured the button matches the style of other links in the modal.
  - Used a CSS rule to hide the button by default and only show it when appropriate.

**User Experience:**
- **Web browser users:** Do not see the "Check for Updates" button (since they're always up-to-date).
- **React Native app users:** See the button, which opens the relevant app store page in a new tab for easy updating.

**Other Notes:**
- This approach is consistent with how other external links (like Explorer, Network, GitHub) are handled in the app.
- No impact on users who are not running the app inside the React Native WebView.