### PR TITLE
Fix for messages not shifting up when the keyboard is opened

### DIFF
--- a/app.js
+++ b/app.js
@@ -6390,7 +6390,7 @@ class ChatModal {
     });
 
     // Add focus event listener for message input to handle scrolling
-    this.messageInput.addEventListener('focus', function () {
+    this.messageInput.addEventListener('focus', () => {
       if (this.messagesContainer) {
         // Check if we're already at the bottom (within 50px threshold)
         const isAtBottom =
@@ -6399,6 +6399,7 @@ class ChatModal {
           // Wait for keyboard to appear and viewport to adjust
           setTimeout(() => {
             this.messagesContainer.scrollTop = this.messagesContainer.scrollHeight;
+            this.messageInput.scrollIntoView({ behavior: 'smooth', block: 'center' }); // To provide smoother, more reliable scrolling on mobile.
           }, 300); // Increased delay to ensure keyboard is fully shown
         }
       }

--- a/app.js
+++ b/app.js
@@ -6400,7 +6400,7 @@ class ChatModal {
           setTimeout(() => {
             this.messagesContainer.scrollTop = this.messagesContainer.scrollHeight;
             this.messageInput.scrollIntoView({ behavior: 'smooth', block: 'center' }); // To provide smoother, more reliable scrolling on mobile.
-          }, 300); // Increased delay to ensure keyboard is fully shown
+          }, 500); // Increased delay to ensure keyboard is fully shown
         }
       }
     });


### PR DESCRIPTION
- Fix using function () { ... } with an arrow function () => {}
- added property for smoother scrolling experience on mobile