### PR TITLE
Enhance Remove Account Modal with Backup Option and Improved Styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -4506,6 +4506,7 @@ class RemoveAccountModal {
     this.modal = document.getElementById('removeAccountModal');
     document.getElementById('closeRemoveAccountModal').addEventListener('click', () => this.close());
     document.getElementById('confirmRemoveAccount').addEventListener('click', () => this.submit());
+    document.getElementById('openBackupFromRemove').addEventListener('click', () => backupAccountModal.open());
   }
 
   signin() {

--- a/index.html
+++ b/index.html
@@ -1106,13 +1106,22 @@
           <div class="modal-title">Remove Account</div>
         </div>
         <div class="form-container">
-          <div style="padding: 1rem">
-            <p>
-              Before removing your account, please export your account data to ensure you have a backup. This action
-              only removes the account from this device and not from the network. You can use the account again after
-              restoring it from the backup file.
-            </p>
-            <button id="confirmRemoveAccount" class="update-button" style="margin-top: 1rem">Remove</button>
+          <div class="modal-content-wrapper">
+            <div class="modal-text-content">
+              <h3 class="modal-heading">
+                Please backup your account before removing it.
+              </h3>
+              <p>
+                This only removes the account from this device, not from the network.
+              </p>
+              <p>
+                You can restore and use your account again anytime with the backup file.
+              </p>
+            </div>
+            <div>
+              <button id="openBackupFromRemove" class="primary-button">Backup Account</button>
+              <button id="confirmRemoveAccount" class="update-button">Remove</button>
+            </div>
           </div>
           <a class="last-item" href="#"> </a>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1962,7 +1962,81 @@ input[type='file'].form-control {
   margin-bottom: 1rem;
   font-family: var(--font-primary);
   font-size: var(--font-size-base);
-  color: #333;
+  color: var(--text-color);
+}
+
+/* Button container styling */
+#removeAccountModal .form-container > div > div {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  padding: 0 16px;
+  margin-top: 1rem;
+}
+
+/* Remove Account Modal Button Styles */
+#removeAccountModal .update-button,
+#removeAccountModal .primary-button {
+  width: calc(100% - 32px);
+  height: 48px;
+  border-radius: 24px;
+  margin: 0 16px;
+  font-family: var(--font-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+#removeAccountModal .primary-button {
+  background-color: var(--primary-color);
+  color: var(--background-color);
+}
+
+#removeAccountModal .primary-button:hover {
+  background-color: var(--primary-hover);
+  opacity: 0.9;
+}
+
+#removeAccountModal .update-button {
+  background-color: var(--danger-color);
+  color: var(--background-color);
+}
+
+#removeAccountModal .update-button:hover {
+  background-color: #c82333;
+  opacity: 0.9;
+}
+
+/* Remove Account Modal Content Styling */
+#removeAccountModal .modal-content-wrapper {
+  padding: 1rem;
+}
+
+#removeAccountModal .modal-text-content {
+  text-align: center;
+  line-height: 1.5;
+}
+
+#removeAccountModal .modal-heading {
+  margin: 0 0 1rem 0;
+  color: var(--text-color);
+  font-weight: var(--font-weight-semibold);
+  font-family: var(--font-primary);
+  font-size: var(--font-size-lg);
+}
+
+#removeAccountModal .modal-text-content p {
+  margin: 0 0 0.75rem 0;
+  font-family: var(--font-primary);
+  font-size: var(--font-size-base);
+  color: var(--text-color);
+}
+
+#removeAccountModal .modal-text-content p:last-child {
+  margin: 0;
 }
 #signInModal select.form-control {
   appearance: none;


### PR DESCRIPTION
- Added a button to open the backup account modal directly from the remove account modal, encouraging users to back up their data before account removal.
- Updated the modal content to emphasize the importance of backing up the account, with clearer messaging and improved layout.
- Enhanced CSS styles for the remove account modal, including button styles and layout adjustments for better user experience.