### PR TITLE
Add stake info section and learn more button when not yet staked

### DIFF
--- a/app.js
+++ b/app.js
@@ -5833,6 +5833,9 @@ class ValidatorStakingModal {
     this.loadingElement = document.getElementById('validator-loading');
     this.errorElement = document.getElementById('validator-error-message');
 
+    // Stake info section
+    this.stakeInfoSection = document.getElementById('validator-stake-info');
+
     // Display elements
     this.totalStakeElement = document.getElementById('validator-total-stake');
     this.totalStakeUsdElement = document.getElementById('validator-total-stake-usd');
@@ -5840,6 +5843,8 @@ class ValidatorStakingModal {
     this.userStakeUsdElement = document.getElementById('validator-user-stake-usd');
     this.nomineeLabelElement = document.getElementById('validator-nominee-label');
     this.nomineeValueElement = document.getElementById('validator-nominee');
+    this.earnMessageElement = document.getElementById('validator-earn-message');
+    this.learnMoreButton = document.getElementById('validator-learn-more');
 
     // Skeleton bar elements
     this.pendingSkeletonBar = document.getElementById('pending-nominee-skeleton-1');
@@ -5856,6 +5861,11 @@ class ValidatorStakingModal {
 
     this.unstakeButton.addEventListener('click', () => this.handleUnstake());
     this.backButton.addEventListener('click', () => this.close());
+    
+    // Set up the learn more button click handler
+    if (this.learnMoreButton) {
+      this.learnMoreButton.addEventListener('click', this.handleLearnMoreClick.bind(this));
+    }
   }
 
   async open() {
@@ -5868,9 +5878,14 @@ class ValidatorStakingModal {
     // Reset conditional elements to default state
     this.nomineeLabelElement.textContent = 'Nominated Validator:';
     this.nomineeValueElement.textContent = '';
-    // Ensure stake items are visible by default
-    this.userStakeLibElement.style.display = 'flex';
-    this.userStakeUsdElement.style.display = 'flex';
+    // Ensure stake info section and items are visible by default
+    this.stakeInfoSection.style.display = 'block';
+    this.userStakeLibElement.parentElement.style.display = 'flex';
+    this.userStakeUsdElement.parentElement.style.display = 'flex';
+    // Hide earn message by default
+    if (this.earnMessageElement) {
+      this.earnMessageElement.style.display = 'none';
+    }
     // Disable unstake button initially
     this.unstakeButton.disabled = true;
     this.stakeButton.disabled = false;
@@ -6018,13 +6033,17 @@ class ValidatorStakingModal {
       this.marketStakeUsdValue.textContent = displayMarketStakeUsd;
 
       if (!nominee) {
-        this.nomineeLabelElement.textContent = 'No Nominated Validator';
-        this.nomineeValueElement.textContent = ''; // Ensure value is empty
-        this.userStakeLibElement.style.display = 'none'; // Hide LIB stake item
-        this.userStakeUsdElement.style.display = 'none'; // Hide USD stake item
+        // Case: No Nominee - Hide the stake info section completely and show earn message
+        this.stakeInfoSection.style.display = 'none';
+        
+        // Show earn message and learn more button
+        if (this.earnMessageElement) {
+          this.earnMessageElement.style.display = 'block';
+        }
       } else {
-        // Case: Nominee Exists
-
+        // Case: Nominee Exists - Show staking info section
+        this.stakeInfoSection.style.display = 'block';
+        
         // userStakedBaseUnits is a BigInt object or null/undefined. Pass its string representation.
         const displayUserStakedLib = userStakedBaseUnits != null ? big2str(userStakedBaseUnits, 18).slice(0, 6) : 'N/A';
         const displayUserStakedUsd = userStakedUsd != null ? '$' + userStakedUsd.toFixed(6) : 'N/A';
@@ -6033,9 +6052,11 @@ class ValidatorStakingModal {
         this.nomineeValueElement.textContent = nominee;
         this.userStakeLibElement.textContent = displayUserStakedLib;
         this.userStakeUsdElement.textContent = displayUserStakedUsd;
-        // Ensure items are visible (using flex as defined in CSS) - redundant due to reset, but safe
-        this.userStakeLibElement.style.display = 'flex';
-        this.userStakeUsdElement.style.display = 'flex';
+        
+        // Hide earn message
+        if (this.earnMessageElement) {
+          this.earnMessageElement.style.display = 'none';
+        }
       }
 
       this.detailsElement.style.display = 'block'; // Or 'flex' if it's a flex container
@@ -6063,6 +6084,11 @@ class ValidatorStakingModal {
 
   close() {
     this.modal.classList.remove('active');
+  }
+  
+  handleLearnMoreClick() {
+    const validatorUrl = network.validatorUrl || 'https://liberdus.com/validator';
+    window.open(validatorUrl, '_blank');
   }
 
   async handleUnstake() {

--- a/index.html
+++ b/index.html
@@ -1299,7 +1299,7 @@
             <!-- No Validator Message - shown when no nominee exists -->
             <div id="validator-earn-message" style="display: none; margin-bottom: 20px;">
               <div class="action-item">
-                <p class="action-description" style="margin-bottom: 10px;">Now you can earn LIB for running a validator node</p>
+                <p class="action-description" style="margin-bottom: 10px;">Now you can earn LIB for running a validator node.</p>
                 <button id="validator-learn-more" class="button full-width">Learn More</button>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -1296,7 +1296,16 @@
 
           <!-- Validator Details Display Area -->
           <div id="validator-details" class="validator-info-container" style="display: block">
-            <div class="info-section">
+            <!-- No Validator Message - shown when no nominee exists -->
+            <div id="validator-earn-message" style="display: none; margin-bottom: 20px;">
+              <div class="action-item">
+                <p class="action-description" style="margin-bottom: 10px;">Now you can earn LIB for running a validator node</p>
+                <button id="validator-learn-more" class="button full-width">Learn More</button>
+              </div>
+            </div>
+            
+            <!-- Your Stake Info - only shown when a nominee exists -->
+            <div id="validator-stake-info" class="info-section">
               <h4>Your Stake Info</h4>
               <!-- New Skeleton Bars for Pending Nominee Info -->
               <div

--- a/network.js
+++ b/network.js
@@ -12,5 +12,6 @@ const network = {
     "627510f0cb0bf5e82b0cc8bace10a1a3649c74d9b733af9a32e26d495e5799fe", // old
     "fd1b56b08fd1e5035aa19eb631f7f1ad0395175c5d3dfc49411dfa528e6af7c3", // old
   ],
+  "validatorUrl": "https://liberdus.com/validator",
   "stakeUrl": "https://liberdus.com/stake",
 }

--- a/styles.css
+++ b/styles.css
@@ -4146,6 +4146,16 @@ small {
   background-color: var(--primary-hover);
 }
 
+#validatorModal #validator-learn-more {
+  background-color: var(--primary-color);
+  color: var(--background-color);
+  border: none;
+}
+#validatorModal #validator-learn-more:hover {
+  background-color: var(--primary-hover);
+}
+
+
 /* Ensure secondary button style (now danger) */
 #validatorModal #submitUnstake {
   /* Styles inherited from .button, .full-width, .secondary-button */


### PR DESCRIPTION
If the user is not staked the stake info section will be hidden and instead a given a button that links to a (not yet implimented) validator info page 
<img width="408" height="804" alt="image" src="https://github.com/user-attachments/assets/c9add1a1-9ef9-48ef-9dbf-5425213b7cf0" />
