### PR TITLE
Handle notification click

### DIFF
--- a/app.js
+++ b/app.js
@@ -11304,10 +11304,19 @@ class ReactNativeApp {
 
           if (data.type === 'NOTIFICATION_TAPPED') {
             console.log('🔔 Notification tapped, opening chat with:', data.to);
+            
+            // Check if user is signed in
+            if (!myData || !myAccount) {
+              // User is not signed in - save the notification address and open sign-in modal
+              console.log('🔔 User not signed in, saving notification address for priority');
+              this.saveNotificationAddress(data.to);
+              return;
+            }
+            
+            // User is signed in - check if it's the right account
             if (data.to && myData.contacts[data.to]) {
               console.log('🔔 Your account that received a new message');
               
-              // Check if we're currently signed in to the account that received the notification
               const isCurrentAccount = this.isCurrentAccount(data.to);
               
               if (isCurrentAccount) {

--- a/app.js
+++ b/app.js
@@ -11326,7 +11326,7 @@ class ReactNativeApp {
               console.log('🔔 You are signed in to the account that received the message');
               // TODO: Open chat modal when z-index issue is resolved
               // chatModal.open(data.from);
-              showToast('You are signed in to the account that received the message', 5000, 'success');
+              /* showToast('You are signed in to the account that received the message', 5000, 'success'); */
             } else {
               // We're signed in to a different account, ask user what to do
               const shouldSignOut = confirm('You received a message for a different account. Would you like to sign out to switch to that account?');

--- a/app.js
+++ b/app.js
@@ -11314,31 +11314,26 @@ class ReactNativeApp {
             }
             
             // User is signed in - check if it's the right account
-            if (data.to && myData.contacts[data.to]) {
-              console.log('🔔 Your account that received a new message');
-              
-              const isCurrentAccount = this.isCurrentAccount(data.to);
-              
-              if (isCurrentAccount) {
-                /* chatModal.open(data.from); */
-                // for now do nothing since z-index could be an issue
-                console.log('🔔 You are signed in to the account that received the message');
-              } else {
-                // We're signed in to a different account, ask user what to do
-                const shouldSignOut = confirm('You received a message for a different account. Would you like to sign out to switch to that account?');
-                
-                if (shouldSignOut) {
-                  // Sign out and save the notification address for priority
-                  this.saveNotificationAddress(data.to);
-                  menuModal.handleSignOut();
-                } else {
-                  // User chose to stay signed in, just save the address for next time
-                  this.saveNotificationAddress(data.to);
-                  console.log('User chose to stay signed in - notified account will appear first next time');
-                }
-              }
+            const isCurrentAccount = this.isCurrentAccount(data.to);
+            
+            if (isCurrentAccount) {
+              // We're signed in to the account that received the notification
+              console.log('🔔 You are signed in to the account that received the message');
+              // TODO: Open chat modal when z-index issue is resolved
+              // chatModal.open(data.from);
             } else {
-              console.warn('Contact not found for notification:', data.to);
+              // We're signed in to a different account, ask user what to do
+              const shouldSignOut = confirm('You received a message for a different account. Would you like to sign out to switch to that account?');
+              
+              if (shouldSignOut) {
+                // Sign out and save the notification address for priority
+                this.saveNotificationAddress(data.to);
+                menuModal.handleSignOut();
+              } else {
+                // User chose to stay signed in, just save the address for next time
+                this.saveNotificationAddress(data.to);
+                console.log('User chose to stay signed in - notified account will appear first next time');
+              }
             }
           }
         } catch (error) {
@@ -11417,23 +11412,11 @@ class ReactNativeApp {
     }
   }
 
-  isCurrentAccount(contactAddress) {
-    if (!myAccount) return false;
+  isCurrentAccount(recipientAddress) {
+    if (!myData || !myAccount) return false;
     
-    const { netid } = network;
-    const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
-    const netidAccounts = existingAccounts.netids[netid];
-    
-    if (!netidAccounts?.usernames) return false;
-    
-    // Check if the current account owns this contact
-    for (const [username, accountData] of Object.entries(netidAccounts.usernames)) {
-      if (accountData.address === contactAddress) {
-        return username === myAccount.username;
-      }
-    }
-    
-    return false;
+    // Check if the current user's address matches the recipient address
+    return myData.account.keys.address === recipientAddress;
   }
 
   saveNotificationAddress(contactAddress) {

--- a/app.js
+++ b/app.js
@@ -11304,34 +11304,40 @@ class ReactNativeApp {
 
           if (data.type === 'NOTIFICATION_TAPPED') {
             console.log('🔔 Notification tapped, opening chat with:', data.to);
+
+            // normalize the address
+            const normalizedToAddress = normalizeAddress(data.to);
             
             // Check if user is signed in
             if (!myData || !myAccount) {
               // User is not signed in - save the notification address and open sign-in modal
               console.log('🔔 User not signed in, saving notification address for priority');
-              this.saveNotificationAddress(data.to);
+              this.saveNotificationAddress(normalizedToAddress);
               return;
             }
             
             // User is signed in - check if it's the right account
-            const isCurrentAccount = this.isCurrentAccount(data.to);
-            
+            const isCurrentAccount = this.isCurrentAccount(normalizedToAddress);
+            /* showToast('isCurrentAccount: ' + isCurrentAccount, 10000, 'success');
+            showToast('data.to: ' + normalizedToAddress, 10000, 'success');
+            showToast('myData.account.keys.address: ' + myData.account.keys.address, 10000, 'success'); */
             if (isCurrentAccount) {
               // We're signed in to the account that received the notification
               console.log('🔔 You are signed in to the account that received the message');
               // TODO: Open chat modal when z-index issue is resolved
               // chatModal.open(data.from);
+              showToast('You are signed in to the account that received the message', 5000, 'success');
             } else {
               // We're signed in to a different account, ask user what to do
               const shouldSignOut = confirm('You received a message for a different account. Would you like to sign out to switch to that account?');
               
               if (shouldSignOut) {
                 // Sign out and save the notification address for priority
-                this.saveNotificationAddress(data.to);
+                this.saveNotificationAddress(normalizedToAddress);
                 menuModal.handleSignOut();
               } else {
                 // User chose to stay signed in, just save the address for next time
-                this.saveNotificationAddress(data.to);
+                this.saveNotificationAddress(normalizedToAddress);
                 console.log('User chose to stay signed in - notified account will appear first next time');
               }
             }
@@ -12056,7 +12062,7 @@ class LocalStorageMonitor {
         localStorage.setItem(testKey, verifyData);
         localStorage.removeItem(testKey);
       } catch (e) {
-        // If verification fails, reduce by small amount and retry
+        // If verification fails, reduce by small amount
         maxCharacters = Math.max(0, maxCharacters - 1024);
       }
     }


### PR DESCRIPTION
## **PR Summary**

### **Purpose**
Enhance the user experience for multi-account users by prioritizing accounts that receive notifications, making it easier to switch to the relevant account when messages arrive.

### **Changes Made**

• **Added notification handler** - Listens for `NOTIFICATION_TAPPED` events from React Native app
• **Implemented account prioritization** - When a notification is received for a different account, the user gets a choice to sign out immediately or stay signed in
• **Enhanced sign-in modal** - Accounts that received notifications appear first in the account selection list
• **Added automatic cleanup** - Notification priorities are cleared after any user signs in
• **Added helper methods** - `isCurrentAccount()`, `saveNotificationAddress()`, and `clearNotificationAddress()` for managing notification state

### **User Experience**
- **Current account notification** → User sees a log message (chat opening temporarily disabled due to z-index concerns)
- **Different account notification** → User gets an alert asking if they want to switch accounts
- **Next sign-in** → The notified account appears at the top of the account list
- **After sign-in** → Priority system resets automatically

The implementation uses a simple localStorage-based approach that's safe and doesn't risk data corruption.