### PR TITLE
Enhance username selection in SignInModal by adding notification indicators for accounts associated with the notified address. 

### DIFF
--- a/app.js
+++ b/app.js
@@ -1848,7 +1848,12 @@ class SignInModal {
     // Populate select with sorted usernames
     this.usernameSelect.innerHTML = `
       <option value="" disabled selected hidden>Select an account</option>
-      ${sortedUsernames.map((username) => `<option value="${username}">${username}</option>`).join('')}
+      ${sortedUsernames.map((username) => {
+        // Check if this username owns the notified address
+        const isNotifiedAccount = notifiedAddress && netidAccounts.usernames[username]?.address === notifiedAddress;
+        const dotIndicator = isNotifiedAccount ? ' 🔔' : '';
+        return `<option value="${username}">${username}${dotIndicator}</option>`;
+      }).join('')}
     `;
 
     // If a username should be auto-selected (either preselect or only one account), do it


### PR DESCRIPTION
This improves user experience by visually distinguishing notified accounts in the dropdown list.

### **Key Changes Made**
• **Visual Indicator** - Added bell emoji (🔔) next to account names that received notifications in the sign-in dropdown

### **User Experience Flow**
1. **Notification received** → System checks if user is signed into the correct account
2. **Same account** → No action needed (ready for future chat modal integration)
3. **Different account** → User gets choice to switch immediately or stay signed in
4. **Next sign-in** → Notified account appears first in list with visual bell indicator
5. **After sign-in** → Notification priority is cleared for all accounts

The implementation provides a seamless way for multi-account users to quickly identify and switch to accounts that have received new messages, significantly improving the notification experience.
Iphone:
<img width="574" height="1241" alt="image" src="https://github.com/user-attachments/assets/3c8a86aa-052f-4b06-98ff-a3373fcb2a51" />
android:
<img width="397" height="744" alt="image" src="https://github.com/user-attachments/assets/e59248ec-5a01-4b38-bb9d-3e958d98abf7" />
