### PR TITLE
More Options checkbox on Create Account modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -8369,13 +8369,16 @@ class CreateAccountModal {
     this.togglePrivateKeyVisibility = document.getElementById('togglePrivateKeyVisibility');
     this.migrateAccountsSection = document.getElementById('migrateAccountsSection');
     this.migrateAccountsButton = document.getElementById('migrateAccountsButton');
-    this.launchSection = document.getElementById('launchSection');
     this.launchButton = document.getElementById('launchButton');
+    this.updateButton = document.getElementById('updateButton');
+    this.toggleMoreOptions = document.getElementById('toggleMoreOptions');
+    this.moreOptionsSection = document.getElementById('moreOptionsSection');
 
     // Setup event listeners
     this.form.addEventListener('submit', (e) => this.handleSubmit(e));
     this.usernameInput.addEventListener('input', (e) => this.handleUsernameInput(e));
     this.toggleButton.addEventListener('change', () => this.handleTogglePrivateKeyInput());
+    this.toggleMoreOptions.addEventListener('change', () => this.handleToggleMoreOptions());
     this.backButton.addEventListener('click', () => this.closeWithReload());
 
     // Add listener for the password visibility toggle
@@ -8389,9 +8392,12 @@ class CreateAccountModal {
 
     this.migrateAccountsButton.addEventListener('click', async () => await migrateAccountsModal.open());
     if (window.ReactNativeWebView) {
-      this.launchSection.style.display = 'block';
       this.launchButton.addEventListener('click', () => {
         launchModal.open()
+      });
+      
+      this.updateButton.addEventListener('click', () => {
+        aboutModal.openStore();
       });
     }
   }
@@ -8427,6 +8433,14 @@ class CreateAccountModal {
     this.privateKeyInput.value = '';
     this.usernameAvailable.style.display = 'none';
     this.privateKeyError.style.display = 'none';
+    
+    // Reset More Options section
+    this.toggleMoreOptions.checked = false;
+    this.moreOptionsSection.style.display = 'none';
+    this.toggleButton.checked = false;
+    this.privateKeySection.style.display = 'none';
+    this.launchButton.style.display = 'none';
+    this.updateButton.style.display = 'none';
     
     // Open the modal
     this.open();
@@ -8490,6 +8504,25 @@ class CreateAccountModal {
     
     if (!isChecked) {
       this.privateKeyError.style.display = 'none';
+    }
+  }
+  
+  handleToggleMoreOptions() {
+    const isChecked = this.toggleMoreOptions.checked;
+    this.moreOptionsSection.style.display = isChecked ? 'block' : 'none';
+    
+    if (!isChecked) {
+      // Reset private key options when more options is unchecked
+      this.toggleButton.checked = false;
+      // Hide private key section if More Options is unchecked
+      this.privateKeySection.style.display = 'none';
+      this.privateKeyInput.value = '';
+      this.privateKeyError.style.display = 'none';
+      this.launchButton.style.display = 'none';
+      this.updateButton.style.display = 'none';
+    } else if (window.ReactNativeWebView) {
+      this.launchButton.style.display = 'block';
+      this.updateButton.style.display = 'block';
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -359,33 +359,6 @@
         <a class="last-item" href="#"> </a>
       </div>
 
-      <!-- Update Warning Modal -->
-      <div class="modal fixed-header" id="updateWarningModal">
-        <div class="modal-header">
-          <button class="back-button" id="closeUpdateWarningModal"></button>
-          <div class="modal-title">⚠️ Update Warning</div>
-        </div>
-        <div class="modal-content">
-          <div class="form-container">
-            <div class="warning-content">
-              <p>
-                WARNING: If you accidentally uninstall the app during the update process, all your local data will be permanently lost.
-              </p>
-              <p>
-                <strong>We strongly recommend backing up your data first.</strong>
-              </p>
-            </div>
-            <button id="backupFirstBtn" class="update-button">
-              🛡️ Backup My Data First
-            </button>
-            <button id="proceedToStoreBtn" class="secondary-button">
-              Continue to App Store
-            </button>
-          </div>
-        </div>
-        <a class="last-item" href="#"> </a>
-      </div>
-
       <!-- Lock Modal -->
       <div class="modal fixed-header" id="lockModal">
         <div class="modal-header">
@@ -498,12 +471,6 @@
                   />
                 </div>
               </div>
-              <div class="form-group">
-                <input type="checkbox" id="togglePrivateKeyInput" />
-                <label for="togglePrivateKeyInput" style="display: inline; margin-left: 5px"
-                  >Use my own private key (Advanced)</label
-                >
-              </div>
               <div id="privateKeySection" style="display: none">
                 <div class="form-group">
                   <label for="newPrivateKey"
@@ -525,6 +492,20 @@
                 </div>
               </div>
               <button type="submit" class="update-button" disabled>Create Account</button>
+              
+              <div class="form-group" style="margin-top: 20px;">
+                <input type="checkbox" id="toggleMoreOptions" />
+                <label for="toggleMoreOptions" style="display: inline; margin-left: 5px">More Options</label>
+              </div>
+              
+              <div id="moreOptionsSection" style="display: none;">
+                <div class="form-group">
+                  <input type="checkbox" id="togglePrivateKeyInput" />
+                  <label for="togglePrivateKeyInput" style="display: inline; margin-left: 5px">
+                    Use my own private key (Advanced)
+                  </label>
+                </div>
+              </div>
             </form>
             <div class="form-group" id="migrateAccountsSection" style="display: none; margin-top: 50px; padding: 0 16px">
               <label for="migrateAccountsButton">Check if you have accounts that can be migrated to this network</label>
@@ -532,13 +513,39 @@
                 Migrate Accounts
               </button>
             </div>
-            <div class="form-group" id="launchSection" style="display: none; margin-top: 20px; padding: 0 16px">
-              <!-- have the bellow label be centered -->
-              <label for="launchButton" style="text-align: center;">Launch a different Liberdus instance</label>
-              <button type="button" id="launchButton" class="secondary-button" style="margin-top: 10px;">
-                Launch
-              </button>
+            <button type="button" id="launchButton" class="secondary-button" style="display: none; margin-top: 10px;">
+              Launch
+            </button>
+            <button type="button" id="updateButton" class="secondary-button" style="display: none; margin-top: 10px;">
+              Check for Updates
+            </button>
+          </div>
+        </div>
+        <a class="last-item" href="#"> </a>
+      </div>
+
+      <!-- Update Warning Modal -->
+      <div class="modal fixed-header" id="updateWarningModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeUpdateWarningModal"></button>
+          <div class="modal-title">⚠️ Update Warning</div>
+        </div>
+        <div class="modal-content">
+          <div class="form-container">
+            <div class="warning-content">
+              <p>
+                WARNING: If you accidentally uninstall the app during the update process, all your local data will be permanently lost.
+              </p>
+              <p>
+                <strong>We strongly recommend backing up your data first.</strong>
+              </p>
             </div>
+            <button id="backupFirstBtn" class="update-button">
+              🛡️ Backup My Data First
+            </button>
+            <button id="proceedToStoreBtn" class="secondary-button">
+              Continue to App Store
+            </button>
           </div>
         </div>
         <a class="last-item" href="#"> </a>


### PR DESCRIPTION
Adds a More Options checkbox to the Create Account modal when checked reveals the following:
- Use my own private key checkbox
- Launch button (only in native app)
- Check for Updates button (only in native app)

moved the update warning modal lower in the html so it would show above the create account modal

<img width="301" height="353" alt="image" src="https://github.com/user-attachments/assets/276040ce-5128-4e13-9372-d06019924d87" />
<img width="301" height="456" alt="image" src="https://github.com/user-attachments/assets/12abc0b0-9fa8-41ea-ba64-501ca1fc55e8" />
<img width="301" height="594" alt="image" src="https://github.com/user-attachments/assets/419f1c1f-a957-4dd7-bcf1-be8dd144da38" />
