### PR TITLE
Fix injectTx to handle stake/unstake transactions with nominee field

### DIFF
--- a/app.js
+++ b/app.js
@@ -3401,13 +3401,10 @@ async function injectTx(tx, txid) {
         pendingTxData.friend = tx.friend;
       } else if (tx.type === 'read') {
         pendingTxData.oldContactTimestamp = tx.oldContactTimestamp;
-      } else if (
-        tx.type === 'message' ||
-        tx.type === 'transfer' ||
-        tx.type === 'deposit_stake' ||
-        tx.type === 'withdraw_stake'
-      ) {
+      } else if (tx.type === 'message' || tx.type === 'transfer') {
         pendingTxData.to = normalizeAddress(tx.to);
+      } else if (tx.type === 'deposit_stake' || tx.type === 'withdraw_stake') {
+        pendingTxData.to = tx.nominee; // Store 64-character address as-is for stake transactions
       }
       myData.pending.push(pendingTxData);
     } else {


### PR DESCRIPTION
### Summary
Stake and unstake transactions use `nominee` field instead of `to`, causing "address is undefined" and "Invalid address length after normalization" errors. This PR splits the transaction handling logic to properly store the 64-character nominee address without normalization.

### Changes
- **File**: `app.js` (lines ~3401-3410)
- **Split transaction handling**:
  - Messages/transfers: continue using `normalizeAddress(tx.to)`
  - Stake/unstake: store `tx.nominee` as-is (64-char hex)

```diff
- } else if (
-   tx.type === 'message' ||
-   tx.type === 'transfer' ||
-   tx.type === 'deposit_stake' ||
-   tx.type === 'withdraw_stake'
- ) {
-   pendingTxData.to = normalizeAddress(tx.to);
- }
+ } else if (tx.type === 'message' || tx.type === 'transfer') {
+   pendingTxData.to = normalizeAddress(tx.to);
+ } else if (tx.type === 'deposit_stake' || tx.type === 'withdraw_stake') {
+   pendingTxData.to = tx.nominee; // Store 64-character address as-is for stake transactions
+ }
```

### Impact
- Fixes stake/unstake transaction injection errors
- Maintains existing message/transfer functionality