### PR TITLE
Add client-side stake lock validation to Validator modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -6197,7 +6197,7 @@ class ValidatorStakingModal {
     }
 
     // Validator active (immediate blocker; no countdown)
-    if (rewardStartTimeMs > 0 && (rewardEndTimeMs === 0)) {
+    if (rewardStartTimeMs > 0 && rewardEndTimeMs === 0) {
       remainingCandidates.push({ rem: -1, reason: 'validator active' });
     }
 

--- a/app.js
+++ b/app.js
@@ -6197,7 +6197,7 @@ class ValidatorStakingModal {
     }
 
     // Validator active (immediate blocker; no countdown)
-    if (rewardStartTimeMs > 0 && (rewardEndTimeMs === 0 || rewardEndTimeMs === 0n)) {
+    if (rewardStartTimeMs > 0 && (rewardEndTimeMs === 0)) {
       remainingCandidates.push({ rem: -1, reason: 'validator active' });
     }
 

--- a/app.js
+++ b/app.js
@@ -6176,8 +6176,8 @@ class ValidatorStakingModal {
         const validatorRes = await queryNetwork(`/account/${nomineeAddress}`);
         const rs = validatorRes?.account?.rewardStartTime || 0; // seconds
         const re = validatorRes?.account?.rewardEndTime || 0;   // seconds
-        rewardStartTimeMs = rs > 0 ? rs * 1000 : 0;
-        rewardEndTimeMs = re > 0 ? re * 1000 : 0;
+        rewardStartTimeMs = rs * 1000;
+        rewardEndTimeMs = re * 1000;
       }
     } catch (e) {
       console.warn('ValidatorStakingModal: Failed to fetch validator account for stake-lock calc:', e);

--- a/app.js
+++ b/app.js
@@ -6036,7 +6036,7 @@ class ValidatorStakingModal {
     // If the button is disabled for any reason, show the current reason and exit
     if (this.unstakeButton.disabled) {
       const message = this.unstakeButton.title || this.unstakeLockInfoElement?.textContent || 'Unstake unavailable.';
-      if (message) showToast(message, 5000, 'error');
+      if (message) showToast(message, 0, 'error');
       return;
     }
 
@@ -6045,11 +6045,11 @@ class ValidatorStakingModal {
     if (info) {
       const { remainingMs, remainingReason } = info;
       if (remainingReason === 'validator active') {
-        showToast(`Unstake unavailable (validator active).`, 5000, 'error');
+        showToast(`Unstake unavailable (validator active).`, 0, 'error');
         return;
       } else if (remainingMs > 0) {
         const durationInWords = this.formatDuration(remainingMs);
-        showToast(`Unstake unavailable (${remainingReason}). Please wait ${durationInWords} before trying again.`, 5000, 'error');
+        showToast(`Unstake unavailable (${remainingReason}). Please wait ${durationInWords} before trying again.`, 0, 'error');
         return;
       }
     }

--- a/app.js
+++ b/app.js
@@ -6126,11 +6126,6 @@ class ValidatorStakingModal {
       if (data && data.account) {
         const account = data.account;
         // Active if reward has started (not 0) but hasn't ended (is 0)
-        /**
-           *  when rewardStartTime is 0, the validator is inactive
-           *  when rewardStartTime is not 0 and rewardEndTime is 0, the validator is active
-           *  when rewardStartTime is not 0 and rewardEndTime is not 0, the validator is active
-         */
         const isActive =
           account.rewardStartTime &&
           account.rewardStartTime !== 0 &&

--- a/app.js
+++ b/app.js
@@ -6157,7 +6157,7 @@ class ValidatorStakingModal {
     await getNetworkParams();
 
     const now = getCorrectedTimestamp();
-    const stakeLockTime = (parameters && parameters.current && parameters.current.stakeLockTime) || 0;
+    const stakeLockTime = parameters?.current?.stakeLockTime || 0;
 
     // Gather nominator (user) side info
     const nominatorAddress = myData?.account?.keys?.address;

--- a/index.html
+++ b/index.html
@@ -1468,6 +1468,7 @@
 
           <div class="action-item">
             <button id="submitUnstake" class="button full-width secondary-button">Unstake</button>
+            <div id="unstake-lock-info" class="unstake-lock-info" aria-live="polite"></div>
             <p class="action-description">Withdraw your delegated LIB from a validator node.</p>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,11 @@
+/* Unstake lock info under the Unstake button */
+#unstake-lock-info,
+.unstake-lock-info {
+  font-size: 0.85em;
+  color: #dc3545;
+  margin-top: 6px;
+  min-height: 1em; /* keep layout stable when empty */
+}
 :root {
   --border-color: #dee2e6;
   --background-color: white;


### PR DESCRIPTION
### Changes Made
- **Stake Lock Validation**: Added client-side checks for unstake availability before transaction submission
- **UI Feedback**: Enhanced Validator modal with inline lock status messages and disabled button states
- **Performance**: Cached lock calculations to avoid redundant network calls

### Key Features
- **Lock Period Checks**: Validates three conditions before allowing unstake:
  - Certificate expiration (`certExp > currentTime`)
  - Validator active state (`rewardStartTime > 0 && rewardEndTime == 0`)
  - Recent deactivation cooldown (`currentTime - rewardEndTime < stakeLockTime`)
- **User Experience**: Shows specific lock reasons and remaining time in tooltips and inline messages
- **Error Prevention**: Blocks unstake attempts with clear error messages instead of backend failures

### Technical Details
- Added `calculateStakeLockRemaining()` method with reason-aware lock detection
- Centralized UI updates via `updateUnstakeLockUI()` method
- Static HTML/CSS for lock info display (moved from dynamic creation)
- Simplified `handleUnstake()` to use cached lock state with disabled button guard

### Files Modified
- `app.js`: Added stake lock validation logic and UI management
- `index.html`: Added static lock info display element
- `styles.css`: Added styling for lock info messages