### PR TITLE
Fix Friend Modal Submit Button State Management

### DIFF
--- a/app.js
+++ b/app.js
@@ -2323,6 +2323,7 @@ class FriendModal {
   load() {
     this.modal = document.getElementById('friendModal');
     this.friendForm = document.getElementById('friendForm');
+    this.submitButton = this.friendForm.querySelector('button[type="submit"]');
 
     // Friend modal form submission
     this.friendForm.addEventListener('submit', (event) => this.handleFriendSubmit(event));
@@ -2340,6 +2341,9 @@ class FriendModal {
     const status = contact?.friend.toString();
     const radio = this.friendForm.querySelector(`input[value="${status}"]`);
     if (radio) radio.checked = true;
+
+    // re-enable the submit button
+    this.submitButton.disabled = false;
 
     this.modal.classList.add('active');
   }
@@ -2381,6 +2385,8 @@ class FriendModal {
    */
   async handleFriendSubmit(event) {
     event.preventDefault();
+
+    this.submitButton.disabled = true;
 
     if (!this.currentContactAddress) return;
 
@@ -2431,6 +2437,7 @@ class FriendModal {
 
     // Close the friend modal
     this.closeFriendModal();
+    this.submitButton.disabled = false;
   }
 
   // setAddress fuction that sets a global variable that can be used to set the currentContactAddress

--- a/app.js
+++ b/app.js
@@ -2323,7 +2323,7 @@ class FriendModal {
   load() {
     this.modal = document.getElementById('friendModal');
     this.friendForm = document.getElementById('friendForm');
-    this.submitButton = this.friendForm.querySelector('button[type="submit"]');
+    this.submitButton = document.getElementById('friendSubmitButton');
 
     // Friend modal form submission
     this.friendForm.addEventListener('submit', (event) => this.handleFriendSubmit(event));
@@ -2341,8 +2341,6 @@ class FriendModal {
     const status = contact?.friend.toString();
     const radio = this.friendForm.querySelector(`input[value="${status}"]`);
     if (radio) radio.checked = true;
-
-    // re-enable the submit button
     this.submitButton.disabled = false;
 
     this.modal.classList.add('active');

--- a/index.html
+++ b/index.html
@@ -947,7 +947,7 @@
               </label>
             </div>
           <div class="form-actions">
-            <button type="submit" class="btn btn--primary btn--pill btn--full">Update</button>
+            <button id="friendSubmitButton" type="submit" class="btn btn--primary btn--pill btn--full">Update</button>
           </div>
           </form>
           <a class="last-item" href="#"></a>


### PR DESCRIPTION
**Reason for PR:**
- Prevents users from accidentally submitting the friend status form multiple times
- Improves user experience by providing visual feedback during form submission
- Fixes potential race conditions in friend status updates

**Changes Made:**
- **Added submit button reference** - Store reference to submit button during modal load
- **Disable button on submit** - Disable submit button immediately when form submission starts
- **Re-enable button on modal open** - Ensure button is enabled when modal is opened
- **Re-enable button after completion** - Re-enable button after successful form submission and modal close
- **Prevent double submissions** - Button remains disabled during the entire submission process

The changes ensure that users cannot accidentally trigger multiple friend status updates while a transaction is being processed, improving the reliability of the friend management system.