### PR TITLE
Remove File Type Restrictions for Chat Attachments

### DIFF
--- a/app.js
+++ b/app.js
@@ -7586,20 +7586,6 @@ console.warn('in send message', txid)
       return;
     }
 
-    // Validate file type
-    const allowedTypePrefixes = ['image/', 'audio/', 'video/'];
-    const allowedExplicitTypes = [
-      'application/pdf', // PDF
-      'text/plain',      // TXT
-      'application/msword', // DOC
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document' // DOCX
-    ];
-    if (!(allowedTypePrefixes.some(prefix => file.type.startsWith(prefix)) || allowedExplicitTypes.includes(file.type))) {
-      showToast('File type not supported.', 0, 'error');
-      event.target.value = ''; // Reset file input
-      return;
-    }
-
     try {
       this.isEncrypting = true;
       this.sendButton.disabled = true; // Disable send button during encryption

--- a/index.html
+++ b/index.html
@@ -791,12 +791,7 @@
             </div>
             <input type="hidden" id="retryOfTxId" />
             <!-- Add hidden file input for chat attachments -->
-            <input type="file" id="chatFileInput"
-            accept="image/*,video/*,audio/*,video/mp4,video/x-m4v,
-            .jpg,.jpeg,.png,.gif,.webp,.mp4,.mov,.webm,.ogg,.ogv,
-            .avi,.wmv,.flv,.mkv,.mp3,.wav,.ogg,.m4a,.aac,.flac,
-            .pdf,.txt,.doc,.docx"
-            style="display:none;">
+            <input type="file" id="chatFileInput" style="display:none;">
             <button class="send-button" id="handleSendMessage">
               <svg viewBox="0 0 24 24">
                 <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />


### PR DESCRIPTION
**Reason for PR:**
- Removes restrictive file type validation to allow users to attach any file type
- Simplifies the file attachment interface by removing complex accept attributes
- Enables more flexible file sharing capabilities in chat

**Changes Made:**
- **Removed file type validation** - Eliminated the `allowedTypePrefixes` and `allowedExplicitTypes` validation logic in `app.js`
- **Simplified file input** - Removed the complex `accept` attribute from the file input element in `index.html`
- **Maintained size limits** - Kept the 10MB file size limit for performance and storage considerations
- **Preserved encryption** - File encryption and upload functionality remains unchanged

The changes allow users to attach any file type to their chat messages while maintaining the existing encryption, upload, and size limit functionality. This provides more flexibility for users who need to share various file types that weren't previously supported.