### PR TITLE
Restrict restore file upload to JSON format only

### DIFF
--- a/index.html
+++ b/index.html
@@ -709,7 +709,7 @@
             <form id="importForm" class="form--narrow">
               <div class="form-group">
                 <label for="importFile">Select File</label>
-                <input type="file" id="importFile" class="form-control" required />
+                <input type="file" id="importFile" class="form-control" required accept=".json,application/json" />
               </div>
               <div class="form-group">
                 <label for="importPassword">Password (if encrypted)</label>


### PR DESCRIPTION
Limit the file input to accept only JSON files in the restore account modal.