### PR TITLE
Add share invite link functionality to Invite Modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -5580,7 +5580,7 @@ class InviteModal {
   async shareLiberdusInvite() {
     const url = "https://liberdus.com/download";
     const title = "Join me on Liberdus";
-    const text = `Message me on Liberdus! ${url}`;
+    const text = `Message ${myAccount.username} on Liberdus! ${url}`;
 
     // 1) Try native share sheet
     if (navigator.share) {

--- a/app.js
+++ b/app.js
@@ -5474,6 +5474,7 @@ class InviteModal {
     this.submitButton = document.querySelector('#inviteForm button[type="submit"]');
     this.closeButton = document.getElementById('closeInviteModal');
     this.inviteForm = document.getElementById('inviteForm');
+    this.shareButton = document.getElementById('shareInviteButton');
 
     this.closeButton.addEventListener('click', () => this.close());
     this.inviteForm.addEventListener('submit', (event) => this.handleSubmit(event));
@@ -5484,6 +5485,8 @@ class InviteModal {
     this.invitePhoneInput.addEventListener('input', () => this.invitePhoneInput.value = normalizePhone(this.invitePhoneInput.value));
     this.invitePhoneInput.addEventListener('blur', () => this.invitePhoneInput.value = normalizePhone(this.invitePhoneInput.value, true));
     this.invitePhoneInput.addEventListener('input', () => this.validateInputs());
+
+    this.shareButton.addEventListener('click', () => this.shareLiberdusInvite());
   }
 
   validateInputs() {
@@ -5571,6 +5574,35 @@ class InviteModal {
       }
     } catch (error) {
       showToast('Failed to send invitation. Please try again.', 0, 'error');
+    }
+  }
+
+  async shareLiberdusInvite() {
+    const url = "https://liberdus.com/download";
+    const title = "Join me on Liberdus";
+    const text = `Message me on Liberdus! ${url}`;
+
+    // 1) Try native share sheet
+    if (navigator.share) {
+      try {
+        await navigator.share({ url, text, title });
+        return; // success
+      } catch (err) {
+        // iOS Safari/WKWebView: cancel → AbortError / "Share canceled"
+        if (err && (err.name === "AbortError" || /canceled/i.test(String(err.message || "")))) {
+          showToast("Share canceled", 2000, "warning");
+          return; // don't fallback: user activation is gone
+        }
+        // fall through to clipboard on real errors
+      }
+    }
+
+    // 2) Clipboard fallback (no mailto)
+    try {
+      await navigator.clipboard.writeText(text);
+      showToast("Invite copied to clipboard!", 3000, "success");
+    } catch {
+      showToast("Could not copy invite link.", 0, "error");
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -1806,6 +1806,15 @@
               <div class="form-actions">
                 <button type="submit" class="btn btn--primary btn--pill btn--full">Send Invitation</button>
               </div>
+              <div class="form-group">
+                <p class="modal-summary">Or share your invite link</p>
+                <button type="button"
+                        id="shareInviteButton"
+                        class="btn btn--secondary btn--pill btn--full"
+                        aria-label="Share invite link">
+                  Share Invite Link
+                </button>
+              </div>
             </form>
           </div>
         </div>


### PR DESCRIPTION
Adds a Share Invite Link button to the Invite Modal. It will try to invoke the device's native share sheet, if that is unavailable it will copy the invite to the clipboard.

Share message: "Message {username} on Liberdus! https://liberdus.com/download"

<img width="404" height="408" alt="image" src="https://github.com/user-attachments/assets/feed4213-5f77-4a3c-87c3-4d2ec2e5ef56" />
