### PR TITLE
message previews for new message types

### DIFF
--- a/app.js
+++ b/app.js
@@ -1030,6 +1030,12 @@ class ChatsScreen {
             // Memo is stored in the 'message' field for transfers
             previewHTML += ` <span class="memo-preview"> | ${truncateMessage(escapeHtml(latestActivity.message), 25)}</span>`;
           }
+        } else if (latestActivity.type === 'call') {
+          previewHTML = `<span><i>Join call</i></span>`;
+        } else if (latestActivity.type === 'vm') {
+          previewHTML = `<span><i>Voice message</i></span>`;
+        } else if ((!latestActivity.message || String(latestActivity.message).trim() === '') && latestActivity.xattach) {
+          previewHTML = `<span><i>Attachment</i></span>`;
         } else {
           // Latest item is a regular message
           const messageText = escapeHtml(latestActivity.message);


### PR DESCRIPTION
Adds custom message preview on Chats List Screen for:
- call message
- voice message
- attachments without a message

<img width="386" height="67" alt="image" src="https://github.com/user-attachments/assets/20c8d65e-0b1c-40eb-aeb5-ce97d643429e" />
<img width="386" height="60" alt="image" src="https://github.com/user-attachments/assets/e8d8f2f2-8911-46d5-aa29-16c29e8b06cb" />
<img width="389" height="67" alt="image" src="https://github.com/user-attachments/assets/c8770934-07b7-40da-a085-3cb810f499c5" />

