### PR TITLE
Fix: Fallback username check on create account submission for length

### DIFF
--- a/app.js
+++ b/app.js
@@ -10488,7 +10488,7 @@ class CreateAccountModal {
     
     // Check if username is too short after normalization
     if (username.length < 3) {
-      this.usernameAvailable.textContent = 'Username too short after normalization';
+      this.usernameAvailable.textContent = 'too short';
       this.usernameAvailable.style.color = '#dc3545';
       this.usernameAvailable.style.display = 'inline';
       this.reEnableControls();


### PR DESCRIPTION
When bug on certain phones when pressing suggested emoji, showing valid username allowed submitting username less than 3 characters. 

Now on submission also checking for correct amount of characters.