### PR TITLE
Add error handling for missing transaction fees in balance validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1704,7 +1704,18 @@ async function validateBalance(amount, assetIndex = 0, balanceWarning = null) {
 
   await getNetworkParams();
   const asset = myData.wallet.assets[assetIndex];
-  const feeInWei = parameters.current.transactionFee || 1n * wei;
+  
+  // Check if transaction fee is available from network parameters
+  if (!parameters.current || !parameters.current.transactionFee) {
+    console.error('Transaction fee not available from network parameters');
+    if (balanceWarning) {
+      balanceWarning.textContent = 'Network error: Cannot determine transaction fee';
+      balanceWarning.style.display = 'inline';
+    }
+    return false;
+  }
+  
+  const feeInWei = parameters.current.transactionFee;
   const totalRequired = amount + feeInWei;
   const hasInsufficientBalance = BigInt(asset.balance) < totalRequired;
 


### PR DESCRIPTION
## **PR Summary:**

**Reason for PR:**
- Removes unsafe fallback that could mask network connectivity issues
- Prevents `NaN` errors when transaction fees are unavailable from network

**Changes Made:**
- Replace hardcoded fallback `|| 1n * wei` with proper error handling
- Add validation to check if `parameters.current.transactionFee` exists
- Display user-friendly error message when network data is unavailable
- Return `false` gracefully instead of proceeding with invalid data
- Log console errors for debugging network connectivity issues

**Impact:**
- Improves error handling and user experience during network outages
- Maintains function integrity by failing safely when required data is missing
- Provides clear feedback about network connectivity status