### PR TITLE
Fix Message Context Menu Off-Screen Rendering on Android

### DIFF
--- a/app.js
+++ b/app.js
@@ -8775,29 +8775,24 @@ console.warn('in send message', txid)
    */
   positionContextMenu(menu, messageEl) {
     const rect = messageEl.getBoundingClientRect();
-    const menuWidth = 200; // match CSS
+    const container = messageEl.closest('.messages-container');
+    const containerRect = container?.getBoundingClientRect() || { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight };
+    
+    const menuWidth = 200;
     const menuHeight = 100;
-
-    let left = rect.left + (rect.width / 2) - (menuWidth / 2);
-    // If menu would overflow right, push left
-    if (left + menuWidth > window.innerWidth - 10) {
-      left = window.innerWidth - menuWidth - 10;
+    
+    // Center horizontally, clamp to container
+    let left = Math.max(containerRect.left + 10, 
+                        Math.min(containerRect.right - menuWidth - 10, 
+                                 rect.left + rect.width/2 - menuWidth/2));
+    
+    // Prefer below, fallback to above, clamp to container
+    let top = rect.bottom + 10;
+    if (top + menuHeight > containerRect.bottom) {
+      top = Math.max(containerRect.top + 10, rect.top - menuHeight - 10);
     }
-    // If menu would overflow left, push right
-    if (left < 10) {
-      left = 10;
-    }
-
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const spaceAbove = rect.top;
-    const top = (spaceBelow >= menuHeight || spaceBelow > spaceAbove)
-      ? rect.bottom + 10
-      : rect.top - menuHeight - 10;
-
-    Object.assign(menu.style, {
-      left: `${left}px`,
-      top: `${top}px`
-    });
+    
+    Object.assign(menu.style, { left: `${left}px`, top: `${top}px` });
   }
 
   /**


### PR DESCRIPTION
## Summary
Updated the message context menu positioning logic to prevent it from rendering off-screen when users tap message content near the bottom of the chat container, particularly addressing issues on older Android devices.

## Changes Made
- **Modified `positionContextMenu()` function** in `app.js` to clamp menu positioning within `.messages-container` bounds
- **Replaced viewport-based positioning** with container-relative positioning using `getBoundingClientRect()`
- **Simplified overflow detection** using `Math.max/min` for cleaner boundary clamping
- **Added fallback positioning** to show menu above message when below placement would overflow

## Technical Details
- Menu now respects chat container boundaries instead of just viewport edges
- Horizontal centering with left/right clamping within container
- Vertical positioning prioritizes below-message placement, falls back to above-message when needed
- Maintains 10px padding from container edges for consistent spacing

## Impact
- Fixes context menu being cut off or rendered off-screen on older Android devices
- Improves user experience when accessing message options near keyboard/navigation areas
- Maintains existing functionality while adding robust boundary detection