### PR TITLE
Add keyboard detection functionality in ChatModal to decide to render context-menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -8743,18 +8743,18 @@ console.warn('in send message', txid)
     if (e.target.closest('.attachment-row')) return;
     if (e.target.closest('.voice-message-play-button')) return;
 
+    // Check if keyboard is open - if so, don't show context menu
+    if (this.isKeyboardOpen()) {
+      console.log('⌨️ Keyboard is open, preventing context menu');
+      return;
+    }
+
     if (e.target.tagName === 'A' || e.target.closest('a')) return;
     
     const messageEl = e.target.closest('.message');
     if (!messageEl) return;
 
     if (messageEl.classList.contains('deleted-message')) return;
-
-    // Check if keyboard is open - if so, don't show context menu
-    if (this.isKeyboardOpen()) {
-      console.log('⌨️ Keyboard is open, preventing context menu');
-      return;
-    }
 
     if (messageEl.dataset.status === 'failed') {
       const isPayment = messageEl.classList.contains('payment-info');

--- a/app.js
+++ b/app.js
@@ -7243,6 +7243,10 @@ class ChatModal {
 
     // Abort controller for cancelling file operations
     this.abortController = new AbortController();
+    
+    // Keyboard detection properties
+    this.isKeyboardVisible = false; // Track keyboard state
+    this.initialViewportHeight = window.innerHeight; // Store initial viewport height
   }
 
   /**
@@ -7325,6 +7329,21 @@ class ChatModal {
 
       // Save draft (text is already limited to 2000 chars by maxlength attribute)
       this.debouncedSaveDraft(e.target.value);
+    });
+
+    // Add viewport resize listener for keyboard detection
+    window.addEventListener('resize', () => {
+      const currentHeight = window.innerHeight;
+      const heightDifference = this.initialViewportHeight - currentHeight;
+      
+      // If viewport height decreased significantly, keyboard is likely open
+      if (heightDifference > 150) { // 150px threshold for keyboard detection
+        this.isKeyboardVisible = true;
+        console.log('⌨️ Keyboard detected as open (viewport height decreased by', heightDifference, 'px)');
+      } else if (heightDifference < 50) { // If height increased or stayed similar, keyboard is likely closed
+        this.isKeyboardVisible = false;
+        console.log('⌨️ Keyboard detected as closed (viewport height difference:', heightDifference, 'px)');
+      }
     });
 
     // Add focus event listener for message input to handle scrolling
@@ -8708,6 +8727,15 @@ console.warn('in send message', txid)
   }
 
   /**
+   * Detects if the keyboard is currently open
+   * @returns {boolean} True if keyboard is likely open
+   */
+  isKeyboardOpen() {
+    // Use the tracked state from resize listener for more reliable detection
+    return this.isKeyboardVisible;
+  }
+
+  /**
    * Handles message click events
    * @param {Event} e - Click event
    */
@@ -8721,6 +8749,12 @@ console.warn('in send message', txid)
     if (!messageEl) return;
 
     if (messageEl.classList.contains('deleted-message')) return;
+
+    // Check if keyboard is open - if so, don't show context menu
+    if (this.isKeyboardOpen()) {
+      console.log('⌨️ Keyboard is open, preventing context menu');
+      return;
+    }
 
     if (messageEl.dataset.status === 'failed') {
       const isPayment = messageEl.classList.contains('payment-info');


### PR DESCRIPTION
- Introduced properties to track keyboard visibility and initial viewport height.
- Implemented a resize event listener to detect keyboard state based on viewport height changes.
- Added a method to check if the keyboard is open, preventing context menu display when the keyboard is active.