### PR TITLE
Implement Edit & Resend functionality for failed payments in context menu of ChatModal

### DIFF
--- a/app.js
+++ b/app.js
@@ -11966,18 +11966,6 @@ class SendAssetConfirmModal {
         return;
       }
       toAddress = normalizeAddress(data.address);
-
-      // hidden input field retryOfTxId value is not an empty string
-      if (sendAssetFormModal.retryTxIdInput.value) {
-        // remove from myData use txid from hidden field retryOfPaymentTxId
-        removeFailedTx(sendAssetFormModal.retryTxIdInput.value, toAddress);
-
-        // clear the field
-        failedTransactionModal.txid = '';
-        failedTransactionModal.address = '';
-        failedTransactionModal.memo = '';
-        sendAssetFormModal.retryTxIdInput.value = '';
-      }
     } catch (error) {
       console.error('Error looking up username:', error);
       showToast('Error looking up username', 0, 'error');
@@ -12101,6 +12089,18 @@ class SendAssetConfirmModal {
           await sendAssetFormModal.reopen();
         }
         throw new Error('Transaction failed');
+      }
+
+      // hidden input field retryOfTxId value is not an empty string
+      if (sendAssetFormModal.retryTxIdInput.value) {
+        // remove from myData use txid from hidden field retryOfPaymentTxId
+        removeFailedTx(sendAssetFormModal.retryTxIdInput.value, toAddress);
+
+        // clear the field
+        failedTransactionModal.txid = '';
+        failedTransactionModal.address = '';
+        failedTransactionModal.memo = '';
+        sendAssetFormModal.retryTxIdInput.value = '';
       }
 
       /* if (!response || !response.result || !response.result.success) {

--- a/app.js
+++ b/app.js
@@ -8758,9 +8758,12 @@ console.warn('in send message', txid)
 
     if (messageEl.dataset.status === 'failed') {
       const isPayment = messageEl.classList.contains('payment-info');
-      return isPayment 
-        ? failedTransactionModal.open(messageEl.dataset.txid, messageEl)
-        : failedMessageMenu.open(e, messageEl);
+      if (isPayment) {
+        // Open main context menu but configure for failed payment
+        this.showMessageContextMenu(e, messageEl);
+        return;
+      }
+      return failedMessageMenu.open(e, messageEl);
     }
 
     this.showMessageContextMenu(e, messageEl);
@@ -8789,14 +8792,23 @@ console.warn('in send message', txid)
     const copyOption = this.contextMenu.querySelector('[data-action="copy"]');
     const joinOption = this.contextMenu.querySelector('[data-action="join"]');
     const inviteOption = this.contextMenu.querySelector('[data-action="call-invite"]');
+    const editResendOption = this.contextMenu.querySelector('[data-action="edit-resend"]');
+    const isFailedPayment = messageEl.dataset.status === 'failed' && messageEl.classList.contains('payment-info');
+    // For failed payment messages, hide copy and delete-for-all regardless of sender
+    if (isFailedPayment) {
+      if (copyOption) copyOption.style.display = 'none';
+      if (deleteForAllOption) deleteForAllOption.style.display = 'none';
+    }
     if (isCall) {
       if (copyOption) copyOption.style.display = 'none';
       if (joinOption) joinOption.style.display = 'flex';
       if (inviteOption) inviteOption.style.display = 'flex';
+      if (editResendOption) editResendOption.style.display = 'none';
     } else {
       if (copyOption) copyOption.style.display = 'flex';
       if (joinOption) joinOption.style.display = 'none';
       if (inviteOption) inviteOption.style.display = 'none';
+      if (editResendOption) editResendOption.style.display = isFailedPayment ? 'flex' : 'none';
     }
     
     this.positionContextMenu(this.contextMenu, messageEl);
@@ -8859,14 +8871,65 @@ console.warn('in send message', txid)
         callInviteModal.open(messageEl);
         break;
       case 'delete':
-        this.deleteMessage(messageEl);
+        if (messageEl.dataset.status === 'failed' && messageEl.classList.contains('payment-info')) {
+          this.deleteFailedPayment(messageEl);
+        } else {
+          this.deleteMessage(messageEl);
+        }
         break;
       case 'delete-for-all':
         this.deleteMessageForAll(messageEl);
         break;
+      case 'edit-resend':
+        this.handleFailedPaymentEditResend(messageEl);
+        break;
     }
     
     this.closeContextMenu();
+  }
+
+  /**
+   * Deletes a failed payment
+   * @param {HTMLElement} messageEl
+   */
+  deleteFailedPayment(messageEl) {
+      const txid = messageEl.dataset.txid;
+      if (txid) {
+        const currentAddress = this.address;
+        removeFailedTx(txid, currentAddress);
+        this.appendChatModal();
+      }
+  }
+
+  /**
+   * Prefill Send form for a failed payment to edit and resend
+   * @param {HTMLElement} messageEl
+   */
+  handleFailedPaymentEditResend(messageEl) {
+    const txid = messageEl.dataset.txid;
+    const address = messageEl?.dataset?.address || this.address;
+    const memo = messageEl.querySelector('.payment-memo')?.textContent || '';
+
+    if (!sendAssetFormModal?.modal || !sendAssetFormModal?.retryTxIdInput) return;
+
+    // Open send modal
+    sendAssetFormModal.open();
+
+    // Hidden retry txid input (used later to remove original failed tx on successful resend)
+    sendAssetFormModal.retryTxIdInput.value = txid || '';
+
+    // Memo
+    sendAssetFormModal.memoInput.value = memo || '';
+
+    // Recipient username (best-effort from contacts)
+    sendAssetFormModal.usernameInput.value = myData.contacts[address]?.username || '';
+    sendAssetFormModal.usernameInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Amount from wallet history (BigInt → string)
+    const amountBig = myData.wallet.history.find((tx) => tx.txid === txid)?.amount;
+    if (typeof amountBig === 'bigint') {
+      sendAssetFormModal.amountInput.value = big2str(amountBig, 18);
+    }
   }
 
 

--- a/index.html
+++ b/index.html
@@ -910,6 +910,11 @@
           <span class="context-menu-icon"></span>
           <span class="context-menu-text">Invite</span>
         </div>
+        <!-- Failed payment specific action: Edit & Resend -->
+        <div class="context-menu-option" data-action="edit-resend" data-icon="retry" style="display: none;">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Edit &amp; Resend</span>
+        </div>
         <div class="context-menu-option" data-action="delete" data-icon="delete">
           <span class="context-menu-icon"></span>
           <span class="context-menu-text">Delete for me</span>
@@ -962,7 +967,7 @@
         </div>
         <div class="context-menu-option" data-action="delete" data-icon="delete">
           <span class="context-menu-icon"></span>
-          <span class="context-menu-text">Delete</span>
+          <span class="context-menu-text">Delete for me</span>
         </div>
         <a class="last-item" href="#"> </a>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -3533,6 +3533,11 @@ small {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z'%3E%3C/path%3E%3C/svg%3E"); 
 }
 
+/* Edit & Resend icon for context menu */
+.context-menu-option[data-icon="retry"] .context-menu-icon {
+  background-image: url("data:image/svg+xml,%3Csvg fill='none' stroke='currentColor' stroke-width='2' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpolyline points='1 4 1 10 7 10'/%3E%3Cpath d='M3.51 15a9 9 0 1 0 2.13-9.36L1 10'/%3E%3C/svg%3E");
+}
+
 /* Styles for Payment Messages in Chat */
 
 /* Base styles for payment header (center, monospace, gap) */


### PR DESCRIPTION
- Added a new context menu option for editing and resending failed payment messages.
- Introduced methods to handle the deletion of failed payments and prefill the send form for resending.
- Updated context menu display logic to hide certain options for failed payments, enhancing user experience.