### PR TITLE
Fix false negative in updateWalletBalances due to truthy check

### DIFF
--- a/app.js
+++ b/app.js
@@ -1306,7 +1306,7 @@ class WalletScreen {
             continue;
           }
           console.log('balance', data);
-          if (data?.balance) {
+          if (data?.balance !== undefined) {
             // Update address balance
             addr.balance = data.balance;
           }


### PR DESCRIPTION
Update balance check in WalletScreen to ensure proper handling of undefined values. This change enhances the reliability of balance updates by explicitly checking for undefined instead of relying on truthy evaluation.