### PR TITLE
Convert Toll System to USD-Only Input with LIB Equivalent Display

### DIFF
--- a/app.js
+++ b/app.js
@@ -9180,9 +9180,12 @@ console.warn('in send message', txid)
     const decimals = 18;
     const factor = getStabilityFactor();
     const tollFloat = parseFloat(big2str(toll, decimals));
-    // Always show USD only
+    // Compute USD and LIB values; show USD with LIB equivalent in parentheses
     const usdValue = tollUnit === 'USD' ? tollFloat : tollFloat * factor;
-    const usdString = `${usdValue.toFixed(6)} USD`;
+    const libValue = factor > 0 ? (usdValue / factor) : NaN;
+    const usdString = isNaN(libValue)
+      ? `${usdValue.toFixed(6)} USD`
+      : `${usdValue.toFixed(6)} USD (≈ ${libValue.toFixed(6)} LIB)`;
     let display;
     if (contact.tollRequiredToSend == 1) {
       display = `${usdString}`;
@@ -11352,7 +11355,8 @@ class SendAssetFormModal {
     const factor = getStabilityFactor();
     const mainValue = parseFloat(big2str(toll, decimals));
     const usd = tollUnit === 'USD' ? mainValue : (mainValue * factor);
-    const usdString = usd.toFixed(6) + ' USD';
+    const lib = factor > 0 ? (usd / factor) : NaN;
+    const usdString = lib ? `${usd.toFixed(6)} USD (≈ ${lib.toFixed(6)} LIB)` : `${usd.toFixed(6)} USD`;
     let display;
     if (this.tollInfo.required == 1) {
       display = `${usdString}`;

--- a/index.html
+++ b/index.html
@@ -1716,7 +1716,7 @@
                     required
                   />
                   <!-- Static currency label (USD) -->
-                  <span id="tollCurrencySymbol" class="toggle-balance" style="pointer-events: none;">USD</span>
+                  <span id="tollCurrencySymbol" class="usd-amount" style="pointer-events: none;">USD</span>
                 </div>
                 <div id="equivalentLibDisplay" class="help-text" style="min-height: 15px;"></div>
                 <div id="minTollDisplay" class="help-text">Minimum toll: Loading...</div>

--- a/styles.css
+++ b/styles.css
@@ -4002,7 +4002,7 @@ small {
   /* width: auto; /* Overrides the default form-control width: 100% */
 }
 
-/* Styles for the toggle button */
+/* Styles for the static USD label in toll modal */
 .usd-amount {
   height: 56px; /* Match the form-control height */
   padding: 0 16px; /* Horizontal padding */
@@ -4020,9 +4020,28 @@ small {
   width: 62px
 }
 
-.toggle-balance:hover {
-  background-color: var(--button-hover-background);
+/* Preserve interactive styling for real toggle buttons (e.g., send form) */
+.toggle-balance {
+  height: 56px; /* Match the form-control height */
+  padding: 0 16px; /* Horizontal padding */
+  background-color: var(--button-background);
+  color: var(--button-text);
+  border: 1.5px solid var(--border-color);
+  border-radius: 12px; /* Full border radius to match form-control */
+  font-family: var(--font-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+  white-space: nowrap; /* Prevent text like "USD" from wrapping */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 62px
 }
+.toggle-balance:hover { background-color: var(--button-hover-background); }
 
 /* Toll Modal Specific Styles */
 


### PR DESCRIPTION
### Overview
Convert the toll system from dual-currency (LIB/USD) toggle to USD-only input while maintaining backward compatibility and showing LIB equivalents for user clarity.

### Changes Made

**Toll Modal (`TollModal` class)**
- Remove currency toggle button and related event handlers
- Replace with static USD label on input right side
- Add live LIB equivalent display below input field
- Show minimum toll in USD instead of LIB
- Display current toll as "X.XXXXXX USD (≈ Y.XXXXXX LIB)"

**Toll Display Updates**
- Chat header toll: Show USD with LIB equivalent in parentheses
- Memo toll hint: Display USD with LIB equivalent
- Modal current toll: Format as "X.XXXXXX USD (≈ Y.XXXXXX LIB)"

**UI/UX Improvements**
- Remove LIB-only display box from modal
- Update help text to clarify USD input with LIB payout
- Add real-time LIB conversion preview while typing
- Maintain consistent decimal precision (6 places for USD, 6 for LIB)

**Code Cleanup**
- Remove obsolete `handleToggleTollCurrency` method
- Clean up unused DOM references and event listeners
- Separate CSS classes for interactive toggle vs static USD label
- Preserve existing send form toggle functionality

### Technical Details
- Toll transactions now post with `tollUnit: 'USD'`
- Backward compatibility: Reads existing LIB-stored tolls and converts to USD for display
- All toll displays use centralized conversion logic via `getStabilityFactor()`
- No changes to send/payment transaction logic or validation

### Files Modified
- `app.js`: TollModal class updates, display method changes
- `index.html`: Remove toggle button, add static USD label and LIB equivalent display
- `styles.css`: Separate styling for static USD label vs interactive toggle buttons