### PR TITLE
Fix Chat Message Toll Validation Error

### DIFF
--- a/app.js
+++ b/app.js
@@ -9199,7 +9199,14 @@ console.warn('in send message', txid)
     }
     tollValue.textContent = display;
 
-    this.toll = toll;
+    // Store the toll in LIB format for message creation (chat messages expect LIB wei)
+    if (tollUnit === 'USD') {
+      // Convert USD toll to LIB wei for internal use
+      this.toll = bigxnum2big(wei, (usdValue / factor).toString());
+    } else {
+      // Already in LIB format
+      this.toll = toll;
+    }
     this.tollUnit = tollUnit;
   }
 


### PR DESCRIPTION
### Overview
Fix toll format mismatch that was causing "toll amount is incorrect" errors when sending chat messages after converting the toll system to USD-only input.

### Problem
- After converting toll system to USD-only, chat message creation still expected tolls in LIB wei format
- `updateTollAmountUI` was setting `this.toll` to raw contact toll value (could be USD or LIB)
- `createChatMessage` expected `tollInLib` in LIB wei format
- This caused validation failures when contacts had USD-stored tolls

### Solution
- Modified `updateTollAmountUI` to convert USD tolls to LIB wei before setting `this.toll`
- Ensures `this.toll` is always in LIB wei format for message creation
- Maintains USD display with LIB equivalent in UI
- Preserves backward compatibility for LIB-stored tolls

### Technical Details
- Added conditional conversion: USD tolls → LIB wei using `bigxnum2big(wei, (usdValue / factor).toString())`
- LIB tolls remain unchanged
- No impact on toll display or user experience
- Fixes chat message sending without affecting other toll functionality

### Files Modified
- `app.js`: Updated `updateTollAmountUI` method in chat modal class

### Result
Chat messages can now be sent successfully regardless of whether the recipient's toll is stored in USD or LIB format.