### PR TITLE
Use transaction type for clicking stake txn in history modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -2864,8 +2864,8 @@ class HistoryModal {
       return;
     }
     
-    const memo = item.querySelector('.transaction-memo')?.textContent;
-    if (memo === 'stake' || memo === 'unstake') {
+    const type = item.querySelector('.transaction-type')?.textContent;
+    if (type.includes('stake')) {
       validatorStakingModal.open();
       return;
     }


### PR DESCRIPTION
User transaction type instead of memo to open staking modal from clicking stake/unstake txn in the history modal