### PR TITLE
Feat: no call notification on phone when a scheduled call message is sent

### DIFF
--- a/app.js
+++ b/app.js
@@ -9791,7 +9791,7 @@ console.warn('in send message', txid)
       // Create and send the call message transaction
       let tollInLib = myData.contacts[currentAddress].tollRequiredToSend == 0 ? 0n : this.toll;
       const chatMessageObj = await this.createChatMessage(currentAddress, payload, tollInLib, keys);
-      // if there's a callobj.calltime is present and is 0 set callType to true
+      // if there's a callobj.calltime is present and is 0 set callType to true to make recipient phone ring
       if (callObj?.callTime === 0) {
         chatMessageObj.callType = true;
       }


### PR DESCRIPTION
Update callType assignment logic in chat message creation to conditionally set based on callObj.callTime

If there's a callobj.calltime is present and is 0 set callType to true then phone call notification will occur otherwise just a message notification will show up on mobile.