### PR TITLE
Fetch missing public keys during call invite process

### DIFF
--- a/app.js
+++ b/app.js
@@ -10181,10 +10181,9 @@ console.warn('in send message', txid)
   }
 
   buildCallScheduleHTML(callTime) {
-    if (this.isFutureCall(callTime)) {
-      return `<div class="call-message-schedule">Scheduled: ${this.formatLocalDateTime(callTime)}</div>`;
-    }
-    return '';
+    if (!callTime) return '';
+    callTime = Number(callTime);
+    return `<div class="call-message-schedule">Scheduled: ${this.formatLocalDateTime(callTime)}</div>`;
   }
 }
 
@@ -10323,9 +10322,10 @@ class CallInviteModal {
           break;
         }
 
-        const payload = { type: 'call', url: msgCallLink };
-        let messagePayload = {};
+        const payload = { type: 'call', url: msgCallLink, callTime: msgCallTime };
+        console.log('payload', payload);
 
+        let messagePayload = {}
         const contact = myData.contacts[addr];
         const ok = await ensureContactKeys(addr);
         if (!ok) {
@@ -10388,7 +10388,8 @@ class CallInviteModal {
           my: true,
           txid: txid,
           status: 'sent',
-          type: 'call'
+          type: 'call',
+          callTime: payload.callTime
         };
         insertSorted(contact.messages, newMessage, 'timestamp');
 

--- a/app.js
+++ b/app.js
@@ -10376,15 +10376,15 @@ class CallInviteModal {
         let recipientPubKey = contact.public;
         let pqRecPubKey = contact.pqPublic;
         if (!recipientPubKey || !pqRecPubKey) {
-          const recipientInfo = await queryNetwork(`/account/${longAddress(this.address)}`);
+          const recipientInfo = await queryNetwork(`/account/${longAddress(addr)}`);
           if (!recipientInfo?.account?.publicKey) {
             showToast(`Skipping ${contact.username || addr} (cannot get public key)`, 2000, 'warning');
             continue;
           }
           recipientPubKey = recipientInfo.account.publicKey;
-          myData.contacts[this.address].public = recipientPubKey;
+          myData.contacts[addr].public = recipientPubKey;
           pqRecPubKey = recipientInfo.account.pqPublicKey;
-          myData.contacts[this.address].pqPublic = pqRecPubKey;
+          myData.contacts[addr].pqPublic = pqRecPubKey;
         }
         
         const {dhkey, cipherText} = dhkeyCombined(keys.secret, recipientPubKey, pqRecPubKey);

--- a/app.js
+++ b/app.js
@@ -8875,8 +8875,8 @@ console.warn('in send message', txid)
    */
   async getRecipientDhKey(recipientAddress) {
     const ok = await ensureContactKeys(recipientAddress);
-      if (!ok) {
-        throw new Error('Recipient keys unavailable');
+    if (!ok) {
+      throw new Error('Recipient keys unavailable');
     }
     const recipient = myData.contacts[recipientAddress];
     return dhkeyCombined(myAccount.keys.secret, recipient.public, recipient.pqPublic);


### PR DESCRIPTION
Retrieve public keys from the network if they are missing in the local contact data when initiating a call invite.