### PR TITLE
Send read transaction only when online in ChatModal close method

### DIFF
--- a/app.js
+++ b/app.js
@@ -7690,6 +7690,8 @@ class ChatModal {
       }
       
       this.sendReclaimTollTransaction(this.address);
+    } else {
+      showToast('Offline: toll not processed', 0, 'error');
     }
 
     // Save any unsaved draft before closing


### PR DESCRIPTION
Ensure that the read and reclaim toll transactions are sent only when the user is online.