### PR TITLE
Update `CallInviteModal` to set `callTime` to 0 for calls about to happen within 5 of call time and after

### DIFF
--- a/app.js
+++ b/app.js
@@ -10357,6 +10357,7 @@ class CallInviteModal {
     if (!msgCallLink) return showToast('Call link not found', 2000, 'error');
     let msgCallTime = Number(this.messageEl.getAttribute('data-call-time')) || 0;
     const now = getCorrectedTimestamp();
+    // if call time is within 5 minutes of now, set to 0 so recipient phone rings
     if (msgCallTime <= now + 5 * 60 * 1000) {
       msgCallTime = 0;
     }

--- a/app.js
+++ b/app.js
@@ -10356,12 +10356,6 @@ class CallInviteModal {
     const msgCallLink = this.messageEl.querySelector('.call-message a')?.href;
     if (!msgCallLink) return showToast('Call link not found', 2000, 'error');
     let msgCallTime = Number(this.messageEl.getAttribute('data-call-time')) || 0;
-    const now = getCorrectedTimestamp();
-    // if call time is within 5 minutes of now, set to 0 so recipient phone rings
-    if (msgCallTime <= now + 5 * 60 * 1000) {
-      msgCallTime = 0;
-    }
-
     this.inviteSendButton.disabled = true;
     this.inviteSendButton.textContent = 'Sending...';
 
@@ -10421,8 +10415,8 @@ class CallInviteModal {
         }
 
         const messageObj = await chatModal.createChatMessage(addr, messagePayload, toll, keys);
-        // set callType to true if callTime is 0 so recipient phone rings
-        if (payload?.callTime === 0) {
+        // set callType to true if callTime is within 5 minutes of now or after callTime
+        if (payload?.callTime <= getCorrectedTimestamp() + 5 * 60 * 1000) {
           messageObj.callType = true
         }
         await signObj(messageObj, keys);

--- a/app.js
+++ b/app.js
@@ -10354,8 +10354,12 @@ class CallInviteModal {
     const addresses = selectedBoxes.map(cb => cb.value).slice(0,10);
     // get call link from original message
     const msgCallLink = this.messageEl.querySelector('.call-message a')?.href;
-    const msgCallTime = Number(this.messageEl.getAttribute('data-call-time')) || 0;
     if (!msgCallLink) return showToast('Call link not found', 2000, 'error');
+    let msgCallTime = Number(this.messageEl.getAttribute('data-call-time')) || 0;
+    const now = getCorrectedTimestamp();
+    if (msgCallTime <= now + 5 * 60 * 1000) {
+      msgCallTime = 0;
+    }
 
     this.inviteSendButton.disabled = true;
     this.inviteSendButton.textContent = 'Sending...';


### PR DESCRIPTION
* Adjusted call time handling in CallInviteModal to reset the call time to 0 if it is within 5 minutes of the current timestamp, improving the logic for managing immediate call invitations.
* Enhanced the retrieval of call time from data attributes, ensuring it is consistently treated as a number for better type consistency.