### PR TITLE
Add Calls Modal to Settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -3011,7 +3011,7 @@ class CallsModal {
   }
 
   /**
-   * Renders the calls list
+   * Renders the calls list by looping through calls and creating a list item for each call
    * @returns {void}
    */
   render() {
@@ -3019,7 +3019,7 @@ class CallsModal {
     const empty = list.querySelector('.empty-state');
     const hasCalls = this.calls.length > 0;
     const existingItems = list.querySelectorAll('.chat-item');
-
+    // if no calls, show empty state and remove existing items
     if (!hasCalls) {
       if (empty) empty.style.display = 'block';
       if (existingItems.length) existingItems.forEach((el) => el.remove());
@@ -3027,12 +3027,14 @@ class CallsModal {
     }
 
     if (empty) empty.style.display = 'none';
+    // create a fragment to append new items to
     const fragment = document.createDocumentFragment();
     this.calls.forEach((c, i) => {
       const li = document.createElement('li');
       li.className = 'chat-item';
       li.setAttribute('data-index', String(i));
       li.setAttribute('data-address', c.address);
+      // format the call time
       const when = chatModal.formatLocalDateTime(c.callTime);
       const identicon = generateIdenticon(c.address);
       li.innerHTML = `
@@ -3050,7 +3052,7 @@ class CallsModal {
       `;
       fragment.appendChild(li);
     });
-    // Remove previous items and append new
+    // remove previous items and append new items
     if (existingItems.length) existingItems.forEach((el) => el.remove());
     list.appendChild(fragment);
   }

--- a/app.js
+++ b/app.js
@@ -404,6 +404,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Failed Transaction Modal
   failedTransactionModal.load();
+
+  // Calls Modal
+  callsModal.load();
   
   // Friend Modal
   friendModal.load();
@@ -1473,6 +1476,9 @@ class SettingsModal {
     this.modal = document.getElementById('settingsModal');
     this.closeButton = document.getElementById('closeSettings');
     this.closeButton.addEventListener('click', () => this.close());
+    
+    this.callsButton = document.getElementById('openCallsModal');
+    this.callsButton.addEventListener('click', () => callsModal.open());
     
     this.profileButton = document.getElementById('openAccountForm');
     this.profileButton.addEventListener('click', () => myProfileModal.open());
@@ -2906,6 +2912,151 @@ class HistoryModal {
 
 // Create singleton instance
 const historyModal = new HistoryModal();
+
+class CallsModal {
+  constructor() {
+    this.calls = [];
+  }
+
+  load() {
+    this.modal = document.getElementById('callsModal');
+    this.list = document.getElementById('callList');
+    this.closeButton = document.getElementById('closeCallsModal');
+    this.closeButton.addEventListener('click', () => this.close());
+
+    // Click on list item: open chat
+    this.list.addEventListener('click', (e) => {
+      const li = e.target.closest('.chat-item');
+      if (!li) return;
+      const address = li.getAttribute('data-address');
+      const action = e.target.closest('.call-join');
+      if (action) {
+        this.handleJoinClick(li);
+        return;
+      }
+      chatModal.open(address);
+    });
+  }
+
+  /**
+   * Opens the calls modal
+   * @returns {void}
+   */
+  open() {
+    this.refreshCalls();
+    this.render();
+    this.modal.classList.add('active');
+  }
+
+  /**
+   * Closes the calls modal
+   * @returns {void}
+   */
+  close() {
+    this.modal.classList.remove('active');
+  }
+
+  /**
+   * Refreshes the calls list by looping through contacts and getting calls that are within last 2 hours or in future
+   * @returns {void}
+   */
+  refreshCalls() {
+    this.calls = [];
+    if (!myData?.contacts) return;
+    const now = getCorrectedTimestamp();
+    const twoHoursMs = 2 * 60 * 60 * 1000;
+    const threshold = now - twoHoursMs;
+    // loop through contacts and get calls that are within last 2 hours or in future
+    for (const [address, contact] of Object.entries(myData.contacts)) {
+      const messages = contact?.messages || [];
+      const displayName = getContactDisplayName(contact);
+      for (const msg of messages) {
+        if (msg?.type !== 'call') continue;
+        const callTime = Number(msg.callTime);
+        // Only include valid scheduled calls: positive timestamp within last 2h or in future
+        if (!Number.isFinite(callTime) || callTime <= 0) continue;
+        if (callTime >= threshold) {
+          this.calls.push({
+            address,
+            calling: displayName,
+            callTime,
+            callUrl: msg.message,
+            txid: msg.txid || ''
+          });
+        }
+      }
+    }
+    this.calls.sort((a, b) => (a.callTime || 0) - (b.callTime || 0));
+  }
+
+  /** 
+   * Handles the join click event for a call
+   * @param {HTMLElement} li - The list item element
+   * @returns {void}
+   */
+  handleJoinClick(li) {
+    const idx = Number(li.getAttribute('data-index'));
+    const item = this.calls[idx];
+    if (!item) return;
+    // Gate future calls
+    if (chatModal.isFutureCall(item.callTime)) {
+      showToast(`Call scheduled for ${chatModal.formatLocalDateTime(item.callTime)}`, 2500, 'info');
+      return;
+    }
+    if (!item.callUrl) {
+      showToast('Call link not found', 2000, 'error');
+      return;
+    }
+    window.open(item.callUrl, '_blank');
+  }
+
+  /**
+   * Renders the calls list
+   * @returns {void}
+   */
+  render() {
+    const list = this.list;
+    const empty = list.querySelector('.empty-state');
+    const hasCalls = this.calls.length > 0;
+    const existingItems = list.querySelectorAll('.chat-item');
+
+    if (!hasCalls) {
+      if (empty) empty.style.display = 'block';
+      if (existingItems.length) existingItems.forEach((el) => el.remove());
+      return;
+    }
+
+    if (empty) empty.style.display = 'none';
+    const fragment = document.createDocumentFragment();
+    this.calls.forEach((c, i) => {
+      const li = document.createElement('li');
+      li.className = 'chat-item';
+      li.setAttribute('data-index', String(i));
+      li.setAttribute('data-address', c.address);
+      const when = chatModal.formatLocalDateTime(c.callTime);
+      const identicon = generateIdenticon(c.address);
+      li.innerHTML = `
+        <div class="chat-avatar">${identicon}</div>
+        <div class="chat-content">
+          <div class="chat-header">
+            <div class="chat-name">${escapeHtml(c.calling)}</div>
+            <button class="call-join call-message-phone-button" aria-label="Join Call"></button>
+          </div>
+          <div class="chat-message">
+            <div class="call-time">${when}</div>
+            <span class="chat-time-chevron"></span>
+          </div>
+        </div>
+      `;
+      fragment.appendChild(li);
+    });
+    // Remove previous items and append new
+    if (existingItems.length) existingItems.forEach((el) => el.remove());
+    list.appendChild(fragment);
+  }
+}
+
+const callsModal = new CallsModal();
 
 async function updateAssetPricesIfNeeded() {
   if (!myData || !myData.wallet || !myData.wallet.assets) {

--- a/index.html
+++ b/index.html
@@ -258,6 +258,7 @@
         </div>
         <div class="modal-content">
           <ul class="menu-list">
+            <li class="menu-item" id="openCallsModal" data-icon="call">Calls</li>
             <li class="menu-item" id="openAccountForm" data-icon="user">Profile</li>
             <li class="menu-item" id="openToll" data-icon="dollar-sign">Toll</li>
             <li class="menu-item" id="openLockModal" data-icon="lock">Lock</li>
@@ -797,6 +798,26 @@
                 </div>
               </div>
             </form>
+          </div>
+        </div>
+        <a class="last-item" href="#"> </a>
+      </div>
+
+      <!-- Calls Modal -->
+      <div class="modal fixed-header" id="callsModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeCallsModal"></button>
+          <div class="modal-title">Calls</div>
+        </div>
+        <div class="modal-content">
+          <div class="form-container">
+            <ul class="chat-list" id="callList">
+              <div class="empty-state">
+                <div></div>
+                <div>No Scheduled Calls</div>
+                <div>Scheduled calls will appear here</div>
+              </div>
+            </ul>
           </div>
         </div>
         <a class="last-item" href="#"> </a>

--- a/styles.css
+++ b/styles.css
@@ -582,8 +582,53 @@ body {
 .chat-header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   margin-bottom: 4px;
+}
+
+/* Calls list specific enhancements */
+#callsModal .chat-item {
+  border-bottom: 1px solid var(--border-color, rgba(0,0,0,0.06));
+}
+
+#callsModal .chat-avatar svg {
+  width: 44px;
+  height: 44px;
+}
+
+#callsModal .chat-name {
+  font-weight: 600;
+  font-size: 0.98rem;
+}
+
+#callsModal .chat-item {
+  position: relative;
+}
+
+#callsModal .chat-content {
+  padding-right: 64px; /* room for the floating call button */
+}
+
+#callsModal .call-join.call-message-phone-button {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+  background-color: var(--primary-color, #3b82f6);
+}
+
+#callsModal .chat-message {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#callsModal .call-time {
+  font-size: 0.88rem;
+  color: var(--secondary-text-color);
 }
 
 .chat-name {
@@ -683,6 +728,10 @@ body {
 /* History empty state - using clock SVG */
 #historyModal .empty-state::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cpolyline points='12 6 12 12 16 14'%3E%3C/polyline%3E%3C/svg%3E");
+}
+/* Calls empty state - using phone SVG */
+#callsModal .empty-state::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 h1 {
@@ -4374,6 +4423,10 @@ small {
 
 .menu-item[data-icon="lock"]::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='11' width='18' height='11' rx='2' ry='2'%3E%3C/rect%3E%3Cpath d='M7 11V7a5 5 0 0 1 10 0v4'%3E%3C/path%3E%3C/svg%3E");
+}
+/* Calls icon for settings menu */
+.menu-item[data-icon="call"]::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 .menu-item[data-icon="arrow-right-arrow-left"]::before {

--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,12 @@
   --button-text: #1c1c21;
   --button-hover-background: #e4e6e9;
 
+  /* Icon SVGs */
+  --icon-phone: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z'%3E%3C/path%3E%3C/svg%3E");
+  --icon-chat: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'%3E%3C/path%3E%3C/svg%3E");
+  --icon-contacts: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2'%3E%3C/path%3E%3Ccircle cx='9' cy='7' r='4'%3E%3C/circle%3E%3Cpath d='M23 21v-2a4 4 0 0 0-3-3.87'%3E%3C/path%3E%3Cpath d='M16 3.13a4 4 0 0 1 0 7.75'%3E%3C/path%3E%3C/svg%3E");
+  --icon-clock: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cpolyline points='12 6 12 12 16 14'%3E%3C/polyline%3E%3C/svg%3E");
+
   /* Typography tokens */
   --font-primary: 'Inter', sans-serif;
   --font-monospace: monospace;
@@ -712,12 +718,12 @@ body {
 
 /* Chats empty state - using chat bubble SVG */
 #chatsScreen .empty-state::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: var(--icon-chat);
 }
 
 /* Contacts empty state - using contacts SVG */
 #contactsScreen .empty-state::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2'%3E%3C/path%3E%3Ccircle cx='9' cy='7' r='4'%3E%3C/circle%3E%3Cpath d='M23 21v-2a4 4 0 0 0-3-3.87'%3E%3C/path%3E%3Cpath d='M16 3.13a4 4 0 0 1 0 7.75'%3E%3C/path%3E%3C/svg%3E");
+  background-image: var(--icon-contacts);
 }
 
 /* Assets empty state - using wallet SVG */
@@ -727,11 +733,11 @@ body {
 
 /* History empty state - using clock SVG */
 #historyModal .empty-state::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cpolyline points='12 6 12 12 16 14'%3E%3C/polyline%3E%3C/svg%3E");
+  background-image: var(--icon-clock);
 }
 /* Calls empty state - using phone SVG */
 #callsModal .empty-state::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: var(--icon-phone);
 }
 
 h1 {
@@ -936,11 +942,11 @@ button:disabled {
 }
 
 .nav-button#switchToChats::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: var(--icon-chat);
 }
 
 .nav-button#switchToContacts::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2'%3E%3C/path%3E%3Ccircle cx='9' cy='7' r='4'%3E%3C/circle%3E%3Cpath d='M23 21v-2a4 4 0 0 0-3-3.87'%3E%3C/path%3E%3Cpath d='M16 3.13a4 4 0 0 1 0 7.75'%3E%3C/path%3E%3C/svg%3E");
+  background-image: var(--icon-contacts);
 }
 
 .nav-button#switchToWallet::before {
@@ -1715,7 +1721,7 @@ input[type='file'].form-control::file-selector-button {
 
 /* History icon (clock) */
 #openHistoryModal .action-icon {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cpolyline points='12 6 12 12 16 14'%3E%3C/polyline%3E%3C/svg%3E");
+  background-image: var(--icon-clock);
 }
 
 /* Profile Sharing Note */
@@ -2687,7 +2693,7 @@ mark {
 /* Icon button styles (for chat button) */
 .icon-button.chat-icon {
   color: var(--text-color);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: var(--icon-chat);
 }
 
 /* Contact section headers */
@@ -4424,9 +4430,9 @@ small {
 .menu-item[data-icon="lock"]::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='11' width='18' height='11' rx='2' ry='2'%3E%3C/rect%3E%3Cpath d='M7 11V7a5 5 0 0 1 10 0v4'%3E%3C/path%3E%3C/svg%3E");
 }
-/* Calls icon for settings menu */
+/* Calls icon for settings menu - reuse existing phone icon */
 .menu-item[data-icon="call"]::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: var(--icon-phone);
 }
 
 .menu-item[data-icon="arrow-right-arrow-left"]::before {


### PR DESCRIPTION
**Purpose:** Add a dedicated Calls view accessible from Settings to display scheduled calls with join functionality.

**Changes Made:**
- **Settings Integration:** Added "Calls" menu item at top of Settings modal with phone icon
- **New Calls Modal:** Created `CallsModal` class with list rendering similar to `HistoryModal`/`ChatsScreen`
- **Call Detection:** Scans all contacts' messages for `type: 'call'` with valid `callTime` within last 2 hours or future
- **Smart Filtering:** Only includes scheduled calls (excludes `callTime: 0` or missing values)
- **Interactive UI:** 
  - Click username/time → opens chat with that contact
  - Click phone button → joins call or shows "scheduled for..." toast for future calls
- **Modern Styling:** Vertically centered call buttons, clean list with separators, phone icon for empty state
- **Performance:** Optimized rendering with precomputed values and cached DOM queries

**Technical Details:**
- Reuses existing call gating logic (`chatModal.isFutureCall`, `formatLocalDateTime`)
- Maintains consistent modal patterns and event handling
- No data mutation; read-only view of existing call messages