### PR TITLE
 Validate Public Key Hash Against Account Address

### DIFF
--- a/app.js
+++ b/app.js
@@ -3207,8 +3207,20 @@ async function ensureContactKeys(address) {
     const netPub = accountInfo?.account?.publicKey;
     const netPq = accountInfo?.account?.pqPublicKey;
     if (netPub) {
-      contact.public = netPub;
-      hasPub = true;
+      try {
+        const derivedHex = bin2hex(generateAddress(hex2bin(netPub)));
+        const expected = normalizeAddress(address);
+        if (derivedHex === expected) {
+          contact.public = netPub;
+          hasPub = true;
+        } else {
+          console.error('ensureContactKeys: public key/address mismatch', { address: expected, derivedHex });
+          return false;
+        }
+      } catch (verr) {
+        console.error('ensureContactKeys: failed to verify public key', verr);
+        return false;
+      }
     }
     if (netPq) {
       contact.pqPublic = netPq;
@@ -3216,7 +3228,7 @@ async function ensureContactKeys(address) {
     }
     return hasPub && hasPq;
   } catch (e) {
-    console.log('ensureContactKeys error:', e);
+    console.error('ensureContactKeys error:', e);
     return false;
   }
 }
@@ -3255,7 +3267,7 @@ async function processChats(chats, keys) {
 
         newTimestamp = tx.timestamp > newTimestamp ? tx.timestamp : newTimestamp;
         mine = tx.from == longAddress(keys.address) ? true : false;
-if (mine) console.warn('txid in processChats is', txidHex)
+        if (mine) console.warn('txid in processChats is', txidHex)
         if (tx.type == 'message') {
           const payload = tx.xmessage; // changed to use .message
           if (mine){


### PR DESCRIPTION
### Purpose
- **Security Enhancement**: Ensure fetched public keys from the network actually correspond to the claimed account address before storing them locally
- **Prevent Key Spoofing**: Block potential attacks where malicious network responses provide incorrect public keys for an address

### Changes Made
- **Enhanced `ensureContactKeys` function**:
  - Added public key validation using existing `generateAddress()` and `normalizeAddress()` utilities
  - Derive address from fetched public key and compare against expected contact address
  - Only store public key if hash matches the account address
  - Return `false` immediately on mismatch or verification error (treating as missing key)

- **Error Handling**:
  - Changed error logging from `console.log` to `console.error` for better visibility
  - Added specific error logging for public key/address mismatches
  - Graceful failure: mismatched keys are treated as missing rather than causing crashes

- **Code Quality**:
  - Fixed minor indentation issue in `processChats` function

### Technical Implementation
- Uses existing crypto utilities: `generateAddress()`, `hex2bin()`, `bin2hex()`, `normalizeAddress()`
- Validation occurs at the point of key storage, ensuring all downstream usage gets verified keys
- Maintains backward compatibility - existing cached keys continue to work normally