### PR TITLE
Refactor offline indicator to have red text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2913,14 +2913,10 @@ mark {
 
 /* Offline indicator in header */
 .offline-indicator {
-  background-color: var(--danger-color);
-  color: white;
+  color: var(--danger-color);
   font-size: 12px;
   font-weight: 600;
-  padding: 4px 8px;
   border-radius: 12px;
-  opacity: 0;
-  visibility: hidden;
   transition:
     opacity 0.3s ease,
     width 0.3s ease,


### PR DESCRIPTION
- Updated the offline indicator styles to change the text color to use the red variable for better visibility.
- Removed unnecessary padding, opacity, and visibility properties to streamline the CSS and improve maintainability.

<img width="536" height="301" alt="image" src="https://github.com/user-attachments/assets/c98989b5-4db5-4598-9a83-ca908bf4fc82" />
