### PR TITLE
Fix null check for accountsObj for locking with no accounts

### DIFF
--- a/app.js
+++ b/app.js
@@ -505,7 +505,7 @@ async function encryptAllAccounts(oldPassword, newPassword) {
   const newEncKey = !newPassword ? null : await passwordToKey(newPassword+'liberdusData');
   // Get all accounts from localStorage
   const accountsObj = parse(localStorage.getItem('accounts') || 'null');
-  if (!accountsObj.netids) return;
+  if (!accountsObj?.netids) return;
 
   console.log('looping through all netids')
   for (const netid in accountsObj.netids) {


### PR DESCRIPTION
Improve the null check for accountsObj to prevent errors when accessing netids for locking and removing lock when there are no  accounts on the device