### PR TITLE
Refine regex pattern to ensure username and netid with single underscore

### DIFF
--- a/app.js
+++ b/app.js
@@ -4962,7 +4962,7 @@ class RemoveAccountsModal {
       if (!storageKey) continue;
       
       // Use regex to extract username and netid from storage key
-      const match = storageKey.match(/(.+)_(.+)$/);
+      const match = storageKey.match(/^([^_]+)_([^_]+)$/);
       if (!match) continue;
       
       const [, username, netid] = match;
@@ -14011,14 +14011,16 @@ console.log('    result is',result)
       // Skip the 'accounts' key itself
       if (key === 'accounts') return false;
       
-      const match = key.match(/(.+)_(.+)$/);
+      // Only match keys with exactly one underscore
+      const match = key.match(/^[^_]+_[^_]+$/);
       if (!match) return false;
       
       return true;
     });
     
     for (const key of accountFileKeys) {
-      const match = key.match(/(.+)_(.+)$/);
+      // Extract username and netid ensuring only one underscore is present
+      const match = key.match(/^([^_]+)_([^_]+)$/);
       if (!match) continue;
       const [, username, netid] = match;
       


### PR DESCRIPTION
_localStorage_total_capacity_ was showing up as an account to remove in the Remove Accounts modal since the regex was looking for any key with an underscore in it. This updates the regex to only find keys with a single underscore in between non underscore characters.