### PR TITLE
Show edited label next to timestamp on memos

### DIFF
--- a/app.js
+++ b/app.js
@@ -8638,8 +8638,8 @@ console.warn('in send message', txid)
                             <span class="payment-direction">${directionText}</span>
                             <span class="payment-amount">${amountDisplay}</span>
                         </div>
-                        ${itemMemo ? `<div class="payment-memo">${linkifyUrls(itemMemo)}${item.edited ? ' <span class="message-edited-label">edited</span>' : ''}</div>` : ''}
-                        <div class="message-time">${timeString}</div>
+                        ${itemMemo ? `<div class="payment-memo">${linkifyUrls(itemMemo)}</div>` : ''}
+                        <div class="message-time">${timeString}${item.edited ? ' <span class="message-edited-label">edited</span>' : ''}</div>
                     </div>
                 `;
       } else {


### PR DESCRIPTION
Display an "edited" label next to the timestamp for payments with memos that have been edited.

<img width="457" height="254" alt="image" src="https://github.com/user-attachments/assets/805226a6-cf5c-48f3-af44-8b82d1a8c884" />
