### PR TITLE
Remove border-radius from icon buttons in chat footer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3049,7 +3049,6 @@ mark {
   width: 20px;
   height: 48px;
   padding: 0;
-  border-radius: 50%;
   flex-shrink: 0;
   pointer-events: auto;
 }
@@ -3059,7 +3058,6 @@ mark {
   width: 20px;
   height: 48px;
   padding: 0;
-  border-radius: 50%;
   flex-shrink: 0;
   pointer-events: auto;
   color: var(--danger-color);
@@ -4723,7 +4721,6 @@ small {
   width: 20px;
   height: 48px;
   padding: 0;
-  border-radius: 50%;
   flex-shrink: 0;
   pointer-events: auto;
 }


### PR DESCRIPTION
- Removes the border radius from the icon buttons in the chat modal footer causing the on hover to be an oval. Now on hover is a rectangle matching the header icon buttons.

<img width="428" height="123" alt="image" src="https://github.com/user-attachments/assets/f8d7a0f1-d5a1-451d-b748-1e10b40021e1" />
