### PR TITLE
Add lastChangeTimeStamp to FriendModal for tracking status updates to prevent user getting stuck pending transaction

### DIFF
--- a/app.js
+++ b/app.js
@@ -2530,6 +2530,7 @@ class FriendModal {
     // If there's already a pending tx (friend != friendOld) keep disabled
     if (contact.friend !== contact.friendOld) {
       const SIXTY_SECONDS = 60 * 1000;
+      // if the last change was more than 60 seconds ago, reset the friend status so user does not get stuck
       if (this.lastChangeTimeStamp < (Date.now - SIXTY_SECONDS)) {
         contact.friend = contact.friendOld
       } else {


### PR DESCRIPTION
- Introduced lastChangeTimeStamp to track the last time the friend status was changed.
- Updated logic to prevent submitting a transaction if the status was changed within the last 60 seconds, to prevent user from getting stuck friend transaction.
- Improved toast notifications for pending transactions to provide clearer user feedback.