### PR TITLE
Update time validation logic in CallScheduleDateModal to allow 5 minute slack to future time allowed

### DIFF
--- a/app.js
+++ b/app.js
@@ -10919,7 +10919,8 @@ class CallScheduleDateModal {
     const localMs = new Date(year, month - 1, day, hour24, minute, 0, 0).getTime();
     const corrected = localMs + timeSkew;
     const nowCorrected = getCorrectedTimestamp();
-    if (corrected <= nowCorrected) {
+    const minAllowed = nowCorrected - 5 * 60 * 1000;
+    if (corrected < minAllowed) {
       showToast('Please choose a time in the future', 2000, 'error');
       return;
     }


### PR DESCRIPTION
- Changed the condition to ensure that the selected time is at least 5 minutes in the future, improving UI when scheduling calls when user waited a few minutes before submitting if top minute value is selected.