### PR TITLE
Add margin to voice recording control buttons for improved spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4941,6 +4941,10 @@ small {
   gap: 1rem;
 }
 
+.voice-recording-controls button{
+  margin: 0 5px;
+}
+
 .voice-btn {
   padding: 12px 24px;
   border: none;


### PR DESCRIPTION
Add spacing between buttons on the voice recording modal
<img width="414" height="344" alt="image" src="https://github.com/user-attachments/assets/e44e1bac-4268-4dfc-be75-abecb2c17a6f" />
<img width="409" height="346" alt="image" src="https://github.com/user-attachments/assets/b23f1345-e928-404f-a144-e6ecb0bcd288" />
