### PR TITLE
Refactor showToast() Function for Better Maintainability

### DIFF
--- a/app.js
+++ b/app.js
@@ -4644,9 +4644,11 @@ function showToast(message, duration = 2000, type = 'default', isHTML = false, d
   // Show with a slight delay to ensure rendering
   setTimeout(() => {
     toast.classList.add('show');
-    // For error toasts, keep it up until the user clicks somewhere to make it go away
-    if (type === 'error') {
-      // Add a close button to error toasts
+    
+    // Duration determines behavior: <= 0 = sticky (requires close button), > 0 = auto-dismiss
+    // Exception: loading toasts are never manually closable by user
+    if (duration <= 0 && type !== 'loading') {
+      // Sticky toast - add close button and click handler (but not for loading toasts)
       toast.style.pointerEvents = 'auto';
       const closeBtn = document.createElement('button');
       closeBtn.className = 'toast-close-btn';
@@ -4654,27 +4656,17 @@ function showToast(message, duration = 2000, type = 'default', isHTML = false, d
       closeBtn.innerHTML = '&times;';
       toast.appendChild(closeBtn);
 
-      // Make the whole toast clickable
+      // Make the whole toast clickable to close
       toast.onclick = () => {
         hideToast(toastId);
       };
-    } else if (duration <= 0) {
-      // Sticky non-error toast (e.g., info) with close button
-      toast.style.pointerEvents = 'auto';
-      const closeBtn = document.createElement('button');
-      closeBtn.className = 'toast-close-btn';
-      closeBtn.setAttribute('aria-label', 'Close');
-      closeBtn.innerHTML = '&times;';
-      toast.appendChild(closeBtn);
-
-      toast.onclick = () => {
-        hideToast(toastId);
-      };
-    } else {
+    } else if (duration > 0) {
+      // Auto-dismiss toast - no close button needed
       setTimeout(() => {
         hideToast(toastId);
       }, duration);
     }
+    // If duration <= 0 and type === 'loading', do nothing - toast stays until programmatically removed
   }, 10);
 
   return toastId;


### PR DESCRIPTION
**Reason for PR:**
* Eliminate code duplication and improve maintainability in toast notification system
* Separate concerns between visual styling and dismissal behavior

**Changes Made:**
* **Removed duplicate close button logic** - Consolidated two separate code blocks that created identical close buttons
* **Simplified dismissal behavior** - Duration now exclusively controls whether toasts are sticky (≤0) or auto-dismiss (>0)
* **Removed special case for error toasts** - Error toasts no longer forced to be sticky, allowing flexible duration control
* **Added special handling for loading toasts** - Loading type toasts never show close button, ensuring they can only be dismissed programmatically
* **Improved code clarity** - Single responsibility: types handle styling, duration handles behavior

<img width="502" height="999" alt="image" src="https://github.com/user-attachments/assets/cae12d8b-dda3-4b1f-9f3b-dec9a8ca6ffe" />

<img width="502" height="999" alt="image" src="https://github.com/user-attachments/assets/db5844a7-7bd5-4a57-884e-9c89d47116ca" />

<img width="502" height="999" alt="image" src="https://github.com/user-attachments/assets/32ee413a-a305-49be-842b-1bfb7f58a8ef" />

