### PR TITLE
Refactor showToast function to use blake to determine duplicated messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,6 @@ async function forceReload(urls) {
 // Needed to stringify and parse bigints; also deterministic stringify
 //   modified to use export
 import { stringify, parse } from './external/stringify-shardus.js';
-import blake from './external/blake2b.js';
 
 // Import crypto functions from crypto.js
 import {
@@ -4614,7 +4613,7 @@ function generateMessageHash(message) {
     return '';
   }
   const hex = hashBytes(message);
-  return hex.slice(0, 10);
+  return hex.slice(0, 20);
 }
 
 // Add this function before the ContactInfoModal class


### PR DESCRIPTION
**Reason for PR:**
* Eliminate code duplication and improve maintainability in toast notification system
* Simplify API by removing explicit deduplication key management

**Changes Made:**
* **Removed `deduplicateKey` parameter** from `showToast()` function signature
* **Added automatic message-based deduplication** using Blake2b hash (first 10 characters)
* **Updated all 80+ `showToast()` calls** to remove explicit deduplication keys
* **Removed redundant `, false` parameters** where `isHTML` defaults to `false`
* **Added Blake2b import** for efficient hash generation with fallback to simple hash

**Benefits:**
* **Cleaner API** - No need to manage deduplication keys manually
* **Automatic deduplication** - Identical messages won't show duplicates
* **More maintainable** - Single source of truth for deduplication logic
* **Consistent behavior** - All toast types follow same dismissal rules