### PR TITLE
Show deleted message and identify sent messages in chat screen preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -1007,7 +1007,9 @@ class ChatsScreen {
         const latestItemTimestamp = latestActivity.timestamp;
 
         // Check if the latest activity is a payment/transfer message
-        if (typeof latestActivity.amount === 'bigint') {
+        if (latestActivity.deleted === 1) {
+          previewHTML = `<span><i>${latestActivity.message}</i></span>`;
+        } else if (typeof latestActivity.amount === 'bigint') {
           // Latest item is a payment/transfer
           const amountStr = parseFloat(big2str(latestActivity.amount, 18)).toFixed(6);
           const amountDisplay = `${amountStr} ${latestActivity.symbol || 'LIB'}`;
@@ -1030,9 +1032,7 @@ class ChatsScreen {
         } else {
           // Latest item is a regular message
           const messageText = escapeHtml(latestActivity.message);
-          // Add "You:" prefix for sent messages
-          const prefix = latestActivity.my ? 'You: ' : '';
-          previewHTML = `${prefix}${truncateMessage(messageText, 50)}`; // Truncate for preview
+          previewHTML = `${truncateMessage(messageText, 50)}`; // Truncate for preview
         }
 
         // Use the determined latest timestamp for display
@@ -1053,7 +1053,7 @@ class ChatsScreen {
                 </div>
                 <div class="chat-message">
                     ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : ''}
-                    ${previewHTML}
+                    ${latestActivity.my ? 'You: ' : ''}${previewHTML}
                 </div>
             </div>
         `;


### PR DESCRIPTION
Display a preview for deleted messages and ensure sent messages are prefixed with "You:" in the chat interface.

- Previously only payment and plain messages would show the deleted text when deleted. Now any message type ( call, vm, attachment, ect) will show the deleted text in the chat list preview.
- Previously only plain sent messages showed "You:" in front of the message in the chat list preview, now all message types sent by the user will be prefixed with "You:"

<img width="423" height="215" alt="image" src="https://github.com/user-attachments/assets/8a6a2659-c7e7-44ed-ab07-76eb9bd99e66" />
<img width="429" height="210" alt="image" src="https://github.com/user-attachments/assets/fe59b0e2-6674-4a0d-941c-1bfa83313097" />
<img width="413" height="205" alt="image" src="https://github.com/user-attachments/assets/3194f488-0e52-465d-a4e1-68cdbfe775e4" />
