### PR TITLE
Highlight active scheduled calls in calls modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -3074,6 +3074,13 @@ class CallsModal {
     this.render();
     this.modal.classList.add('active');
     this.clockTimer.start();
+    // start periodic refresh to update call button states every 5s
+    this._stateInterval = setInterval(() => {
+      // Only re-render if modal still active
+      if (this.modal.classList.contains('active')) {
+        this.render();
+      }
+    }, 5000); 
   }
 
   /**
@@ -3083,6 +3090,10 @@ class CallsModal {
   close() {
     this.clockTimer.stop();
     this.modal.classList.remove('active');
+    if (this._stateInterval) {
+      clearInterval(this._stateInterval);
+      this._stateInterval = null;
+    }
   }
 
   /**
@@ -3228,12 +3239,35 @@ class CallsModal {
         li.querySelector('.chat-name').textContent = participant.calling;
         li.querySelector('.call-time').textContent = when;
       }
+      // annotate scheduled time for state updates
+      li.setAttribute('data-call-time', String(callGroup.callTime));
       
       fragment.appendChild(li);
     });
     // remove previous items and append new items
     if (existingItems.length) existingItems.forEach((el) => el.remove());
     list.appendChild(fragment);
+    // After rendering, update button states
+    this.updateJoinButtonStates();
+  }
+
+  /**
+   * Updates the color of join buttons based on current time
+   */
+  updateJoinButtonStates() {
+    if (!this.list) return;
+      this.list.querySelectorAll('.chat-item').forEach(li => {
+        const callTime = Number(li.getAttribute('data-call-time'));
+        const joinBtn = li.querySelector('.call-join');
+        if (!joinBtn || !Number.isFinite(callTime)) return;
+        const isFuture = chatModal.isFutureCall(callTime);
+        joinBtn.classList.remove('call-join--future', 'call-join--active');
+        if (isFuture) {
+          joinBtn.classList.add('call-join--future');
+        } else {
+          joinBtn.classList.add('call-join--active');
+        }
+    });
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -3078,6 +3078,7 @@ class CallsModal {
     this._stateInterval = setInterval(() => {
       // Only re-render if modal still active
       if (this.modal.classList.contains('active')) {
+        this.refreshCalls();
         this.render();
       }
     }, 5000); 

--- a/app.js
+++ b/app.js
@@ -3076,7 +3076,6 @@ class CallsModal {
     this.clockTimer.start();
     // start periodic refresh to update call button states every 5s
     this._stateInterval = setInterval(() => {
-      // Only re-render if modal still active
       if (this.modal.classList.contains('active')) {
         this.refreshCalls();
         this.render();

--- a/styles.css
+++ b/styles.css
@@ -782,6 +782,15 @@ body {
   color: var(--secondary-text-color);
 }
 
+#callsModal .call-join.call-message-phone-button.call-join--future {
+  background-color: var(--button-hover-background);
+  opacity: 0.85;
+}
+
+#callsModal .call-join.call-message-phone-button.call-join--active {
+  background-color: var(--success-color);
+}
+
 .chat-name {
   font-family: var(--font-primary);
   font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
Updates the styling in the call modal to highlight in progress calls.

- Call button on future calls in now grey
- Call button on in progress calls is now green
- Adds a 5 second interval to refresh and rerender the list and update button colors while the calls modal is active

<img width="427" height="330" alt="image" src="https://github.com/user-attachments/assets/fae4c507-3a49-40af-aa7b-5c4065c25a53" />
