### PR TITLE
Enhance flexbox styles in styles.css in edit contact info for better responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2933,10 +2933,13 @@ mark {
   align-items: center;
   gap: 8px;
   flex-direction: row;
+  min-width: 0; /* Allow flex items to shrink below their content size */
+  width: 100%; /* Ensure it takes full width of parent */
 }
 
 .edit-field-input {
   flex: 1;
+  min-width: 0; /* Allow input to shrink below its content size */
   font-family: var(--font-primary);
   font-size: var(--font-size-base);
   padding: 8px 12px;


### PR DESCRIPTION
- Added min-width: 0 to allow flex items to shrink below their content size.
- Set width: 100% for the mark class to ensure it takes the full width of its parent.
- Updated edit-field-input to also allow shrinking below content size.
<img width="419" height="1079" alt="image" src="https://github.com/user-attachments/assets/93d85ff5-0ad0-4b5b-ae1b-2a1272b5bda0" />
