### PR TITLE
Improve IOS fil attacment menu pop up position for add-attachment button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3344,17 +3344,6 @@ mark {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='12' y1='5' x2='12' y2='19'%3E%3C/line%3E%3Cline x1='5' y1='12' x2='19' y2='12'%3E%3C/line%3E%3C/svg%3E");
 }
 
-/* .icon-button.add-attachment-button:hover {
-  opacity: 1;
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-.icon-button.add-attachment-button:active {
-  opacity: 1;
-  background-color: rgba(255, 255, 255, 0.2);
-  transform: scale(0.95);
-} */
-
 /* If you're not using Font Awesome, we can create a custom chevron icon */
 .chat-time-chevron {
   display: inline-block;


### PR DESCRIPTION
### **Changes Made:**
• **Increased add-attachment button size** from 20px to 44px width (iOS recommended minimum touch target)
• **Increased voice-record button size** from 20px to 32px width for better mobile usability
• **Removed gap spacing** from message-input-row to accommodate larger button sizes
• **Added min-width constraint** to add-attachment button to prevent shrinking

### **Reason for PR:**
• **Fix file picker positioning issues** - larger touch targets reduce missed clicks that cause modal to appear at wrong location
• **Improve mobile accessibility** - buttons now meet iOS touch target guidelines (44px minimum)
• **Better user experience** - more reliable button interactions on mobile devices

### **Impact:**
• **Reduced user frustration** with file attachment modal appearing at top center of screen
• **Improved touch accuracy** on mobile devices
• **Better compliance** with mobile accessibility standards