### PR TITLE
WalletScreen initial load to display -.-- instead of 0.00

### DIFF
--- a/app.js
+++ b/app.js
@@ -1211,7 +1211,7 @@ const contactsScreen = new ContactsScreen();
 
 class WalletScreen {
   constructor() {
-
+    this.firstTimeLoad = true;
   }
 
   load() {
@@ -1270,7 +1270,24 @@ class WalletScreen {
   async updateWalletView() {
     const walletData = myData.wallet;
 
-    await this.updateWalletBalances();
+    // Show loading toast if we're about to fetch fresh data
+    let loadingToastId = null;
+    // only show toast if myData.wallet.timestamp is not 0
+    if (this.firstTimeLoad && isOnline) {
+      loadingToastId = showToast('Loading wallet balance...', 0, 'loading');
+      this.firstTimeLoad = false;
+    }
+
+    try {
+      await this.updateWalletBalances();
+    } catch (error) {
+      console.error('Error updating wallet balances:', error);
+    } finally {
+      // Always hide loading toast if it was shown, regardless of success or failure
+      if (loadingToastId) {
+        hideToast(loadingToastId);
+      }
+    }
 
     // Update total networth
     this.totalBalance.textContent = (walletData.networth || 0).toFixed(2);

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
         <div class="wallet-balance">
           <div class="balance-label">Total Balance</div>
           <div class="balance-amount">
-            <span id="walletTotalBalance">0.00</span>
+            <span id="walletTotalBalance">-.--</span>
             <button class="refresh-button" id="refreshBalance">↻</button>
           </div>
         </div>


### PR DESCRIPTION
Enhance wallet screen initial loading UX by replacing misleading `0.00` placeholder with proper loading states and user feedback.

**UI/UX Improvements:**
- Replace default balance display from `0.00` to `-.--` in HTML
- Add loading toast notification during initial balance fetch
- Implement `firstTimeLoad` flag to show loading toast only on first wallet view

**Code Quality:**
- Add proper error handling with try-catch-finally blocks
- Ensure loading toast cleanup in all scenarios (success/failure)
- Initialize `firstTimeLoad = true` in WalletScreen constructor

**User Experience:**
- Users see `-.--` instead of confusing `0.00` before balance loads
- Clear "Loading wallet balance..." toast provides feedback during fetch
- Loading toast automatically disappears when operation completes
- No duplicate toast cleanup or hanging loading states

###  **Technical Details**
- Uses `finally` block for guaranteed toast cleanup
- `firstTimeLoad` flag prevents showing loading toast on subsequent wallet refreshes
- Maintains existing 5-second cache logic for balance updates
- Preserves all existing wallet functionality

### �� **Result**
Users now get clear visual feedback during wallet loading instead of seeing misleading zero balances, creating a more professional and intuitive experience.

<img width="495" height="989" alt="image" src="https://github.com/user-attachments/assets/3f05224b-76b9-4e6c-99e1-27764c13abc7" />