### PR TITLE
Add empty state to call invite modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -10984,6 +10984,13 @@ class CallInviteModal {
       others: allContacts.filter(c => ![2,3,0].includes(c.friend)).sort((a,b) => a.username.toLowerCase().localeCompare(b.username.toLowerCase())),
     };
 
+    if (allContacts.length === 0) {
+      this.modal.querySelector('.empty-state').style.display = 'block';
+      // initial counter update to ensure Invite button is disabled
+      this.updateCounter();
+      return;
+    }
+
     const sectionMeta = [
       { key: 'friends', label: 'Friends' },
       { key: 'acquaintances', label: 'Connections' },

--- a/index.html
+++ b/index.html
@@ -1093,6 +1093,11 @@
         <div class="modal-content">
           <div class="form-container call-invite-modal-container">
             <div class="call-invite-contacts-scroll">
+                <div class="empty-state">
+                  <div></div>
+                  <div>No Contacts Found</div>
+                  <div>Add contacts to invite them to calls</div>
+                </div>
               <div class="contacts-list" id="callInviteContactsList">
                 <!-- Contacts will be populated here -->
               </div>

--- a/styles.css
+++ b/styles.css
@@ -871,6 +871,15 @@ body {
   opacity: 0.5;
 }
 
+#callInviteModal .empty-state {
+  display: none; /* Hidden by default */
+  padding: 0;
+}
+#callInviteModal .empty-state::before {
+  width: 0;
+  height: 0;
+}
+
 /* Chats empty state - using chat bubble SVG */
 #chatsScreen .empty-state::before {
   background-image: var(--icon-chat);


### PR DESCRIPTION
Introduce an empty state in the call invite modal to inform users when no contacts are available for invitation. 

<img width="466" height="282" alt="image" src="https://github.com/user-attachments/assets/59d1a11a-21cc-4fe2-9da7-0a13feac4a37" />
