### PR TITLE
Fix autofill not enabling UnlockModal submit button

### DIFF
--- a/app.js
+++ b/app.js
@@ -15219,6 +15219,7 @@ class UnlockModal {
 
   open() {
     this.modal.classList.add('active');
+    setTimeout(() => this.updateButtonState(), 100);
   }
 
   close() {


### PR DESCRIPTION
Add timeout in open of unlockModal that will invoke button state since if password manager autofills password we never get an event the input changed.