### PR TITLE
Add draft indicator to chat screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -1075,7 +1075,7 @@ class ChatsScreen {
                     <div class="chat-time">${timeDisplay} <span class="chat-time-chevron"></span></div>
                 </div>
                 <div class="chat-message">
-                  ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : (contact.draft && contact.draft.trim() ? `<span class="chat-draft" title="Draft"></span>` : '')}
+                  ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : (contact.draft ? `<span class="chat-draft" title="Draft"></span>` : '')}
                   ${latestActivity.my ? 'You: ' : ''}${previewHTML}
                 </div>
             </div>

--- a/app.js
+++ b/app.js
@@ -1075,8 +1075,8 @@ class ChatsScreen {
                     <div class="chat-time">${timeDisplay} <span class="chat-time-chevron"></span></div>
                 </div>
                 <div class="chat-message">
-                    ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : ''}
-                    ${latestActivity.my ? 'You: ' : ''}${previewHTML}
+                  ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : (contact.draft && contact.draft.trim() ? `<span class="chat-draft" title="Draft"></span>` : '')}
+                  ${latestActivity.my ? 'You: ' : ''}${previewHTML}
                 </div>
             </div>
         `;

--- a/styles.css
+++ b/styles.css
@@ -846,6 +846,17 @@ body {
   margin-left: 8px;
 }
 
+/* Orange draft indicator shown when there is a saved draft and no unread messages */
+.chat-draft {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background-color: var(--warning-color);
+  border-radius: 50%;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 .empty-state {
   text-align: center;
   padding: 2rem;


### PR DESCRIPTION
Adds an orange dot on the chat in the chats screen when the chat has a draft. Does not show the orange dot if there are unread messages.
<img width="449" height="544" alt="image" src="https://github.com/user-attachments/assets/1295d6b4-6268-41a0-ba8c-5d597bde9ed1" />
