### PR TITLE
Clear notifications only when all chats are read

### DIFF
--- a/app.js
+++ b/app.js
@@ -8364,10 +8364,6 @@ class ChatModal {
         // Clear bell icon for signed-in account
         logsModal.log('Clearing notification address for', myAccount.keys.address);
         reactNativeApp.clearNotificationAddress(myAccount.keys.address);
-        // This is required to clear the notification from the react native side
-        // without it ALL_NOTIFICATIONS_IN_PANEL gets triggered in the sign in modal and the bell icon reappears
-        // this also clears the bubble on the app icon which we don't want until there are no addresses with notifications
-        reactNativeApp.sendClearNotifications();
       }
       // 2. Check if all bell icons are cleared local storage notification addresses empty
       const notificationAddresses = reactNativeApp.getNotificationAddresses();


### PR DESCRIPTION
No longer clear notifications on sign in  and sign out, now notifications are cleared when unread chats are opened.

Currently there is a limitation with the native app. We can only clear ALL notifications AND the notification badge with the `sendClearNotifications` 'CLEAR_NOTI' message, but if we don't send that after a single account has read all its messaged then the bell icon will never get removed from the sign in modal until ALL accounts on the decive read all thier messages.