### PR TITLE
Fix contact search debounce logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -4595,7 +4595,10 @@ class SearchContactsModal {
             this.displayContactResults(results, searchText);
           }
         },
-        (searchText) => (searchText.length === 1 ? 600 : 300)
+        (event) => {
+          const searchText = event?.target?.value ?? '';
+          return searchText.trim().length === 1 ? 600 : 300;
+        }
       )
     );
   }


### PR DESCRIPTION
Fixed a bug with contact search input where searchText was out of scope and would always cause the delay to be 300ms, now it properly gets the text length from the event to determine length of the delay.