### PR TITLE
Refactor backup account submission methods to remove unused event parameter

### DIFF
--- a/app.js
+++ b/app.js
@@ -5750,19 +5750,17 @@ class BackupAccountModal {
     // Determine which backup method to use
     if (myData && !this.backupAllAccountsCheckbox.checked) {
       // User is signed in and wants to backup only current account
-      await this.handleSubmitOne(event);
+      await this.handleSubmitOne();
     } else {
       // User wants to backup all accounts (either not signed in or checkbox checked)
-      await this.handleSubmitAll(event);
+      await this.handleSubmitAll();
     }
   }
 
   /**
    * Handle the submission of a single account backup.
-   * @param {Event} event - The event object.
    */
-  async handleSubmitOne(event) {
-    event.preventDefault();
+  async handleSubmitOne() {
     saveState();
 
     // Disable button to prevent multiple submissions
@@ -5832,10 +5830,8 @@ class BackupAccountModal {
 
   /**
    * Handle the submission of a backup for all accounts.
-   * @param {Event} event - The event object.
    */
-  async handleSubmitAll(event) {
-    event.preventDefault();
+  async handleSubmitAll() {
 
     // Disable button to prevent multiple submissions
     this.submitButton.disabled = true;

--- a/app.js
+++ b/app.js
@@ -5761,10 +5761,10 @@ class BackupAccountModal {
    * Handle the submission of a single account backup.
    */
   async handleSubmitOne() {
-    saveState();
-
     // Disable button to prevent multiple submissions
     this.submitButton.disabled = true;
+
+    saveState();
 
     const password = this.passwordInput.value;
     // Build new structured backup object
@@ -5792,7 +5792,6 @@ class BackupAccountModal {
 
       // Create and trigger download
       const blob = new Blob([finalData], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
       const filename = this.generateBackupFilename(myAccount.username);
       // Detect if running inside React Native WebView
       if (window.ReactNativeWebView?.postMessage) {
@@ -5809,6 +5808,7 @@ class BackupAccountModal {
         reader.readAsDataURL(blob);
       } else {
         // Regular browser download
+        const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
         a.download = filename;


### PR DESCRIPTION
minor audit fixes
- Remove the unused event parameter from the backup account submission methods 
- in handleSubmitOne disable the submit button before anything else incase the saveState takes some time
- move url closer to where it is used 