### PR TITLE
Fix search message preview: prevent HTML tag truncation and improve search accuracy

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -322,6 +322,19 @@ export function truncateMessage(message, maxLength = 100) {
     }
     // --- End Adjustment ---
 
+    // --- Ensure we don't cut through HTML tags ---
+    // Check if we're cutting through a tag at the end
+    if (endIndex < message.length && message.lastIndexOf('<', endIndex) > message.lastIndexOf('>', endIndex)) {
+        endIndex = message.lastIndexOf('<', endIndex);
+    }
+    // Check if we're starting inside a tag
+    if (startIndex > 0) {
+        const nextClose = message.indexOf('>', startIndex);
+        const nextOpen = message.indexOf('<', startIndex);
+        if (nextClose !== -1 && (nextOpen === -1 || nextClose < nextOpen)) {
+            startIndex = nextClose + 1;
+        }
+    }
 
     // Extract the substring
     let preview = message.substring(startIndex, endIndex);


### PR DESCRIPTION
**Changes:**
1. Fixed `<mark>` tags being counted toward character limit, causing previews to be cut short
2. Prevented truncation from cutting through HTML tags (avoiding broken `<ma...` or `</mar...>` in results)
3. Fixed search text not being escaped for regex, which could cause errors with special characters
4. Preserved trailing spaces in search queries to allow exact matching (e.g., "car " vs "carp")

**Technical Details:**
- Modified `SearchMessagesModal.searchMessages()` to:
  - Escape search text with `escapeRegExp()` before creating regex
  - Calculate adjusted max length accounting for `<mark>` tag overhead (13 chars per highlight)
  - Use `trimStart()` instead of `trim()` to preserve meaningful trailing spaces
- Enhanced `truncateMessage()` in `lib.js` to detect and avoid cutting through HTML tags

**Impact:**
- Search results now display approximately 100 characters of actual text (not including HTML markup)
- No more broken HTML artifacts in search previews
- More reliable search with special characters and trailing spaces