### PR TITLE
Use full border on amount fields

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4441,7 +4441,6 @@ small {
 .amount-container .form-control {
   flex: 1; /* Allows the input to take available space */
   min-width: 0; /* Important for flex item shrinkage */
-  border-right: 1px solid #ccc; /* Restore right border */
   /* width: auto; /* Overrides the default form-control width: 100% */
 }
 


### PR DESCRIPTION
Remove the right border from amount fields to create a full border appearance. Affects the amount field in Toll, Send Asset, and Receive modal. Previously the currency button was connected to the field so the right border was removed. Now that the button is disconnected it should display a full border.

<img width="462" height="462" alt="image" src="https://github.com/user-attachments/assets/9d1dd91d-a9b8-4298-b890-58e27ea3ced4" />
