### PR TITLE
Fix offline account editing and CSS pointer events

### DIFF
--- a/app.js
+++ b/app.js
@@ -5003,7 +5003,6 @@ function markConnectivityDependentElements() {
     '#addFriendButton',
 
     // Profile related
-    '#accountForm button[type="submit"]',
     '#createAccountForm button[type="submit"]',
     '#importForm button[type="submit"]',
 

--- a/index.html
+++ b/index.html
@@ -692,9 +692,7 @@
               <!-- My info fields -->
               <div class="contact-info-item" style="display: none">
                 <div class="contact-info-label">Name</div>
-                <div class="contact-info-value-container">
-                  <div class="contact-info-value" id="myInfoName"></div>
-                </div>
+                <div class="contact-info-value" id="myInfoName"></div>
               </div>
               <div class="contact-info-item" style="display: none">
                 <div class="contact-info-label">Email</div>

--- a/styles.css
+++ b/styles.css
@@ -3213,7 +3213,6 @@ mark {
   opacity: 0.6;
   cursor: not-allowed !important;
   position: relative;
-  pointer-events: none;
 }
 
 /* Offline indicator in header */


### PR DESCRIPTION
- remove accountForm submit from network dependent elements since that only affects local storage.
- fix MyInfo modal to properly show the name field
- removed `pointer-events: none` from offline disabled elements since that was causing the standard cursor to show instead of the not-allowed cursor.