### PR TITLE
Refactor account removal modal: DRY up counting logic and surface decryption errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -5546,8 +5546,8 @@ class RemoveAccountsModal {
       const storageKey = localStorage.key(i);
       if (!storageKey) continue;
       
-  // Use regex to extract username and netid from storage key: username_<64-hex>
-  const match = storageKey.match(/^([^_]+)_([0-9a-fA-F]{64})$/);
+      // Use regex to extract username and netid from storage key: username_<64-hex>
+      const match = storageKey.match(/^([^_]+)_([0-9a-fA-F]{64})$/);
       if (!match) continue;
       
       const [, username, netid] = match;

--- a/app.js
+++ b/app.js
@@ -5555,10 +5555,6 @@ class RemoveAccountsModal {
       // Validate username and netid
       if (!username || !netid) continue;
       
-      // Check if this account is already in our result list
-      const already = result.find(r => r.username === username && r.netid === netid);
-      if (already) continue;
-      
       // Check if this account is registered in the accounts object
       const isRegistered = accountsObj.netids[netid]?.usernames?.[username];
       if (isRegistered) continue;


### PR DESCRIPTION
### Changes
This PR refactors the account removal modal to eliminate code duplication and provide better visibility into data loading errors.

**Key improvements:**
1. **DRY Principle**: Extracted `getContactsAndMessagesCount()` helper function that was duplicated between regular and orphaned account processing
2. **Better Error Detection**: Added explicit checks to distinguish between "no data exists" vs "decryption failed" scenarios
3. **User-Friendly Display**: Shows "unable to load data" instead of confusing "-1 contacts, -1 messages" or misleading "0 contacts, 0 messages" 
4. **Enhanced Logging**: Console warnings now specify whether decryption failed vs other errors

**Why this matters:**
Previously, when `decryptChacha()` returned `null` due to decryption failure, accounts appeared to have 0 contacts/messages, which was misleading. Now users can see which accounts have data loading issues, making it easier to identify corrupted/inaccessible accounts.

### Testing
- Verify normal accounts display correctly
- Verify orphaned accounts display correctly  
- Verify accounts with decryption failures show "unable to load data"
- Check console logs for improved error messages


<img width="465" height="704" alt="image" src="https://github.com/user-attachments/assets/8d607b59-581b-4ba3-92a6-121e35424fe1" />
