### PR TITLE
Add padding-top in order to keep messages-list scrollable to prevent React Native container scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1687,6 +1687,7 @@ input[type='file'].form-control::file-selector-button {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding-top:1000px; /* keeps message list scrollable */
 }
 
 .message {


### PR DESCRIPTION
Add padding to file selector button for improved message list scrollability in styles.css