### PR TITLE
Remove unnecessary toast for chatModal toll when closing modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -8630,7 +8630,7 @@ class ChatModal {
       
       this.sendReclaimTollTransaction(this.address);
     } else {
-      showToast('Offline: toll not processed', 0, 'error');
+      console.warn('Offline: toll not processed');
     }
 
     // Save any unsaved draft before closing


### PR DESCRIPTION
Update error handling in ChatModal to log warnings instead of showing toast notifications for offline toll processing