### PR TITLE
Remove inviteModal button selector from markConnectivityDependentElements

### DIFF
--- a/app.js
+++ b/app.js
@@ -5059,9 +5059,6 @@ function markConnectivityDependentElements() {
     // tollModal
     '#saveNewTollButton',
 
-    //inviteModal
-    '#inviteForm button[type="submit"]',
-
     //unstakeModal
     '#submitUnstake',
 


### PR DESCRIPTION
Remove inviteModal button selector from markConnectivityDependentElements function to allow function when app is offline.