### PR TITLE
Keep offline TollModal  save button disabled when typing in input

### DIFF
--- a/app.js
+++ b/app.js
@@ -6741,7 +6741,7 @@ class TollModal {
    */
   updateSaveButtonState() {
     // If offline, keep button disabled
-    if (!isOnline || netIdMismatch) {
+    if (!isOnline) {
       this.saveButton.disabled = true;
       return;
     }

--- a/app.js
+++ b/app.js
@@ -6740,6 +6740,12 @@ class TollModal {
    * Updates the save button state and warning message based on input validation
    */
   updateSaveButtonState() {
+    // If offline, keep button disabled
+    if (!isOnline || netIdMismatch) {
+      this.saveButton.disabled = true;
+      return;
+    }
+
     const warningMessage = this.getWarningMessage();
     const isValid = !warningMessage;
 


### PR DESCRIPTION
Implement logic to disable the save button in TollModal when offline or if network ID mismatches, enhancing input validation handling.