### PR TITLE
Update connectivity checks to only use `offline` when handling offline UI changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -5117,7 +5117,7 @@ function updateUIForConnectivity() {
   }
 
   networkDependentElements.forEach((element) => {
-    if (!isOnline || netIdMismatch) {
+    if (!isOnline) {
       // Disable element
       element.disabled = true;
       element.classList.add('offline-disabled');
@@ -16849,6 +16849,7 @@ async function getNetworkParams() {
       if (network.netid !== parameters.networkId) {
         // treat as offline
         netIdMismatch = true;
+        isOnline = false;
         updateUIForConnectivity();
         console.error(`getNetworkParams: Network ID mismatch. Network ID from network.js: ${network.netid}, Network ID from parameters: ${parameters.networkId}`);
         console.log(parameters)


### PR DESCRIPTION
* Remove network ID mismatch condition from UI update logic, ensuring elements are disabled solely based on online status.
* Set isOnline to false when a network ID mismatch is detected, enhancing the clarity of connectivity state management.