### PR TITLE
 Fix: Prevent context menu from appearing on voice messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -10152,6 +10152,8 @@ console.warn('in send message', txid)
 
     if (messageEl.classList.contains('deleted-message')) return;
 
+    if (messageEl.querySelector('.voice-message')) return;
+
     if (messageEl.dataset.status === 'failed') {
       const isPayment = messageEl.classList.contains('payment-info');
       if (isPayment) {


### PR DESCRIPTION
**Reason for PR:**
- Voice messages were incorrectly showing the message context menu when clicked, which shouldn't happen since voice messages have their own specific controls (play, speed, seek)

**Changes made:**
- Added check in `handleMessageClick` to detect if a message contains a voice message component
- Prevents context menu from appearing when clicking anywhere on a voice message (including timestamp, padding, or background)
- Voice message interactive controls (play button, speed button, seek bar) continue to function normally with their dedicated handlers