### PR TITLE
 Hide Copy/Edit options for content-less attachments and payments

### DIFF
--- a/app.js
+++ b/app.js
@@ -10232,6 +10232,14 @@ console.warn('in send message', txid)
       }
     }
     
+    // Hide copy and edit for attachment/payment without text content
+    const hasTextContent = messageEl.querySelector('.message-content')?.textContent.trim() || 
+                           messageEl.querySelector('.payment-memo')?.textContent.trim();
+    if ((messageEl.querySelector('.attachment-row') || messageEl.classList.contains('payment-info')) && !hasTextContent) {
+      if (copyOption) copyOption.style.display = 'none';
+      if (editOption) editOption.style.display = 'none';
+    }
+    
     this.positionContextMenu(this.contextMenu, messageEl);
     this.contextMenu.style.display = 'block';
   }


### PR DESCRIPTION
**Reason for PR:**
- Messages containing only attachments (no text) or only payment amounts (no memo) were incorrectly showing Copy and Edit options in the context menu, which don't make sense when there's no text to copy or edit

**Changes made:**
- Added text content detection in `showMessageContextMenu` method to check for `.message-content` (regular messages) and `.payment-memo` (payment messages)
- Added logic to hide Copy and Edit context menu options when message has attachments or is a payment but contains no text content
- Messages with attachments/payments that include text will still show Copy/Edit options for the text portion