### PR TITLE
Fix Voice Message Slider Seeking & Time Display

### DIFF
--- a/app.js
+++ b/app.js
@@ -8617,19 +8617,19 @@ class ChatModal {
     updateVmTimeFromSeek (seekEl) {
       const voiceMessageElement = seekEl.closest('.voice-message');
       if (!voiceMessageElement) return;
-    
+
       const timeDisplayElement = voiceMessageElement.querySelector('.voice-message-time-display');
 
       const newTime = Number(seekEl.value || 0);
 
       const totalSeconds = Math.floor(Number(seekEl.max) || Number(voiceMessageElement.dataset.duration) || 0);
-
+      // updates the on-screen "current / total" label
       if (timeDisplayElement) {
         const currentTime = this.formatDuration(newTime);
         const totalTime = this.formatDuration(totalSeconds);
         timeDisplayElement.textContent = `${currentTime} / ${totalTime}`;
       }
-
+      // ensures playback starts at the chosen position when audio is ready
       voiceMessageElement.pendingSeekTime = newTime;
     };
 


### PR DESCRIPTION
**Reason for Changes:**
- Time label didn't update when moving the slider before pressing play
- Original time update logic was inside `playVoiceMessage`, so listeners didn't exist until after first playback
- Caused confusing UX where slider movement had no visible feedback until audio started

**Changes Made:**

**Added Delegated Event Listeners** (lines 8591-8631)
- Created `updateVmTimeFromSeek` helper function that:
  - Updates time label from slider position (no audio element required)
  - Computes total duration from `seekEl.max` or `data-duration` (both already validated as finite)
  - Stores `pendingSeekTime` so playback starts at user's chosen position
- Attached `input` listener for live updates while dragging slider thumb
- Attached `change` listener for click-to-seek updates on mouse/touch release
- Uses event delegation on `.messages-list` so one handler works for all voice messages

**Removed Redundant Code** (inside `playVoiceMessage`)
- Removed time display updates from `updateFromSeekValue` (lines 11336-11342) - delegated listeners now own this
- Removed redundant `pendingSeekTime` setting before `audio.play()` (lines 11432-11437) - delegated listeners already handle this on every slider interaction

**Result:**
- Time label updates immediately when moving/clicking slider, even before first playback
- Cleaner separation: delegated listeners handle display updates; `playVoiceMessage` handles audio control
- Less code duplication and more maintainable