### PR TITLE
Voice Message Playback Management & Cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -8669,6 +8669,7 @@ class ChatModal {
     if (!voiceMessageElement) return;
     // Revoke blob URL to prevent memory leak (critical - blobs aren't auto-cleaned)
     if (voiceMessageElement.audioUrl) URL.revokeObjectURL(voiceMessageElement.audioUrl);
+    // TODO: delete these when we set up listeners properly since we don't have to remove them manually and will be set up during load()
     // Remove event listeners from seekEl by cloning (removes all listeners at once)
     const seekEl = voiceMessageElement.querySelector('.voice-message-seek');
     if (seekEl && voiceMessageElement.seekSetup) {


### PR DESCRIPTION
**Reason for PR:**
- No cleanup of voice message audio when closing/switching chats (memory leaks)
- Multiple voice messages could play simultaneously (poor UX)
- Switching messages required re-downloading and re-decrypting audio (slow)

**Changes Made:**

**Helper Methods for Voice Message Management**
- `setVoiceMessageButton()` - Centralized button icon updates (play/pause SVG)
- `resetVoiceMessageUI()` - Resets button, slider, and time display to initial state
- `cleanupVoiceMessageResources()` - Revokes blob URLs and deletes audio references
- `pauseVoiceMessage()` - Pauses audio and updates button (keeps audio cached for quick resume)
- `stopVoiceMessage()` - Full stop with cleanup (frees all resources)

**Only One Message Plays at a Time**
- When playing a message, all other playing messages are paused (not stopped)
- Keeps decrypted audio cached in memory for instant resume
- No re-downloading or re-decrypting when switching between messages

**Cleanup on Modal Open/Close**
- `open()`: Stops and cleans up all voice messages from previous conversation before rendering new one
- `close()`: Stops and cleans up all voice messages when closing modal

**Optimized Resource Management**
- `pauseVoiceMessage()`: Lightweight pause when switching messages (keeps cache)
- `stopVoiceMessage()`: Full cleanup when switching chats or closing modal
- `audio.onended`/`audio.onerror`: Cleanup when playback naturally ends or errors

**Code Quality Improvements**
- Removed duplicate SVG strings (3 instances)
- Centralized button state management
- DRY principle - reusable helpers for all cleanup scenarios

**Result:**
- No memory leaks from orphaned audio elements
- Better UX: only one message plays at a time
- Faster switching: cached audio = instant resume
- Cleaner code: 62 lines condensed to 48 lines (-22%)