### PR TITLE
Pause voice messages on header action button clicks in ChatModal

### DIFF
--- a/app.js
+++ b/app.js
@@ -8772,7 +8772,7 @@ class ChatModal {
     // TODO: create event listener instead of onclick here
     const userInfo = this.modal.querySelector('.chat-user-info');
     userInfo.onclick = () => {
-      this.messagesList?.querySelectorAll('.voice-message').forEach(vm => this.pauseVoiceMessage(vm));
+      this.pauseVoiceMessages();
       const contact = myData.contacts[address];
       if (contact) {
         contactInfoModal.open(createDisplayInfo(contact));
@@ -8782,7 +8782,7 @@ class ChatModal {
     // Add click handler for edit button
     // TODO: create event listener instead of onclick here
     this.editButton.onclick = () => {
-      this.messagesList?.querySelectorAll('.voice-message').forEach(vm => this.pauseVoiceMessage(vm));
+      this.pauseVoiceMessages();
       const contact = myData.contacts[address];
       if (contact) {
         contactInfoModal.open(createDisplayInfo(contact));
@@ -11313,9 +11313,7 @@ console.warn('in send message', txid)
     if (!voiceMessageElement) return;
 
     // Pause all other playing voice messages (keeps audio cached for quick resume)
-    this.messagesList?.querySelectorAll('.voice-message').forEach(vm => {
-      if (vm !== voiceMessageElement) this.pauseVoiceMessage(vm);
-    });
+    this.pauseVoiceMessages();
 
     // Check if audio is already playing/paused
     const existingAudio = voiceMessageElement.audioElement;


### PR DESCRIPTION
- Implement a new function to pause all voice messages when any header action button is clicked, enhancing user experience by preventing overlapping audio playback.
- Update event listeners for the send money, call, and add friend buttons to include this functionality, ensuring consistent behavior across interactions.
- Add pause logic to user info and edit button click handlers to maintain audio control throughout the chat modal.