### PR TITLE
Make new chat floating button transparent to see underlapping items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1550,12 +1550,11 @@ input[type='file'].form-control::file-selector-button {
   width: 60px;
   height: 60px;
   border-radius: 50%;
-  background-color: var(--primary-color);
-  color: var(--background-color);
+  background-color: var(--primary-tint-20);
+  color: var(--text-color);
   font-size: 24px;
   font-weight: 400;
   border: none;
-  box-shadow: var(--shadow-primary);
   cursor: pointer;
   display: none;
   align-items: center;
@@ -1577,8 +1576,8 @@ input[type='file'].form-control::file-selector-button {
 }
 
 .floating-button:hover {
-  background-color: var(--primary-hover);
-  transform: scale(1.05);
+  opacity: 0.9;
+  transition: all 0.2s ease;
 }
 
 @media (min-width: 769px) {


### PR DESCRIPTION
- Make floating button transparent by default
  - Changed background from solid `--primary-color` to `--primary-tint-20` (20% opacity)
  - Changed text color from white (`--background-color`) to `--text-color` for visibility on transparent background
  - Removed box-shadow for cleaner appearance

- Simplify hover interaction
  - Replaced background color change and scale transform with opacity transition (0.9 on hover)
  - Added smooth transition for better UX

**Result:** The "+" button is now transparent by default, allowing text behind it to be readable, while maintaining clear hover feedback with a subtle opacity change.

<img width="497" height="996" alt="image" src="https://github.com/user-attachments/assets/d0fdb521-df3d-433d-9cea-5d90f674714d" />
