### PR TITLE
Update faucet URL handling in WalletScreen to include network information

### DIFF
--- a/app.js
+++ b/app.js
@@ -1329,12 +1329,13 @@ class WalletScreen {
         // Mainnet: open bridge modal
         bridgeModal.open();
       } else {
-        // Not mainnet: open faucet URL with account address
+        // Not mainnet: open faucet URL with account address and network
         if (myAccount?.keys?.address) {
           try {
             const address = longAddress(myAccount.keys.address);
             const encodedAddress = encodeURIComponent(address);
-            const faucetUrl = `https://liberdus.com/faucet?address=${encodedAddress}`;
+            const encodedNetwork = encodeURIComponent(network?.name || '');
+            const faucetUrl = `https://liberdus.com/faucet?address=${encodedAddress}&network=${encodedNetwork}`;
             const newWindow = window.open(faucetUrl, '_blank');
             if (!newWindow) {
               showToast('Please allow popups to open the faucet page', 0, 'error');


### PR DESCRIPTION
- Modify the faucet URL construction to append the network name alongside the account address, enhancing the functionality for non-mainnet scenarios.
- Improve user experience by ensuring the correct network context is passed when opening the faucet page.