### PR TITLE
Update faucet endpoints to use unified API with networkId support

### DIFF
--- a/app.js
+++ b/app.js
@@ -1532,7 +1532,7 @@ class WalletScreen {
       
     } catch (error) {
       console.error('Faucet request error:', error);
-      showToast(`Faucet request failed: ${error.message}`, 0, 'error');
+      showToast(`Faucet request failed: ${error.message || 'Unknown error'}`, 0, 'error');
     } finally {
       hideToast(toastId);
       this.isFaucetRequestInProgress = false;


### PR DESCRIPTION
## Summary

- Added `networkId` to validator staking faucet payload in `StakeValidatorModal.requestFromFaucet()`
- Replaced wallet faucet external URL redirect with direct API call to `network.faucetUrl`
- Added `requestFromFaucet()` method to `WalletScreen` class with error handling and loading states
- Added `isFaucetRequestInProgress` flag to prevent duplicate requests in wallet faucet
- Reordered payload fields to match backend requirements (username, userAddress, networkId, nodeAddress for validators)

**Changes:**
- Validator faucet now includes `networkId: network.netid` in signed payload
- Wallet faucet now makes direct POST request instead of opening external URL
- Both implementations use the same unified endpoint with proper payload structure