### PR TITLE
Fix faucet transfer processing when xmemo is missing

### DIFF
--- a/app.js
+++ b/app.js
@@ -4104,8 +4104,14 @@ async function processChats(chats, keys) {
 
         //   Process transfer messages; this is a payment with an optional memo 
         else if (tx.type == 'transfer') {
-          const payload = tx.xmemo;
-          if (useTxTimestamp){ 
+          // Handle transfers without xmemo (e.g., faucet transfers)
+          // Ensure payload is always an object, even if xmemo is null/undefined
+          let payload = tx.xmemo;
+          if (!payload || typeof payload !== 'object') {
+            payload = {};
+          }
+          // Set sent_timestamp - use tx.timestamp if useTxTimestamp is true, otherwise use payload.sent_timestamp or tx.timestamp
+          if (useTxTimestamp || !payload.sent_timestamp) {
             payload.sent_timestamp = tx.timestamp;
           }
           if (mine) {


### PR DESCRIPTION
**Summary:**
- Handle transfers without `xmemo` (e.g., faucet transfers with `memo: null`)
- Initialize `payload` as an empty object when `tx.xmemo` is null/undefined/non-object
- Prevent "Cannot set properties of undefined" when setting `sent_timestamp`
- Ensure faucet transfers are added to wallet history
- Update timestamp logic to always set `sent_timestamp` when missing

**Problem:**
Faucet transfers have `memo: null` and no `xmemo`, causing `payload` to be undefined and errors when accessing properties.

**Solution:**
Add defensive checks to ensure `payload` is always an object before processing, allowing transfers without `xmemo` to be processed correctly.