### PR TITLE
Fix thumbnail caching by capturing blob before async worker callback

### DIFF
--- a/app.js
+++ b/app.js
@@ -10081,6 +10081,8 @@ console.warn('in send message', txid)
         console.warn('Failed to generate thumbnail for attached image:', error);
       }
     }
+
+    const capturedThumbnailBlob = thumbnailBlob;
     
     try {
       this.isEncrypting = true;
@@ -10134,9 +10136,9 @@ console.warn('in send message', txid)
               selfKey
             });
             
-            // Cache thumbnail if we generated one
-            if (thumbnailBlob && isImage) {
-              thumbnailCache.save(attachmentUrl, thumbnailBlob, file.type).catch(err => {
+            // Cache thumbnail if we generated one - use captured variable
+            if (capturedThumbnailBlob && isImage) {
+              thumbnailCache.save(attachmentUrl, capturedThumbnailBlob, file.type).catch(err => {
                 console.warn('Failed to cache thumbnail for attached image:', err);
               });
             }
@@ -10194,7 +10196,6 @@ console.warn('in send message', txid)
     } finally {
       hideToast(loadingToastId);
       event.target.value = ''; // Reset the file input value
-      thumbnailBlob = null;
     }
   }
 


### PR DESCRIPTION
**PR Summary:**
- Capture thumbnail blob in const before async worker operation to prevent premature clearing
- Use captured thumbnail blob in worker callback instead of original variable
- Remove premature thumbnail blob cleanup from finally block that was preventing cache saves
- Fixes issue where thumbnails were not being saved to IndexedDB cache when uploading images
- The variable capturedThumbnailBlob will be garbage collected.