### PR TITLE
Increase avatar crop circle size

### DIFF
--- a/app.js
+++ b/app.js
@@ -5113,7 +5113,7 @@ class AvatarEditModal {
     this.initialOffsetX = 0;
     this.initialOffsetY = 0;
     this.zoomRange = null;
-    this.circleSize = 180;
+    this.circleSize = 218;
     this.squareSize = 220;
     this.enableTransform = false;
     this.coverOverscan = 16; // extra pixels to ensure circle is always fully covered
@@ -5272,7 +5272,7 @@ class AvatarEditModal {
     const displayInfo = contact ? createDisplayInfo(contact) : { address: this.currentAddress, hasAvatar: false };
 
     if (this.pendingDelete) {
-      this.previewContainer.innerHTML = generateIdenticon(this.currentAddress, 180);
+      this.previewContainer.innerHTML = generateIdenticon(this.currentAddress, 218);
       this.enableTransform = false;
       this.updateZoomUI();
       if (this.previewBg) this.previewBg.style.display = 'none';
@@ -5299,7 +5299,7 @@ class AvatarEditModal {
     }
 
     // Fallback to identicon if no avatar blob
-    const avatarHtml = await getContactAvatarHtml(displayInfo, 180);
+    const avatarHtml = await getContactAvatarHtml(displayInfo, 218);
     this.previewContainer.innerHTML = avatarHtml;
     this.enableTransform = false;
     this.updateZoomUI();

--- a/styles.css
+++ b/styles.css
@@ -2812,10 +2812,10 @@ button.about-link {
 
 .avatar-edit-circle {
   position: relative;
-  width: 180px;
-  height: 180px;
-  min-width: 180px;
-  min-height: 180px;
+  width: 218px;
+  height: 218px;
+  min-width: 218px;
+  min-height: 218px;
   border-radius: 50%;
   background: transparent;
   border: 2px solid rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
# PR Summary

- Increased crop circle size from 180px to 218px
  - Updated `.avatar-edit-circle` CSS dimensions to 218px (2px smaller than 220px container to account for border)
  - Updated `circleSize` in `AvatarEditModal` constructor to match
  - Updated identicon size references in `refreshPreview()` to 218px
  - Allows users to crop more of the image by extending the circle closer to the container edge



**Impact**: Increases the crop area for better image selection. 