### PR TITLE
Block new chat when private field does not match

### DIFF
--- a/app.js
+++ b/app.js
@@ -14675,7 +14675,7 @@ class NewChatModal {
       const recipientIsPrivate = recipientAccountRes?.account?.private === true;
 
       if (recipientIsPrivate !== myIsPrivate) {
-        showToast('Private accounts can only chat with other private accounts.', 0, 'error');
+        showToast(`${myIsPrivate ? 'Private' : 'Public'} accounts can only chat with other ${myIsPrivate ? 'private' : 'public'} accounts.`, 0, 'error');
         return;
       }
     } catch (error) {


### PR DESCRIPTION
In the new chat modal, check the private field on the accounts on clicking submit. If they do not match show an error toast and prevent starting the chat.

<img width="453" height="358" alt="image" src="https://github.com/user-attachments/assets/2efa7f9a-3334-4e7f-96b9-fb730f7fc309" />
<img width="447" height="300" alt="image" src="https://github.com/user-attachments/assets/2146976c-409e-4635-862a-6e39c563fa67" />

