### PR TITLE
Style private usernames as red

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -488,6 +488,10 @@ body {
   cursor: pointer;
 }
 
+.app-name.is-private {
+  color: var(--danger-color);
+}
+
 .header-icons {
   display: flex;
   gap: 16px;
@@ -1434,6 +1438,11 @@ select.form-control {
   background-position: right 15px center;
   background-size: 16px;
   padding-right: 45px;
+}
+
+select.form-control.is-private {
+  color: var(--danger-color);
+  border-color: var(--danger-color);
 }
 
 textarea.form-control {


### PR DESCRIPTION
Style private usernames with a red color to indicate their private status in the sign in dropdown and the header
<img width="482" height="571" alt="image" src="https://github.com/user-attachments/assets/15b82de5-3e1b-443c-8ae9-c1640f83215e" />
<img width="472" height="582" alt="image" src="https://github.com/user-attachments/assets/e2645c52-138f-4262-9d57-dbf4cdb72856" />
