### PR TITLE
feat: Add context menu for image attachments with Preview/Save options

### DIFF
--- a/index.html
+++ b/index.html
@@ -1199,6 +1199,31 @@
         <a class="last-item" href="#"> </a>
       </div>
 
+      <!-- Image Attachment Context Menu -->
+      <div class="message-context-menu" id="imageAttachmentContextMenu" style="display: none;">
+        <div class="context-menu-option" data-action="preview-or-save" data-icon="download">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Preview</span>
+        </div>
+        <div class="context-menu-option" data-action="reply" data-icon="reply">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Reply</span>
+        </div>
+        <div class="context-menu-option" data-action="copy" data-icon="copy" style="display: none;">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Copy</span>
+        </div>
+        <div class="context-menu-option" data-action="delete" data-icon="delete">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Delete for me</span>
+        </div>
+        <div class="context-menu-option" data-action="delete-for-all" data-icon="delete" style="display: none;">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Delete for all</span>
+        </div>
+        <a class="last-item" href="#"> </a>
+      </div>
+
       <!-- Call Invite Modal -->
       <div class="modal fixed-header" id="callInviteModal">
         <div class="modal-header">

--- a/styles.css
+++ b/styles.css
@@ -5283,6 +5283,10 @@ small {
   background-image: var(--icon-reply, url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 19l-7-7 7-7"/><path d="M3 12h11a4 4 0 1 0 0-8"/></svg>'));
 }
 
+.context-menu-option[data-icon="download"] .context-menu-icon {
+  background-image: var(--icon-download);
+}
+
 @keyframes contextMenuAppear {
   from {
     opacity: 0;


### PR DESCRIPTION
## PR Summary

### Changes
- **Image attachments no longer auto-download on click** — clicking an image opens a context menu instead
- **New image attachment context menu** with:
  - **Preview/Save** — Preview decrypts and generates thumbnail (no download); Save uses existing download flow. Label switches based on IndexedDB thumbnail cache
  - **Reply** — Reply to messages with image attachments
  - **Copy** — Only shown when parent message has text content
  - **Delete for me / Delete for all** — Same gating as message context menu
- **Refactored decrypt logic** — Extracted shared `decryptAttachmentToBlob()` helper used by both Preview and Save flows
- **Consolidated click handlers** — Moved attachment click handling into `handleMessageClick()` to remove duplicate event listeners
- **Menu state management** — Ensures only one context menu (message or image) is open at a time

### Files Changed
- `index.html` — Added `#imageAttachmentContextMenu` markup
- `styles.css` — Added download icon styling for context menu
- `app.js` — Image menu logic, refactored decrypt helper, consolidated click handling

### UX Improvements
- Users can reply to images without clicking the border
- Preview generates thumbnails without downloading full images
- Consistent menu behavior between message and image contexts