### PR TITLE
Show Preview and Save buttons together for new image attachments

### DIFF
--- a/app.js
+++ b/app.js
@@ -12750,7 +12750,6 @@ console.warn('in send message', txid)
     if (!this.imageAttachmentContextMenu) return;
     this.imageAttachmentContextMenu.style.display = 'none';
     this.currentImageAttachmentRow = null;
-    delete this.imageAttachmentContextMenu.dataset.previewMode;
   }
 
   /**
@@ -12788,8 +12787,8 @@ console.warn('in send message', txid)
 
     const isImageAttachment = attachmentRow.dataset.imageAttachment === 'true';
 
-    // Decide Preview vs Save:
-    // - Images: Preview when no thumbnail exists in IndexedDB; Save when it exists
+    // Decide Preview/Save vs Save:
+    // - Images: Show both Preview and Save when no thumbnail exists; Show only Save when it exists
     // - Non-images: always Save (no thumbnail concept)
     let hasThumb = true;
     if (isImageAttachment) {
@@ -12804,11 +12803,9 @@ console.warn('in send message', txid)
       }
     }
 
-    const previewOptText = this.imageAttachmentContextMenu.querySelector(
-      '[data-action="preview-or-save"] .context-menu-text'
-    );
-    if (previewOptText) previewOptText.textContent = hasThumb ? 'Save' : 'Preview';
-    this.imageAttachmentContextMenu.dataset.previewMode = hasThumb ? 'save' : 'preview';
+    // Show Preview only for images without a thumbnail; Save is always visible
+    const previewOpt = this.imageAttachmentContextMenu.querySelector('[data-action="preview"]');
+    if (previewOpt) previewOpt.style.display = (isImageAttachment && !hasThumb) ? '' : 'none';
 
     this.positionContextMenu(this.imageAttachmentContextMenu, attachmentRow);
     this.imageAttachmentContextMenu.style.display = 'block';
@@ -12820,15 +12817,12 @@ console.warn('in send message', txid)
 
     const { messageEl } = this.getAttachmentContextFromRow(row);
     switch (action) {
-      case 'preview-or-save': {
-        const mode = this.imageAttachmentContextMenu?.dataset?.previewMode;
-        if (mode === 'save') {
-          void this.saveImageAttachment(row);
-        } else {
-          void this.previewImageAttachment(row);
-        }
+      case 'preview':
+        void this.previewImageAttachment(row);
         break;
-      }
+      case 'save':
+        void this.saveImageAttachment(row);
+        break;
       case 'reply':
         if (messageEl) this.startReplyToMessage(messageEl);
         break;

--- a/index.html
+++ b/index.html
@@ -1201,9 +1201,13 @@
 
       <!-- Image Attachment Context Menu -->
       <div class="message-context-menu" id="imageAttachmentContextMenu" style="display: none;">
-        <div class="context-menu-option" data-action="preview-or-save" data-icon="download">
+        <div class="context-menu-option" data-action="preview" data-icon="download" style="display: none;">
           <span class="context-menu-icon"></span>
           <span class="context-menu-text">Preview</span>
+        </div>
+        <div class="context-menu-option" data-action="save" data-icon="download">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Save</span>
         </div>
         <div class="context-menu-option" data-action="reply" data-icon="reply">
           <span class="context-menu-icon"></span>


### PR DESCRIPTION
## PR Summary

### Changes
- **New image attachments (no thumbnail)**: Context menu shows both "Preview" and "Save" buttons
- **Existing thumbnails**: Context menu shows only "Save" button
- **Non-image attachments**: Context menu shows only "Save" button (unchanged)

### Implementation
- Added separate "Save" button to image attachment context menu
- Renamed `preview-or-save` action to `preview` for clarity
- Removed deprecated `previewMode` dataset logic
- Simplified action handlers — each button has a single purpose
- Save button always visible; Preview button shown only for new images

### Benefits
- Users can preview or save new images without extra steps
- Cleaner code: removed dual-purpose button logic
- Better UX: both actions available immediately for new images

### Files Changed
- `index.html`: Added separate Save button, renamed Preview action
- `app.js`: Simplified context menu logic, removed `previewMode` dataset