### PR TITLE
Fix avatar pan touch events bubbling to modal on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2858,6 +2858,7 @@ button.about-link {
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  touch-action: none;
 }
 
 .avatar-edit-square::before {


### PR DESCRIPTION
**Summary:**
- Add `touch-action: none` to `.avatar-edit-square` to prevent touch gestures from bubbling
- Prevents modal movement on iOS and stretching on Android during avatar panning
- CSS-only fix that blocks native touch gestures on the preview area