### PR TITLE
Add save option for voice messages in context menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -1162,6 +1162,11 @@
 
       <!-- Message Context Menu -->
       <div class="message-context-menu" id="messageContextMenu" style="display: none;">
+        <!-- Voice message specific action: Save -->
+        <div class="context-menu-option" data-action="save" data-icon="download" style="display: none;">
+          <span class="context-menu-icon"></span>
+          <span class="context-menu-text">Save</span>
+        </div>
         <div class="context-menu-option" data-action="reply" data-icon="reply">
           <span class="context-menu-icon"></span>
           <span class="context-menu-text">Reply</span>


### PR DESCRIPTION
## Summary

- Added "Save" option to message context menu
  - Shown at the top for voice messages only
  - Uses existing download icon styling

- Refactored voice message data attributes for consistency
  - Changed `data-voice-url` → `data-url` to match attachment format
  - Added `data-name` and `data-type` attributes
  - Updated `playVoiceMessage()` and `handleFailedMessageRetry()` to use `dataset.url`

- Implemented voice message save functionality
  - Created `saveVoiceMessage()` method that reuses existing `handleAttachmentDownload()` flow
  - Includes concurrent download prevention

- Code improvements
  - Removed temporary element workaround by standardizing attribute names
  - Simplified implementation by reusing attachment download infrastructure
  - No breaking changes; voice messages and attachments remain mutually exclusive

This change enables users to save voice messages directly from the context menu, consistent with attachment downloads.