### PR TITLE
Remove encryption keys from DOM and refactor decrypt to use message data

### DIFF
--- a/app.js
+++ b/app.js
@@ -15540,7 +15540,6 @@ class FailedMessageMenu {
     if (voiceEl) {
       const voiceUrl = voiceEl.dataset.url || '';
       const duration = Number(voiceEl.dataset.duration || 0);
-      const timestamp = parseInt(messageEl.dataset.messageTimestamp || '0', 10);
 
       if (!txid || !voiceUrl || !duration) {
         console.error('Error preparing voice message retry: Necessary elements or data missing.');
@@ -15553,9 +15552,7 @@ class FailedMessageMenu {
         console.error('Error preparing voice message retry: Contact/messages not found.');
         return;
       }
-      const messageIndex = contact.messages.findIndex(msg => 
-        msg.timestamp == timestamp || msg.txid === txid
-      );
+      const messageIndex = contact.messages.findIndex(msg => msg.txid === txid);
       
       if (messageIndex < 0) {
         console.error('Error preparing voice message retry: Message not found.');


### PR DESCRIPTION
### Changes

- **Removed encryption keys from HTML attributes**
  - Removed `data-pqEncSharedKey` and `data-selfKey` from attachment rows
  - Removed `data-pqEncSharedKey` and `data-selfKey` from voice message elements

- **Refactored decryption to use message data as source of truth**
  - `decryptAttachmentToBlob()` now reads keys from `myData.contacts[...].messages[...]`
  - Attachments: looks up per-file keys from `item.xattach[]` by URL
  - Voice messages: uses `item.audioSelfKey/audioPqEncSharedKey` with fallback to message-level keys

- **Updated voice message playback and retry flows**
  - `playVoiceMessage()` reads keys from message object instead of DOM
  - `handleFailedMessageRetry()` finds message by timestamp/txid and retrieves keys from message data
  - Added validation checks for missing contact/message data

- **Fixed PQ key type handling**
  - Added base64→bytes conversion for `pqEncSharedKey` before passing to `dhkeyCombined()`
  - Ensures compatibility with stored base64 strings while meeting crypto function requirements

- **Code quality improvements**
  - Removed redundant optional chaining after validation checks
  - Simplified `findIndex` result validation (returns -1, never null)
  - Added error messages for missing keys/data