### PR TITLE
Fix send button positioning when offline in chat modal

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1753,6 +1753,11 @@ input[type='file'].form-control::file-selector-button {
   fill: currentColor;
 }
 
+/* Exception for send button - don't apply position:relative from offline-disabled */
+.send-button.offline-disabled {
+  position: absolute; /* Keep the original positioning */
+}
+
 .messages-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
**PR Summary:**
- Fixed send button appearing partially outside text input field when offline
- Issue caused by offline-disabled class applying position:relative, overriding send button's position:absolute
- Added CSS exception for .send-button.offline-disabled to maintain absolute positioning
- Follows same pattern as existing floating-button.offline-disabled fix