### PR TITLE
Fix send button not appearing when retrying failed messages or editing messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -13788,6 +13788,8 @@ console.warn('in send message', txid)
       this.cancelEditButton.style.display = '';
       // Disable attachments while editing
       this.addAttachmentButton.disabled = true;
+      // Toggle button visibility to show send button since input has content
+      this.toggleSendButtonVisibility();
       // Focus input and move caret to end
       this.messageInput.focus();
       this.messageInput.selectionStart = this.messageInput.selectionEnd = this.messageInput.value.length;
@@ -15735,6 +15737,7 @@ class FailedMessageMenu {
     if (chatModal.messageInput && chatModal.retryOfTxId && messageContent && txid) {
       chatModal.messageInput.value = messageContent;
       chatModal.retryOfTxId.value = txid;
+      chatModal.toggleSendButtonVisibility();
       chatModal.messageInput.focus();
       return;
     }


### PR DESCRIPTION
- Fixed send button not appearing after retrying a failed message
- Fixed send button not appearing when editing an existing message
- Issue caused by input field being populated programmatically without triggering button visibility toggle
- Added toggleSendButtonVisibility() call in handleFailedMessageRetry and startEditMessage methods
- Ensures send button appears correctly when input is pre-filled, matching behavior when typing