### PR TITLE
Fix offline overlay for chat modal buttons and new chat form Continue button

### DIFF
--- a/app.js
+++ b/app.js
@@ -6374,6 +6374,8 @@ function markConnectivityDependentElements() {
   const networkDependentElements = [
     // Chat related
     '#handleSendMessage',
+    '#voiceRecordButton',
+    '#newChatForm button[type="submit"]',
 
     // Wallet related
     '#refreshBalance',

--- a/styles.css
+++ b/styles.css
@@ -1758,6 +1758,22 @@ input[type='file'].form-control::file-selector-button {
   position: absolute; /* Keep the original positioning */
 }
 
+/* Exception for voice record button - don't apply position:relative from offline-disabled */
+.icon-button.voice-record-button.offline-disabled {
+  position: absolute; /* Keep the original positioning */
+}
+
+/* Voice record button has circular hover area, so make overlay match that shape */
+.icon-button.voice-record-button.offline-disabled::after {
+  /* Override to match the circular hover area instead of button's rectangular shape */
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%; /* Circular shape to match hover state */
+  inset: auto; /* Override inset: 0 from base rule */
+}
+
 .messages-list {
   display: flex;
   flex-direction: column;
@@ -3654,7 +3670,7 @@ mark {
   }
 }
 
-.offline-disabled::before {
+.offline-disabled::after {
   content: '';
   position: absolute;
   top: 0;


### PR DESCRIPTION
**Changes:**
- Added `#voiceRecordButton` to `networkDependentElements` to disable voice record button when offline
- Added `#newChatForm button[type="submit"]` to `networkDependentElements` to disable Continue button when offline
- Refactored offline-disabled overlay from `::before` to `::after` to avoid conflicts with icon elements that use `::before`
- Added positioning exceptions for send button and voice record button to maintain absolute positioning when offline-disabled
- Added circular overlay override for voice record button to match its hover state shape (40px circle)
- Updated overlay to automatically match element shape using `border-radius: inherit`
- Fixed send button visibility by calling `toggleSendButtonVisibility()` when retrying failed messages or editing messages

**Issues Fixed:**
- Voice record button disabled when offline with visible overlay pattern
- Voice record button icon no longer shifts when disabled
- Continue button in new chat modal shows offline overlay pattern when disabled
- Overlay pattern visible and correctly shaped on disabled elements
- Send button appears correctly when editing or retrying messages