### PR TITLE
Prevent clicks on offline-disabled non-form elements

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3600,6 +3600,7 @@ mark {
   opacity: 0.6;
   cursor: not-allowed !important;
   position: relative;
+  pointer-events: none; /* Prevent clicks on non-form elements (like div.context-menu-option) */
 }
 
 /* Offline indicator in header */


### PR DESCRIPTION
**Changes:**
- Added `pointer-events: none` to `.offline-disabled` CSS class to prevent clicks on non-form elements (like `div.context-menu-option`)

**Issue Fixed:**
- Context menu options and other non-form elements with the `offline-disabled` class were showing the overlay pattern but still responding to clicks. The `disabled` property only works on form elements (`<button>`, `<input>`, etc.), so non-form elements like `<div>` needed `pointer-events: none` in CSS to prevent interactions when offline.

**Solution:**
- Using CSS `pointer-events: none` on `.offline-disabled` prevents all pointer events (clicks, hovers, etc.) for any element with that class, regardless of element type. This ensures consistent behavior across form and non-form elements when offline.