### PR TITLE
Fix context menu preview icon to use eye icon instead of download

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@
 
       <!-- Image Attachment Context Menu -->
       <div class="message-context-menu" id="imageAttachmentContextMenu" style="display: none;">
-        <div class="context-menu-option" data-action="preview" data-icon="download" style="display: none;">
+        <div class="context-menu-option" data-action="preview" data-icon="eye" style="display: none;">
           <span class="context-menu-icon"></span>
           <span class="context-menu-text">Preview</span>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,7 @@
   --icon-file-text: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'%3E%3C/path%3E%3Cpolyline points='14,2 14,8 20,8'%3E%3C/polyline%3E%3Cline x1='16' y1='13' x2='8' y2='13'%3E%3C/line%3E%3Cline x1='16' y1='17' x2='8' y2='17'%3E%3C/line%3E%3Cline x1='10' y1='9' x2='8' y2='9'%3E%3C/line%3E%3C/svg%3E");
   --icon-file: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z'%3E%3C/path%3E%3Cpolyline points='13,2 13,9 20,9'%3E%3C/polyline%3E%3C/svg%3E");
   --icon-camera: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z'%3E%3C/path%3E%3Ccircle cx='12' cy='13' r='4'%3E%3C/circle%3E%3C/svg%3E");
+  --icon-eye: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z'%3E%3C/path%3E%3Ccircle cx='12' cy='12' r='3'%3E%3C/circle%3E%3C/svg%3E");
 
   /* Typography tokens */
   --font-primary: 'Inter', sans-serif;
@@ -5382,6 +5383,10 @@ small {
 
 .context-menu-option[data-icon="download"] .context-menu-icon {
   background-image: var(--icon-download);
+}
+
+.context-menu-option[data-icon="eye"] .context-menu-icon {
+  background-image: var(--icon-eye);
 }
 
 @keyframes contextMenuAppear {


### PR DESCRIPTION
- Changed preview action icon from 'download' to 'eye' in image attachment context menu
- Added new CSS variable --icon-eye with eye SVG icon
- Added CSS styling for context menu items with data-icon='eye'
- Resolves issue where preview and download actions had identical icons