### PR TITLE
Disable additional wallet, profile, and stake form elements when offline

### DIFF
--- a/app.js
+++ b/app.js
@@ -6377,8 +6377,6 @@ function markConnectivityDependentElements() {
 
     // Wallet related
     '#refreshBalance',
-    '#openBuyButton',
-    '#openSellButton',
     '#openFaucetBridgeButton',
     '#sendForm button[type="submit"]',
 


### PR DESCRIPTION
**Summary:**
- Add wallet action buttons (Faucet) to network-dependent elements
- Add send asset form recipient input (`#sendToAddress`) to network-dependent elements
- Add profile form inputs (`#newUsername`, `#newPrivateKey`, `#migrateAccountsButton`) to network-dependent elements
- Add stake modal node address input (`#stakeNodeAddress`) to network-dependent elements

All listed elements are disabled when offline and show the striped overlay pattern.