### PR TITLE
Revert google auth sessionID back to use uuid

### DIFF
--- a/app.js
+++ b/app.js
@@ -7588,7 +7588,7 @@ class BackupAccountModal {
    *          Resolves with token data on success; rejects with Error on cancel/deny/timeout/error.
    */
   async startGoogleDriveAuth() {
-    const sessionId = bin2hex(generateRandomBytes(16));
+    const sessionId = crypto.randomUUID();
     const url = this.buildOAuthServerUrl(sessionId);
     const isReactNative = reactNativeApp.isReactNativeWebView;
     


### PR DESCRIPTION
PR #1026 unintentionally changed crypto.randomUUID() to bin2hex(generateRandomBytes(16)) this causes the google auth to fail since UUID format is required here. 