### PR TITLE
Add UUID generation for oauth server session ID

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,6 +91,7 @@ import {
   passwordToKey,
   dhkeyCombined,
   decryptChacha,
+  generateUUIDv4,
 } from './crypto.js';
 
 // Put standalone conversion function in lib.js
@@ -7591,7 +7592,7 @@ class BackupAccountModal {
    *          Resolves with token data on success; rejects with Error on cancel/deny/timeout/error.
    */
   async startGoogleDriveAuth() {
-    const sessionId = crypto.randomUUID();
+    const sessionId = generateUUIDv4();
     const url = this.buildOAuthServerUrl(sessionId);
     const isReactNative = reactNativeApp.isReactNativeWebView;
     

--- a/crypto.js
+++ b/crypto.js
@@ -268,3 +268,21 @@ export function generateRandomBytes(length) {
 export function generateAddress(publicKey) {
     return keccak256(publicKey.slice(1)).slice(-20);
 }
+
+export function generateUUIDv4() {
+    const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+
+    // RFC 4122 version & variant bits
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+
+    const hex = bin2hex(bytes);
+
+    return (
+        hex.slice(0, 8) + '-' +
+        hex.slice(8, 12) + '-' +
+        hex.slice(12, 16) + '-' +
+        hex.slice(16, 20) + '-' +
+        hex.slice(20)
+    );
+}


### PR DESCRIPTION
Implement a custom UUID generation function to replace the default `crypto.randomUUID()` for creating oath server session IDs.