### PR TITLE
Fix tolled deposit toast alignment and update app version requirements

### DIFF
--- a/app.js
+++ b/app.js
@@ -11481,9 +11481,9 @@ class ChatModal {
       if (!this.isActive() || this.address !== address) return;
 
       showToast(
-        '<strong>This user has deposited a toll to message you.</strong><ul style="margin: 8px 0 0 0; padding-left: 20px; text-align: center;"><li style="text-align: center;">Change their status to a connection or friend to refund the toll</li><li style="text-align: center;">Reply to collect the full toll</li><li style="text-align: center;">Ignore to collect half the toll</li></ul>',
+        '<strong>This user has deposited a toll to message you.</strong><ul style="margin: 8px 0 0 0; padding-left: 20px;"><li>Change their status to a connection or friend to refund the toll</li><li>Reply to collect the full toll</li><li>Ignore to collect half the toll</li></ul>',
         0,
-        'info',
+        'toll',
         true
       );
 

--- a/network.js
+++ b/network.js
@@ -37,8 +37,8 @@ const network = {
   "bridgeUrl": "./bridge",
   // App version requirements for native apps (format: YYYY.MMDD.HHmm)
   "app_version": {
-    "ios": "2025.0916.1621",
-    "android": "2025.0916.1621"
+    "ios": "2025.1211.1145",
+    "android": "2025.1211.1145"
   },
   // Google Drive OAuth config for backup
   "googleDrive": {


### PR DESCRIPTION
**Summary:**
- Fixed bulleted list alignment in tolled deposit toast by switching toast type from `'info'` to `'toll'`
- Removed inline center alignment styles from `<ul>` and `<li>` elements; now uses `.toast.toll` CSS class for proper left alignment
- Updated app version requirements in network.js: iOS and Android versions bumped from `2025.0916.1621` to `2025.1211.1145`

The toast now displays the bulleted list left-aligned, matching the existing toll info message styling.

<img width="309" height="161" alt="image" src="https://github.com/user-attachments/assets/73cd222a-ca89-41f8-bb35-5025adc83efc" />