### PR TITLE
Add contact notes field to contact info

### DIFF
--- a/app.js
+++ b/app.js
@@ -2817,6 +2817,8 @@ class ContactInfoModal {
     this.avatarEditButton = document.createElement('button');
     this.avatarEditButton.className = 'icon-button edit-icon avatar-edit-button avatar-edit-button-outside';
     this.avatarEditButton.setAttribute('aria-label', 'Edit photo');
+    this.notesElement = document.getElementById('contactInfoNotes');
+    this.notesEditButton = document.getElementById('notesEditButton');
 
     // Back button
     this.backButton.addEventListener('click', () => this.close());
@@ -2849,6 +2851,12 @@ class ContactInfoModal {
     this.avatarEditButton.addEventListener('click', (e) => {
       e.stopPropagation(); // Prevent triggering avatar click
       this.openAvatarEdit();
+    });
+
+    // Notes edit button
+    this.notesEditButton.addEventListener('click', (e) => {
+      e.stopPropagation();
+      editContactModal.open();
     });
 
     // Make the avatar itself clickable
@@ -2922,6 +2930,10 @@ class ContactInfoModal {
         element.textContent = value;
       }
     });
+
+    // Notes
+    const notesRaw = displayInfo.notes ?? (displayInfo.address && myData.contacts?.[displayInfo.address]?.notes);
+    this.notesElement.textContent = notesRaw || 'Not Entered';
   }
 
   // Set up chat button functionality
@@ -3243,15 +3255,20 @@ class EditContactModal {
   load() {
     this.modal = document.getElementById('editContactModal');
     this.nameInput = document.getElementById('editContactNameInput');
-    this.nameActionButton = this.nameInput.parentElement.querySelector('.field-action-button');
+    this.nameClearButton = document.getElementById('nameClearButton');
     this.providedNameContainer = document.getElementById('editContactProvidedNameContainer');
+    this.notesInput = document.getElementById('editContactNotesInput');
+    this.notesClearButton = document.getElementById('notesClearButton');
+    this.saveButton = document.getElementById('saveEditContactButton');
     this.backButton = document.getElementById('closeEditContactModal');
 
     // Setup event listeners
     this.nameInput.addEventListener('input', (e) => this.handleNameInput(e));
     this.nameInput.addEventListener('blur', () => this.handleNameBlur());
     this.nameInput.addEventListener('keydown', (e) => this.handleNameKeydown(e));
-    this.nameActionButton.addEventListener('click', () => this.handleNameButton());
+    this.nameClearButton.addEventListener('click', () => this.handleNameClear());
+    this.notesClearButton.addEventListener('click', () => this.handleNotesClear());
+    this.saveButton.addEventListener('click', () => this.handleSave());
     this.providedNameContainer.addEventListener('click', () => this.handleProvidedNameClick());
     this.backButton.addEventListener('click', () => this.close());
   }
@@ -3292,8 +3309,6 @@ class EditContactModal {
     // Set up the input field with the original name
     this.nameInput.value = originalName;
 
-    // field-action-button should be clear
-    this.nameActionButton.className = 'field-action-button clear';
 
     // Get the current contact info from the contact info modal
     this.currentContactAddress = contactInfoModal.currentContactAddress;
@@ -3301,6 +3316,10 @@ class EditContactModal {
       console.error('No current contact found');
       return;
     }
+
+    // Populate notes field
+    const contactNotes = myData.contacts[this.currentContactAddress]?.notes || '';
+    this.notesInput.value = contactNotes;
 
     // Show the edit contact modal
     this.modal.classList.add('active');
@@ -3343,14 +3362,6 @@ class EditContactModal {
     // normalize the input using normalizeName
     const normalizedName = normalizeName(this.nameInput.value);
     this.nameInput.value = normalizedName;
-
-    // if already 'add' class, return early
-    if (this.nameActionButton.classList.contains('add')) {
-      return;
-    }
-
-    this.nameActionButton.className = 'field-action-button add';
-    this.nameActionButton.setAttribute('aria-label', 'Save');
   }
 
   handleNameBlur() {
@@ -3359,16 +3370,16 @@ class EditContactModal {
     this.nameInput.value = normalizedName;
   }
 
-  handleNameButton() {
-    if (this.nameActionButton.classList.contains('clear')) {
-      this.nameInput.value = '';
-      // Always show save button after clearing
-      this.nameActionButton.className = 'field-action-button add';
-      this.nameActionButton.setAttribute('aria-label', 'Save');
-      this.nameInput.focus();
-    } else {
-      this.handleSave();
-    }
+  handleNameClear() {
+    // Clear the name field
+    this.nameInput.value = '';
+    this.nameInput.focus();
+  }
+
+  handleNotesClear() {
+    // Clear the notes field
+    this.notesInput.value = '';
+    this.notesInput.focus();
   }
 
   handleNameKeydown(e) {
@@ -3381,9 +3392,11 @@ class EditContactModal {
   handleSave() {
     // Save changes - if input is empty/spaces, it will become undefined
     const newName = this.nameInput.value.trim() || null;
+    const newNotes = this.notesInput.value.trim() || null;
     const contact = myData.contacts[this.currentContactAddress];
     if (contact) {
       contact.name = newName;
+      contact.notes = newNotes;
       contactInfoModal.needsContactListUpdate = true;
     }
 

--- a/index.html
+++ b/index.html
@@ -1436,6 +1436,13 @@
                   <a href="#" id="contactInfoX" class="contact-info-link" target="_blank" rel="noopener noreferrer"></a>
                 </div>
               </div>
+              <div class="contact-info-item">
+                <div class="contact-info-label">Notes</div>
+                <div class="contact-info-value-container">
+                  <div class="contact-info-value" id="contactInfoNotes"></div>
+                  <button class="icon-button edit-icon" id="notesEditButton" aria-label="Edit notes"></button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -2014,7 +2021,7 @@
                       id="editContactNameInput"
                       placeholder="Enter contact name"
                     />
-                    <button class="field-action-button clear" aria-label="Add"></button>
+                    <button class="field-action-button clear" id="nameClearButton" aria-label="Clear"></button>
                   </div>
                 </div>
               </div>
@@ -2037,6 +2044,18 @@
               <div class="contact-info-item" style="display: none">
                 <div class="contact-info-label">X-Twitter</div>
                 <div class="contact-info-value" id="editContactX"></div>
+              </div>
+              <div class="contact-info-item">
+                <div class="contact-info-label">Notes</div>
+                <div class="contact-info-value-container">
+                  <div class="contact-info-value editing">
+                    <textarea id="editContactNotesInput" class="form-control" rows="4" placeholder="Enter notes about this contact"></textarea>
+                    <button class="field-action-button clear" id="notesClearButton" aria-label="Clear"></button>
+                  </div>
+                </div>
+              </div>
+              <div class="form-actions" style="padding: 1rem;">
+                <button id="saveEditContactButton" class="btn btn--primary btn--pill btn--full">Save</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Introduce new notes field for contacts
- Adds notes to contact info and edit contact modals
- Changes functionality of clear/save button on edit contact modal. Now one save button at the bottom of the form. There is a clear button for each field (name and notes). The clear button no longer changes to a save button when text is entered. 

<img width="425" height="817" alt="image" src="https://github.com/user-attachments/assets/6e6ccdaa-ddd9-4abb-90e2-d53384ed1411" />
<img width="417" height="664" alt="image" src="https://github.com/user-attachments/assets/8fa375ac-afc3-45b5-a3ae-3afd23387bff" />
<img width="442" height="665" alt="image" src="https://github.com/user-attachments/assets/c42ae11d-58d9-46e3-adc6-945b9363d76d" />
