### PR TITLE
Stick search bar to top

### DIFF
--- a/index.html
+++ b/index.html
@@ -1959,7 +1959,7 @@
           <div class="modal-title">Search Messages</div>
         </div>
         <div class="modal-content">
-          <div class="form-container">
+          <div class="search-bar-container">
             <div class="search-bar">
               <span class="search-icon"></span>
               <input
@@ -1972,6 +1972,8 @@
                 maxlength="30"
               />
             </div>
+          </div>
+          <div class="form-container">
             <div id="searchResults" class="chat-list">
               <!-- Results will be populated here -->
             </div>
@@ -1987,7 +1989,7 @@
           <div class="modal-title">Search Contacts</div>
         </div>
         <div class="modal-content">
-          <div class="form-container">
+          <div class="search-bar-container">
             <div class="search-bar">
               <span class="search-icon"></span>
               <input
@@ -2000,6 +2002,9 @@
                 maxlength="30"
               />
             </div>
+          </div>
+          <div class="form-container">
+            
             <div id="contactSearchResults" class="chat-list">
               <!-- Contact search results will be populated here -->
             </div>

--- a/styles.css
+++ b/styles.css
@@ -1452,9 +1452,14 @@ button:disabled {
   box-sizing: border-box;
 }
 
+.search-modal .form-container {
+  padding-top: 0px;
+}
+
 .modal-content {
   flex: 1;
   overflow-y: auto;
+  scrollbar-width: thin;
 }
 
 .form-group {
@@ -3224,6 +3229,8 @@ button.about-link {
 .search-bar-container {
   padding: 8px 16px;
   background: var(--background-color);
+  position: sticky;
+  top: env(safe-area-inset-top, 0);
 }
 
 /* Search Bar - Common styles for all search bars */
@@ -3280,11 +3287,6 @@ button.about-link {
   background-position: center;
   background-repeat: no-repeat;
   background-size: contain;
-}
-
-/* Modal specific search bar container */
-.modal .form-container .search-bar {
-  margin-bottom: 16px;
 }
 
 /* Search Modal */


### PR DESCRIPTION
- Make the search bar sticky at the top of the modal
- make scroll bar width thin in modals to match the rest of the app
<img width="425" height="818" alt="image" src="https://github.com/user-attachments/assets/8bba4cbe-4240-4f12-96bc-0bf983aecd0a" />
