### PR TITLE
Fix: The loading toast with spinner should now display during the entire upload process.

### DIFF
--- a/app.js
+++ b/app.js
@@ -12933,7 +12933,6 @@ console.warn('in send message', txid)
       this.addAttachmentButton.disabled = false;
       this.isEncrypting = false;
     } finally {
-      hideToast(loadingToastId);
       event.target.value = ''; // Reset the file input value
     }
   }


### PR DESCRIPTION
It was getting removed early in the "finally" block previously.