### PR TITLE
Fix search bar position on Android in fullscreen mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3230,7 +3230,7 @@ button.about-link {
   padding: 8px 16px;
   background: var(--background-color);
   position: sticky;
-  top: env(safe-area-inset-top, 0);
+  top: 0; /* Header handles safe-area-inset-top */
 }
 
 /* Search Bar - Common styles for all search bars */


### PR DESCRIPTION
- Change `.search-bar-container` `top` from `env(safe-area-inset-top, 0)` to `0`
- The header already handles the safe area inset, so the search bar doesn't need it
- Ensures the search bar appears directly below the header on Android in fullscreen
- No impact on iOS/Desktop (already working)