### PR TITLE
Explicitly hide edit option for voice messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -13522,6 +13522,7 @@ console.warn('in send message', txid)
       if (inviteOption) inviteOption.style.display = 'none';
       if (joinOption) joinOption.style.display = 'none';
       if (replyOption) replyOption.style.display = 'flex';
+      if (editOption) editOption.style.display = 'none';
     } else {
       if (copyOption) copyOption.style.display = 'flex';
       if (joinOption) joinOption.style.display = 'none';


### PR DESCRIPTION
Explicitly hide the edit option in the context menu for voice messages so it does not stick around after clicking on a text message.