### PR TITLE
Fix: Search message scroll and filtering improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -14494,7 +14494,7 @@ console.warn('in send message', txid)
     requestAnimationFrame(() => {
       const elementTop = target.offsetTop;
       const containerHeight = container.clientHeight;
-      const inputContainerHeight = this.modal?.querySelector('.message-input-container')?.offsetHeight || 100;
+      const inputContainerHeight = this.modal?.querySelector('.message-input-container')?.offsetHeight || 80;
       const availableHeight = containerHeight - inputContainerHeight - 20;
       const scrollTarget = Math.max(0, elementTop - (availableHeight / 4));
       


### PR DESCRIPTION
### Summary
Fixes search result scrolling and filters unwanted messages from search results.

### Changes

**Search filtering:**
- Excludes deleted messages (`message.deleted > 0`) from search results
- Excludes call messages (`message.type === 'call'`) from search results

**Scroll-to-message:**
- Makes `handleSearchResultClick` async and awaits `chatModal.open()` before scrolling
- Adds `skipAutoScroll` parameter to `chatModal.open()` and `appendChatModal()` to prevent auto-scroll conflicts
- Updates `scrollToMessage()` to account for input container height
- Positions messages at 1/4 from top of available viewport (above input area)
- Uses `requestAnimationFrame` instead of `setTimeout` for better timing

### Technical details
- `scrollToMessage()` now calculates available viewport height excluding the input container
- Messages are positioned to remain visible above the input area
- Prevents race conditions between auto-scroll and manual scroll-to-message