### PR TITLE
Fix: Improve message scroll positioning to avoid header and input overlap

### DIFF
--- a/app.js
+++ b/app.js
@@ -14495,8 +14495,10 @@ console.warn('in send message', txid)
       const elementTop = target.offsetTop;
       const containerHeight = container.clientHeight;
       const inputContainerHeight = this.modal?.querySelector('.message-input-container')?.offsetHeight || 80;
-      const availableHeight = containerHeight - inputContainerHeight - 20;
-      const scrollTarget = Math.max(0, elementTop - (availableHeight / 4));
+      const topPadding = 10; // Space to keep message below header
+      const bottomPadding = 20; // Space above input
+      const availableHeight = containerHeight - inputContainerHeight - topPadding - bottomPadding;
+      const scrollTarget = Math.max(0, elementTop - (availableHeight / 3) - topPadding);
       
       container.scrollTo?.({ top: scrollTarget, behavior: 'smooth' }) || (container.scrollTop = scrollTarget);
       target.classList.add('highlighted');


### PR DESCRIPTION
### Summary
Fixes scroll-to-message positioning so messages don't appear under the header or get covered by the input area.

### Changes

**Scroll calculation improvements:**
- Adds `topPadding` (10px) to keep messages below the header
- Adds `bottomPadding` (20px) to keep messages above the input container
- Updates `availableHeight` to account for both paddings
- Changes scroll position from 1/4 to 1/3 from top for better visibility
- Includes `topPadding` in `scrollTarget` calculation

**Code quality:**
- Extracts magic numbers into named constants (`topPadding`, `bottomPadding`)
- Improves readability and maintainability

### Technical details
- Messages are positioned at 1/3 from the top of the available viewport
- Accounts for header height (10px padding) and input container height (20px padding)
- Ensures messages remain fully visible and accessible