### PR TITLE
Center message vertically when scrolling to search result

### DIFF
--- a/app.js
+++ b/app.js
@@ -14501,11 +14501,8 @@ console.warn('in send message', txid)
     requestAnimationFrame(() => {
       const elementTop = target.offsetTop;
       const containerHeight = container.clientHeight;
-      const inputContainerHeight = this.modal?.querySelector('.message-input-container')?.offsetHeight || 80;
-      const topPadding = 10; // Space to keep message below header
-      const bottomPadding = 20; // Space above input
-      const availableHeight = containerHeight - inputContainerHeight - topPadding - bottomPadding;
-      const scrollTarget = Math.max(0, elementTop - (availableHeight / 3) - topPadding);
+      const elementHeight = target.offsetHeight;
+      const scrollTarget = Math.max(0, elementTop - (containerHeight / 2) + (elementHeight / 2));
       
       container.scrollTo?.({ top: scrollTarget, behavior: 'smooth' }) || (container.scrollTop = scrollTarget);
       target.classList.add('highlighted');


### PR DESCRIPTION
**PR Summary:**

- **Scroll behavior:** Center the target message vertically in the viewport instead of positioning it at 1/3 from the top with header/footer padding
- **Simplified logic:** Removed header/footer padding calculations; uses `elementTop - (containerHeight / 2) + (elementHeight / 2)` to center the message
- **Cleanup:** Removed unused variables (`inputContainerHeight`, `topPadding`, `bottomPadding`, `availableHeight`)