### PR TITLE
Fix message input textarea height adjustment for retry and edit flows

### DIFF
--- a/app.js
+++ b/app.js
@@ -12214,6 +12214,7 @@ console.warn('in send message', txid)
       if (editInput) editInput.value = '';
       // Clear input text and reset height
       this.messageInput.value = '';
+      this.messageInput.style.height = '48px';
       this.messageByteCounter.style.display = 'none';
       // Clear any saved draft
       if (typeof this.debouncedSaveDraft === 'function') {
@@ -14355,6 +14356,17 @@ console.warn('in send message', txid)
       this.cancelEditButton.style.display = '';
       // Disable attachments while editing
       this.addAttachmentButton.disabled = true;
+      
+      // Trigger input event for other listeners (byte counter, etc.)
+      this.messageInput.dispatchEvent(new Event('input'));
+      
+      // Manually resize textarea after browser has updated layout
+      // requestAnimationFrame ensures scrollHeight is accurate
+      requestAnimationFrame(() => {
+        this.messageInput.style.height = '48px';
+        this.messageInput.style.height = Math.min(this.messageInput.scrollHeight, 120) + 'px';
+      });
+      
       // Toggle button visibility to show send button since input has content
       this.toggleSendButtonVisibility();
       // Focus input and move caret to end
@@ -16314,6 +16326,17 @@ class FailedMessageMenu {
     if (chatModal.messageInput && chatModal.retryOfTxId && messageContent && txid) {
       chatModal.messageInput.value = messageContent;
       chatModal.retryOfTxId.value = txid;
+      
+      // Trigger input event to ensure all listeners fire (byte counter, draft save, etc.)
+      chatModal.messageInput.dispatchEvent(new Event('input'));
+      
+      // Manually resize textarea after browser has updated layout
+      // requestAnimationFrame ensures scrollHeight is accurate
+      requestAnimationFrame(() => {
+        chatModal.messageInput.style.height = '48px';
+        chatModal.messageInput.style.height = Math.min(chatModal.messageInput.scrollHeight, 120) + 'px';
+      });
+      
       chatModal.toggleSendButtonVisibility();
       chatModal.messageInput.focus();
       return;


### PR DESCRIPTION
**Summary:**
- Fix textarea not auto-resizing when retrying failed messages
  - Add `requestAnimationFrame`-wrapped resize in `handleFailedMessageRetry` so the browser recalculates `scrollHeight` before reading it
  - Dispatch `input` event to trigger other listeners (byte counter, draft save)
- Fix textarea not auto-resizing when editing messages
  - Add the same resize logic in `startEditMessage` to handle multi-line wrapped text
- Fix textarea height not resetting when canceling edit
  - Reset height to `48px` in `cancelEdit` to match behavior in other clear operations

**Technical details:**
When setting `.value` programmatically, dispatching the `input` event immediately can read stale `scrollHeight`. Using `requestAnimationFrame` defers the resize until after layout, ensuring accurate height calculation.