### PR TITLE
Fix call message text overflow on narrow screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1901,7 +1901,11 @@ input[type='file'].form-control::file-selector-button {
 .message-content {
   overflow-wrap: break-word;
   word-wrap: break-word;
-  word-break: break-word;
+  word-break: normal; /* Use normal word breaking to allow hyphens to work */
+  white-space: normal; /* Ensure text can wrap */
+  -webkit-hyphens: auto; /* Add hyphens at line breaks (Chrome/Safari) */
+  -moz-hyphens: auto; /* Add hyphens at line breaks (Firefox) */
+  hyphens: auto; /* Add hyphens at line breaks */
 }
 
 /* Wrapper for the send button and the toll information */
@@ -6200,9 +6204,10 @@ small {
 .call-message-text {
   color: var(--text-color);
   overflow-wrap: break-word;
-  -webkit-hyphens: auto; /* Add hyphens at line breaks (Chrome/Safari) */
-  hyphens: auto; /* Add hyphens at line breaks */
   white-space: normal; /* Allow text to wrap */
+  -webkit-hyphens: auto; /* Add hyphens at line breaks (Chrome/Safari) */
+  -moz-hyphens: auto; /* Add hyphens at line breaks (Firefox) */
+  hyphens: auto; /* Add hyphens at line breaks */
 }
 
 /* Allow call-message div children (wrapper divs and direct call-message-text) to shrink */


### PR DESCRIPTION
## Fix text overflow and add hyphenation support

- **Fixed text overflow in call messages**
  - Added `min-width: 0` to `.call-message` to allow flex shrinking
  - Added wrapping properties to `.call-message-text` (`overflow-wrap: break-word`, `white-space: normal`)
  - Added hyphenation support (`-webkit-hyphens: auto`, `-moz-hyphens: auto`, `hyphens: auto`)
  - Made wrapper divs flexible with `flex: 1` and `min-width: 0` to prevent username overflow

- **Fixed secret key display overflow**
  - Added wrapping properties to `#secretHexDisplay` (`overflow-wrap: break-word`, `white-space: normal`)
  - Changed from fixed `height: 56px` to `height: auto` with `min-height: 56px` to allow multi-line wrapping
  - Added `min-width: 0` to parent flex container and display element to prevent overflow

- **Enhanced message content hyphenation**
  - Changed `word-break: break-word` to `word-break: normal` in `.message-content` to allow hyphenation
  - Added hyphenation support with vendor prefixes for cross-browser compatibility

**Impact:** Text now wraps correctly in call messages, secret key display, and regular messages on narrow screens, with automatic hyphenation where supported, preventing overflow while maintaining layout.

<img width="171" height="722" alt="image" src="https://github.com/user-attachments/assets/e58879bf-5dc9-4577-95eb-a8ecb968a16b" />
