### PR TITLE
Fix: Prevent half-modal issue when opening SignInModal after unlock

### DIFF
--- a/app.js
+++ b/app.js
@@ -2384,11 +2384,9 @@ class SignInModal {
     this.preselectedUsername = preselectedUsername_;
 
     // Update username select and get usernames BEFORE opening modal
-    // This prevents DOM manipulation during modal transition which can cause half-modal issues
     const { usernames } = this.updateUsernameSelect();
 
     // Wait for browser to process DOM changes before starting modal transition
-    // This ensures layout is stable and prevents half-modal issues
     requestAnimationFrame(async () => {
       this.modal.classList.add('active');
 


### PR DESCRIPTION
- Move dropdown population before modal opening
  - Run `updateUsernameSelect()` before setting the modal to active
  - Ensures DOM manipulation happens while the modal is hidden
- Use `requestAnimationFrame` to stabilize layout
  - Delay `classList.add('active')` until after the browser processes DOM changes
  - Prevents CSS transitions from starting during layout recalculation
- Include browser automation files in `.gitignore`
  - Excludes Playwright MCP and browser automation artifacts

**Problem solved:**
Fixes the half-modal glitch when opening SignInModal immediately after entering the lock password. The modal now opens with stable layout and a ready dropdown.