### PR TITLE
Add one-time toast for editing message fee notification

### DIFF
--- a/app.js
+++ b/app.js
@@ -14478,11 +14478,9 @@ class ChatModal {
       }
 
       // One-time toast
-      if (myData?.account) {
-        if (!checkFirstTimeTip('editMessageFee')) {
-          showToast('Editing a message costs the same transaction fee as sending a new message.', 0, 'info');
-          setFirstTimeTipShown('editMessageFee');
-        }
+      if (!checkFirstTimeTip('editMessageFee')) {
+        showToast('Editing a message costs the same transaction fee as sending a new message.', 0, 'info');
+        setFirstTimeTipShown('editMessageFee');
       }
 
       // If this is a payment, edit the memo; else edit plain message content


### PR DESCRIPTION
- Add a one time toast per account when editing a message for the first time to inform the user there is a transaction fee.
- bool stored local storeage per account under new object firstTimeTips.editMessageFee
<img width="422" height="175" alt="image" src="https://github.com/user-attachments/assets/870808a5-9661-4e71-9151-5dd4d6517f05" />
