### PR TITLE
Change delete request toast to loading state with spinner

### DIFF
--- a/app.js
+++ b/app.js
@@ -14918,7 +14918,7 @@ class ChatModal {
         return showToast('Failed to delete message: ' + (response?.result?.reason || 'Unknown error'), 0, 'error');
       }
 
-      showToast('Delete request sent', 3000, 'success');
+      showToast('Delete request sent', 5000, 'loading');
       
       // Best effort delete attachments from server
       if (message.xattach && Array.isArray(message.xattach)) {


### PR DESCRIPTION
Update the toast notification for delete requests to indicate a loading state with a spinner instead of a success toast.

<img width="419" height="818" alt="image" src="https://github.com/user-attachments/assets/edbc719f-4a05-419b-838a-3d4c53961c24" />
