### PR TITLE
Phase 2: Display Server-Stored Thumbnails on Recipient Side

### DIFF
--- a/app.js
+++ b/app.js
@@ -14411,7 +14411,7 @@ class ChatModal {
       
       // Get pUrl from data attributes
       const pUrl = attachmentRow.dataset.pUrl;
-      if (!pUrl || pUrl === '' || pUrl === 'undefined') {
+      if (!pUrl) {
         showToast('Preview not available for this attachment', 2000, 'info');
         return;
       }


### PR DESCRIPTION
### Summary
Implements recipient-side display of server-stored thumbnails (`pUrl`). Preview now downloads the pre-uploaded thumbnail instead of the full file, reducing bandwidth and improving performance.

### Changes

- **Added `data-p-url` attribute to attachment rows** (`appendChatModal`)
  - Stores thumbnail URL in DOM for preview access
  - Falls back to empty string for old messages without `pUrl`

- **Refactored `decryptAttachmentToBlob()` to support thumbnail decryption**
  - Added optional `urlOverride` parameter to fetch from `pUrl` instead of main URL
  - Uses main URL for key lookup, `urlOverride` for download
  - Returns `image/jpeg` type when `urlOverride` is provided

- **Updated `previewMediaAttachment()` to use server thumbnails**
  - Downloads and decrypts thumbnail from `pUrl` instead of full file
  - Reuses existing key derivation logic via `decryptAttachmentToBlob()`
  - Shows "Preview not available" toast for old messages without `pUrl`
  - Caches decrypted thumbnail for future use

### Behavior

- **On modal open**: Thumbnails load from IndexedDB cache if available (no network request)
- **On Preview click**: Downloads thumbnail from `pUrl` (small file, fast)
- **After preview**: Thumbnail cached locally for instant display on next open
- **Old messages**: Gracefully handles attachments without `pUrl` (shows toast)

### Technical Details

- Thumbnails use the same encryption keys as the main file (reuses `pqEncSharedKey`/`selfKey`)
- Cache key remains the main attachment URL (not `pUrl`) for consistency
- No breaking changes - fully backward compatible with existing messages