### PR TITLE
Remove chevron from chat list and right-align message time

### DIFF
--- a/app.js
+++ b/app.js
@@ -1217,7 +1217,7 @@ class ChatsScreen {
           <div class="chat-content">
               <div class="chat-header">
                   <div class="chat-name">${escapeHtml(contactName)}</div>
-                  <div class="chat-time">${timeDisplay} <span class="chat-time-chevron"></span></div>
+                  <div class="chat-time">${timeDisplay}</div>
               </div>
               <div class="chat-message">
                 ${contact.unread ? `<span class="chat-unread">${contact.unread}</span>` : ((contact.draft || contact.draftReplyTxid || hasDraftAttachment) ? `<span class="chat-draft" title="Draft"></span>` : '')}

--- a/styles.css
+++ b/styles.css
@@ -858,6 +858,7 @@ body {
   font-size: var(--font-size-sm);
   color: var(--secondary-text-color);
   white-space: nowrap;
+  text-align: right;
 }
 
 #searchResults .chat-message {


### PR DESCRIPTION
### Changes in `app.js`:
- Removed the chevron icon (`<span class="chat-time-chevron"></span>`) from the chat list item template in the `ChatsScreen.updateChatList()` method
- Updated the chat time display to show only the time without the trailing chevron

**Before:** `<div class="chat-time">${timeDisplay} <span class="chat-time-chevron"></span></div>`  
**After:** `<div class="chat-time">${timeDisplay}</div>`