### PR TITLE
Replace "You: " prefix with arrow characters in chat list and search

### DIFF
--- a/app.js
+++ b/app.js
@@ -1206,7 +1206,7 @@ class ChatsScreen {
         displayPreview = attachmentCount === 1 
           ? '📎 Attachment' 
           : `📎 ${attachmentCount} attachments`;
-        displayPrefix = '<';
+        displayPrefix = '< ';
       }
       // Create the list item element
       const li = document.createElement('li');


### PR DESCRIPTION
### Changes in `app.js`:

**Chat list updates (`ChatsScreen.updateChatList()`):**
- Replaced "You: " with "< " for messages sent by the user
- Added "> " prefix for messages sent by contacts (previously no prefix)
- Updated draft message prefix from "You: " to "< "
- Updated draft attachment prefix from "You: " to "< "

**Search results updates (`SearchMessagesModal.displaySearchResults()`):**
- Replaced "You: " prefix with "< " for user messages
- Added "> " prefix for contact messages in search results