### PR TITLE
Share timezone in sender info and display in schedule call

### DIFF
--- a/index.html
+++ b/index.html
@@ -1078,6 +1078,7 @@
               <p class="modal-summary">Choose to call now or schedule a future time.</p>
               <div class="form--narrow">
                 <div class="form-actions">
+                  <div class="contact-time" id="callScheduleChoiceRecipientTime" aria-label="Recipient current time"></div>
                   <button type="button" id="callScheduleNowBtn" class="btn btn--primary btn--pill btn--full">Call Now</button>
                   <button type="button" id="openCallScheduleDateBtn" class="btn btn--primary btn--pill btn--full">Schedule</button>
                   <button type="button" id="cancelCallScheduleChoice" class="btn btn--secondary btn--pill btn--full">Cancel</button>

--- a/styles.css
+++ b/styles.css
@@ -1428,7 +1428,6 @@ button:disabled {
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin: 0 0 8px 0;
 }
 
 .menu-list {


### PR DESCRIPTION
- Include the sender's timezone in sender info if the contact is a connection or friend
- Call schedule date modal will display the recipient's local time for the selected scheduled time.
- Display recipient's current time above call now button on the call schedule choice modal
<img width="414" height="820" alt="image" src="https://github.com/user-attachments/assets/6ed1d951-eff3-46fc-915c-59be8fc1807f" />
<img width="430" height="818" alt="image" src="https://github.com/user-attachments/assets/b691b095-8c66-4090-9e5e-c6f6fa910f2e" />
