### PR TITLE
Hide Email and Phone fields from Contact Info modals (UI only)

### DIFF
--- a/app.js
+++ b/app.js
@@ -2982,8 +2982,9 @@ class ContactInfoModal {
       Username: 'contactInfoUsername',
       Name: 'contactInfoName',
       ProvidedName: 'contactInfoProvidedName',
-      Email: 'contactInfoEmail',
-      Phone: 'contactInfoPhone',
+      // Email and Phone fields hidden - may want to restore later
+      // Email: 'contactInfoEmail',
+      // Phone: 'contactInfoPhone',
       LinkedIn: 'contactInfoLinkedin',
       X: 'contactInfoX',
     };

--- a/index.html
+++ b/index.html
@@ -1438,6 +1438,7 @@
                 <div class="contact-info-label">Provided Name</div>
                 <div class="contact-info-value" id="contactInfoProvidedName"></div>
               </div>
+              <!-- Email and Phone fields hidden - may want to restore later
               <div class="contact-info-item" style="display: none">
                 <div class="contact-info-label">Email</div>
                 <div class="contact-info-value">
@@ -1448,6 +1449,7 @@
                 <div class="contact-info-label">Phone</div>
                 <div class="contact-info-value" id="contactInfoPhone"></div>
               </div>
+              -->
               <div class="contact-info-item" style="display: none">
                 <div class="contact-info-label">LinkedIn</div>
                 <div class="contact-info-value">
@@ -2058,6 +2060,7 @@
                 <div class="contact-info-label">Provided Name</div>
                 <div class="contact-info-value" id="editContactProvidedName"></div>
               </div>
+              <!-- Email and Phone fields hidden - may want to restore later
               <div class="contact-info-item" style="display: none">
                 <div class="contact-info-label">Email</div>
                 <div class="contact-info-value" id="editContactEmail"></div>
@@ -2066,6 +2069,7 @@
                 <div class="contact-info-label">Phone</div>
                 <div class="contact-info-value" id="editContactPhone"></div>
               </div>
+              -->
               <div class="contact-info-item" style="display: none">
                 <div class="contact-info-label">LinkedIn</div>
                 <div class="contact-info-value" id="editContactLinkedin"></div>


### PR DESCRIPTION
## Summary

- **Contact Info Modal (Display)**
  - Commented out Email and Phone HTML elements in `contactInfoModal` in `index.html`
  - Removed `Email` and `Phone` from the `fields` object in `ContactInfoModal.updateContactInfo()` in `app.js`

- **Edit Contact Modal**
  - Commented out Email and Phone HTML elements in `editContactModal` in `index.html`

- **Backend support preserved**
  - All commented code marked with "may want to restore later" for easy restoration
  - Data structure remains intact; backend functionality is unaffected
  - Only visual display is hidden; no breaking changes

Fields are hidden from the UI but can be restored. No breaking changes to data storage or backend logic.