### PR TITLE
Add clickable address copy functionality to Contact Info modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -2886,6 +2886,7 @@ class ContactInfoModal {
   constructor() {
     this.currentContactAddress = null;
     this.needsContactListUpdate = false; // track if we need to update the contact list
+    this.fullAddress = null; // Store full address for copying
   }
 
   // Helper method to open avatar edit modal
@@ -2905,7 +2906,8 @@ class ContactInfoModal {
     this.avatarSection = this.modal.querySelector('.contact-avatar-section');
     this.avatarDiv = this.avatarSection.querySelector('.avatar');
     this.nameDiv = this.avatarSection.querySelector('.name');
-    this.subtitleDiv = this.avatarSection.querySelector('.subtitle');
+    this.subtitleDiv = document.getElementById('contactInfoDisplayAddress');
+    this.copyButton = document.getElementById('contactInfoCopyAddress');
     this.usernameDiv = document.getElementById('contactInfoUsername');
     this.avatarEditButton = document.createElement('button');
     this.avatarEditButton.className = 'icon-button edit-icon avatar-edit-button avatar-edit-button-outside';
@@ -2962,6 +2964,10 @@ class ContactInfoModal {
     if (!this.avatarDiv.contains(this.avatarEditButton)) {
       this.avatarDiv.appendChild(this.avatarEditButton);
     }
+
+    // Copy address functionality
+    this.copyButton.addEventListener('click', () => this.copyAddress());
+    this.subtitleDiv.addEventListener('click', () => this.copyAddress());
   }
 
   // Update contact info values
@@ -2976,7 +2982,11 @@ class ContactInfoModal {
       this.avatarDiv.appendChild(this.avatarEditButton);
     }
     this.nameDiv.textContent = displayInfo.name !== 'Not Entered' ? displayInfo.name : displayInfo.username;
-    this.subtitleDiv.textContent = displayInfo.address;
+    
+    // Store and display address
+    const addressWithPrefix = displayInfo.address?.startsWith('0x') ? displayInfo.address : `0x${displayInfo.address || ''}`;
+    this.fullAddress = addressWithPrefix;
+    this.subtitleDiv.textContent = addressWithPrefix;
 
     const fields = {
       Username: 'contactInfoUsername',
@@ -3036,6 +3046,22 @@ class ContactInfoModal {
       this.chatButton.style.display = 'block';
     } else {
       this.chatButton.style.display = 'none';
+    }
+  }
+
+  async copyAddress() {
+    // Copy the full address, not the displayed truncated version and toast
+    const address = this.fullAddress || this.subtitleDiv.textContent;
+    try {
+      await navigator.clipboard.writeText(address);
+      showToast('Address copied to clipboard', 2000, 'success');
+      this.copyButton.classList.add('success');
+      setTimeout(() => {
+        this.copyButton.classList.remove('success');
+      }, 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      showToast('Failed to copy address', 0, 'error');
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -1413,7 +1413,14 @@
               <div class="contact-avatar-section">
                 <div class="avatar" id="contactInfoAvatar"></div>
                 <div class="name"></div>
-                <div class="subtitle"></div>
+                <div class="address-container">
+                  <div id="contactInfoDisplayAddress" class="subtitle"></div>
+                  <button
+                    id="contactInfoCopyAddress"
+                    class="icon-button address-copy-button"
+                    aria-label="Copy address"
+                  ></button>
+                </div>
               </div>
               <!-- Template for contact info items -->
               <template id="contactInfoItemTemplate">

--- a/styles.css
+++ b/styles.css
@@ -3252,6 +3252,18 @@ button.about-link {
   text-align: center;
 }
 
+.contact-avatar-section .address-container {
+  width: 100%;
+  min-width: 0;
+}
+
+.contact-avatar-section .address-container .subtitle {
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+  font-size: 0.8rem;
+}
+
 .contact-info-item {
   padding: 0.2rem;
 }


### PR DESCRIPTION
- Make the address string in the Contact Info modal clickable to copy to clipboard
- Add a copy icon button next to the address (matches My Info modal pattern)
- Store full address for copying (handles 0x prefix)
- Show success toast and icon state change on copy
- Style the address container to allow wrapping on smaller screens
- Use existing address-container and address-copy-button classes for consistency

**Changes:**
- Added `address-container` wrapper with copy button in Contact Info modal HTML
- Implemented `copyAddress()` method in `ContactInfoModal` class
- Added click handlers for both address text and copy button
- Added CSS styling for address container layout 
- Maintains same visual appearance as original subtitle