### PR TITLE
Standardize logo and avatar sizes to 40×40px

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -456,7 +456,6 @@ body {
 #logo img {
   width: 40px;
   height: 40px;
-  padding: 1px;
   object-fit: contain;
 }
 
@@ -490,8 +489,8 @@ body {
 }
 
 .app-name-avatar {
-  width: 28px;
-  height: 28px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   flex-shrink: 0;
   overflow: hidden;


### PR DESCRIPTION
**Summary:**
- **Logo sizing**
  - Removed `1px` padding from `#logo img` so it matches the avatar size
- **Header avatar sizing**
  - Increased `.app-name-avatar` from **28×28px** to **40×40px** to match the logo
- **Result**
  - Logo and header avatar are both **40×40px** for consistent sizing