### PR TITLE
Focus correct input field when opening edit contact modal from name/notes edit icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -2931,7 +2931,7 @@ class ContactInfoModal {
     // Back button
     this.backButton.addEventListener('click', () => this.close());
 
-    this.nameEditButton.addEventListener('click', () => editContactModal.open());
+    this.nameEditButton.addEventListener('click', () => editContactModal.open('name'));
 
     // Add chat button handler for contact info modal
     this.chatButton.addEventListener('click', () => {
@@ -2964,7 +2964,7 @@ class ContactInfoModal {
     // Notes edit button
     this.notesEditButton.addEventListener('click', (e) => {
       e.stopPropagation();
-      editContactModal.open();
+      editContactModal.open('notes');
     });
 
     // Make the avatar itself clickable
@@ -3413,7 +3413,7 @@ class EditContactModal {
     this.backButton.addEventListener('click', () => this.close());
   }
 
-  open() {
+  open(focusField = 'name') {
     // Get the avatar section elements
     const avatarSection = document.querySelector('#editContactModal .contact-avatar-section');
     const avatarDiv = avatarSection.querySelector('.avatar');
@@ -3465,9 +3465,10 @@ class EditContactModal {
     this.modal.classList.add('active');
     // Delay focus to ensure transition completes (modal transition is 300ms)
     setTimeout(() => {
-      this.nameInput.focus();
+      const inputToFocus = focusField === 'notes' ? this.notesInput : this.nameInput;
+      inputToFocus.focus();
       // Set cursor position to the end of the input content
-      this.nameInput.setSelectionRange(this.nameInput.value.length, this.nameInput.value.length);
+      inputToFocus.setSelectionRange(inputToFocus.value.length, inputToFocus.value.length);
     }, 325);
   }
 


### PR DESCRIPTION
## PR Summary

- **Context-aware focus**: `EditContactModal.open()` now accepts an optional `focusField` parameter to focus the correct input based on which edit icon was clicked
- **Name edit icon**: Clicking the name edit icon focuses the name input field
- **Notes edit icon**: Clicking the notes edit icon focuses the notes input field
- **Backward compatible**: Defaults to focusing name input if no parameter is provided
- **Consistent UX**: Maintains the 325ms delay to avoid interrupting modal transitions, with cursor positioned at the end of the focused field

**Rationale**: Previously, the modal always focused the name input regardless of which edit icon was clicked. Now it focuses the field corresponding to the icon clicked, improving the editing flow.