### PR TITLE
Add avatar edit functionality to EditContactModal with real-time updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1480,56 +1480,6 @@
         <a class="last-item" href="#"> </a>
       </div>
 
-      <!-- Avatar Edit Modal -->
-      <div class="modal fixed-header" id="avatarEditModal">
-        <div class="modal-header">
-          <button class="back-button" id="closeAvatarEditModal"></button>
-          <div class="modal-title">Edit Photo</div>
-        </div>
-        <div class="modal-content">
-          <div class="form-container">
-            <div class="avatar-edit-preview">
-              <div class="avatar-edit-square" id="avatarEditSquare">
-                <div class="avatar-edit-circle" id="avatarEditPreview"></div>
-              </div>
-            </div>
-            <div class="avatar-edit-controls">
-              <label for="avatarZoomRange">Zoom</label>
-              <input type="range" id="avatarZoomRange" min="1" max="3" step="0.01" value="1" />
-            </div>
-            <div class="avatar-edit-actions">
-              <input type="file" id="avatarEditFileInput" accept="image/*" style="display:none" />
-              <button class="primary-button" id="avatarEditUploadButton">Upload</button>
-              <button class="secondary-button danger-button" id="avatarEditDeleteButton">Delete</button>
-              <button class="btn btn--primary" id="avatarEditSaveButton" style="display: none;">Save</button>
-              <button class="btn btn--secondary btn--danger" id="avatarEditCancelButton" style="display: none;">Cancel</button>
-            </div>
-            <!-- Avatar selection options: contact-sent, mine (local), identicon -->
-            <div class="avatar-options" id="avatarOptionsContainer">
-              <div class="avatar-options-label">Choose avatar to use:</div>
-              <div class="avatar-options-list">
-                <div class="avatar-option" data-value="mine" id="avatarOptionUploaded">
-                  <div class="avatar-thumb" id="avatarThumbUploaded"></div>
-                  <div class="avatar-option-label">Mine</div>
-                </div>
-                <div class="avatar-option" data-value="contact" id="avatarOptionContact">
-                  <div class="avatar-thumb" id="avatarThumbContact"></div>
-                  <div class="avatar-option-label">Contact</div>
-                </div>
-                <div class="avatar-option" data-value="identicon" id="avatarOptionIdenticon">
-                  <div class="avatar-thumb" id="avatarThumbIdenticon"></div>
-                  <div class="avatar-option-label">Identicon</div>
-                </div>
-              </div>
-            </div>
-            <div class="avatar-options-actions" id="avatarOptionsActions">
-              <button class="btn btn--primary" id="avatarUseButton" disabled>Use</button>
-            </div>
-          </div>
-        </div>
-        <a class="last-item" href="#"> </a>
-      </div>
-
       <!-- Friend Modal -->
       <div class="modal fixed-header" id="friendModal">
         <div class="modal-header">
@@ -2095,6 +2045,56 @@
               <div class="form-actions" style="padding: 1rem;">
                 <button id="saveEditContactButton" class="btn btn--primary btn--pill btn--full">Save</button>
               </div>
+            </div>
+          </div>
+        </div>
+        <a class="last-item" href="#"> </a>
+      </div>
+
+      <!-- Avatar Edit Modal -->
+      <div class="modal fixed-header" id="avatarEditModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeAvatarEditModal"></button>
+          <div class="modal-title">Edit Photo</div>
+        </div>
+        <div class="modal-content">
+          <div class="form-container">
+            <div class="avatar-edit-preview">
+              <div class="avatar-edit-square" id="avatarEditSquare">
+                <div class="avatar-edit-circle" id="avatarEditPreview"></div>
+              </div>
+            </div>
+            <div class="avatar-edit-controls">
+              <label for="avatarZoomRange">Zoom</label>
+              <input type="range" id="avatarZoomRange" min="1" max="3" step="0.01" value="1" />
+            </div>
+            <div class="avatar-edit-actions">
+              <input type="file" id="avatarEditFileInput" accept="image/*" style="display:none" />
+              <button class="primary-button" id="avatarEditUploadButton">Upload</button>
+              <button class="secondary-button danger-button" id="avatarEditDeleteButton">Delete</button>
+              <button class="btn btn--primary" id="avatarEditSaveButton" style="display: none;">Save</button>
+              <button class="btn btn--secondary btn--danger" id="avatarEditCancelButton" style="display: none;">Cancel</button>
+            </div>
+            <!-- Avatar selection options: contact-sent, mine (local), identicon -->
+            <div class="avatar-options" id="avatarOptionsContainer">
+              <div class="avatar-options-label">Choose avatar to use:</div>
+              <div class="avatar-options-list">
+                <div class="avatar-option" data-value="mine" id="avatarOptionUploaded">
+                  <div class="avatar-thumb" id="avatarThumbUploaded"></div>
+                  <div class="avatar-option-label">Mine</div>
+                </div>
+                <div class="avatar-option" data-value="contact" id="avatarOptionContact">
+                  <div class="avatar-thumb" id="avatarThumbContact"></div>
+                  <div class="avatar-option-label">Contact</div>
+                </div>
+                <div class="avatar-option" data-value="identicon" id="avatarOptionIdenticon">
+                  <div class="avatar-thumb" id="avatarThumbIdenticon"></div>
+                  <div class="avatar-option-label">Identicon</div>
+                </div>
+              </div>
+            </div>
+            <div class="avatar-options-actions" id="avatarOptionsActions">
+              <button class="btn btn--primary" id="avatarUseButton" disabled>Use</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Changes

- **EditContactModal enhancements:**
  - Added avatar edit button and click handler to open AvatarEditModal
  - Added `updateAvatar()` to refresh avatar when changed
  - Added `isActive()` for modal state checks
  - Cached `avatarSection` and `avatarDiv` in `load()` to avoid redundant queries
  - Simplified `open()` to use cached references

- **AvatarEditModal integration:**
  - Updated "Use" button handler to refresh EditContactModal avatar when active and showing the same contact
  - Updated upload handler to refresh EditContactModal avatar after successful upload
  - Made `updateContactInfo()` calls `await` to ensure UI updates complete

- **DOM structure fix:**
  - Moved `AvatarEditModal` after `EditContactModal` in `index.html` to fix z-index stacking (AvatarEditModal now appears on top)

### Technical details

- Avatar updates in EditContactModal when changed via AvatarEditModal
- Clicking avatar or edit button opens AvatarEditModal
- Uses cached DOM references to reduce queries
- Simplified `updateAvatar()` to set `innerHTML` directly