### PR TITLE
Add Google Drive backup reminder functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -8559,7 +8559,13 @@ class BackupAccountModal {
   }
 
   getGDriveReminderTs() {
-    return this._getStoredTimestamp(this.GDRIVE_REMINDER_TS_KEY);
+    // If this returns null, set timestamp to 3 days from now
+    const ts = this._getStoredTimestamp(this.GDRIVE_REMINDER_TS_KEY);
+    if (!ts) {
+      this.setGDriveReminderTs(getCorrectedTimestamp() + 3 * 24 * 60 * 60 * 1000);
+      return getCorrectedTimestamp() + 3 * 24 * 60 * 60 * 1000;
+    }
+    return ts;
   }
 
   setGDriveReminderTs(timestamp = getCorrectedTimestamp()) {


### PR DESCRIPTION
- Implemented a toast notification for Google Drive backup reminders in the WelcomeScreen class, triggered if the user has not backed up in over seven days and has not been reminded in the last three days.
- Added functions to manage Google Drive backup and reminder timestamps in local storage.
- Updated the BackupAccountModal to set the backup timestamp upon successful upload to Google Drive.