### PR TITLE
Remove duplicate inject call in CallInviteModal

### DIFF
--- a/app.js
+++ b/app.js
@@ -17104,7 +17104,6 @@ class CallInviteModal {
         }
         await signObj(messageObj, keys);
         const txid = getTxid(messageObj);
-        await injectTx(messageObj, txid);
 
         // Create new message object for local display immediately
         const newMessage = {


### PR DESCRIPTION
Eliminate redundant injection of transactions in the CallInviteModal which was causing the `Transaction is already in queue` error