### PR TITLE
Add contact validation on network in ImportContactsModal

### DIFF
--- a/app.js
+++ b/app.js
@@ -17447,7 +17447,7 @@ class ShareContactsModal {
   handleClose() {
     if (this.selectedContacts.size > 0 && !this.warningShown) {
       this.warningShown = true;
-      showToast('You have contacts selected. Click back again to discard.', 3000, 'warning');
+      showToast('You have contacts selected. Click back again to discard.', 0, 'warning');
       return;
     }
     this.close();
@@ -18068,7 +18068,7 @@ class ImportContactsModal {
   handleClose() {
     if (this.selectedContacts.size > 0 && !this.warningShown) {
       this.warningShown = true;
-      showToast('You have contacts selected. Click back again to discard.', 3000, 'warning');
+      showToast('You have contacts selected. Click back again to discard.', 0, 'warning');
       return;
     }
     this.close();


### PR DESCRIPTION
- Introduced a new method, `validateContactOnNetwork`, to validate contacts by username lookup, ensuring only public accounts can be imported.
- Enhanced the import process to validate selected contacts in parallel, providing detailed success and error feedback for each contact.
- Updated the contact import logic to use network addresses instead of VCF addresses, improving accuracy and user experience.
- Added user notifications for successful imports and failures, enhancing feedback during the import process.