### PR TITLE
Show testnet warning toast once per account

### DIFF
--- a/app.js
+++ b/app.js
@@ -1671,13 +1671,10 @@ class WalletScreen {
 
   open() {
     this.screen.classList.add('active');
-    // Show testnet warning toast if on testnet and not shown this session
-    if (!this.isMainnet()) {
-      const hasBeenShown = sessionStorage.getItem('testnetWarningShown');
-      if (hasBeenShown !== 'true') {
-        showToast('The LIB in this Testnet is not of any value and will not be transferred to the Mainnet.', 0, 'info');
-        sessionStorage.setItem('testnetWarningShown', 'true');
-      }
+    // Show testnet warning toast once per account (first-time tip).
+    if (!this.isMainnet() && !checkFirstTimeTip('testnetWarning')) {
+      showToast('The LIB in this Testnet is not of any value and will not be transferred to the Mainnet.', 0, 'info');
+      setFirstTimeTipShown('testnetWarning');
     }
   }
 


### PR DESCRIPTION
Display the testnet warning toast only once per account instead of once per session using first time tip