### PR TITLE
Call Invite modal: match Share Contacts layout and reuse styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1501,14 +1501,6 @@
                 <!-- Contacts will be populated here -->
               </div>
             </div>
-            <template id="callInviteContactTemplate">
-              <div class="call-invite-contact-row" data-address="">
-                <label class="call-invite-contact-label">
-                  <input type="checkbox" class="call-invite-contact-checkbox" value="" />
-                  <span class="call-invite-contact-name"></span>
-                </label>
-              </div>
-            </template>
             <div class="call-invite-modal-footer">
               <div id="callInviteCounter" class="call-invite-counter">0 selected (max 10)</div>
               <div class="call-invite-footer-actions">

--- a/styles.css
+++ b/styles.css
@@ -4665,39 +4665,6 @@ small {
   min-height: 0;
 }
 
-.call-invite-section-header {
-  padding: 8px 12px;
-  font-weight: var(--font-weight-bold);
-  color: var(--primary-text-color);
-  background: transparent;
-  border-top: 1px solid rgba(0,0,0,0.04);
-}
-
-.call-invite-contact-row {
-  padding: 8px 12px;
-  display: flex;
-  align-items: center;
-}
-
-.call-invite-contact-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  cursor: pointer;
-}
-
-.call-invite-contact-checkbox {
-  width: 18px;
-  height: 18px;
-}
-
-.call-invite-contact-name {
-  flex: 1 1 auto;
-  text-align: left;
-  font-size: var(--font-size-base);
-}
-
 .call-invite-modal-footer {
   border-top: 1px solid rgba(0,0,0,0.06);
   padding: 10px 8px;


### PR DESCRIPTION
- **UI:** Call Invite list now shows avatar, name, and checkbox on the right, reusing Share Contacts layout and `share-contact-*` CSS.
- **Markup:** Removed `callInviteContactTemplate`; list is built in JS with `renderSection()` (section headers + rows).
- **Display name:** Uses `getContactDisplayName(contact)` (same as chat header); name and sort key are computed once per contact when building the list.
- **Avatar:** Call Invite uses user-selected → contact-provided → identicon; avatars loaded in batch with `Promise.all`.
- **Selection:** Row click toggles checkbox; selectors use `call-invite-checkbox`; max 10 and counter/Invite button logic unchanged.
- **Cleanup:** Dropped Call Invite–only CSS (section header, row, label, checkbox, name); layout comes from shared Share Contacts styles.