### PR TITLE
Use transaction-specific timestamp helper with +500ms offset

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,6 +139,7 @@ const wei = 10n ** BigInt(weiDigits);
 const MAX_MEMO_BYTES = 1000; // 1000 bytes for memos
 const MAX_CHAT_MESSAGE_BYTES = 1000; // 1000 bytes for chat messages
 const BRIDGE_USERNAME = 'liberdusbridge';
+const TRANSACTION_TIMESTAMP_OFFSET_MS = 500; // Transaction offset to allow for slow connections
 
 let myData = null;
 let myAccount = null; // this is set to myData.account for convience
@@ -4236,7 +4237,7 @@ class FriendModal {
       chatId: chatId_,
       required: requiredNum,
       type: 'update_toll_required',
-      timestamp: getCorrectedTimestamp(),
+      timestamp: getTransactionTimestamp(),
       networkId: network.netid,
     };
     const txid = await signObj(tx, myAccount.keys);
@@ -6184,7 +6185,7 @@ async function postAssetTransfer(to, amount, memo, keys) {
     // TODO backend is not allowing memo > 140 characters; by pass using xmemo; we might have to check the total tx size instead
     // memo: stringify(memo),
     xmemo: memo,
-    timestamp: getCorrectedTimestamp(),
+    timestamp: getTransactionTimestamp(),
     fee: getTransactionFeeWei(), // This is not used by the backend
     networkId: network.netid,
   };
@@ -6207,7 +6208,7 @@ async function postRegisterAlias(alias, keys, isPrivate = false) {
     alias: alias,
     publicKey: keys.public,
     pqPublicKey: pqPublicKey,
-    timestamp: getCorrectedTimestamp(),
+    timestamp: getTransactionTimestamp(),
     networkId: network.netid,
     private: isPrivate,
   };
@@ -8459,6 +8460,10 @@ function getCorrectedTimestamp() {
   return correctedTime;
 }
 
+function getTransactionTimestamp() {
+  return getCorrectedTimestamp() + TRANSACTION_TIMESTAMP_OFFSET_MS;
+}
+
 // Validator Modals
 
 // fetching market price by invoking `updateAssetPricesIfNeeded` and extracting from myData.assetPrices
@@ -10642,7 +10647,7 @@ class TollModal {
       from: longAddress(myAccount.keys.address),
       toll: toll,
       type: 'toll',
-      timestamp: getCorrectedTimestamp(),
+      timestamp: getTransactionTimestamp(),
       tollUnit: tollUnit,
       networkId: network.netid,
     };
@@ -11678,7 +11683,7 @@ class ValidatorStakingModal {
       nominator: longAddress(myAccount?.keys?.address),
       nominee: nodeAddress,
       force: false,
-      timestamp: getCorrectedTimestamp(),
+      timestamp: getTransactionTimestamp(),
       networkId: network.netid,
     };
 
@@ -12017,7 +12022,7 @@ class StakeValidatorModal {
       nominator: longAddress(myAccount.keys.address),
       nominee: nodeAddress,
       stake: amount,
-      timestamp: getCorrectedTimestamp(),
+      timestamp: getTransactionTimestamp(),
       networkId: network.netid,
     };
 
@@ -13144,7 +13149,7 @@ class ChatModal {
       from: longAddress(myData.account.keys.address),
       to: longAddress(contactAddress),
       chatId: hashBytes([longAddress(myData.account.keys.address), longAddress(contactAddress)].sort().join('')),
-      timestamp: getCorrectedTimestamp(),
+      timestamp: getTransactionTimestamp(),
       networkId: network.netid,
     };
     const txid = await signObj(tx, myAccount.keys);
@@ -13211,7 +13216,7 @@ class ChatModal {
       from: longAddress(myData.account.keys.address),
       to: longAddress(contactAddress),
       chatId: hashBytes([longAddress(myData.account.keys.address), longAddress(contactAddress)].sort().join('')),
-      timestamp: getCorrectedTimestamp(),
+      timestamp: getTransactionTimestamp(),
       oldContactTimestamp: myData.contacts[contactAddress].timestamp,
       networkId: network.netid,
     };
@@ -13691,7 +13696,7 @@ class ChatModal {
       chatId: hashBytes([fromAddr, toAddr].sort().join('')),
       message: 'x',
       xmessage: payload,
-      timestamp: getCorrectedTimestamp(),
+      timestamp: getTransactionTimestamp(),
       fee: getTransactionFeeWei(), // This is not used by the backend
       networkId: network.netid,
     };


### PR DESCRIPTION
Introduce a new timestamp helper that adds a 500ms offset to the corrected timestamp for transactions. This adjustment accommodates potential delays in slow connections. Update all relevant functions to utilize the new helper.