### PR TITLE
Refresh header call icon when calls are deleted or changed

### DIFF
--- a/app.js
+++ b/app.js
@@ -5475,6 +5475,7 @@ async function processChats(chats, keys) {
   const timestamp = myAccount.chatTimestamp || 0;
   const messageQueryTimestamp = Math.max(0, timestamp+1);
   let hasAnyTransfer = false;
+  let needsUpcomingCallsUiRefresh = false;
 
   for (let sender in chats) {
     // Fetch messages using the adjusted timestamp
@@ -5646,7 +5647,7 @@ async function processChats(chats, keys) {
                     reactNativeApp.sendCancelScheduledCall(contact?.username, Number(messageToDelete.callTime));
                   }
                   if (didDeleteMessage && messageToDelete.type === 'call' && shouldRefreshUpcomingCallsUiForCallTime(messageToDelete.callTime)) {
-                    refreshUpcomingCallsUi();
+                    needsUpcomingCallsUiRefresh = true;
                   }
                   
                   if (chatModal.isActive() && chatModal.address === from) {
@@ -5853,7 +5854,7 @@ async function processChats(chats, keys) {
           
           insertSorted(contact.messages, payload, 'timestamp');
           if (payload.type === 'call' && shouldRefreshUpcomingCallsUiForCallTime(payload.callTime)) {
-            refreshUpcomingCallsUi();
+            needsUpcomingCallsUiRefresh = true;
           }
           // if we are not in the chatModal of who sent it, playChatSound or if device visibility is hidden play sound
           if (!inActiveChatWithSender || document.visibilityState === 'hidden') {
@@ -6090,6 +6091,10 @@ async function processChats(chats, keys) {
     if (historyModal.isActive()) historyModal.refresh();
     // Update wallet view if it's active
     if (walletScreen.isActive()) walletScreen.updateWalletView();
+  }
+
+  if (needsUpcomingCallsUiRefresh) {
+    refreshUpcomingCallsUi();
   }
 
   // Update the global timestamp AFTER processing all senders


### PR DESCRIPTION
- **Issue:** The header “upcoming calls” icon did not update when a scheduled call was deleted or when call messages were processed (e.g. delete-for-me, delete-for-all, or new call messages).
- **Approach:** Introduced shared helpers and wired them into all places that change call state so the header stays in sync.
- **New helpers**
  - `refreshUpcomingCallsUi()` – Recomputes scheduled calls and updates the header calls icon (`callsModal.refreshCalls()` + `header.updateCallsIcon()`).
  - `shouldRefreshUpcomingCallsUiForCallTime(callTime)` – Returns whether a call time is “relevant” for refresh (valid positive `callTime` within the last 2 hours or in the future), matching `CallsModal` refresh logic.
- **Call refresh when processing chats**
  - In `processChats`, track `needsUpcomingCallsUiRefresh` and set it when:
    - A call message is deleted (delete-for-me or delete-for-all) and its `callTime` is eligible, or
    - A new call message with an eligible `callTime` is inserted.
  - After processing all senders, if the flag is set, call `refreshUpcomingCallsUi()`.
- **Call refresh on user-initiated delete**
  - In `ChatModal` delete flow, compute `shouldRefreshCallsUi` from the message’s `type === 'call'` and `shouldRefreshUpcomingCallsUiForCallTime(message.callTime)`; after a successful delete, call `refreshUpcomingCallsUi()` when true.
- **Call refresh on cancel/edit scheduled call**
  - In `ChatModal`, after the operation that uses `normalizedCallTime`, call `refreshUpcomingCallsUi()` when `shouldRefreshUpcomingCallsUiForCallTime(normalizedCallTime)`.