### PR TITLE
Refactor ChatModal send button revalidation call sites

### DIFF
--- a/app.js
+++ b/app.js
@@ -8284,6 +8284,7 @@ function revalidateButtonStates() {
 
   // re-validate chat modal buttons
   if (typeof chatModal !== 'undefined' && chatModal.isActive() && chatModal.address) {
+    chatModal.revalidateSendButtonState();
     if (chatModal.voiceRecordButton) {
       chatModal.voiceRecordButton.disabled = chatModal.blockedByRecipient || !isOnline;
     }
@@ -12566,12 +12567,10 @@ class ChatModal {
       this.messageInput.style.height = Math.min(this.messageInput.scrollHeight, 120) + 'px';
 
       const messageText = e.target.value;
-      const messageValidation = this.validateMessageSize(messageText);
-      this.updateMessageByteCounter(messageValidation);
+      this.revalidateSendButtonState();
 
       // Save draft (text is already limited to 2000 chars by maxlength attribute)
-      this.debouncedSaveDraft(e.target.value);
-      this.toggleSendButtonVisibility();
+      this.debouncedSaveDraft(messageText);
     });
 
     // allow ctlr+enter or cmd+enter to send message
@@ -14438,8 +14437,7 @@ class ChatModal {
           );
           refreshChatsScreenIfActive();
           
-          const messageValidation = this.validateMessageSize(this.messageInput.value);
-          this.updateMessageByteCounter(messageValidation); // Re-enable send button if message size is valid
+          this.revalidateSendButtonState();
 
           this.addAttachmentButton.disabled = this.isEditingMessage() || this.blockedByRecipient;
         } else {
@@ -14507,9 +14505,7 @@ class ChatModal {
               }
             }
             
-            const messageValidation = this.validateMessageSize(this.messageInput.value);
-            this.updateMessageByteCounter(messageValidation); // Re-enable send button if message size is valid
-            this.toggleSendButtonVisibility();
+            this.revalidateSendButtonState();
 
             this.addAttachmentButton.disabled = this.isEditingMessage() || this.blockedByRecipient;
             if (activeChatMatchesUpload) {
@@ -14546,8 +14542,7 @@ class ChatModal {
               refreshChatsScreenIfActive();
             }
             
-            const messageValidation = this.validateMessageSize(this.messageInput.value);
-            this.updateMessageByteCounter(messageValidation); // Re-enable send button if message size is valid
+            this.revalidateSendButtonState();
             this.isEncrypting = false;
 
             this.addAttachmentButton.disabled = this.isEditingMessage() || this.blockedByRecipient;
@@ -14568,8 +14563,7 @@ class ChatModal {
         refreshChatsScreenIfActive();
         this.isEncrypting = false;
         
-        const messageValidation = this.validateMessageSize(this.messageInput.value);
-        this.updateMessageByteCounter(messageValidation); // Re-enable send button if message size is valid
+        this.revalidateSendButtonState();
 
             this.addAttachmentButton.disabled = this.isEditingMessage() || this.blockedByRecipient;
         worker.terminate();
@@ -14599,8 +14593,7 @@ class ChatModal {
       }
       
       // Re-enable buttons
-      const messageValidation = this.validateMessageSize(this.messageInput.value);
-      this.updateMessageByteCounter(messageValidation); // Re-enable send button if message size is valid
+      this.revalidateSendButtonState();
       this.isEncrypting = false;
 
       this.addAttachmentButton.disabled = this.isEditingMessage() || this.blockedByRecipient;


### PR DESCRIPTION
### Motivation
- Reduce duplicated logic that manually re-validates send-button state and ensure a single consistent code path for enabling/disabling the send button. 
- Ensure the chat send button is correctly revalidated when returning from offline or when attachments change state (success/error).

### Description
- Replaced repeated inline validation sequences (`validateMessageSize` + `updateMessageByteCounter` + `toggleSendButtonVisibility`) with a single call to `revalidateSendButtonState()` in `ChatModal` input and attachment flows. 
- Updated the message input handler to call `this.revalidateSendButtonState()` and reuse the local `messageText` for `debouncedSaveDraft`. 
- Replaced send-button revalidation occurrences in attachment/encryption/upload paths (success, fetch errors, worker errors, and finally blocks) with `this.revalidateSendButtonState()`. 
- Added `chatModal.revalidateSendButtonState()` to the global `revalidateButtonStates()` function so the chat send state is rechecked when coming back online. 

### Testing
- Ran `node --check app.js` to validate the updated file syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948986df0c832cab557a29ea471f59)