### PR TITLE
Enforce network min toll when sending tolled transactions

### DIFF
--- a/app.js
+++ b/app.js
@@ -13345,7 +13345,7 @@ class ChatModal {
         return;
       }
 
-      const amount = myData.contacts[this.address].tollRequiredToSend == 1 ? this.toll : 0n;
+      const amount = myData.contacts[this.address].tollRequiredToSend == 1 ? getEffectiveTollLibWei(this.toll) : 0n;
       const sufficientBalance = await validateBalance(amount);
       if (!sufficientBalance) {
         const msg = `Insufficient balance for fee${amount > 0n ? ' and toll' : ''}. Go to the wallet to add more LIB.`;


### PR DESCRIPTION
### Motivation
- The client only enforced `minTollUsdStr` in the toll modal when a user edited their toll, so send paths could still use a contact's lower cached toll when the network minimum increased. This change ensures the network minimum is enforced when composing transactions that include a toll. 

### Description
- Added helper `getNetworkMinTollLibWei()` and `getEffectiveTollLibWei(tollWei, tollUnit)` to compute the network minimum in LIB wei and return the effective toll as `max(contact/user toll, network min)`. 
- Replaced direct uses of cached contact/send toll with `getEffectiveTollLibWei(...)` across send flows including message send, call invite, delete-for-all, voice message send, voice recording gating, and share-attachment batching so the network min is enforced consistently. 
- Updated send-asset memo validation to use `getEffectiveTollLibWei(...)` when validating that a payment with a memo meets the required toll. 
- Normalized cached in-modal toll unit to `LIB` (`this.tollUnit = 'LIB'`) so effective-toll conversion is consistent.
- Chat and Send Asset Form modals now display the network minimum toll if the user's toll is less than. 0 toll still displays as 0.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a7930580832cbaf61b3ad8d04d66)