### PR TITLE
Refresh wallet balance after auth events

### DIFF
--- a/app.js
+++ b/app.js
@@ -3638,6 +3638,14 @@ class SignInModal {
     reactNativeApp.handleNativeAppUnsubscribe();
     reactNativeApp.sendNavigationBarVisibility(false);
 
+    // Refresh wallet balance on sign-in so fee-dependent flows (e.g. Toll modal) have fresh data.
+    try {
+      myData.wallet.timestamp = 0;
+      await walletScreen.updateWalletBalances();
+    } catch (error) {
+      console.error('Failed to refresh wallet balances after sign-in:', error);
+    }
+
     // Close modal and proceed to app
     this.close();
     welcomeScreen.close();
@@ -21827,6 +21835,15 @@ class CreateAccountModal {
         existingAccounts.netids[netid].usernames[username] = { address: myAccount.keys.address };
         localStorage.setItem('accounts', stringify(existingAccounts));
         saveState();
+
+        // Refresh wallet balance immediately after account creation for fee-dependent screens.
+        try {
+          myData.wallet.timestamp = 0;
+          await walletScreen.updateWalletBalances();
+        } catch (error) {
+          console.error('Failed to refresh wallet balances after account creation:', error);
+        }
+
         // handleNativeAppSubscription();
 
         signInModal.open(username);


### PR DESCRIPTION
## Summary
- refresh wallet balances immediately after successful sign-in
- refresh wallet balances immediately after successful account creation
- force the refresh by resetting `myData.wallet.timestamp` before calling `walletScreen.updateWalletBalances()`

## Why
This prevents stale/missing wallet balance state in fee-dependent flows (like Toll modal) right after entering the app, especially for newly created accounts.

## Changes
- `app.js`
  - `SignInModal.handleSignIn`: added post-auth wallet balance refresh with error logging
  - `CreateAccountModal.handleSubmit` success path: added immediate wallet balance refresh before opening sign-in flow

## Testing
- Not run (static code change only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e83dd07c832ea1cc9cc9428207b4)