### PR TITLE
Update contact status colors: tolled -> yellow, connection -> green

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4084,7 +4084,7 @@ mark {
 }
 .icon-button.add-friend-icon.status-1 {
   /* Yellow user icon for status 1 (tolled) */
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23ffc107' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='8' r='4'/%3E%3Cpath d='M4 20v-2a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v2'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23e0a800' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='8' r='4'/%3E%3Cpath d='M4 20v-2a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v2'/%3E%3C/svg%3E");
 }
 .icon-button.add-friend-icon.status-2 {
   /* Green user icon for status 2 (connection) */


### PR DESCRIPTION
### Motivation
- Align the Contact Status UI with the requested color mapping so Blocked stays red, Tolled is yellow, and Connection is green.
- Ensure the chat-session person/add-friend icon visually matches the Contact Status mapping for consistent UX.

### Description
- Updated `styles.css` to change `.radio-option.status-1` to use a yellow accent (`--secondary-warning-color`) and a yellow-tinted background for Tolled entries.
- Updated `.radio-option.status-2` to use the success/green token (`--success-color`) and a green-tinted background for Connection entries.
- Updated `.icon-button.add-friend-icon.status-*` SVG background-images to use token-consistent hex values so status-0 remains red, status-1 is yellow, and status-2 is green (no JS or behavior changes).
- Kept the blocked (red) styling unchanged and preserved existing theme tokens from the top of `styles.css` for consistency.

<img width="448" height="535" alt="image" src="https://github.com/user-attachments/assets/ad596728-58d9-4515-ab43-eb5b8526860a" />

<img width="440" height="177" alt="image" src="https://github.com/user-attachments/assets/0ce2e60f-3944-4d60-bf3f-28cd26da34d3" />

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d6e6f708832c9ac0e59edce400c7)