### PR TITLE
Add manual E2E workflow with artifact reporting

### DIFF
--- a/.github/workflows/manual-client-e2e.yml
+++ b/.github/workflows/manual-client-e2e.yml
@@ -1,4 +1,4 @@
-name: Manual Client E2E (localhost)
+name: Manual Client E2E
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- add manual GitHub Actions workflow to run client tests against a selected web-client-v2 ref served on localhost
- checkout Liberdus/client-testing at a selectable ref and run Playwright against `http://127.0.0.1:${port}`
- upload run-scoped artifacts (Playwright HTML report, raw test results, server log)
- add clear PASS/FAIL job summary with refs, browser, workers, and target URL

## Why
- supports ad-hoc testing of any PR/branch without overwriting shared Pages output
- keeps historical run evidence tied to each workflow run via artifacts

## Notes
- workflow is manual-only (`workflow_dispatch`)
- both repos are public, so no additional secret is required for checkout
