### PR TITLE
Filter bridge accounts from share modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -18477,7 +18477,7 @@ class ShareAttachmentModal {
     const currentChatAddress = chatModal.address;
     const allContacts = Object.values(myData.contacts || {})
       .filter(c => c.address !== myAccount.address && c.address !== currentChatAddress)
-      .filter(c => !isFaucetAddress(c.address))
+      .filter(c => !isFaucetAddress(c.address) && !isBridgeContact(c))
       .map(c => {
         const displayName = getContactDisplayName(c);
         return {
@@ -18997,8 +18997,8 @@ class ShareContactsModal {
       : null;
     
     const filteredContacts = currentChatAddress
-      ? allContacts.filter(c => !isFaucetAddress(c.address) && normalizeAddress(c.address) !== currentChatAddress)
-      : allContacts.filter(c => !isFaucetAddress(c.address));
+      ? allContacts.filter(c => !isFaucetAddress(c.address) && !isBridgeContact(c) && normalizeAddress(c.address) !== currentChatAddress)
+      : allContacts.filter(c => !isFaucetAddress(c.address) && !isBridgeContact(c));
     
     const sortByShareDisplayName = (a, b) =>
       this.getContactDisplayNameForShare(a)
@@ -26060,6 +26060,28 @@ function isFaucetAddress(address) {
   return faucetAddresses.some(faucetAddr => 
     normalizeAddress(faucetAddr) === normalizedAddress
   );
+}
+
+/**
+ * Checks whether a contact is one of the configured network bridge accounts.
+ * Bridge identities are defined by username in network.bridges.
+ * @param {Object} contact - Contact object
+ * @returns {boolean} - True if contact username matches a bridge username
+ */
+function isBridgeContact(contact) {
+  if (!contact || !Array.isArray(network.bridges) || network.bridges.length === 0) {
+    return false;
+  }
+
+  const username = normalizeUsername(contact.username || '');
+  if (!username) {
+    return false;
+  }
+
+  return network.bridges.some((bridge) => {
+    const bridgeUsername = normalizeUsername(bridge?.username || '');
+    return bridgeUsername && bridgeUsername === username;
+  });
 }
 
 function isMobile() {


### PR DESCRIPTION
Filters out the bridge accounts from share contact and share attachments modal. Adds a new `isBridgeContact` function which compares the user against the bridge usernames in `network.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964f73c898832c9036afc4bf118ebe)