### PR TITLE
Left-align text for error/info/warning toasts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3816,10 +3816,12 @@ mark {
 
 .toast.error {
   background: rgba(220, 53, 69, 0.9);
+  text-align: left;
 }
 
 .toast.warning {
   background: rgba(239, 108, 0, 0.9);
+  text-align: left;
 }
 
 .toast-list-content {
@@ -3855,6 +3857,7 @@ mark {
 
 .toast.info {
   background: rgba(0, 123, 255, 0.9);
+  text-align: left;
 }
 
 /* Update available toast content */


### PR DESCRIPTION
### Motivation
- Toast messages for error, warning, and info types were inheriting centered alignment from the base `.toast` rule which reduces readability for multi-line or list content, so these types should be left-aligned for clearer presentation.

### Description
- Added `text-align: left;` to `.toast.error`, `.toast.warning`, and `.toast.info` in `styles.css` to ensure those toast types render left-aligned text.

### Testing
- Served the app locally with `python3 -m http.server 4173` and ran a Playwright script that invoked `showToast(...)` for `error`, `warning`, and `info` toasts and captured a screenshot, which verified the left alignment and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69974db0bfcc832cb54cccc44bdec522)