### PR TITLE
Fix New Chat handling for 0x-prefixed usernames

### DIFF
--- a/app.js
+++ b/app.js
@@ -21646,12 +21646,8 @@ class NewChatModal {
 
     this.hideRecipientError();
 
-    // Check if input is an Ethereum address
-    if (input.startsWith('0x')) {
-      if (!isValidEthereumAddress(input)) {
-        this.showRecipientError('Invalid Ethereum address format');
-        return;
-      }
+    // Treat as an address only when the full input is a valid Ethereum address.
+    if (isValidEthereumAddress(input)) {
       // Input is valid Ethereum address, normalize it
       recipientAddress = normalizeAddress(input);
     } else {


### PR DESCRIPTION
## Summary

This PR fixes a New Chat validation mismatch for usernames that begin with `0x`, such as `0xhayder`.

Before this change, the New Chat modal could show the recipient as `found` during live validation, but clicking `Continue` could still fail with `Invalid Ethereum address format`.

## Problem

The recipient field in New Chat supports usernames, and the live validation path already treats values like `0xhayder` as usernames:

- it normalizes the input as a username
- it checks username availability on the network
- it enables `Continue` when a matching account is found

However, the submit handler used a different rule. Any input starting with `0x` was treated as an Ethereum address first. That meant usernames beginning with `0x` were never allowed through the username lookup path on submit, even though the live validator had already accepted them.

This created a user-facing contradiction:

- live validation said the username was found
- submit rejected the same value as an invalid Ethereum address

## Root Cause

The New Chat submit flow relied on a prefix check (`startsWith('0x')`) instead of actual address validation to decide whether the recipient should be parsed as an address.

That rule was too broad. It classified any `0x...` value as an address candidate, including legitimate usernames that simply happen to start with `0x`.

## Resolution

The submit handler now treats the input as an address only when the full value is a valid Ethereum address.

Specifically:

- valid 42-character `0x...` Ethereum addresses still follow the address path
- all other values, including usernames that start with `0x`, follow the existing username lookup path

This makes submit behavior consistent with the existing live validation behavior and resolves issue #1200 without changing any send-asset behavior.

## Scope

This PR is intentionally limited to the New Chat flow.

A related mismatch in Send Asset was filed separately in issue #1204 so that it can be addressed in a separate PR.

## Validation

- `node --check app.js`

## User Impact

Users can now start a new chat with valid usernames that begin with `0x` without being blocked by an incorrect Ethereum address format error.

Closes #1200