### PR TITLE
Phase 2: Part 1 - Add reaction picker click handlers

### DIFF
--- a/app.js
+++ b/app.js
@@ -17102,7 +17102,6 @@ class ChatModal {
 
   /**
    * Handles quick reaction row clicks for the main message context menu.
-   * Phase 2 Part 1 only logs the selected reaction and target txid.
    * @param {HTMLElement} reactionButton
    */
   handleReactionPickerClick(reactionButton) {
@@ -17112,7 +17111,6 @@ class ChatModal {
 
   /**
    * Handles quick reaction row clicks for the image attachment context menu.
-   * Phase 2 Part 1 only logs the selected reaction and target txid.
    * @param {HTMLElement} reactionButton
    */
   handleImageAttachmentReactionPickerClick(reactionButton) {
@@ -17122,7 +17120,7 @@ class ChatModal {
   }
 
   /**
-   * Logs the quick reaction selection against the current target message. Will get removed next phase.
+   * Logs the quick reaction selection against the current target message.
    * @param {HTMLElement} reactionButton
    * @param {HTMLElement | null} messageEl
    */


### PR DESCRIPTION
Part 1 of #1209

## What changed
- wire the quick reaction buttons in the main message context menu
- wire the quick reaction buttons in the image attachment context menu
- resolve the target outer message element and log the selected reaction with its message txid

## Notes
- this PR only adds handler wiring and logging
- it does not build or send reaction messages yet

## Validation
- `node --check app.js`