### PR TITLE
Phase 2: Part 2 - extract shared chat send helpers

### DIFF
--- a/app.js
+++ b/app.js
@@ -14141,6 +14141,7 @@ class ChatModal {
             */
       const currentAddress = this.address;
       if (!currentAddress) return;
+      const contact = chatsData.contacts[currentAddress];
 
       // Check if trying to message self
       if (currentAddress === myAccount.address) {


### PR DESCRIPTION
## Summary
This PR extracts the shared encrypted chat-send logic in `ChatModal` into reusable helpers:

- adds `buildChatSenderInfo()` for sender metadata construction
- adds `prepareEncryptedChatContext()` for recipient key lookup and shared crypto setup
- adds `buildEncryptedStructuredChatTx()` for payload construction, transaction creation, and signing
- updates `handleSendMessage()` to use the shared helpers while preserving the existing send flow order

## Why an intermediate PR in Phase 2
The next Phase 2 step needs to send reaction control messages from outside the composer flow. That work needs the same encrypted chat transaction building used by normal composer sends, but without inheriting all of `handleSendMessage()`'s composer-specific UI behavior.

Splitting this into an intermediate PR keeps the phase reviewable:

- this PR isolates the helper extraction
- the follow-up PR can focus only on reaction-send behavior
- review risk stays lower because the refactor and the new feature are not mixed together

## Functional impact
This PR is intended to be non-functional from a user perspective. It reorganizes existing chat-send logic into shared helpers and keeps the existing behavior intact.

One detail worth calling out: the helper split keeps recipient crypto preparation before edit-mode attachment cleanup so the send order still matches `phase2-reaction-handlers-part-1`.

## Validation
- `node --check app.js`
- compared diff against `phase2-reaction-handlers-part-1` to confirm this PR is helper extraction / flow preservation only