### PR TITLE
Phase 3: process incoming reaction events onto target message

### DIFF
--- a/app.js
+++ b/app.js
@@ -6121,17 +6121,27 @@ async function processChats(chats, keys) {
                     payload.replyOwnerIsMine = parsedMessage.replyOwnerIsMine;
                   }
                 } else if (parsedMessage.type === 'message') {
-                  if (parsedMessage.reactId) {
-                    const reactId = parsedMessage.reactId.trim();
+                  const hasReactionFields =
+                    typeof parsedMessage.reactId !== 'undefined' ||
+                    typeof parsedMessage.reactAction !== 'undefined' ||
+                    typeof parsedMessage.reactMessage !== 'undefined';
+                  if (hasReactionFields) {
+                    const reactId = typeof parsedMessage.reactId === 'string'
+                      ? parsedMessage.reactId.trim()
+                      : '';
                     if (!reactId) {
                       console.error('Reaction message is missing reactId');
                       continue;
                     }
 
                     const sender = normalizeAddress(tx.from);
-                    const reactAction = parsedMessage.reactAction;
+                    const reactAction = typeof parsedMessage.reactAction === 'string'
+                      ? parsedMessage.reactAction.trim()
+                      : '';
                     if (reactAction === 'set') {
-                      const emoji = parsedMessage.reactMessage.trim();
+                      const emoji = typeof parsedMessage.reactMessage === 'string'
+                        ? parsedMessage.reactMessage.trim()
+                        : '';
                       if (!emoji) {
                         console.error('Reaction set is missing emoji');
                         continue;


### PR DESCRIPTION
## Summary
- process incoming reaction control messages during chat sync instead of treating them as normal chat bubbles
- queue and replay reaction updates in chronological order so the final stored state is deterministic within each fetch batch
- apply per-sender reaction state directly onto the target message for later rendering phases

## Why
This branch implements phase 3 of the reaction feature plan so received reaction events update local message state safely and idempotently.

Closes #1210

## Validation
- `node --check app.js`