### PR TITLE
Phase 8/9: optimistic reaction set fallback and pending cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -5837,7 +5837,7 @@ async function ensureContactKeys(address) {
 }
 
 /**
- * @typedef {{ sender: string, reactId: string, action: 'remove', timestamp: number, reactionTxId?: string } | { sender: string, reactId: string, action: 'set', emoji: string, timestamp: number, reactionTxId?: string, keepFallback?: boolean }} ReactionUpdate
+ * @typedef {{ sender: string, reactId: string, action: 'remove', timestamp: number, reactionTxId?: string } | { sender: string, reactId: string, action: 'set', emoji: string, timestamp: number, reactionTxId?: string }} ReactionUpdate
  */
 
 /**
@@ -5951,6 +5951,45 @@ function purgeContactReactionsForTarget(contact, targetTxid) {
 }
 
 /**
+ * Applies an optimistic outgoing reaction set while keeping the prior reaction as fallback.
+ * @param {Object} contact
+ * @param {Extract<ReactionUpdate, { action: 'set' }>} reaction
+ * @returns {{ didApply: boolean, previousReaction: Object | null }}
+ */
+function applyOptimisticReactionSet(contact, reaction) {
+  const targetMessage = contact.messages.find((message) => message.txid === reaction.reactId);
+  if (!targetMessage || isDeleted(targetMessage)) {
+    console.warn('Reaction target not found locally', reaction);
+    return { didApply: false, previousReaction: null };
+  }
+
+  if (!Array.isArray(contact.reactions)) {
+    contact.reactions = [];
+  }
+
+  const sender = normalizeAddress(reaction.sender);
+  const previousReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
+  const emoji = reaction.emoji.trim();
+
+  if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
+    return { didApply: false, previousReaction };
+  }
+
+  if (previousReaction && previousReaction.emoji === emoji) {
+    return { didApply: false, previousReaction };
+  }
+
+  insertSorted(contact.reactions, {
+    sender,
+    targetTxid: reaction.reactId,
+    emoji,
+    timestamp: reaction.timestamp,
+    reactionTxId: reaction.reactionTxId
+  }, 'timestamp');
+  return { didApply: true, previousReaction };
+}
+
+/**
  * Applies a reaction control message to the contact-level active reaction state.
  * @param {Object} contact
  * @param {ReactionUpdate} reaction
@@ -5979,6 +6018,7 @@ function applyIncomingReaction(contact, reaction) {
 
     case 'set': {
       const emoji = reaction.emoji.trim();
+      // don't allow duplicate reactions
       if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
         return false;
       }
@@ -5986,10 +6026,7 @@ function applyIncomingReaction(contact, reaction) {
       if (currentReaction && currentReaction.emoji === emoji) {
         return false;
       }
-
-      if (!reaction.keepFallback) {
-        purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
-      }
+      purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
 
       insertSorted(contact.reactions, {
         sender,
@@ -18000,19 +18037,17 @@ class ChatModal {
     if (reaction.reactAction === 'set') {
       const sender = normalizeAddress(keys.address);
       assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
-      const previousReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
-      assert(!previousReaction || previousReaction.reactionTxId, 'Previous reaction txid is required');
       const localReaction = {
         sender,
         reactId: reaction.reactId,
         action: 'set',
         emoji: reaction.reactMessage,
         timestamp: payload.sent_timestamp,
-        reactionTxId: txid,
-        keepFallback: true
+        reactionTxId: txid
       };
-      const didApplyLocally = applyIncomingReaction(contact, localReaction);
+      const { didApply: didApplyLocally, previousReaction } = applyOptimisticReactionSet(contact, localReaction);
       if (didApplyLocally) {
+        assert(!previousReaction || previousReaction.reactionTxId, 'Previous reaction txid is required');
         reactionPendingState = {
           action: 'set',
           targetTxid: reaction.reactId,

--- a/app.js
+++ b/app.js
@@ -1551,8 +1551,8 @@ class ChatsScreen {
       // In chat list don't show people that are blocked
       if (Number(contact?.friend) === 0) continue;
 
-      const latestActivity = getLatestChatMessageActivity(contact);
-      // If there's no latest activity (no messages), skip this chat item
+      const latestActivity = getLatestChatMessageActivity(contact) || contact.messages[0];
+      // If there's no latest activity (no messages at all), skip this chat item
       if (!latestActivity) continue;
 
       chatItems.push({ chat, contact, latestActivity });

--- a/app.js
+++ b/app.js
@@ -6831,6 +6831,9 @@ async function processChats(chats, keys) {
             syncChatLatestActivityTimestamp(from, contact);
             didChangeReactionPreview = true;
             touchedReactionTargetTxids.add(pendingReaction.reactId);
+            if (pendingReaction.sender === from && (!inActiveChatWithSender || document.visibilityState === 'hidden')) {
+              playChatSound();
+            }
             if (pendingReaction.sender === from && !inActiveChatWithSender) {
               if (pendingReaction.action === 'set') {
                 nextReactionUnread += 1;

--- a/app.js
+++ b/app.js
@@ -6307,6 +6307,14 @@ async function processChats(chats, keys) {
                   if (!messageToDelete) {
                     continue; // ignore delete control messages for missing txid
                   }
+                  const unreadIncomingMessageCount = Math.max(0, contact.unread || 0);
+                  const wasUnreadIncomingMessage = unreadIncomingMessageCount > 0
+                    && !messageToDelete.my
+                    && !inActiveChatWithSender
+                    && contact.messages
+                      .filter((message) => !message.my && !isDeleted(message))
+                      .slice(0, unreadIncomingMessageCount)
+                      .some((message) => message.txid === messageToDelete.txid);
                   let didDeleteMessage = false;
                   
                   // Only allow deletion if the sender of this delete tx is the same who sent the original message
@@ -6375,6 +6383,9 @@ async function processChats(chats, keys) {
                     purgeContactReactionsForTarget(contact, messageToDelete.txid);
                     syncChatLatestActivityTimestamp(from, contact);
                     didChangeReactionPreview = true;
+                    if (wasUnreadIncomingMessage) {
+                      contact.unread = Math.max(0, unreadIncomingMessageCount - 1);
+                    }
                     if (!inActiveChatWithSender && hadIncomingEffectiveReaction) {
                       nextReactionUnread = Math.max(0, nextReactionUnread - 1);
                     }

--- a/app.js
+++ b/app.js
@@ -18065,11 +18065,14 @@ class ChatModal {
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
       if (reactionPendingState) {
-        reconcilePendingReactionSet({
+        const didRevert = reconcilePendingReactionSet({
           txid,
           to: currentAddress,
           reactionPending: reactionPendingState
         }, 'failure');
+        if (didRevert) {
+          showToast('Reaction failed to send and was reverted', 0, 'error');
+        }
         saveState();
       }
       return false;
@@ -27033,7 +27036,10 @@ async function checkPendingTransactions() {
       //console.log(`DEBUG: txid ${txid} res: ${JSON.stringify(res)}`);
       if (submittedts < thirtySecondsAgo && (res.transaction === null || Object.keys(res.transaction).length === 0)) {
         console.error(`DEBUG: txid ${txid} timed out, removing completely`);
-        reconcilePendingReactionSet(pendingTxInfo, 'failure');
+        const didRevert = reconcilePendingReactionSet(pendingTxInfo, 'failure');
+        if (didRevert) {
+          showToast('Reaction timed out and was reverted', 0, 'error');
+        }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
         continue;
@@ -27103,8 +27109,10 @@ async function checkPendingTransactions() {
         } else {
           // Show toast notification with the failure reason
           if (pendingTxInfo.reactionPending) {
-            reconcilePendingReactionSet(pendingTxInfo, 'failure');
-            showToast(userFailureReason, 0, 'error');
+            const didRevert = reconcilePendingReactionSet(pendingTxInfo, 'failure');
+            showToast(didRevert
+              ? `Reaction failed and was reverted: ${userFailureReason}`
+              : userFailureReason, 0, 'error');
           } else if (type === 'withdraw_stake') {
             showToast(`Unstake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'deposit_stake') {

--- a/app.js
+++ b/app.js
@@ -1551,7 +1551,7 @@ class ChatsScreen {
       // In chat list don't show people that are blocked
       if (Number(contact?.friend) === 0) continue;
 
-      const latestActivity = contact.messages && contact.messages.length > 0 ? contact.messages[0] : null;
+      const latestActivity = getLatestChatMessageActivity(contact);
       // If there's no latest activity (no messages), skip this chat item
       if (!latestActivity) continue;
 
@@ -1582,9 +1582,6 @@ class ChatsScreen {
         const reactionTarget = reactionPreview.target;
         const reactionText = `${reactionActor} reacted ${reactionPreview.emoji} to "${reactionTarget}"`;
         previewHTML = truncateMessage(escapeHtml(reactionText), 50);
-      } else if (isDeleted(latestActivity)) {
-        // Check if the latest activity is a payment/transfer message
-        previewHTML = `<span><i>${escapeHtml(getDeletedPlaceholderText(latestActivity))}</i></span>`;
       } else if (typeof latestActivity.amount === 'bigint') {
         // Latest item is a payment/transfer
         const amountStr = parseFloat(big2str(latestActivity.amount, 18)).toFixed(6);
@@ -6076,13 +6073,30 @@ function getLatestChatReactionActivity(contact) {
 }
 
 /**
+ * Returns the newest non-deleted message for chat-list activity purposes.
+ * @param {Object} contact
+ * @returns {Object|null}
+ */
+function getLatestChatMessageActivity(contact) {
+  const messages = Array.isArray(contact.messages) ? contact.messages : [];
+
+  for (const message of messages) {
+    if (!isDeleted(message)) {
+      return message;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Recomputes the chat-list timestamp from the current message and reaction state.
  * @param {string} chatAddress
  * @param {Object} contact
  * @returns {void}
  */
 function syncChatLatestActivityTimestamp(chatAddress, contact) {
-  const latestMessage = contact.messages[0];
+  const latestMessage = getLatestChatMessageActivity(contact);
   if (!latestMessage) return;
 
   const latestReaction = getLatestChatReactionActivity(contact);

--- a/app.js
+++ b/app.js
@@ -6326,7 +6326,7 @@ async function processChats(chats, keys) {
                     && !messageToDelete.my
                     && !inActiveChatWithSender
                     && contact.messages
-                      .filter((message) => !message.my && !isDeleted(message))
+                      .filter((message) => !message.my && !isDeleted(message) && typeof message.amount !== 'bigint')
                       .slice(0, unreadIncomingMessageCount)
                       .some((message) => message.txid === messageToDelete.txid);
                   let didDeleteMessage = false;

--- a/app.js
+++ b/app.js
@@ -6022,7 +6022,6 @@ function applyIncomingReaction(contact, reaction) {
       if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
         return false;
       }
-
       if (currentReaction && currentReaction.emoji === emoji) {
         return false;
       }
@@ -6359,6 +6358,7 @@ async function processChats(chats, keys) {
                     continue; // ignore delete control messages for missing txid
                   }
                   const unreadIncomingMessageCount = Math.max(0, contact.unread || 0);
+                  // check if the message is unread and not in the active chat and not a payment
                   const wasUnreadIncomingMessage = unreadIncomingMessageCount > 0
                     && !messageToDelete.my
                     && !inActiveChatWithSender

--- a/app.js
+++ b/app.js
@@ -5874,7 +5874,7 @@ function getEffectiveReactionForSenderTarget(contact, targetTxid, sender) {
  */
 function getContactReactionsForTarget(contact, targetTxid) {
   const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
-  const seenSenders = new Set();
+  const seen = new Set();
   const effectiveReactions = [];
 
   for (const reaction of reactions) {
@@ -5883,11 +5883,11 @@ function getContactReactionsForTarget(contact, targetTxid) {
     }
 
     const senderKey = normalizeAddress(reaction.sender);
-    if (seenSenders.has(senderKey)) {
+    if (seen.has(senderKey)) {
       continue;
     }
 
-    seenSenders.add(senderKey);
+    seen.add(senderKey);
     effectiveReactions.push(reaction);
   }
 
@@ -5954,13 +5954,13 @@ function purgeContactReactionsForTarget(contact, targetTxid) {
  * Applies an optimistic outgoing reaction set while keeping the prior reaction as fallback.
  * @param {Object} contact
  * @param {Extract<ReactionUpdate, { action: 'set' }>} reaction
- * @returns {{ didApply: boolean, previousReaction: Object | null }}
+ * @returns {{ didApply: false } | { didApply: true, previousReactionTxId: string | null }}
  */
 function applyOptimisticReactionSet(contact, reaction) {
   const targetMessage = contact.messages.find((message) => message.txid === reaction.reactId);
   if (!targetMessage || isDeleted(targetMessage)) {
     console.warn('Reaction target not found locally', reaction);
-    return { didApply: false, previousReaction: null };
+    return { didApply: false };
   }
 
   if (!Array.isArray(contact.reactions)) {
@@ -5972,12 +5972,15 @@ function applyOptimisticReactionSet(contact, reaction) {
   const emoji = reaction.emoji.trim();
 
   if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
-    return { didApply: false, previousReaction };
+    return { didApply: false };
   }
 
   if (previousReaction && previousReaction.emoji === emoji) {
-    return { didApply: false, previousReaction };
+    return { didApply: false };
   }
+
+  const previousReactionTxId = previousReaction ? previousReaction.reactionTxId : null;
+  assert(previousReaction === null || previousReactionTxId, 'Previous reaction txid is required');
 
   insertSorted(contact.reactions, {
     sender,
@@ -5986,7 +5989,7 @@ function applyOptimisticReactionSet(contact, reaction) {
     timestamp: reaction.timestamp,
     reactionTxId: reaction.reactionTxId
   }, 'timestamp');
-  return { didApply: true, previousReaction };
+  return { didApply: true, previousReactionTxId };
 }
 
 /**
@@ -6084,13 +6087,13 @@ function getReactionTargetPreviewText(message) {
 function getLatestChatReactionActivity(contact) {
   const currentUserAddress = normalizeAddress(myAccount.keys.address);
   const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
-  const seenReactionKeys = new Set();
+  const seen = new Set();
   for (const reaction of reactions) {
     const reactionKey = `${reaction.targetTxid}:${normalizeAddress(reaction.sender)}`;
-    if (seenReactionKeys.has(reactionKey)) {
+    if (seen.has(reactionKey)) {
       continue;
     }
-    seenReactionKeys.add(reactionKey);
+    seen.add(reactionKey);
 
     const targetMessage = contact.messages.find((message) => message.txid === reaction.targetTxid);
     if (!targetMessage || isDeleted(targetMessage)) {
@@ -17006,13 +17009,13 @@ class ChatModal {
 
     const reactionsByTargetTxid = new Map();
     const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
-    const seenReactionKeys = new Set();
+    const seen = new Set();
     for (const reaction of reactions) {
       const reactionKey = `${reaction.targetTxid}:${normalizeAddress(reaction.sender)}`;
-      if (seenReactionKeys.has(reactionKey)) {
+      if (seen.has(reactionKey)) {
         continue;
       }
-      seenReactionKeys.add(reactionKey);
+      seen.add(reactionKey);
 
       const current = reactionsByTargetTxid.get(reaction.targetTxid) || [];
       current.push(reaction);
@@ -18045,13 +18048,12 @@ class ChatModal {
         timestamp: payload.sent_timestamp,
         reactionTxId: txid
       };
-      const { didApply: didApplyLocally, previousReaction } = applyOptimisticReactionSet(contact, localReaction);
-      if (didApplyLocally) {
-        assert(!previousReaction || previousReaction.reactionTxId, 'Previous reaction txid is required');
+      const optimisticApply = applyOptimisticReactionSet(contact, localReaction);
+      if (optimisticApply.didApply) {
         reactionPendingState = {
           action: 'set',
           targetTxid: reaction.reactId,
-          previousReactionTxId: previousReaction ? previousReaction.reactionTxId : null
+          previousReactionTxId: optimisticApply.previousReactionTxId
         };
         syncReactionUiState(currentAddress, contact, reaction.reactId);
       } else {

--- a/app.js
+++ b/app.js
@@ -5840,18 +5840,101 @@ async function ensureContactKeys(address) {
 }
 
 /**
- * @typedef {{ sender: string, reactId: string, action: 'remove', timestamp: number } | { sender: string, reactId: string, action: 'set', emoji: string, timestamp: number }} ReactionUpdate
+ * @typedef {{ sender: string, reactId: string, action: 'remove', timestamp: number, reactionTxId?: string } | { sender: string, reactId: string, action: 'set', emoji: string, timestamp: number, reactionTxId?: string, keepFallback?: boolean }} ReactionUpdate
  */
 
 /**
- * Returns the active reactions for a specific target message.
+ * @typedef {{ action: 'set', targetTxid: string, previousReactionTxId: string | null }} PendingReactionSet
+ */
+
+/**
+ * Returns the newest effective reaction for a specific sender and target message.
+ * The raw reaction array may contain older fallback entries behind the newest one.
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @param {string} sender
+ * @returns {Object|null}
+ */
+function getEffectiveReactionForSenderTarget(contact, targetTxid, sender) {
+  const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
+  const normalizedSender = normalizeAddress(sender);
+
+  for (const reaction of reactions) {
+    if (reaction.targetTxid === targetTxid && normalizeAddress(reaction.sender) === normalizedSender) {
+      return reaction;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns the effective reactions for a specific target message.
+ * Older duplicate entries for the same sender are hidden fallback state.
  * @param {Object} contact
  * @param {string} targetTxid
  * @returns {Array<Object>}
  */
 function getContactReactionsForTarget(contact, targetTxid) {
   const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
-  return reactions.filter((reaction) => reaction.targetTxid === targetTxid);
+  const seenSenders = new Set();
+  const effectiveReactions = [];
+
+  for (const reaction of reactions) {
+    if (reaction.targetTxid !== targetTxid) {
+      continue;
+    }
+
+    const senderKey = normalizeAddress(reaction.sender);
+    if (seenSenders.has(senderKey)) {
+      continue;
+    }
+
+    seenSenders.add(senderKey);
+    effectiveReactions.push(reaction);
+  }
+
+  return effectiveReactions;
+}
+
+/**
+ * Removes every raw reaction entry for a given sender and target.
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @param {string} sender
+ * @returns {boolean}
+ */
+function purgeReactionStackForSenderTarget(contact, targetTxid, sender) {
+  if (!Array.isArray(contact.reactions)) {
+    return false;
+  }
+
+  const normalizedSender = normalizeAddress(sender);
+  const initialLength = contact.reactions.length;
+  contact.reactions = contact.reactions.filter((reaction) => {
+    return !(reaction.targetTxid === targetTxid && normalizeAddress(reaction.sender) === normalizedSender);
+  });
+  return contact.reactions.length !== initialLength;
+}
+
+/**
+ * Removes a raw reaction entry by the txid of the reaction-control transaction that created it.
+ * @param {Object} contact
+ * @param {string} reactionTxId
+ * @returns {boolean}
+ */
+function removeReactionByReactionTxId(contact, reactionTxId) {
+  if (!Array.isArray(contact.reactions) || !reactionTxId) {
+    return false;
+  }
+
+  const index = contact.reactions.findIndex((reaction) => reaction.reactionTxId === reactionTxId);
+  if (index === -1) {
+    return false;
+  }
+
+  contact.reactions.splice(index, 1);
+  return true;
 }
 
 /**
@@ -5891,35 +5974,32 @@ function applyIncomingReaction(contact, reaction) {
   }
 
   const sender = normalizeAddress(reaction.sender);
-  const currentReactionIndex = contact.reactions.findIndex((entry) => {
-    return entry.targetTxid === reaction.reactId && entry.sender === sender;
-  });
+  const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
 
   switch (reaction.action) {
     case 'remove':
-      if (currentReactionIndex === -1) {
-        return false;
-      }
-
-      contact.reactions.splice(currentReactionIndex, 1);
-      return true;
+      return purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
 
     case 'set': {
       const emoji = reaction.emoji.trim();
-      const currentReaction = currentReactionIndex === -1 ? null : contact.reactions[currentReactionIndex];
+      if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
+        return false;
+      }
+
       if (currentReaction && currentReaction.emoji === emoji) {
         return false;
       }
 
-      if (currentReaction) {
-        contact.reactions.splice(currentReactionIndex, 1);
+      if (!reaction.keepFallback) {
+        purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
       }
 
       insertSorted(contact.reactions, {
         sender,
         targetTxid: reaction.reactId,
         emoji,
-        timestamp: reaction.timestamp
+        timestamp: reaction.timestamp,
+        reactionTxId: reaction.reactionTxId
       }, 'timestamp');
       return true;
     }
@@ -5971,7 +6051,14 @@ function getReactionTargetPreviewText(message) {
 function getLatestChatReactionActivity(contact) {
   const currentUserAddress = normalizeAddress(myAccount.keys.address);
   const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
+  const seenReactionKeys = new Set();
   for (const reaction of reactions) {
+    const reactionKey = `${reaction.targetTxid}:${normalizeAddress(reaction.sender)}`;
+    if (seenReactionKeys.has(reactionKey)) {
+      continue;
+    }
+    seenReactionKeys.add(reactionKey);
+
     const targetMessage = contact.messages.find((message) => message.txid === reaction.targetTxid);
     if (!targetMessage || isDeleted(targetMessage)) {
       continue;
@@ -6013,6 +6100,68 @@ function syncChatLatestActivityTimestamp(chatAddress, contact) {
 
   chat.timestamp = latestReaction.timestamp;
   insertSorted(myData.chats, chat, 'timestamp');
+}
+
+/**
+ * Refreshes chat list and visible reaction chips after local reaction state changes.
+ * @param {string} contactAddress
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @returns {void}
+ */
+function syncReactionUiState(contactAddress, contact, targetTxid) {
+  syncChatLatestActivityTimestamp(contactAddress, contact);
+  if (chatsScreen.isActive()) {
+    chatsScreen.updateChatList();
+  }
+
+  if (chatModal.isActive() && chatModal.address === contactAddress) {
+    chatModal.syncRenderedReactionTargets([targetTxid]);
+  }
+}
+
+/**
+ * Finalizes or reverts a pending optimistic reaction set that stored fallback metadata.
+ * @param {Object} pendingTxInfo
+ * @param {'success' | 'failure'} result
+ * @returns {boolean}
+ */
+function reconcilePendingReactionSet(pendingTxInfo, result) {
+  if (!pendingTxInfo.reactionPending) {
+    return false;
+  }
+
+  /** @type {PendingReactionSet} */
+  const { reactionPending } = pendingTxInfo;
+  assert(reactionPending.action === 'set', `Unknown pending reaction action: ${reactionPending.action}`);
+
+  const contact = myData.contacts[pendingTxInfo.to];
+  assert(contact, `Missing contact for pending reaction: ${pendingTxInfo.to}`);
+
+  switch (result) {
+    case 'success': {
+      if (!reactionPending.previousReactionTxId) {
+        return false;
+      }
+
+      const didChange = removeReactionByReactionTxId(contact, reactionPending.previousReactionTxId);
+      if (didChange) {
+        syncReactionUiState(pendingTxInfo.to, contact, reactionPending.targetTxid);
+      }
+      return didChange;
+    }
+
+    case 'failure': {
+      const didChange = removeReactionByReactionTxId(contact, pendingTxInfo.txid);
+      if (didChange) {
+        syncReactionUiState(pendingTxInfo.to, contact, reactionPending.targetTxid);
+      }
+      return didChange;
+    }
+
+    default:
+      throw new Error(`Unknown pending reaction result: ${result}`);
+  }
 }
 
 /**
@@ -6348,6 +6497,7 @@ async function processChats(chats, keys) {
                         action: 'set',
                         emoji,
                         timestamp: Number(payload.sent_timestamp),
+                        reactionTxId: txidHex,
                         order: Number(i)
                       });
                       continue; // reaction control messages update target state instead of adding a chat bubble
@@ -6359,6 +6509,7 @@ async function processChats(chats, keys) {
                         reactId,
                         action: 'remove',
                         timestamp: Number(payload.sent_timestamp),
+                        reactionTxId: txidHex,
                         order: Number(i)
                       });
                       continue; // reaction control messages update target state instead of adding a chat bubble
@@ -16715,9 +16866,7 @@ class ChatModal {
     const currentUserAddress = normalizeAddress(myAccount.keys.address);
     const targetTxid = messageEl.dataset.txid;
     const contact = myData.contacts[this.address];
-    const reaction = getContactReactionsForTarget(contact, targetTxid).find((entry) =>
-      entry.sender === currentUserAddress
-    );
+    const reaction = getEffectiveReactionForSenderTarget(contact, targetTxid, currentUserAddress);
     return reaction ? reaction.emoji : '';
   }
 
@@ -16794,7 +16943,14 @@ class ChatModal {
 
     const reactionsByTargetTxid = new Map();
     const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
+    const seenReactionKeys = new Set();
     for (const reaction of reactions) {
+      const reactionKey = `${reaction.targetTxid}:${normalizeAddress(reaction.sender)}`;
+      if (seenReactionKeys.has(reactionKey)) {
+        continue;
+      }
+      seenReactionKeys.add(reactionKey);
+
       const current = reactionsByTargetTxid.get(reaction.targetTxid) || [];
       current.push(reaction);
       reactionsByTargetTxid.set(reaction.targetTxid, current);
@@ -17814,23 +17970,29 @@ class ChatModal {
       reactAction: reaction.reactAction
     });
 
+    let reactionPendingState = null;
     if (reaction.reactAction === 'set') {
+      const sender = normalizeAddress(keys.address);
+      assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
+      const previousReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
+      assert(!previousReaction || previousReaction.reactionTxId, 'Previous reaction txid is required');
       const localReaction = {
-        sender: normalizeAddress(keys.address),
+        sender,
         reactId: reaction.reactId,
         action: 'set',
         emoji: reaction.reactMessage,
-        timestamp: payload.sent_timestamp
+        timestamp: payload.sent_timestamp,
+        reactionTxId: txid,
+        keepFallback: true
       };
       const didApplyLocally = applyIncomingReaction(contact, localReaction);
       if (didApplyLocally) {
-        syncChatLatestActivityTimestamp(currentAddress, contact);
-        if (chatsScreen.isActive()) {
-          chatsScreen.updateChatList();
-        }
-        if (this.isActive() && this.address === currentAddress) {
-          this.syncRenderedReactionTargets([reaction.reactId]);
-        }
+        reactionPendingState = {
+          action: 'set',
+          targetTxid: reaction.reactId,
+          previousReactionTxId: previousReaction ? previousReaction.reactionTxId : null
+        };
+        syncReactionUiState(currentAddress, contact, reaction.reactId);
       } else {
         console.warn('Reaction sent but local optimistic apply was skipped', localReaction);
       }
@@ -17839,7 +18001,22 @@ class ChatModal {
     const response = await injectTx(chatMessageObj, txid);
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
+      if (reactionPendingState) {
+        reconcilePendingReactionSet({
+          txid,
+          to: currentAddress,
+          reactionPending: reactionPendingState
+        }, 'failure');
+        saveState();
+      }
       return false;
+    }
+
+    if (reactionPendingState) {
+      const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+      assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
+      pendingTxInfo.reactionPending = reactionPendingState;
+      saveState();
     }
 
     if (reaction.reactAction === 'remove') {
@@ -26793,6 +26970,7 @@ async function checkPendingTransactions() {
       //console.log(`DEBUG: txid ${txid} res: ${JSON.stringify(res)}`);
       if (submittedts < thirtySecondsAgo && (res.transaction === null || Object.keys(res.transaction).length === 0)) {
         console.error(`DEBUG: txid ${txid} timed out, removing completely`);
+        reconcilePendingReactionSet(pendingTxInfo, 'failure');
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
         continue;
@@ -26801,6 +26979,7 @@ async function checkPendingTransactions() {
       if (res?.transaction?.success === true) {
         // comment out to test the pending txs removal logic
         myData.pending.splice(i, 1);
+        reconcilePendingReactionSet(pendingTxInfo, 'success');
 
         if (type === 'register') {
           pendingPromiseService.resolve(txid, {
@@ -26860,7 +27039,10 @@ async function checkPendingTransactions() {
           pendingPromiseService.reject(txid, new Error(userFailureReason));
         } else {
           // Show toast notification with the failure reason
-          if (type === 'withdraw_stake') {
+          if (pendingTxInfo.reactionPending) {
+            reconcilePendingReactionSet(pendingTxInfo, 'failure');
+            showToast(userFailureReason, 0, 'error');
+          } else if (type === 'withdraw_stake') {
             showToast(`Unstake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'deposit_stake') {
             showToast(`Stake failed: ${userFailureReason}`, 0, 'error');
@@ -26912,9 +27094,11 @@ async function checkPendingTransactions() {
             showToast(userFailureReason, 0, 'error');
           }
 
-          const toAddress = pendingTxInfo.to;
-          updateTransactionStatus(txid, toAddress, 'failed', type);
-          chatModal.refreshCurrentView(txid);
+          if (!pendingTxInfo.reactionPending) {
+            const toAddress = pendingTxInfo.to;
+            updateTransactionStatus(txid, toAddress, 'failed', type);
+            chatModal.refreshCurrentView(txid);
+          }
         }
         // Remove from pending array
         myData.pending.splice(i, 1);

--- a/app.js
+++ b/app.js
@@ -6371,14 +6371,12 @@ async function processChats(chats, keys) {
                     reactNativeApp.sendCancelScheduledCall(contact?.username, Number(messageToDelete.callTime));
                   }
                   if (didDeleteMessage) {
-                    const removedIncomingReactionCount = getContactReactionsForTarget(contact, messageToDelete.txid).filter((reaction) => {
-                      return reaction.targetTxid === messageToDelete.txid && reaction.sender === from;
-                    }).length;
+                    const hadIncomingEffectiveReaction = !!getEffectiveReactionForSenderTarget(contact, messageToDelete.txid, from);
                     purgeContactReactionsForTarget(contact, messageToDelete.txid);
                     syncChatLatestActivityTimestamp(from, contact);
                     didChangeReactionPreview = true;
-                    if (!inActiveChatWithSender && removedIncomingReactionCount > 0) {
-                      nextReactionUnread = Math.max(0, nextReactionUnread - removedIncomingReactionCount);
+                    if (!inActiveChatWithSender && hadIncomingEffectiveReaction) {
+                      nextReactionUnread = Math.max(0, nextReactionUnread - 1);
                     }
                   }
                   if (didDeleteMessage && messageToDelete.type === 'call' && shouldRefreshUpcomingCallsUiForCallTime(messageToDelete.callTime)) {


### PR DESCRIPTION
## Summary
This implements phase 8 reaction `set` behavior and the remaining phase 9 pending-result cleanup on top of the existing chat reaction flow.

The branch adds optimistic local handling for reaction `set` while keeping the previous reaction as hidden fallback until the pending transaction resolves. It also updates reaction rendering and chat-list preview logic so only the newest effective reaction per `sender + targetTxid` is shown, and completes pending success/failure/timeout reconciliation for those optimistic reactions.

## What changed
- add `reactionTxId` tracking on reaction entries
- add optimistic outgoing reaction `set` handling with fallback preservation
- reconcile pending reaction `set` success, failure, and timeout by txid
- keep `remove` non-optimistic in phase 8/9
- dedupe rendered and effective reactions so hidden fallback entries do not appear in chips or picker state
- update chat-list preview and timestamp logic to compare newest valid reaction activity against newest non-deleted message activity
- adjust delete and unread handling so deleting a reacted-to unread message clears both message unread and reaction unread when appropriate
- play chat sound for incoming reaction updates that change effective state when the chat is inactive or hidden

## Why
Phase 8 needs optimistic `set` behavior with rollback, but `contact.reactions` is also used by chat previews and reaction chips. The branch preserves the previous reaction only as temporary fallback state and makes the UI treat the newest entry for each `sender + targetTxid` as the effective reaction. It also closes the follow-up pending-result work that phase 9 was left to cover.

## Validation
- `node --check app.js`
- local branch review against `main`

## Notes
- this PR keeps reaction `remove` non-optimistic
- the two untracked design docs in the local worktree were not included in the PR