### PR TITLE
Fix premature reclaim after chat edits

### DIFF
--- a/app.js
+++ b/app.js
@@ -7405,7 +7405,9 @@ async function injectTx(tx, txid) {
         timeDifference()
         toastMessage += ' (Please try again)';
       }
-      showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
+      if (tx.type !== 'reclaim_toll' || !shouldSuppressReclaimFailureToast(failureReason)) {
+        showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
+      }
     }
     return data;
   } catch (error) {
@@ -7427,6 +7429,17 @@ async function injectTx(tx, txid) {
       saveState();
     }, 1000);
   }
+}
+
+/**
+ * Returns true when a reclaim-toll failure is expected noise and should not surface a toast.
+ * @param {string} failureReason
+ * @returns {boolean}
+ */
+function shouldSuppressReclaimFailureToast(failureReason) {
+  const normalizedReason = String(failureReason || '').toLowerCase();
+  return normalizedReason.includes('user is trying to reclaim toll but the toll pool is empty')
+    || normalizedReason.includes('user is trying to reclaim toll too soon after sending a message');
 }
 
 /**
@@ -14660,18 +14673,53 @@ class ChatModal {
   }
 
   /**
-   * Send a reclaim toll if the newest sent message is older than 7 days and the contact has a value not 0 in payOnReplay or payOnRead
+   * Returns the latest outbound chat activity timestamp used for reclaim gating.
+   * This treats edits as recent outbound activity by considering edited timestamps
+   * on locally stored sent messages in addition to original send timestamps.
+   * @param {string} contactAddress
+   * @returns {number|null}
+   */
+  getLatestOutboundActivityTimestamp(contactAddress = this.address) {
+    const contact = myData.contacts[contactAddress];
+    const messages = Array.isArray(contact?.messages) ? contact.messages : [];
+    let latestTimestamp = null;
+
+    for (const message of messages) {
+      if (!message?.my) {
+        continue;
+      }
+
+      const baseTimestamp = Number(message.sent_timestamp || message.timestamp || 0);
+      const editedTimestamp = Number(message.edited_timestamp || 0);
+      const candidateTimestamp = Math.max(baseTimestamp, editedTimestamp);
+
+      if (!Number.isFinite(candidateTimestamp) || candidateTimestamp <= 0) {
+        continue;
+      }
+
+      latestTimestamp = latestTimestamp === null
+        ? candidateTimestamp
+        : Math.max(latestTimestamp, candidateTimestamp);
+    }
+
+    return latestTimestamp;
+  }
+
+  /**
+   * Send a reclaim toll if the latest outbound chat activity is older than the toll timeout
+   * and the contact has a value not 0 in payOnReplay or payOnRead.
    * @param {string} contactAddress - The address of the contact
    * @returns {Promise<void>}
    */
   async sendReclaimTollTransaction(contactAddress) {
     await getNetworkParams();
     const currentTime = getCorrectedTimestamp();
-    const networkTollTimeoutInMs = parameters.current.tollTimeout; 
-    const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
-    if (!this.newestSentMessage || timeSinceNewestSentMessage < networkTollTimeoutInMs) {
+    const networkTollTimeoutInMs = parameters.current.tollTimeout;
+    const latestOutboundActivityTimestamp = this.getLatestOutboundActivityTimestamp(contactAddress);
+    const timeSinceLatestOutboundActivity = currentTime - latestOutboundActivityTimestamp;
+    if (!latestOutboundActivityTimestamp || timeSinceLatestOutboundActivity < networkTollTimeoutInMs) {
       // console.log(
-      //   `[sendReclaimTollTransaction] timeSinceNewestSentMessage ${timeSinceNewestSentMessage}ms is less than networkTollTimeoutInMs ${networkTollTimeoutInMs}ms, skipping reclaim toll transaction`
+      //   `[sendReclaimTollTransaction] timeSinceLatestOutboundActivity ${timeSinceLatestOutboundActivity}ms is less than networkTollTimeoutInMs ${networkTollTimeoutInMs}ms, skipping reclaim toll transaction`
       // );
       return;
     }
@@ -27419,7 +27467,7 @@ async function checkPendingTransactions() {
             // revert the local myData.contacts[toAddress].timestamp to the old value
             myData.contacts[pendingTxInfo.to].timestamp = pendingTxInfo.oldContactTimestamp;
           } else if (type === 'reclaim_toll') {
-            if (failureReason !== 'user is trying to reclaim toll but the toll pool is empty') {
+            if (!shouldSuppressReclaimFailureToast(failureReason)) {
               showToast(`Reclaim toll failed: ${userFailureReason}`, 0, 'error');
             }
           } else {

--- a/app.js
+++ b/app.js
@@ -3222,6 +3222,7 @@ function createNewContact(addr, username, friendStatus = 1, tolledDepositToastSh
   c.friend = friendStatus;
   c.friendOld = friendStatus;
   c.latestOutboundMessageTxTimestamp = 0;
+  c.latestOutboundMessageTxPendingTxid = '';
   c.tolledDepositToastShown = tolledDepositToastShown;
 }
 
@@ -7459,7 +7460,7 @@ function getLatestVisibleOutboundMessageTxTimestamp(contact) {
   const reactions = contact.reactions || [];
 
   for (const message of contact.messages) {
-    if (!message.my) {
+    if (!message.my || message.status === 'failed') {
       continue;
     }
 
@@ -7497,6 +7498,8 @@ function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
 
   const nextTimestamp = timestamp;
   assert(nextTimestamp > 0, 'Outbound tx timestamp is required');
+  const previousPendingTxid = contact.latestOutboundMessageTxPendingTxid || '';
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
 
   const previousTimestamp = contact.latestOutboundMessageTxTimestamp || 0;
   if (nextTimestamp <= previousTimestamp) {
@@ -7504,13 +7507,14 @@ function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
   }
 
   contact.latestOutboundMessageTxTimestamp = nextTimestamp;
-
-  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
   if (!pendingTxInfo) {
+    contact.latestOutboundMessageTxPendingTxid = '';
     return;
   }
 
+  contact.latestOutboundMessageTxPendingTxid = txid;
   pendingTxInfo.previousLatestOutboundMessageTxTimestamp = previousTimestamp;
+  pendingTxInfo.previousLatestOutboundMessageTxPendingTxid = previousPendingTxid;
   pendingTxInfo.latestOutboundMessageTxTimestamp = nextTimestamp;
 }
 
@@ -7523,41 +7527,22 @@ function restoreLatestOutboundMessageTxTimestamp(pendingTxInfo) {
   const contact = myData.contacts[pendingTxInfo.to];
   assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
 
-  const failedTimestamp = pendingTxInfo.latestOutboundMessageTxTimestamp || 0;
-  if (!failedTimestamp || contact.latestOutboundMessageTxTimestamp !== failedTimestamp) {
+  const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
+  const previousPendingTxid = pendingTxInfo.previousLatestOutboundMessageTxPendingTxid || '';
+
+  for (const pendingTx of myData.pending) {
+    if (pendingTx.previousLatestOutboundMessageTxPendingTxid === pendingTxInfo.txid) {
+      pendingTx.previousLatestOutboundMessageTxTimestamp = previousTimestamp;
+      pendingTx.previousLatestOutboundMessageTxPendingTxid = previousPendingTxid;
+    }
+  }
+
+  if (contact.latestOutboundMessageTxPendingTxid !== pendingTxInfo.txid) {
     return;
   }
 
-  let visibleTimestamp = 0;
-  const myAddress = normalizeAddress(myAccount.keys.address);
-  const reactions = contact.reactions || [];
-  const editedMessageTxid = pendingTxInfo.editedMessageTxid || '';
-
-  for (const message of contact.messages) {
-    if (!message.my || message.txid === pendingTxInfo.txid) {
-      continue;
-    }
-
-    const sentTimestamp = message.sent_timestamp || message.timestamp;
-    const editedTimestamp = message.txid === editedMessageTxid ? 0 : (message.edited_timestamp || 0);
-    const latestMessageTimestamp = Math.max(sentTimestamp, editedTimestamp);
-    if (latestMessageTimestamp > visibleTimestamp) {
-      visibleTimestamp = latestMessageTimestamp;
-    }
-  }
-
-  for (const reaction of reactions) {
-    if (reaction.reactionTxId === pendingTxInfo.txid || normalizeAddress(reaction.sender) !== myAddress) {
-      continue;
-    }
-
-    if (reaction.timestamp > visibleTimestamp) {
-      visibleTimestamp = reaction.timestamp;
-    }
-  }
-
-  const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
-  contact.latestOutboundMessageTxTimestamp = Math.max(previousTimestamp, visibleTimestamp);
+  contact.latestOutboundMessageTxTimestamp = previousTimestamp;
+  contact.latestOutboundMessageTxPendingTxid = previousPendingTxid;
 }
 
 /**
@@ -14831,7 +14816,7 @@ class ChatModal {
     const contact = myData.contacts[contactAddress];
     assert(contact, `Missing contact for reclaim lookup: ${contactAddress}`);
     return Math.max(
-      Number(contact.latestOutboundMessageTxTimestamp || 0),
+      contact.latestOutboundMessageTxTimestamp || 0,
       getLatestVisibleOutboundMessageTxTimestamp(contact)
     );
   }
@@ -22028,6 +22013,7 @@ class ImportContactsModal {
           friend: 2, // Friend status
           friendOld: 2,
           latestOutboundMessageTxTimestamp: 0,
+          latestOutboundMessageTxPendingTxid: '',
           tolledDepositToastShown: true,
         };
 
@@ -27490,6 +27476,7 @@ async function checkPendingTransactions() {
         if (type === 'message') {
           revertPendingOptimisticEdit(pendingTxInfo);
           restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
+          updateTransactionStatus(txid, pendingTxInfo.to, 'failed', type);
           if (chatModal.isActive()) {
             await chatModal.reopen();
           }
@@ -27503,6 +27490,13 @@ async function checkPendingTransactions() {
         // comment out to test the pending txs removal logic
         myData.pending.splice(i, 1);
         reconcilePendingReactionSet(pendingTxInfo, 'success');
+        if (type === 'message') {
+          const contact = myData.contacts[pendingTxInfo.to];
+          assert(contact, `Missing contact for confirmed message tx: ${pendingTxInfo.to}`);
+          if (contact.latestOutboundMessageTxPendingTxid === txid) {
+            contact.latestOutboundMessageTxPendingTxid = '';
+          }
+        }
 
         if (type === 'register') {
           pendingPromiseService.resolve(txid, {

--- a/app.js
+++ b/app.js
@@ -15264,7 +15264,6 @@ class ChatModal {
       } else {
         // Success: for normal message nothing extra; for edit we already updated locally
         if (isEdit) {
-          assert(originalMsgState, `Missing optimistic edit state for ${txid}`);
           const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
           assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
           pendingTxInfo.editedMessageTxid = editTargetTxId;

--- a/app.js
+++ b/app.js
@@ -7437,9 +7437,9 @@ async function injectTx(tx, txid) {
  * @returns {boolean}
  */
 function shouldSuppressReclaimFailureToast(failureReason) {
-  const normalizedReason = String(failureReason || '').toLowerCase();
-  return normalizedReason.includes('user is trying to reclaim toll but the toll pool is empty')
-    || normalizedReason.includes('user is trying to reclaim toll too soon after sending a message');
+  const reason = failureReason.toLowerCase();
+  return reason.includes('user is trying to reclaim toll but the toll pool is empty')
+    || reason.includes('user is trying to reclaim toll too soon after sending a message');
 }
 
 /**
@@ -14677,29 +14677,24 @@ class ChatModal {
    * This treats edits as recent outbound activity by considering edited timestamps
    * on locally stored sent messages in addition to original send timestamps.
    * @param {string} contactAddress
-   * @returns {number|null}
+   * @returns {number}
    */
-  getLatestOutboundActivityTimestamp(contactAddress = this.address) {
+  getLatestOutboundActivityTimestamp(contactAddress) {
     const contact = myData.contacts[contactAddress];
-    const messages = Array.isArray(contact?.messages) ? contact.messages : [];
-    let latestTimestamp = null;
+    assert(contact, `Missing contact for reclaim lookup: ${contactAddress}`);
 
-    for (const message of messages) {
-      if (!message?.my) {
+    let latestTimestamp = 0;
+
+    for (const message of contact.messages) {
+      if (!message.my) {
         continue;
       }
 
-      const baseTimestamp = Number(message.sent_timestamp || message.timestamp || 0);
-      const editedTimestamp = Number(message.edited_timestamp || 0);
-      const candidateTimestamp = Math.max(baseTimestamp, editedTimestamp);
-
-      if (!Number.isFinite(candidateTimestamp) || candidateTimestamp <= 0) {
-        continue;
+      const sentTimestamp = message.sent_timestamp || message.timestamp;
+      const latestMessageTimestamp = Math.max(sentTimestamp, message.edited_timestamp || 0);
+      if (latestMessageTimestamp > latestTimestamp) {
+        latestTimestamp = latestMessageTimestamp;
       }
-
-      latestTimestamp = latestTimestamp === null
-        ? candidateTimestamp
-        : Math.max(latestTimestamp, candidateTimestamp);
     }
 
     return latestTimestamp;
@@ -14717,7 +14712,7 @@ class ChatModal {
     const networkTollTimeoutInMs = parameters.current.tollTimeout;
     const latestOutboundActivityTimestamp = this.getLatestOutboundActivityTimestamp(contactAddress);
     const timeSinceLatestOutboundActivity = currentTime - latestOutboundActivityTimestamp;
-    if (!latestOutboundActivityTimestamp || timeSinceLatestOutboundActivity < networkTollTimeoutInMs) {
+    if (latestOutboundActivityTimestamp === 0 || timeSinceLatestOutboundActivity < networkTollTimeoutInMs) {
       // console.log(
       //   `[sendReclaimTollTransaction] timeSinceLatestOutboundActivity ${timeSinceLatestOutboundActivity}ms is less than networkTollTimeoutInMs ${networkTollTimeoutInMs}ms, skipping reclaim toll transaction`
       // );

--- a/app.js
+++ b/app.js
@@ -7459,16 +7459,7 @@ function shouldSuppressReclaimFailureToast(failureReason) {
  * @returns {{ timestamp: number, pendingTxid: string, inflightTimestamp: number, inflightTxid: string }}
  */
 function getOutboundMessageTxState(contact) {
-  if (contact.latestOutboundMessageTx) {
-    return contact.latestOutboundMessageTx;
-  }
-
-  contact.latestOutboundMessageTx = {
-    timestamp: contact.latestOutboundMessageTxTimestamp || 0,
-    pendingTxid: contact.latestOutboundMessageTxPendingTxid || '',
-    inflightTimestamp: contact.latestOutboundMessageTxInFlightTimestamp || 0,
-    inflightTxid: contact.latestOutboundMessageTxInFlightTxid || '',
-  };
+  assert(contact.latestOutboundMessageTx, 'Missing outbound message tx state');
   return contact.latestOutboundMessageTx;
 }
 
@@ -7577,7 +7568,6 @@ function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
   state.pendingTxid = txid;
   pendingTxInfo.previousLatestOutboundMessageTxTimestamp = previousTimestamp;
   pendingTxInfo.previousLatestOutboundMessageTxPendingTxid = previousPendingTxid;
-  pendingTxInfo.latestOutboundMessageTxTimestamp = timestamp;
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -14674,8 +14674,8 @@ class ChatModal {
 
   /**
    * Returns the latest outbound chat activity timestamp used for reclaim gating.
-   * This treats edits as recent outbound activity by considering edited timestamps
-   * on locally stored sent messages in addition to original send timestamps.
+   * This includes sent messages, edits, and outgoing reactions because the server
+   * treats any outbound message tx as reclaim-resetting activity.
    * @param {string} contactAddress
    * @returns {number}
    */
@@ -14684,6 +14684,7 @@ class ChatModal {
     assert(contact, `Missing contact for reclaim lookup: ${contactAddress}`);
 
     let latestTimestamp = 0;
+    const myAddress = normalizeAddress(myAccount.keys.address);
 
     for (const message of contact.messages) {
       if (!message.my) {
@@ -14694,6 +14695,16 @@ class ChatModal {
       const latestMessageTimestamp = Math.max(sentTimestamp, message.edited_timestamp || 0);
       if (latestMessageTimestamp > latestTimestamp) {
         latestTimestamp = latestMessageTimestamp;
+      }
+    }
+
+    for (const reaction of contact.reactions) {
+      if (normalizeAddress(reaction.sender) !== myAddress) {
+        continue;
+      }
+
+      if (reaction.timestamp > latestTimestamp) {
+        latestTimestamp = reaction.timestamp;
       }
     }
 

--- a/app.js
+++ b/app.js
@@ -14685,6 +14685,7 @@ class ChatModal {
 
     let latestTimestamp = 0;
     const myAddress = normalizeAddress(myAccount.keys.address);
+    const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
 
     for (const message of contact.messages) {
       if (!message.my) {
@@ -14698,7 +14699,7 @@ class ChatModal {
       }
     }
 
-    for (const reaction of contact.reactions) {
+    for (const reaction of reactions) {
       if (normalizeAddress(reaction.sender) !== myAddress) {
         continue;
       }

--- a/app.js
+++ b/app.js
@@ -3221,8 +3221,12 @@ function createNewContact(addr, username, friendStatus = 1, tolledDepositToastSh
   c.tollRequiredToSend = 1;
   c.friend = friendStatus;
   c.friendOld = friendStatus;
-  c.latestOutboundMessageTxTimestamp = 0;
-  c.latestOutboundMessageTxPendingTxid = '';
+  c.latestOutboundMessageTx = {
+    timestamp: 0,
+    pendingTxid: '',
+    inflightTimestamp: 0,
+    inflightTxid: '',
+  };
   c.tolledDepositToastShown = tolledDepositToastShown;
 }
 
@@ -7450,6 +7454,64 @@ function shouldSuppressReclaimFailureToast(failureReason) {
 }
 
 /**
+ * Returns the outbound message tx tracking state for a contact.
+ * @param {Object} contact
+ * @returns {{ timestamp: number, pendingTxid: string, inflightTimestamp: number, inflightTxid: string }}
+ */
+function getOutboundMessageTxState(contact) {
+  if (contact.latestOutboundMessageTx) {
+    return contact.latestOutboundMessageTx;
+  }
+
+  contact.latestOutboundMessageTx = {
+    timestamp: contact.latestOutboundMessageTxTimestamp || 0,
+    pendingTxid: contact.latestOutboundMessageTxPendingTxid || '',
+    inflightTimestamp: contact.latestOutboundMessageTxInFlightTimestamp || 0,
+    inflightTxid: contact.latestOutboundMessageTxInFlightTxid || '',
+  };
+  return contact.latestOutboundMessageTx;
+}
+
+/**
+ * Tracks hidden outbound message tx activity while injectTx is still in flight.
+ * @param {string} contactAddress
+ * @param {string} txid
+ * @param {number} timestamp
+ * @returns {void}
+ */
+function trackInFlightOutboundMessageTx(contactAddress, txid, timestamp) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound in-flight tracking: ${contactAddress}`);
+  assert(timestamp > 0, 'Outbound in-flight tx timestamp is required');
+  const state = getOutboundMessageTxState(contact);
+
+  if (timestamp < state.inflightTimestamp) {
+    return;
+  }
+
+  state.inflightTimestamp = timestamp;
+  state.inflightTxid = txid;
+}
+
+/**
+ * Clears hidden outbound message tx activity after injectTx finishes.
+ * @param {string} contactAddress
+ * @param {string} txid
+ * @returns {void}
+ */
+function clearInFlightOutboundMessageTx(contactAddress, txid) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound in-flight tracking: ${contactAddress}`);
+  const state = getOutboundMessageTxState(contact);
+  if (state.inflightTxid !== txid) {
+    return;
+  }
+
+  state.inflightTimestamp = 0;
+  state.inflightTxid = '';
+}
+
+/**
  * Returns the latest visible outbound message activity stored locally for a contact.
  * @param {Object} contact
  * @returns {number}
@@ -7495,23 +7557,24 @@ function getLatestVisibleOutboundMessageTxTimestamp(contact) {
 function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
   const contact = myData.contacts[contactAddress];
   assert(contact, `Missing contact for outbound tx tracking: ${contactAddress}`);
+  const state = getOutboundMessageTxState(contact);
 
-  const previousTimestamp = contact.latestOutboundMessageTxTimestamp || 0;
+  const previousTimestamp = state.timestamp;
   assert(timestamp > 0, 'Outbound tx timestamp is required');
   if (timestamp <= previousTimestamp) {
     return;
   }
 
-  const previousPendingTxid = contact.latestOutboundMessageTxPendingTxid || '';
+  const previousPendingTxid = state.pendingTxid;
   const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
 
-  contact.latestOutboundMessageTxTimestamp = timestamp;
+  state.timestamp = timestamp;
   if (!pendingTxInfo) {
-    contact.latestOutboundMessageTxPendingTxid = '';
+    state.pendingTxid = '';
     return;
   }
 
-  contact.latestOutboundMessageTxPendingTxid = txid;
+  state.pendingTxid = txid;
   pendingTxInfo.previousLatestOutboundMessageTxTimestamp = previousTimestamp;
   pendingTxInfo.previousLatestOutboundMessageTxPendingTxid = previousPendingTxid;
   pendingTxInfo.latestOutboundMessageTxTimestamp = timestamp;
@@ -7525,6 +7588,7 @@ function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
 function restoreLatestOutboundMessageTxTimestamp(pendingTxInfo) {
   const contact = myData.contacts[pendingTxInfo.to];
   assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
+  const state = getOutboundMessageTxState(contact);
 
   const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
   const previousPendingTxid = pendingTxInfo.previousLatestOutboundMessageTxPendingTxid || '';
@@ -7536,12 +7600,12 @@ function restoreLatestOutboundMessageTxTimestamp(pendingTxInfo) {
     }
   }
 
-  if (contact.latestOutboundMessageTxPendingTxid !== pendingTxInfo.txid) {
+  if (state.pendingTxid !== pendingTxInfo.txid) {
     return;
   }
 
-  contact.latestOutboundMessageTxTimestamp = previousTimestamp;
-  contact.latestOutboundMessageTxPendingTxid = previousPendingTxid;
+  state.timestamp = previousTimestamp;
+  state.pendingTxid = previousPendingTxid;
 }
 
 /**
@@ -14814,8 +14878,10 @@ class ChatModal {
   getLatestOutboundActivityTimestamp(contactAddress) {
     const contact = myData.contacts[contactAddress];
     assert(contact, `Missing contact for reclaim lookup: ${contactAddress}`);
+    const state = getOutboundMessageTxState(contact);
     return Math.max(
-      contact.latestOutboundMessageTxTimestamp || 0,
+      state.timestamp,
+      state.inflightTimestamp,
       getLatestVisibleOutboundMessageTxTimestamp(contact)
     );
   }
@@ -18478,7 +18544,15 @@ class ChatModal {
       }
     }
 
+    if (reaction.reactAction === 'remove') {
+      assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
+      trackInFlightOutboundMessageTx(currentAddress, txid, payload.sent_timestamp);
+    }
+
     const response = await injectTx(chatMessageObj, txid);
+    if (reaction.reactAction === 'remove') {
+      clearInFlightOutboundMessageTx(currentAddress, txid);
+    }
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
       if (reactionPendingState) {
@@ -18888,6 +18962,7 @@ class ChatModal {
    */
   async deleteMessageForAll(messageEl) {
     const { txid, messageTimestamp: timestamp } = messageEl.dataset;
+    let deleteTxid = '';
     
     if (!timestamp || !confirm('Delete this message for all participants?')) return;
     
@@ -18962,10 +19037,12 @@ class ChatModal {
       // Prepare and send the delete message transaction
       const deleteMessageObj = await this.createChatMessage(this.address, payload, tollInLib, keys);
       await signObj(deleteMessageObj, keys);
-      const deleteTxid = getTxid(deleteMessageObj);
+      deleteTxid = getTxid(deleteMessageObj);
+      trackInFlightOutboundMessageTx(this.address, deleteTxid, payload.sent_timestamp);
 
       // Send the delete transaction
       const response = await injectTx(deleteMessageObj, deleteTxid);
+      clearInFlightOutboundMessageTx(this.address, deleteTxid);
 
       if (!response || !response.result || !response.result.success) {
         console.error('Delete message failed to send', response);
@@ -18988,6 +19065,9 @@ class ChatModal {
       
     } catch (error) {
       console.error('Delete for all error:', error);
+      if (this.address && deleteTxid) {
+        clearInFlightOutboundMessageTx(this.address, deleteTxid);
+      }
       showToast('Failed to delete message. Please try again.', 0, 'error');
     }
   }
@@ -21998,8 +22078,12 @@ class ImportContactsModal {
           tollRequiredToSend: 1,
           friend: 2, // Friend status
           friendOld: 2,
-          latestOutboundMessageTxTimestamp: 0,
-          latestOutboundMessageTxPendingTxid: '',
+          latestOutboundMessageTx: {
+            timestamp: 0,
+            pendingTxid: '',
+            inflightTimestamp: 0,
+            inflightTxid: '',
+          },
           tolledDepositToastShown: true,
         };
 
@@ -27479,8 +27563,9 @@ async function checkPendingTransactions() {
         if (type === 'message') {
           const contact = myData.contacts[pendingTxInfo.to];
           assert(contact, `Missing contact for confirmed message tx: ${pendingTxInfo.to}`);
-          if (contact.latestOutboundMessageTxPendingTxid === txid) {
-            contact.latestOutboundMessageTxPendingTxid = '';
+          const state = getOutboundMessageTxState(contact);
+          if (state.pendingTxid === txid) {
+            state.pendingTxid = '';
           }
         }
 

--- a/app.js
+++ b/app.js
@@ -7496,17 +7496,16 @@ function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
   const contact = myData.contacts[contactAddress];
   assert(contact, `Missing contact for outbound tx tracking: ${contactAddress}`);
 
-  const nextTimestamp = timestamp;
-  assert(nextTimestamp > 0, 'Outbound tx timestamp is required');
-  const previousPendingTxid = contact.latestOutboundMessageTxPendingTxid || '';
-  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-
   const previousTimestamp = contact.latestOutboundMessageTxTimestamp || 0;
-  if (nextTimestamp <= previousTimestamp) {
+  assert(timestamp > 0, 'Outbound tx timestamp is required');
+  if (timestamp <= previousTimestamp) {
     return;
   }
 
-  contact.latestOutboundMessageTxTimestamp = nextTimestamp;
+  const previousPendingTxid = contact.latestOutboundMessageTxPendingTxid || '';
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+
+  contact.latestOutboundMessageTxTimestamp = timestamp;
   if (!pendingTxInfo) {
     contact.latestOutboundMessageTxPendingTxid = '';
     return;
@@ -7515,7 +7514,7 @@ function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
   contact.latestOutboundMessageTxPendingTxid = txid;
   pendingTxInfo.previousLatestOutboundMessageTxTimestamp = previousTimestamp;
   pendingTxInfo.previousLatestOutboundMessageTxPendingTxid = previousPendingTxid;
-  pendingTxInfo.latestOutboundMessageTxTimestamp = nextTimestamp;
+  pendingTxInfo.latestOutboundMessageTxTimestamp = timestamp;
 }
 
 /**
@@ -7546,20 +7545,20 @@ function restoreLatestOutboundMessageTxTimestamp(pendingTxInfo) {
 }
 
 /**
- * Reverts an optimistic edit after the pending edit tx fails or times out.
- * @param {Object} pendingTxInfo
+ * Reverts an optimistic edit.
+ * @param {Object} editRollbackInfo
  * @returns {void}
  */
-function revertPendingOptimisticEdit(pendingTxInfo) {
-  const editedMessageTxid = pendingTxInfo.editedMessageTxid;
+function revertOptimisticEdit(editRollbackInfo) {
+  const editedMessageTxid = editRollbackInfo.editedMessageTxid;
   if (!editedMessageTxid) {
     return;
   }
-  const originalEditedMessageState = pendingTxInfo.originalEditedMessageState;
-  assert(originalEditedMessageState, `Missing original edit state for ${pendingTxInfo.txid}`);
+  const originalEditedMessageState = editRollbackInfo.originalEditedMessageState;
+  assert(originalEditedMessageState, `Missing original edit state for ${editRollbackInfo.txid}`);
 
-  const contact = myData.contacts[pendingTxInfo.to];
-  assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
+  const contact = myData.contacts[editRollbackInfo.to];
+  assert(contact, `Missing contact for failed message tx: ${editRollbackInfo.to}`);
 
   const originalMsg = contact.messages.find((message) => message.txid === editedMessageTxid);
   assert(originalMsg, `Missing edited message for failed tx: ${editedMessageTxid}`);
@@ -15242,20 +15241,13 @@ class ChatModal {
           this.appendChatModal();
         } else {
           showToast('Edit failed to send', 0, 'error');
-          // Revert optimistic edit
-          if (originalMsg && originalMsgState) {
-            originalMsg.message = originalMsgState.message;
-            if (originalMsgState.edited) {
-              originalMsg.edited = originalMsgState.edited;
-              originalMsg.edited_timestamp = originalMsgState.edited_timestamp;
-            } else {
-              delete originalMsg.edited;
-              delete originalMsg.edited_timestamp;
-            }
-            // Revert wallet history memo if we changed it optimistically
-            this.revertWalletHistoryEdit(editTargetTxId, originalMsgState.history);
-            this.appendChatModal();
-          }
+          revertOptimisticEdit({
+            to: currentAddress,
+            txid,
+            editedMessageTxid: editTargetTxId,
+            originalEditedMessageState: originalMsgState
+          });
+          this.appendChatModal();
           // Restore edit UI state to allow user to retry or cancel
           editInput.value = editTargetTxId;
           this.cancelEditButton.style.display = '';
@@ -15284,18 +15276,13 @@ class ChatModal {
     } catch (error) {
       console.error('Message error:', error);
       showToast('Failed to send message. Please try again.', 0, 'error');
-      // Revert optimistic edit on exception
-      if (isEdit && originalMsg && originalMsgState) {
-        originalMsg.message = originalMsgState.message;
-        if (originalMsgState.edited) {
-          originalMsg.edited = originalMsgState.edited;
-          originalMsg.edited_timestamp = originalMsgState.edited_timestamp;
-        } else {
-          delete originalMsg.edited;
-          delete originalMsg.edited_timestamp;
-        }
-        // Revert wallet history memo if we changed it optimistically
-        this.revertWalletHistoryEdit(editTargetTxId, originalMsgState.history);
+      if (isEdit && originalMsgState) {
+        revertOptimisticEdit({
+          to: currentAddress,
+          txid,
+          editedMessageTxid: editTargetTxId,
+          originalEditedMessageState: originalMsgState
+        });
         this.appendChatModal();
       }
     } finally {
@@ -27474,7 +27461,7 @@ async function checkPendingTransactions() {
           showToast('Reaction timed out and was reverted', 0, 'error');
         }
         if (type === 'message') {
-          revertPendingOptimisticEdit(pendingTxInfo);
+          revertOptimisticEdit(pendingTxInfo);
           restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
           updateTransactionStatus(txid, pendingTxInfo.to, 'failed', type);
           if (chatModal.isActive()) {
@@ -27567,7 +27554,7 @@ async function checkPendingTransactions() {
           } else if (type === 'deposit_stake') {
             showToast(`Stake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'message') {
-            revertPendingOptimisticEdit(pendingTxInfo);
+            revertOptimisticEdit(pendingTxInfo);
             restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
             if (chatModal.isActive()) {
               await chatModal.reopen();

--- a/app.js
+++ b/app.js
@@ -6321,7 +6321,7 @@ async function processChats(chats, keys) {
             payload.sent_timestamp = tx.timestamp;
           }
           if (mine){
-            trackLatestOutboundMessageTx(from, payload.sent_timestamp, txidHex);
+            trackLatestOutboundMessageTx(from, tx.timestamp, txidHex);
             // console.warn('my message tx', tx)
           }
           else if (payload.encrypted) {

--- a/app.js
+++ b/app.js
@@ -3221,6 +3221,7 @@ function createNewContact(addr, username, friendStatus = 1, tolledDepositToastSh
   c.tollRequiredToSend = 1;
   c.friend = friendStatus;
   c.friendOld = friendStatus;
+  c.latestOutboundMessageTxTimestamp = 0;
   c.tolledDepositToastShown = tolledDepositToastShown;
 }
 
@@ -6320,6 +6321,7 @@ async function processChats(chats, keys) {
             payload.sent_timestamp = tx.timestamp;
           }
           if (mine){
+            trackLatestOutboundMessageTx(from, payload.sent_timestamp, txidHex);
             // console.warn('my message tx', tx)
           }
           else if (payload.encrypted) {
@@ -7387,6 +7389,10 @@ async function injectTx(tx, txid) {
       }
       myData.pending.push(pendingTxData);
 
+      if (tx.type === 'message') {
+        trackLatestOutboundMessageTx(pendingTxData.to, tx.timestamp, txid);
+      }
+
       if (tx.type !== 'register') {
         // After submitting a transaction, warn if user is low on LIB.
         maybeShowLowLibToast();
@@ -7442,6 +7448,74 @@ function shouldSuppressReclaimFailureToast(failureReason) {
     || reason.includes('user is trying to reclaim toll too soon after sending a message');
 }
 
+/**
+ * Returns the latest visible outbound message activity stored locally for a contact.
+ * This covers sent message bubbles, edits, and active outgoing reactions.
+ * @param {Object} contact
+ * @returns {number}
+ */
+function getLatestVisibleOutboundMessageTxTimestamp(contact) {
+  let latestTimestamp = 0;
+  const myAddress = normalizeAddress(myAccount.keys.address);
+  if (!contact.reactions) {
+    contact.reactions = [];
+  }
+
+  for (const message of contact.messages) {
+    if (!message.my) {
+      continue;
+    }
+
+    const sentTimestamp = message.sent_timestamp || message.timestamp;
+    const latestMessageTimestamp = Math.max(sentTimestamp, message.edited_timestamp || 0);
+    if (latestMessageTimestamp > latestTimestamp) {
+      latestTimestamp = latestMessageTimestamp;
+    }
+  }
+
+  for (const reaction of contact.reactions) {
+    if (normalizeAddress(reaction.sender) !== myAddress) {
+      continue;
+    }
+
+    if (reaction.timestamp > latestTimestamp) {
+      latestTimestamp = reaction.timestamp;
+    }
+  }
+
+  return latestTimestamp;
+}
+
+/**
+ * Tracks the latest outbound top-level chat message tx timestamp for a contact.
+ * If the tx is pending, keep enough metadata to restore the cached value if it later fails.
+ * @param {string} contactAddress
+ * @param {number} timestamp
+ * @param {string} txid
+ * @returns {void}
+ */
+function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound tx tracking: ${contactAddress}`);
+
+  const nextTimestamp = timestamp;
+  assert(nextTimestamp > 0, 'Outbound tx timestamp is required');
+
+  const previousTimestamp = contact.latestOutboundMessageTxTimestamp || 0;
+  if (nextTimestamp <= previousTimestamp) {
+    return;
+  }
+
+  contact.latestOutboundMessageTxTimestamp = nextTimestamp;
+
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+  if (!pendingTxInfo) {
+    return;
+  }
+
+  pendingTxInfo.previousLatestOutboundMessageTxTimestamp = previousTimestamp;
+  pendingTxInfo.latestOutboundMessageTxTimestamp = nextTimestamp;
+}
 /**
  * Sign a transaction object and return the transaction ID hash
  * @param {Object} tx - The transaction object to sign
@@ -14682,34 +14756,10 @@ class ChatModal {
   getLatestOutboundActivityTimestamp(contactAddress) {
     const contact = myData.contacts[contactAddress];
     assert(contact, `Missing contact for reclaim lookup: ${contactAddress}`);
-
-    let latestTimestamp = 0;
-    const myAddress = normalizeAddress(myAccount.keys.address);
-    const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
-
-    for (const message of contact.messages) {
-      if (!message.my) {
-        continue;
-      }
-
-      const sentTimestamp = message.sent_timestamp || message.timestamp;
-      const latestMessageTimestamp = Math.max(sentTimestamp, message.edited_timestamp || 0);
-      if (latestMessageTimestamp > latestTimestamp) {
-        latestTimestamp = latestMessageTimestamp;
-      }
-    }
-
-    for (const reaction of reactions) {
-      if (normalizeAddress(reaction.sender) !== myAddress) {
-        continue;
-      }
-
-      if (reaction.timestamp > latestTimestamp) {
-        latestTimestamp = reaction.timestamp;
-      }
-    }
-
-    return latestTimestamp;
+    return Math.max(
+      Number(contact.latestOutboundMessageTxTimestamp || 0),
+      getLatestVisibleOutboundMessageTxTimestamp(contact)
+    );
   }
 
   /**
@@ -21898,6 +21948,7 @@ class ImportContactsModal {
           tollRequiredToSend: 1,
           friend: 2, // Friend status
           friendOld: 2,
+          latestOutboundMessageTxTimestamp: 0,
           tolledDepositToastShown: true,
         };
 
@@ -27435,6 +27486,15 @@ async function checkPendingTransactions() {
           } else if (type === 'deposit_stake') {
             showToast(`Stake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'message') {
+            const contact = myData.contacts[pendingTxInfo.to];
+            assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
+
+            const failedTimestamp = pendingTxInfo.latestOutboundMessageTxTimestamp || 0;
+            if (failedTimestamp && contact.latestOutboundMessageTxTimestamp === failedTimestamp) {
+              const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
+              const visibleTimestamp = getLatestVisibleOutboundMessageTxTimestamp(contact);
+              contact.latestOutboundMessageTxTimestamp = Math.max(previousTimestamp, visibleTimestamp);
+            }
             if (chatModal.isActive()) {
               await chatModal.reopen();
             }

--- a/app.js
+++ b/app.js
@@ -7450,19 +7450,27 @@ function shouldSuppressReclaimFailureToast(failureReason) {
 
 /**
  * Returns the latest visible outbound message activity stored locally for a contact.
- * This covers sent message bubbles, edits, and active outgoing reactions.
  * @param {Object} contact
  * @returns {number}
  */
 function getLatestVisibleOutboundMessageTxTimestamp(contact) {
+  return getLatestVisibleOutboundMessageTxTimestampExcept(contact, '');
+}
+
+/**
+ * Returns the latest visible outbound message activity stored locally for a contact,
+ * excluding one failed pending tx.
+ * @param {Object} contact
+ * @param {string} excludedTxid
+ * @returns {number}
+ */
+function getLatestVisibleOutboundMessageTxTimestampExcept(contact, excludedTxid) {
   let latestTimestamp = 0;
   const myAddress = normalizeAddress(myAccount.keys.address);
-  if (!contact.reactions) {
-    contact.reactions = [];
-  }
+  const reactions = contact.reactions || [];
 
   for (const message of contact.messages) {
-    if (!message.my) {
+    if (!message.my || message.txid === excludedTxid) {
       continue;
     }
 
@@ -7473,8 +7481,8 @@ function getLatestVisibleOutboundMessageTxTimestamp(contact) {
     }
   }
 
-  for (const reaction of contact.reactions) {
-    if (normalizeAddress(reaction.sender) !== myAddress) {
+  for (const reaction of reactions) {
+    if (reaction.reactionTxId === excludedTxid || normalizeAddress(reaction.sender) !== myAddress) {
       continue;
     }
 
@@ -7484,6 +7492,25 @@ function getLatestVisibleOutboundMessageTxTimestamp(contact) {
   }
 
   return latestTimestamp;
+}
+
+/**
+ * Restores the cached latest outbound message tx timestamp after a pending message tx fails.
+ * @param {Object} pendingTxInfo
+ * @returns {void}
+ */
+function restoreLatestOutboundMessageTxTimestamp(pendingTxInfo) {
+  const contact = myData.contacts[pendingTxInfo.to];
+  assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
+
+  const failedTimestamp = pendingTxInfo.latestOutboundMessageTxTimestamp || 0;
+  if (!failedTimestamp || contact.latestOutboundMessageTxTimestamp !== failedTimestamp) {
+    return;
+  }
+
+  const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
+  const visibleTimestamp = getLatestVisibleOutboundMessageTxTimestampExcept(contact, pendingTxInfo.txid);
+  contact.latestOutboundMessageTxTimestamp = Math.max(previousTimestamp, visibleTimestamp);
 }
 
 /**
@@ -27408,6 +27435,9 @@ async function checkPendingTransactions() {
         if (didRevert) {
           showToast('Reaction timed out and was reverted', 0, 'error');
         }
+        if (type === 'message') {
+          restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
+        }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
         continue;
@@ -27478,6 +27508,7 @@ async function checkPendingTransactions() {
           // Show toast notification with the failure reason
           if (pendingTxInfo.reactionPending) {
             const didRevert = reconcilePendingReactionSet(pendingTxInfo, 'failure');
+            restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
             showToast(didRevert
               ? `Reaction failed and was reverted: ${userFailureReason}`
               : userFailureReason, 0, 'error');
@@ -27486,15 +27517,7 @@ async function checkPendingTransactions() {
           } else if (type === 'deposit_stake') {
             showToast(`Stake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'message') {
-            const contact = myData.contacts[pendingTxInfo.to];
-            assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
-
-            const failedTimestamp = pendingTxInfo.latestOutboundMessageTxTimestamp || 0;
-            if (failedTimestamp && contact.latestOutboundMessageTxTimestamp === failedTimestamp) {
-              const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
-              const visibleTimestamp = getLatestVisibleOutboundMessageTxTimestamp(contact);
-              contact.latestOutboundMessageTxTimestamp = Math.max(previousTimestamp, visibleTimestamp);
-            }
+            restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
             if (chatModal.isActive()) {
               await chatModal.reopen();
             }

--- a/app.js
+++ b/app.js
@@ -7454,23 +7454,12 @@ function shouldSuppressReclaimFailureToast(failureReason) {
  * @returns {number}
  */
 function getLatestVisibleOutboundMessageTxTimestamp(contact) {
-  return getLatestVisibleOutboundMessageTxTimestampExcept(contact, '');
-}
-
-/**
- * Returns the latest visible outbound message activity stored locally for a contact,
- * excluding one failed pending tx.
- * @param {Object} contact
- * @param {string} excludedTxid
- * @returns {number}
- */
-function getLatestVisibleOutboundMessageTxTimestampExcept(contact, excludedTxid) {
   let latestTimestamp = 0;
   const myAddress = normalizeAddress(myAccount.keys.address);
   const reactions = contact.reactions || [];
 
   for (const message of contact.messages) {
-    if (!message.my || message.txid === excludedTxid) {
+    if (!message.my) {
       continue;
     }
 
@@ -7482,7 +7471,7 @@ function getLatestVisibleOutboundMessageTxTimestampExcept(contact, excludedTxid)
   }
 
   for (const reaction of reactions) {
-    if (reaction.reactionTxId === excludedTxid || normalizeAddress(reaction.sender) !== myAddress) {
+    if (normalizeAddress(reaction.sender) !== myAddress) {
       continue;
     }
 
@@ -7492,25 +7481,6 @@ function getLatestVisibleOutboundMessageTxTimestampExcept(contact, excludedTxid)
   }
 
   return latestTimestamp;
-}
-
-/**
- * Restores the cached latest outbound message tx timestamp after a pending message tx fails.
- * @param {Object} pendingTxInfo
- * @returns {void}
- */
-function restoreLatestOutboundMessageTxTimestamp(pendingTxInfo) {
-  const contact = myData.contacts[pendingTxInfo.to];
-  assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
-
-  const failedTimestamp = pendingTxInfo.latestOutboundMessageTxTimestamp || 0;
-  if (!failedTimestamp || contact.latestOutboundMessageTxTimestamp !== failedTimestamp) {
-    return;
-  }
-
-  const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
-  const visibleTimestamp = getLatestVisibleOutboundMessageTxTimestampExcept(contact, pendingTxInfo.txid);
-  contact.latestOutboundMessageTxTimestamp = Math.max(previousTimestamp, visibleTimestamp);
 }
 
 /**
@@ -7542,6 +7512,83 @@ function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
 
   pendingTxInfo.previousLatestOutboundMessageTxTimestamp = previousTimestamp;
   pendingTxInfo.latestOutboundMessageTxTimestamp = nextTimestamp;
+}
+
+/**
+ * Restores the cached latest outbound message tx timestamp after a pending message tx fails.
+ * @param {Object} pendingTxInfo
+ * @returns {void}
+ */
+function restoreLatestOutboundMessageTxTimestamp(pendingTxInfo) {
+  const contact = myData.contacts[pendingTxInfo.to];
+  assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
+
+  const failedTimestamp = pendingTxInfo.latestOutboundMessageTxTimestamp || 0;
+  if (!failedTimestamp || contact.latestOutboundMessageTxTimestamp !== failedTimestamp) {
+    return;
+  }
+
+  let visibleTimestamp = 0;
+  const myAddress = normalizeAddress(myAccount.keys.address);
+  const reactions = contact.reactions || [];
+  const editedMessageTxid = pendingTxInfo.editedMessageTxid || '';
+
+  for (const message of contact.messages) {
+    if (!message.my || message.txid === pendingTxInfo.txid) {
+      continue;
+    }
+
+    const sentTimestamp = message.sent_timestamp || message.timestamp;
+    const editedTimestamp = message.txid === editedMessageTxid ? 0 : (message.edited_timestamp || 0);
+    const latestMessageTimestamp = Math.max(sentTimestamp, editedTimestamp);
+    if (latestMessageTimestamp > visibleTimestamp) {
+      visibleTimestamp = latestMessageTimestamp;
+    }
+  }
+
+  for (const reaction of reactions) {
+    if (reaction.reactionTxId === pendingTxInfo.txid || normalizeAddress(reaction.sender) !== myAddress) {
+      continue;
+    }
+
+    if (reaction.timestamp > visibleTimestamp) {
+      visibleTimestamp = reaction.timestamp;
+    }
+  }
+
+  const previousTimestamp = pendingTxInfo.previousLatestOutboundMessageTxTimestamp || 0;
+  contact.latestOutboundMessageTxTimestamp = Math.max(previousTimestamp, visibleTimestamp);
+}
+
+/**
+ * Reverts an optimistic edit after the pending edit tx fails or times out.
+ * @param {Object} pendingTxInfo
+ * @returns {void}
+ */
+function revertPendingOptimisticEdit(pendingTxInfo) {
+  const editedMessageTxid = pendingTxInfo.editedMessageTxid;
+  if (!editedMessageTxid) {
+    return;
+  }
+  const originalEditedMessageState = pendingTxInfo.originalEditedMessageState;
+  assert(originalEditedMessageState, `Missing original edit state for ${pendingTxInfo.txid}`);
+
+  const contact = myData.contacts[pendingTxInfo.to];
+  assert(contact, `Missing contact for failed message tx: ${pendingTxInfo.to}`);
+
+  const originalMsg = contact.messages.find((message) => message.txid === editedMessageTxid);
+  assert(originalMsg, `Missing edited message for failed tx: ${editedMessageTxid}`);
+
+  originalMsg.message = originalEditedMessageState.message;
+  if (originalEditedMessageState.edited) {
+    originalMsg.edited = originalEditedMessageState.edited;
+    originalMsg.edited_timestamp = originalEditedMessageState.edited_timestamp;
+  } else {
+    delete originalMsg.edited;
+    delete originalMsg.edited_timestamp;
+  }
+
+  chatModal.revertWalletHistoryEdit(editedMessageTxid, originalEditedMessageState.history);
 }
 /**
  * Sign a transaction object and return the transaction ID hash
@@ -15240,6 +15287,11 @@ class ChatModal {
       } else {
         // Success: for normal message nothing extra; for edit we already updated locally
         if (isEdit) {
+          assert(originalMsgState, `Missing optimistic edit state for ${txid}`);
+          const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+          assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
+          pendingTxInfo.editedMessageTxid = editTargetTxId;
+          pendingTxInfo.originalEditedMessageState = originalMsgState;
           showToast('Message edited', 2000, 'success');
           this.addAttachmentButton.disabled = this.blockedByRecipient;
         }
@@ -27436,7 +27488,11 @@ async function checkPendingTransactions() {
           showToast('Reaction timed out and was reverted', 0, 'error');
         }
         if (type === 'message') {
+          revertPendingOptimisticEdit(pendingTxInfo);
           restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
+          if (chatModal.isActive()) {
+            await chatModal.reopen();
+          }
         }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
@@ -27517,6 +27573,7 @@ async function checkPendingTransactions() {
           } else if (type === 'deposit_stake') {
             showToast(`Stake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'message') {
+            revertPendingOptimisticEdit(pendingTxInfo);
             restoreLatestOutboundMessageTxTimestamp(pendingTxInfo);
             if (chatModal.isActive()) {
               await chatModal.reopen();


### PR DESCRIPTION
## Summary
Fixes #1218 by preventing premature reclaim after recent chat activity that the server still treats as a sent message.

## Root Cause
The client was deciding reclaim eligibility from the newest visible sent message row. That missed newer outbound `message` transactions that do not create a new bubble, especially edits, and could also drift from the server after reload because the server uses the top-level message tx timestamp.

## What Changed
- reclaim gating now uses `getLatestOutboundActivityTimestamp(contactAddress)` instead of the newest visible sent row
- added `contact.latestOutboundMessageTxTimestamp` as the cached source of truth for the latest outbound chat `message` tx
- update that cache centrally in `injectTx()` when a `message` tx is accepted for pending tracking
- backfill the cache from synced outgoing message history in `processChats()` using the top-level `tx.timestamp`
- on pending `message` failure, restore the cache to the best remaining value
- keep a visible-state fallback scan over sent messages, edits, and outgoing reactions for older local state or incomplete cache state
- suppress reclaim error toasts only for the expected backend rejections:
  - toll pool empty
  - reclaim attempted too soon after sending a message

## Why This Matches The Server
Server reclaim validation checks the newest outbound top-level `message` tx timestamp in chat history. This change aligns the client with that rule instead of relying on chat bubble rendering state.

## Validation
- `node --check app.js`

## Follow-up
- #1240 discusses whether reaction removals should be tracked more explicitly or whether the current behavior is acceptable.