### PR TITLE
Use outbound activity for reclaim gating

### DIFF
--- a/app.js
+++ b/app.js
@@ -7413,7 +7413,9 @@ async function injectTx(tx, txid) {
         timeDifference()
         toastMessage += ' (Please try again)';
       }
-      showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
+      if (tx.type !== 'reclaim_toll' || !shouldSuppressReclaimFailureToast(failureReason)) {
+        showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
+      }
     }
     return data;
   } catch (error) {
@@ -7445,6 +7447,52 @@ async function injectTx(tx, txid) {
 function getOutboundMessageTxState(contact) {
   assert(contact.latestOutboundMessageTx, 'Missing outbound message tx state');
   return contact.latestOutboundMessageTx;
+}
+
+/**
+ * Returns true when a reclaim-toll failure is expected noise and should not surface a toast.
+ * @param {string} failureReason
+ * @returns {boolean}
+ */
+function shouldSuppressReclaimFailureToast(failureReason) {
+  const reason = failureReason.toLowerCase();
+  return reason.includes('user is trying to reclaim toll but the toll pool is empty')
+    || reason.includes('user is trying to reclaim toll too soon after sending a message');
+}
+
+/**
+ * Returns the latest visible outbound message activity stored locally for a contact.
+ * @param {Object} contact
+ * @returns {number}
+ */
+function getLatestVisibleOutboundMessageTxTimestamp(contact) {
+  let latestTimestamp = 0;
+  const myAddress = normalizeAddress(myAccount.keys.address);
+  const reactions = contact.reactions || [];
+
+  for (const message of contact.messages) {
+    if (!message.my || message.status === 'failed') {
+      continue;
+    }
+
+    const sentTimestamp = message.sent_timestamp || message.timestamp;
+    const latestMessageTimestamp = Math.max(sentTimestamp, message.edited_timestamp || 0);
+    if (latestMessageTimestamp > latestTimestamp) {
+      latestTimestamp = latestMessageTimestamp;
+    }
+  }
+
+  for (const reaction of reactions) {
+    if (normalizeAddress(reaction.sender) !== myAddress) {
+      continue;
+    }
+
+    if (reaction.timestamp > latestTimestamp) {
+      latestTimestamp = reaction.timestamp;
+    }
+  }
+
+  return latestTimestamp;
 }
 
 /**
@@ -14697,18 +14745,36 @@ class ChatModal {
   }
 
   /**
-   * Send a reclaim toll if the newest sent message is older than 7 days and the contact has a value not 0 in payOnReplay or payOnRead
+   * Returns the latest outbound chat activity timestamp used for reclaim gating.
+   * This includes sent messages, edits, and outgoing reactions because the server
+   * treats any outbound message tx as reclaim-resetting activity.
+   * @param {string} contactAddress
+   * @returns {number}
+   */
+  getLatestOutboundActivityTimestamp(contactAddress) {
+    const contact = myData.contacts[contactAddress];
+    assert(contact, `Missing contact for reclaim lookup: ${contactAddress}`);
+    return Math.max(
+      getOutboundMessageTxState(contact).timestamp,
+      getLatestVisibleOutboundMessageTxTimestamp(contact)
+    );
+  }
+
+  /**
+   * Send a reclaim toll if the latest outbound chat activity is older than the toll timeout
+   * and the contact has a value not 0 in payOnReplay or payOnRead.
    * @param {string} contactAddress - The address of the contact
    * @returns {Promise<void>}
    */
   async sendReclaimTollTransaction(contactAddress) {
     await getNetworkParams();
     const currentTime = getCorrectedTimestamp();
-    const networkTollTimeoutInMs = parameters.current.tollTimeout; 
-    const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
-    if (!this.newestSentMessage || timeSinceNewestSentMessage < networkTollTimeoutInMs) {
+    const networkTollTimeoutInMs = parameters.current.tollTimeout;
+    const latestOutboundActivityTimestamp = this.getLatestOutboundActivityTimestamp(contactAddress);
+    const timeSinceLatestOutboundActivity = currentTime - latestOutboundActivityTimestamp;
+    if (latestOutboundActivityTimestamp === 0 || timeSinceLatestOutboundActivity < networkTollTimeoutInMs) {
       // console.log(
-      //   `[sendReclaimTollTransaction] timeSinceNewestSentMessage ${timeSinceNewestSentMessage}ms is less than networkTollTimeoutInMs ${networkTollTimeoutInMs}ms, skipping reclaim toll transaction`
+      //   `[sendReclaimTollTransaction] timeSinceLatestOutboundActivity ${timeSinceLatestOutboundActivity}ms is less than networkTollTimeoutInMs ${networkTollTimeoutInMs}ms, skipping reclaim toll transaction`
       // );
       return;
     }
@@ -27459,7 +27525,7 @@ async function checkPendingTransactions() {
             // revert the local myData.contacts[toAddress].timestamp to the old value
             myData.contacts[pendingTxInfo.to].timestamp = pendingTxInfo.oldContactTimestamp;
           } else if (type === 'reclaim_toll') {
-            if (failureReason !== 'user is trying to reclaim toll but the toll pool is empty') {
+            if (!shouldSuppressReclaimFailureToast(failureReason)) {
               showToast(`Reclaim toll failed: ${userFailureReason}`, 0, 'error');
             }
           } else {


### PR DESCRIPTION
## Summary
- Switch reclaim gating from the newest visible sent bubble to outbound chat activity.
- Suppress only the known reclaim failure toasts that are expected backend noise.

## High Level
This PR is the actual reclaim behavior change.

Before this, the client decided reclaim eligibility from the newest visible sent chat bubble. That was too narrow. Recent edits and outgoing reactions can still reset reclaim server-side without creating a newer visible sent row.

After this PR, reclaim uses the latest outbound activity instead of UI bubble ordering.

## What Changed
- Add `shouldSuppressReclaimFailureToast(failureReason)`.
- Add `getLatestVisibleOutboundMessageTxTimestamp(contact)`.
- Add `ChatModal.getLatestOutboundActivityTimestamp(contactAddress)`.
- Update `sendReclaimTollTransaction()` to gate on the latest outbound activity timestamp instead of `this.newestSentMessage`.
- Reuse the suppression helper in both the immediate `injectTx()` failure path and pending reclaim failure handling.

## Why
- The old client logic only reflected visible chat rows.
- Recent edits and outgoing reactions can still reset reclaim server-side even when they do not create a newer visible sent bubble.

## Flow
```mermaid
sequenceDiagram
    participant User as User Closes Chat
    participant Modal as ChatModal
    participant State as Outbound Tx State
    participant Visible as Visible Fallback Scan
    participant Reclaim as sendReclaimTollTransaction()

    User->>Modal: close chat
    Modal->>State: read cached outbound timestamp
    Modal->>Visible: scan visible sent/edit/reaction activity
    Modal->>Reclaim: compare latest outbound activity vs tollTimeout
    Reclaim-->>User: skip reclaim or send reclaim tx
```

## Validation
- `node --check app.js`
