### PR TITLE
Track hidden outbound control messages during inject

### DIFF
--- a/app.js
+++ b/app.js
@@ -3224,6 +3224,8 @@ function createNewContact(addr, username, friendStatus = 1, tolledDepositToastSh
   c.latestOutboundMessageTx = {
     timestamp: 0,
     pendingTxid: '',
+    inflightTimestamp: 0,
+    inflightTxid: '',
   };
   c.tolledDepositToastShown = tolledDepositToastShown;
 }
@@ -7441,16 +7443,6 @@ async function injectTx(tx, txid) {
 }
 
 /**
- * Returns the outbound message tx tracking state for a contact.
- * @param {Object} contact
- * @returns {{ timestamp: number, pendingTxid: string }}
- */
-function getOutboundMessageTxState(contact) {
-  assert(contact.latestOutboundMessageTx, 'Missing outbound message tx state');
-  return contact.latestOutboundMessageTx;
-}
-
-/**
  * Returns true when a reclaim-toll failure is expected noise and should not surface a toast.
  * @param {string} failureReason
  * @returns {boolean}
@@ -7459,6 +7451,55 @@ function shouldSuppressReclaimFailureToast(failureReason) {
   const reason = failureReason.toLowerCase();
   return reason.includes('user is trying to reclaim toll but the toll pool is empty')
     || reason.includes('user is trying to reclaim toll too soon after sending a message');
+}
+
+/**
+ * Returns the outbound message tx tracking state for a contact.
+ * @param {Object} contact
+ * @returns {{ timestamp: number, pendingTxid: string, inflightTimestamp: number, inflightTxid: string }}
+ */
+function getOutboundMessageTxState(contact) {
+  assert(contact.latestOutboundMessageTx, 'Missing outbound message tx state');
+  return contact.latestOutboundMessageTx;
+}
+
+/**
+ * Tracks hidden outbound message tx activity while injectTx is still in flight.
+ * @param {string} contactAddress
+ * @param {string} txid
+ * @param {number} timestamp
+ * @returns {void}
+ */
+function trackInFlightOutboundMessageTx(contactAddress, txid, timestamp) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound in-flight tracking: ${contactAddress}`);
+  assert(timestamp > 0, 'Outbound in-flight tx timestamp is required');
+  const state = getOutboundMessageTxState(contact);
+
+  if (timestamp < state.inflightTimestamp) {
+    return;
+  }
+
+  state.inflightTimestamp = timestamp;
+  state.inflightTxid = txid;
+}
+
+/**
+ * Clears hidden outbound message tx activity after injectTx finishes.
+ * @param {string} contactAddress
+ * @param {string} txid
+ * @returns {void}
+ */
+function clearInFlightOutboundMessageTx(contactAddress, txid) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound in-flight tracking: ${contactAddress}`);
+  const state = getOutboundMessageTxState(contact);
+  if (state.inflightTxid !== txid) {
+    return;
+  }
+
+  state.inflightTimestamp = 0;
+  state.inflightTxid = '';
 }
 
 /**
@@ -7498,8 +7539,8 @@ function getLatestVisibleOutboundMessageTxTimestamp(contact) {
 
 /**
  * Tracks the latest outbound top-level chat message tx timestamp for a contact.
- * @param {string} contactAddress
  * If the tx is pending, keep enough metadata to restore the cached value if it later fails.
+ * @param {string} contactAddress
  * @param {number} timestamp
  * @param {string} txid
  * @returns {void}
@@ -7507,10 +7548,10 @@ function getLatestVisibleOutboundMessageTxTimestamp(contact) {
 function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
   const contact = myData.contacts[contactAddress];
   assert(contact, `Missing contact for outbound tx tracking: ${contactAddress}`);
-  assert(timestamp > 0, 'Outbound tx timestamp is required');
-
   const state = getOutboundMessageTxState(contact);
+
   const previousTimestamp = state.timestamp;
+  assert(timestamp > 0, 'Outbound tx timestamp is required');
   if (timestamp <= previousTimestamp) {
     return;
   }
@@ -7587,7 +7628,6 @@ function revertOptimisticEdit(editRollbackInfo) {
 
   chatModal.revertWalletHistoryEdit(editedMessageTxid, originalEditedMessageState.history);
 }
-
 /**
  * Sign a transaction object and return the transaction ID hash
  * @param {Object} tx - The transaction object to sign
@@ -14828,8 +14868,10 @@ class ChatModal {
   getLatestOutboundActivityTimestamp(contactAddress) {
     const contact = myData.contacts[contactAddress];
     assert(contact, `Missing contact for reclaim lookup: ${contactAddress}`);
+    const state = getOutboundMessageTxState(contact);
     return Math.max(
-      getOutboundMessageTxState(contact).timestamp,
+      state.timestamp,
+      state.inflightTimestamp,
       getLatestVisibleOutboundMessageTxTimestamp(contact)
     );
   }
@@ -18492,7 +18534,15 @@ class ChatModal {
       }
     }
 
+    if (reaction.reactAction === 'remove') {
+      assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
+      trackInFlightOutboundMessageTx(currentAddress, txid, payload.sent_timestamp);
+    }
+
     const response = await injectTx(chatMessageObj, txid);
+    if (reaction.reactAction === 'remove') {
+      clearInFlightOutboundMessageTx(currentAddress, txid);
+    }
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
       if (reactionPendingState) {
@@ -18902,6 +18952,7 @@ class ChatModal {
    */
   async deleteMessageForAll(messageEl) {
     const { txid, messageTimestamp: timestamp } = messageEl.dataset;
+    let deleteTxid = '';
     
     if (!timestamp || !confirm('Delete this message for all participants?')) return;
     
@@ -18976,10 +19027,12 @@ class ChatModal {
       // Prepare and send the delete message transaction
       const deleteMessageObj = await this.createChatMessage(this.address, payload, tollInLib, keys);
       await signObj(deleteMessageObj, keys);
-      const deleteTxid = getTxid(deleteMessageObj);
+      deleteTxid = getTxid(deleteMessageObj);
+      trackInFlightOutboundMessageTx(this.address, deleteTxid, payload.sent_timestamp);
 
       // Send the delete transaction
       const response = await injectTx(deleteMessageObj, deleteTxid);
+      clearInFlightOutboundMessageTx(this.address, deleteTxid);
 
       if (!response || !response.result || !response.result.success) {
         console.error('Delete message failed to send', response);
@@ -19002,6 +19055,9 @@ class ChatModal {
       
     } catch (error) {
       console.error('Delete for all error:', error);
+      if (this.address && deleteTxid) {
+        clearInFlightOutboundMessageTx(this.address, deleteTxid);
+      }
       showToast('Failed to delete message. Please try again.', 0, 'error');
     }
   }
@@ -22015,6 +22071,8 @@ class ImportContactsModal {
           latestOutboundMessageTx: {
             timestamp: 0,
             pendingTxid: '',
+            inflightTimestamp: 0,
+            inflightTxid: '',
           },
           tolledDepositToastShown: true,
         };


### PR DESCRIPTION
## Summary
- Cover the short window before `injectTx()` succeeds for hidden outbound control-message sends.
- This closes the remaining reclaim race for control messages that do not create visible local chat state.

## High Level
Phases 1-3 start tracking outbound message activity once injection succeeds or pending state exists.

This final PR covers the smaller pre-inject gap for hidden control-message sends like reaction removal and delete-for-all. Those sends count server-side, but they do not create visible local message rows, so reclaim can still race ahead during inject latency unless we track them separately.

## What Changed
- Extend `latestOutboundMessageTx` state with:
  - `inflightTimestamp`
  - `inflightTxid`
- Add `trackInFlightOutboundMessageTx(contactAddress, txid, timestamp)`.
- Add `clearInFlightOutboundMessageTx(contactAddress, txid)`.
- Update `getLatestOutboundActivityTimestamp()` to include the in-flight timestamp.
- Track reaction-removal sends before `injectTx()` and clear them immediately after inject completes.
- Track delete-for-all sends before `injectTx()` and clear them on success and error.

## Why
- Reaction removals and delete-for-all are outbound top-level `message` txs server-side.
- They do not create visible local message rows, so the visible fallback alone still leaves a reclaim race until injection succeeds.

## Flow
```mermaid
sequenceDiagram
    participant User as User Removes Reaction / Deletes For All
    participant UI as Hidden Control Send Path
    participant State as latestOutboundMessageTx.inflight*
    participant Inject as injectTx()
    participant Reclaim as getLatestOutboundActivityTimestamp()

    User->>UI: trigger hidden control-message send
    UI->>State: set inflight timestamp before inject
    User->>Reclaim: close chat during inject latency
    Reclaim->>State: read inflight timestamp
    Note over Reclaim: reclaim stays blocked during inject window
    Inject->>State: clear inflight tracking after inject finishes
```

## Validation
- `node --check app.js`
