### PR TITLE
Add outbound message tx state foundation

### DIFF
--- a/app.js
+++ b/app.js
@@ -7452,12 +7452,53 @@ function createOutboundMessageTxState() {
 }
 
 /**
+ * Returns the latest visible outbound chat activity timestamp for a contact.
+ * Used to seed outbound message tx state for older saved contacts.
+ * @param {Object} contact
+ * @returns {number}
+ */
+function getLatestVisibleOutboundMessageTxTimestamp(contact) {
+  let latestTimestamp = 0;
+
+  for (const message of contact.messages) {
+    if (!message.my) {
+      continue;
+    }
+
+    const sentTimestamp = message.sent_timestamp || message.timestamp;
+    const messageTimestamp = Math.max(sentTimestamp, message.edited_timestamp || 0);
+    if (messageTimestamp > latestTimestamp) {
+      latestTimestamp = messageTimestamp;
+    }
+  }
+
+  const myAddress = normalizeAddress(myAccount.keys.address);
+  const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
+  for (const reaction of reactions) {
+    if (normalizeAddress(reaction.sender) !== myAddress) {
+      continue;
+    }
+
+    if (reaction.timestamp > latestTimestamp) {
+      latestTimestamp = reaction.timestamp;
+    }
+  }
+
+  return latestTimestamp;
+}
+
+/**
  * Returns the outbound message tx tracking state for a contact.
  * @param {Object} contact
  * @returns {OutboundMessageTxState}
  */
 function getOutboundMessageTxState(contact) {
-  assert(contact.latestOutboundMessageTx, 'Missing outbound message tx state');
+  if (!contact.latestOutboundMessageTx) {
+    const state = createOutboundMessageTxState();
+    state.timestamp = getLatestVisibleOutboundMessageTxTimestamp(contact);
+    contact.latestOutboundMessageTx = state;
+  }
+
   return contact.latestOutboundMessageTx;
 }
 

--- a/app.js
+++ b/app.js
@@ -3221,6 +3221,7 @@ function createNewContact(addr, username, friendStatus = 1, tolledDepositToastSh
   c.tollRequiredToSend = 1;
   c.friend = friendStatus;
   c.friendOld = friendStatus;
+  c.latestOutboundMessageTx = createOutboundMessageTxState();
   c.tolledDepositToastShown = tolledDepositToastShown;
 }
 
@@ -6320,6 +6321,7 @@ async function processChats(chats, keys) {
             payload.sent_timestamp = tx.timestamp;
           }
           if (mine){
+            trackLatestOutboundMessageTx(from, tx.timestamp, txidHex);
             // console.warn('my message tx', tx)
           }
           else if (payload.encrypted) {
@@ -7382,6 +7384,9 @@ async function injectTx(tx, txid) {
         pendingTxData.oldContactTimestamp = tx.oldContactTimestamp;
       } else if (tx.type === 'message' || tx.type === 'transfer') {
         pendingTxData.to = normalizeAddress(tx.to);
+        if (tx.type === 'message') {
+          trackLatestOutboundMessageTx(pendingTxData.to, tx.timestamp, txid);
+        }
       } else if (tx.type === 'deposit_stake' || tx.type === 'withdraw_stake') {
         pendingTxData.to = tx.nominee; // Store 64-character address as-is for stake transactions
       }
@@ -7427,6 +7432,55 @@ async function injectTx(tx, txid) {
       saveState();
     }, 1000);
   }
+}
+
+/**
+ * @typedef {{ timestamp: number, pendingTxid: string, inflightTimestamp: number, inflightTxid: string }} OutboundMessageTxState
+ */
+
+/**
+ * Creates the default outbound message tx state for a contact.
+ * @returns {OutboundMessageTxState}
+ */
+function createOutboundMessageTxState() {
+  return {
+    timestamp: 0,
+    pendingTxid: '',
+    inflightTimestamp: 0,
+    inflightTxid: '',
+  };
+}
+
+/**
+ * Returns the outbound message tx tracking state for a contact.
+ * @param {Object} contact
+ * @returns {OutboundMessageTxState}
+ */
+function getOutboundMessageTxState(contact) {
+  assert(contact.latestOutboundMessageTx, 'Missing outbound message tx state');
+  return contact.latestOutboundMessageTx;
+}
+
+/**
+ * Tracks the latest outbound top-level chat message tx timestamp for a contact.
+ * @param {string} contactAddress
+ * @param {number} timestamp
+ * @param {string} txid
+ * @returns {void}
+ */
+function trackLatestOutboundMessageTx(contactAddress, timestamp, txid) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound tx tracking: ${contactAddress}`);
+  const state = getOutboundMessageTxState(contact);
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+
+  assert(timestamp > 0, 'Outbound tx timestamp is required');
+  if (timestamp <= state.timestamp) {
+    return;
+  }
+
+  state.timestamp = timestamp;
+  state.pendingTxid = pendingTxInfo ? txid : '';
 }
 
 /**
@@ -21843,6 +21897,7 @@ class ImportContactsModal {
           tollRequiredToSend: 1,
           friend: 2, // Friend status
           friendOld: 2,
+          latestOutboundMessageTx: createOutboundMessageTxState(),
           tolledDepositToastShown: true,
         };
 


### PR DESCRIPTION
## Summary
- add `contact.latestOutboundMessageTx` as the client-side cache for latest outbound top-level chat `message` tx activity
- add `OutboundMessageTxState`, `createOutboundMessageTxState()`, and `getOutboundMessageTxState()` so the state shape is explicit and shared
- lazily seed missing outbound message tx state for older saved contacts from visible local outbound activity instead of asserting
- update `trackLatestOutboundMessageTx()` and wire it into both `injectTx()` and `processChats()`
- initialize the outbound message tx state in both contact creation paths

## High-Level
This PR gives the client a server-shaped place to remember the latest outbound chat `message` transaction per contact. It also makes that state resilient for older saved contacts by lazily creating and seeding it on first use. It does not change reclaim behavior yet; it only lays the state foundation that later PRs will read from.

```mermaid
sequenceDiagram
    participant Network
    participant processChats
    participant injectTx
    participant ContactState

    Network->>processChats: mined outgoing message tx
    processChats->>ContactState: trackLatestOutboundMessageTx(timestamp)

    injectTx->>ContactState: trackLatestOutboundMessageTx(timestamp)
    ContactState-->>ContactState: cache newest outbound message tx time

    ContactState->>ContactState: lazy-init from visible outbound activity when missing
```

## Validation
- `node --check app.js`