### PR TITLE
Track outbound message txs during inject

### DIFF
--- a/app.js
+++ b/app.js
@@ -7503,6 +7503,62 @@ function getOutboundMessageTxState(contact) {
 }
 
 /**
+ * Tracks outbound message tx activity while injectTx is still in flight.
+ * @param {string} contactAddress
+ * @param {string} txid
+ * @param {number} timestamp
+ * @returns {void}
+ */
+function trackInFlightOutboundMessageTx(contactAddress, txid, timestamp) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound in-flight tracking: ${contactAddress}`);
+  assert(timestamp > 0, 'Outbound in-flight tx timestamp is required');
+  const state = getOutboundMessageTxState(contact);
+
+  if (timestamp < state.inflightTimestamp) {
+    return;
+  }
+
+  state.inflightTimestamp = timestamp;
+  state.inflightTxid = txid;
+}
+
+/**
+ * Clears outbound message tx activity after injectTx finishes.
+ * @param {string} contactAddress
+ * @param {string} txid
+ * @returns {void}
+ */
+function clearInFlightOutboundMessageTx(contactAddress, txid) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for outbound in-flight tracking: ${contactAddress}`);
+  const state = getOutboundMessageTxState(contact);
+  if (state.inflightTxid !== txid) {
+    return;
+  }
+
+  state.inflightTimestamp = 0;
+  state.inflightTxid = '';
+}
+
+/**
+ * Tracks a message tx while it is being injected, then clears the in-flight state.
+ * @param {string} contactAddress
+ * @param {string} txid
+ * @param {number} timestamp
+ * @param {Object} chatMessageObj
+ * @returns {Promise<Object>}
+ */
+async function injectTrackedOutboundMessageTx(contactAddress, txid, timestamp, chatMessageObj) {
+  trackInFlightOutboundMessageTx(contactAddress, txid, timestamp);
+  try {
+    return await injectTx(chatMessageObj, txid);
+  } finally {
+    clearInFlightOutboundMessageTx(contactAddress, txid);
+  }
+}
+
+/**
  * Tracks the latest outbound top-level chat message tx timestamp for a contact.
  * @param {string} contactAddress
  * @param {number} timestamp
@@ -15146,7 +15202,7 @@ class ChatModal {
 
       //console.log('payload is', payload)
       // Send the message transaction using createChatMessage with default toll of 1
-      const response = await injectTx(chatMessageObj, txid);
+      const response = await injectTrackedOutboundMessageTx(currentAddress, txid, payload.sent_timestamp, chatMessageObj);
 
       if (!response || !response.result || !response.result.success) {
         console.error('message failed to send', response);
@@ -18418,7 +18474,7 @@ class ChatModal {
       }
     }
 
-    const response = await injectTx(chatMessageObj, txid);
+    const response = await injectTrackedOutboundMessageTx(currentAddress, txid, payload.sent_timestamp, chatMessageObj);
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
       if (reactionPendingState) {
@@ -18905,7 +18961,7 @@ class ChatModal {
       const deleteTxid = getTxid(deleteMessageObj);
 
       // Send the delete transaction
-      const response = await injectTx(deleteMessageObj, deleteTxid);
+      const response = await injectTrackedOutboundMessageTx(this.address, deleteTxid, payload.sent_timestamp, deleteMessageObj);
 
       if (!response || !response.result || !response.result.success) {
         console.error('Delete message failed to send', response);
@@ -19332,7 +19388,7 @@ class ChatModal {
       this.appendChatModal();
 
       // Send the message transaction
-      const response = await injectTx(chatMessageObj, txid);
+      const response = await injectTrackedOutboundMessageTx(currentAddress, txid, payload.sent_timestamp, chatMessageObj);
 
       if (!response || !response.result || !response.result.success) {
         console.error('call message failed to send', response);
@@ -19507,7 +19563,7 @@ class ChatModal {
 
     // Send to network (injectTx may either throw OR return { result: { success:false } })
     try {
-      const response = await injectTx(chatMessageObj, txid);
+      const response = await injectTrackedOutboundMessageTx(this.address, txid, payload.sent_timestamp, chatMessageObj);
 
       if (!response || !response.result || !response.result.success) {
         console.error('voice message failed to send', response);
@@ -20216,7 +20272,7 @@ class CallInviteModal {
         }
 
         // Send the message transaction
-        const response = await injectTx(messageObj, txid);
+        const response = await injectTrackedOutboundMessageTx(addr, txid, messagePayload.sent_timestamp, messageObj);
 
         if (!response || !response.result || !response.result.success) {
           // Refund local reservation when tx broadcast/injection fails.
@@ -20672,7 +20728,7 @@ class ShareAttachmentModal {
         }
 
         // Send the message transaction
-        const response = await injectTx(chatMessageObj, txid);
+        const response = await injectTrackedOutboundMessageTx(addr, txid, messagePayload.sent_timestamp, chatMessageObj);
 
         if (!response || !response.result || !response.result.success) {
           // Refund local reservation when tx broadcast/injection fails.


### PR DESCRIPTION
## Summary
- add `trackInFlightOutboundMessageTx()` and `clearInFlightOutboundMessageTx()` for outbound chat `message` txs before `injectTx()` completes
- add `injectTrackedOutboundMessageTx()` to centralize the in-flight lifecycle around `injectTx()`
- switch outbound chat message send paths to the tracked helper:
  - normal message / edit
  - reaction send
  - delete-for-all
  - call message
  - voice message
  - call invite batch sends
  - attachment share batch sends
- use the in-flight timestamp conservatively so reclaim does not race ahead during the window after send starts but before `injectTx()` responds

## High-Level
Phase 1 tracks outbound message txs once they are injected or replayed from history. This PR adds the earlier lifecycle stage: the short window where a chat `message` tx is already being sent but has not finished `injectTx()` yet.

This matters because reclaim can be triggered during that gap. If the user backs out immediately after sending and the client only looks at confirmed/pending state, reclaim can run against stale data and then be rejected once the outbound `message` tx lands. The in-flight timestamp exists to cover that pre-response window without blocking close on the network round trip.

```mermaid
sequenceDiagram
    participant Sender
    participant Helper as injectTrackedOutboundMessageTx
    participant ContactState
    participant injectTx

    Sender->>Helper: send outbound chat message tx
    Helper->>ContactState: trackInFlightOutboundMessageTx(timestamp)
    Helper->>injectTx: injectTx(chatMessageObj, txid)
    injectTx-->>Helper: success/failure
    Helper->>ContactState: clearInFlightOutboundMessageTx(txid)
```

## Validation
- `node --check app.js`