### PR TITLE
Make toll reclaim explicit on chat open

### DIFF
--- a/app.js
+++ b/app.js
@@ -14731,7 +14731,7 @@ class ChatModal {
     if (status.kind !== 'eligible') {
       return;
     }
-
+    // wait for the next frame to ensure the modal is fully rendered
     await new Promise((resolve) => {
       requestAnimationFrame(() => {
         requestAnimationFrame(resolve);
@@ -27439,7 +27439,6 @@ async function checkPendingTransactions() {
 
         if (type === 'reclaim_toll') {
           console.log(`DEBUG: reclaim_toll transaction successfully processed!`);
-          showToast('Reclaim toll successful.', 3000, 'success');
         }
       } else if (res?.transaction?.success === false) {
         console.log(`DEBUG: txid ${txid} failed, removing completely`);
@@ -27502,9 +27501,7 @@ async function checkPendingTransactions() {
             // revert the local myData.contacts[toAddress].timestamp to the old value
             myData.contacts[pendingTxInfo.to].timestamp = pendingTxInfo.oldContactTimestamp;
           } else if (type === 'reclaim_toll') {
-            if (failureReason === 'user is trying to reclaim toll but the toll pool is empty') {
-              showToast('No reclaimable toll is currently available for this chat.', 3000, 'info');
-            } else {
+            if (failureReason !== 'user is trying to reclaim toll but the toll pool is empty') {
               showToast(`Reclaim toll failed: ${userFailureReason}`, 0, 'error');
             }
           } else {

--- a/app.js
+++ b/app.js
@@ -14734,7 +14734,7 @@ class ChatModal {
   }
 
   /**
-   * @typedef {{ kind: 'eligible' } | { kind: 'offline' } | { kind: 'pending' } | { kind: 'empty' } | { kind: 'too_soon', retryAfterTimestamp: number }} ReclaimStatus
+   * @typedef {{ kind: 'eligible' } | { kind: 'offline' } | { kind: 'pending' } | { kind: 'empty' } | { kind: 'unavailable' } | { kind: 'too_soon', retryAfterTimestamp: number }} ReclaimStatus
    */
 
   /**
@@ -14771,7 +14771,10 @@ class ChatModal {
     const receiverIndex = sortedAddresses.indexOf(longAddress(contactAddress));
     const chatId = hashBytes(sortedAddresses.join(''));
     const chatIdAccount = await queryNetwork(`/messages/${chatId}/toll`);
-    if (!chatIdAccount?.toll) {
+    if (!chatIdAccount) {
+      return { kind: 'unavailable' };
+    }
+    if (!chatIdAccount.toll) {
       return { kind: 'empty' };
     }
 
@@ -14836,6 +14839,9 @@ class ChatModal {
         case 'empty':
           showToast('No reclaimable toll is available for this chat.', 3000, 'info');
           return;
+        case 'unavailable':
+          showToast('Could not check reclaimable toll right now. Please try again later.', 3000, 'error');
+          return;
         case 'too_soon':
           showToast(
             `Toll cannot be reclaimed yet. Try again after ${this.formatLocalDateTime(status.retryAfterTimestamp)}.`,
@@ -14867,6 +14873,10 @@ class ChatModal {
     const txid = await signObj(tx, myAccount.keys);
     const response = await injectTx(tx, txid);
     if (response?.result?.success) {
+      return;
+    }
+    if (!response) {
+      showToast('Could not submit reclaim toll. Please try again later.', 3000, 'error');
       return;
     }
 

--- a/app.js
+++ b/app.js
@@ -14807,6 +14807,15 @@ class ChatModal {
       return;
     }
 
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(resolve);
+      });
+    });
+    if (!this.isActive() || this.address !== contactAddress) {
+      return;
+    }
+
     const contact = myData.contacts[contactAddress];
     assert(contact, `Missing contact for reclaim prompt: ${contactAddress}`);
     const confirmed = window.confirm(`Reclaim unused toll for ${getContactDisplayName(contact)}?`);

--- a/app.js
+++ b/app.js
@@ -14879,11 +14879,6 @@ class ChatModal {
       showToast('Could not submit reclaim toll. Please try again later.', 3000, 'error');
       return;
     }
-
-    const failureReason = normalizeFailureReason(response?.result?.reason || '');
-    if (failureReason === 'user is trying to reclaim toll but the toll pool is empty') {
-      showToast('No reclaimable toll is currently available for this chat.', 3000, 'info');
-    }
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -14447,9 +14447,9 @@ class ChatModal {
 
     // One-time tolled deposit toast (only if explicitly enabled on the contact)
     this.maybeShowTolledDepositToast(address);
-    void this.maybePromptReclaimToll(address);
 
     this.appendChatModal(false, skipAutoScroll); // Call appendChatModal to render messages, ensure highlight=false
+    void this.maybePromptReclaimToll(address);
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -14667,7 +14667,7 @@ class ChatModal {
   async sendReclaimTollTransaction(contactAddress) {
     await getNetworkParams();
     const currentTime = getCorrectedTimestamp();
-    const networkTollTimeoutInMs = parameters.current.tollTimeout;
+    const networkTollTimeoutInMs = parameters.current.tollTimeout; 
     const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
     if (!this.newestSentMessage || timeSinceNewestSentMessage < networkTollTimeoutInMs) {
       // console.log(

--- a/app.js
+++ b/app.js
@@ -14743,7 +14743,7 @@ class ChatModal {
 
     const contact = myData.contacts[contactAddress];
     assert(contact, `Missing contact for reclaim prompt: ${contactAddress}`);
-    const confirmed = window.confirm(`Reclaim unused toll for ${getContactDisplayName(contact)}?`);
+    const confirmed = window.confirm(`Reclaim toll from ${getContactDisplayName(contact)}?`);
     if (!confirmed) {
       return;
     }

--- a/app.js
+++ b/app.js
@@ -7376,7 +7376,7 @@ async function injectTx(tx, txid) {
       if (tx.type === 'register') {
         pendingTxData.username = tx.alias;
         pendingTxData.address = tx.from; // User's address (longAddress form)
-      } else if (tx.type === 'update_toll_required') {
+      } else if (tx.type === 'update_toll_required' || tx.type === 'reclaim_toll') {
         pendingTxData.to = normalizeAddress(tx.to);
       } else if (tx.type === 'read') {
         pendingTxData.oldContactTimestamp = tx.oldContactTimestamp;
@@ -14447,6 +14447,7 @@ class ChatModal {
 
     // One-time tolled deposit toast (only if explicitly enabled on the contact)
     this.maybeShowTolledDepositToast(address);
+    void this.maybePromptReclaimToll(address);
 
     this.appendChatModal(false, skipAutoScroll); // Call appendChatModal to render messages, ensure highlight=false
   }
@@ -14552,7 +14553,6 @@ class ChatModal {
         this.sendReadTransaction(this.address);
       }
       
-      this.sendReclaimTollTransaction(this.address);
     } else {
       console.warn('Offline: toll not processed');
     }
@@ -14667,7 +14667,7 @@ class ChatModal {
   async sendReclaimTollTransaction(contactAddress) {
     await getNetworkParams();
     const currentTime = getCorrectedTimestamp();
-    const networkTollTimeoutInMs = parameters.current.tollTimeout; 
+    const networkTollTimeoutInMs = parameters.current.tollTimeout;
     const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
     if (!this.newestSentMessage || timeSinceNewestSentMessage < networkTollTimeoutInMs) {
       // console.log(
@@ -14731,6 +14731,149 @@ class ChatModal {
       return true;
     }
     return false;
+  }
+
+  /**
+   * @typedef {{ kind: 'eligible' } | { kind: 'offline' } | { kind: 'pending' } | { kind: 'empty' } | { kind: 'too_soon', retryAfterTimestamp: number }} ReclaimStatus
+   */
+
+  /**
+   * Returns the reclaim status for the contact.
+   * @param {string} contactAddress
+   * @returns {Promise<ReclaimStatus>}
+   */
+  async getReclaimStatus(contactAddress) {
+    assert(contactAddress, 'Missing contact address for reclaim');
+    assert(Array.isArray(myData.pending), 'Pending tx array is required');
+
+    if (!isOnline) {
+      return { kind: 'offline' };
+    }
+
+    if (myData.pending.some((pendingTx) => pendingTx.type === 'reclaim_toll' && pendingTx.to === contactAddress)) {
+      return { kind: 'pending' };
+    }
+
+    await getNetworkParams();
+    assert(parameters.current.tollTimeout, 'Missing toll timeout');
+
+    const currentTime = getCorrectedTimestamp();
+    const networkTollTimeoutInMs = parameters.current.tollTimeout;
+    const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
+    if (!this.newestSentMessage) {
+      return { kind: 'empty' };
+    }
+    if (timeSinceNewestSentMessage < networkTollTimeoutInMs) {
+      return { kind: 'too_soon', retryAfterTimestamp: this.newestSentMessage.timestamp + networkTollTimeoutInMs };
+    }
+
+    const sortedAddresses = [longAddress(myData.account.keys.address), longAddress(contactAddress)].sort();
+    const receiverIndex = sortedAddresses.indexOf(longAddress(contactAddress));
+    const chatId = hashBytes(sortedAddresses.join(''));
+    const chatIdAccount = await queryNetwork(`/messages/${chatId}/toll`);
+    if (!chatIdAccount?.toll) {
+      return { kind: 'empty' };
+    }
+
+    const payOnReply = chatIdAccount.toll.payOnReply[receiverIndex];
+    const payOnRead = chatIdAccount.toll.payOnRead[receiverIndex];
+    if (payOnReply === 0n && payOnRead === 0n) {
+      return { kind: 'empty' };
+    }
+
+    return { kind: 'eligible' };
+  }
+
+  /**
+   * Prompts the user to reclaim toll when opening an eligible chat.
+   * @param {string} contactAddress
+   * @returns {Promise<void>}
+   */
+  async maybePromptReclaimToll(contactAddress) {
+    if (!this.isActive() || this.address !== contactAddress || !isOnline) {
+      return;
+    }
+
+    const status = await this.getReclaimStatus(contactAddress);
+    if (!this.isActive() || this.address !== contactAddress) {
+      return;
+    }
+    if (status.kind !== 'eligible') {
+      return;
+    }
+
+    const contact = myData.contacts[contactAddress];
+    assert(contact, `Missing contact for reclaim prompt: ${contactAddress}`);
+    const confirmed = window.confirm(`Reclaim unused toll for ${getContactDisplayName(contact)}?`);
+    if (!confirmed) {
+      return;
+    }
+
+    await this.submitReclaimToll(contactAddress);
+  }
+
+  /**
+   * Submits reclaim toll after explicit user confirmation.
+   * @param {string} contactAddress
+   * @returns {Promise<void>}
+   */
+  async submitReclaimToll(contactAddress) {
+    assert(contactAddress, 'Missing contact address for reclaim submit');
+
+    if (!this.isActive() || this.address !== contactAddress) {
+      return;
+    }
+
+    const status = await this.getReclaimStatus(contactAddress);
+    if (status.kind !== 'eligible') {
+      switch (status.kind) {
+        case 'offline':
+          showToast('You are offline. Reconnect before reclaiming toll.', 3000, 'error');
+          return;
+        case 'pending':
+          showToast('A reclaim toll transaction is already pending for this chat.', 3000, 'warning');
+          return;
+        case 'empty':
+          showToast('No reclaimable toll is available for this chat.', 3000, 'info');
+          return;
+        case 'too_soon':
+          showToast(
+            `Toll cannot be reclaimed yet. Try again after ${this.formatLocalDateTime(status.retryAfterTimestamp)}.`,
+            3000,
+            'info'
+          );
+          return;
+        default:
+          assert(false, `Unknown reclaim status: ${status.kind}`);
+      }
+    }
+
+    const feeBalanceStatus = await getFeeBalanceStatus();
+    if (!feeBalanceStatus.success) {
+      showFeeBalanceFailureToast(feeBalanceStatus.reason);
+      return;
+    }
+
+    showToast('Submitting reclaim toll...', 3000, 'info');
+
+    const tx = {
+      type: 'reclaim_toll',
+      from: longAddress(myData.account.keys.address),
+      to: longAddress(contactAddress),
+      chatId: hashBytes([longAddress(myData.account.keys.address), longAddress(contactAddress)].sort().join('')),
+      timestamp: getTransactionTimestamp(),
+      networkId: network.netid,
+    };
+    const txid = await signObj(tx, myAccount.keys);
+    const response = await injectTx(tx, txid);
+    if (response?.result?.success) {
+      return;
+    }
+
+    const failureReason = normalizeFailureReason(response?.result?.reason || '');
+    if (failureReason === 'user is trying to reclaim toll but the toll pool is empty') {
+      showToast('No reclaimable toll is currently available for this chat.', 3000, 'info');
+    }
   }
 
   /**
@@ -27357,6 +27500,7 @@ async function checkPendingTransactions() {
 
         if (type === 'reclaim_toll') {
           console.log(`DEBUG: reclaim_toll transaction successfully processed!`);
+          showToast('Reclaim toll successful.', 3000, 'success');
         }
       } else if (res?.transaction?.success === false) {
         console.log(`DEBUG: txid ${txid} failed, removing completely`);
@@ -27419,7 +27563,9 @@ async function checkPendingTransactions() {
             // revert the local myData.contacts[toAddress].timestamp to the old value
             myData.contacts[pendingTxInfo.to].timestamp = pendingTxInfo.oldContactTimestamp;
           } else if (type === 'reclaim_toll') {
-            if (failureReason !== 'user is trying to reclaim toll but the toll pool is empty') {
+            if (failureReason === 'user is trying to reclaim toll but the toll pool is empty') {
+              showToast('No reclaimable toll is currently available for this chat.', 3000, 'info');
+            } else {
               showToast(`Reclaim toll failed: ${userFailureReason}`, 0, 'error');
             }
           } else {

--- a/app.js
+++ b/app.js
@@ -14744,7 +14744,9 @@ class ChatModal {
    */
   async getReclaimStatus(contactAddress) {
     assert(contactAddress, 'Missing contact address for reclaim');
-    assert(Array.isArray(myData.pending), 'Pending tx array is required');
+    if (!myData.pending) {
+      myData.pending = [];
+    }
 
     if (!isOnline) {
       return { kind: 'offline' };

--- a/app.js
+++ b/app.js
@@ -14660,80 +14660,6 @@ class ChatModal {
   }
 
   /**
-   * Send a reclaim toll if the newest sent message is older than 7 days and the contact has a value not 0 in payOnReplay or payOnRead
-   * @param {string} contactAddress - The address of the contact
-   * @returns {Promise<void>}
-   */
-  async sendReclaimTollTransaction(contactAddress) {
-    await getNetworkParams();
-    const currentTime = getCorrectedTimestamp();
-    const networkTollTimeoutInMs = parameters.current.tollTimeout; 
-    const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
-    if (!this.newestSentMessage || timeSinceNewestSentMessage < networkTollTimeoutInMs) {
-      // console.log(
-      //   `[sendReclaimTollTransaction] timeSinceNewestSentMessage ${timeSinceNewestSentMessage}ms is less than networkTollTimeoutInMs ${networkTollTimeoutInMs}ms, skipping reclaim toll transaction`
-      // );
-      return;
-    }
-    const canReclaimToll = await this.canSenderReclaimToll(contactAddress);
-    if (!canReclaimToll) {
-      // console.log(
-      //   `[sendReclaimTollTransaction] does not have a value not 0 in payOnReplay or payOnRead, skipping reclaim toll transaction`
-      // );
-      return;
-    }
-    const feeBalanceStatus = await getFeeBalanceStatus();
-    if (!feeBalanceStatus.success) {
-      this.closeFeeFailureToastShown = showCloseFeeFailureWarningOnce(
-        feeBalanceStatus.reason,
-        'claim_fee',
-        this.closeFeeFailureToastShown
-      );
-      return;
-    }
-
-    const tx = {
-      type: 'reclaim_toll',
-      from: longAddress(myData.account.keys.address),
-      to: longAddress(contactAddress),
-      chatId: hashBytes([longAddress(myData.account.keys.address), longAddress(contactAddress)].sort().join('')),
-      timestamp: getTransactionTimestamp(),
-      networkId: network.netid,
-    };
-    const txid = await signObj(tx, myAccount.keys);
-    const response = await injectTx(tx, txid);
-    if (!response || !response.result || !response.result.success) {
-      console.warn('reclaim toll transaction failed to send', response);
-    }
-  }
-
-  /**
-   * return true if when we query chatID account , then check payOnReplay and payOnRead for index of the receiver has a value not 0
-   * @param {string} contactAddress - The address of the contact
-   * @returns {Promise<boolean>} - True if the contact has a value not 0 in payOnReplay or payOnRead, false otherwise
-   */
-  async canSenderReclaimToll(contactAddress) {
-    // keep track receiver index during the sort
-    const sortedAddresses = [longAddress(myData.account.keys.address), longAddress(contactAddress)].sort();
-    const receiverIndex = sortedAddresses.indexOf(longAddress(contactAddress));
-    const chatId = hashBytes(sortedAddresses.join(''));
-    const chatIdAccount = await queryNetwork(`/messages/${chatId}/toll`);
-    if (!chatIdAccount || !chatIdAccount.toll) {
-      console.warn('chatIdAccount not found', chatIdAccount);
-      return false;
-    }
-    const payOnReply = chatIdAccount.toll.payOnReply[receiverIndex]; // bigint
-    const payOnRead = chatIdAccount.toll.payOnRead[receiverIndex]; // bigint
-    if (payOnReply !== 0n) {
-      return true;
-    }
-    if (payOnRead !== 0n) {
-      return true;
-    }
-    return false;
-  }
-
-  /**
    * @typedef {{ kind: 'eligible' } | { kind: 'offline' } | { kind: 'pending' } | { kind: 'empty' } | { kind: 'unavailable' } | { kind: 'too_soon', retryAfterTimestamp: number }} ReclaimStatus
    */
 
@@ -14743,7 +14669,6 @@ class ChatModal {
    * @returns {Promise<ReclaimStatus>}
    */
   async getReclaimStatus(contactAddress) {
-    assert(contactAddress, 'Missing contact address for reclaim');
     if (!myData.pending) {
       myData.pending = [];
     }
@@ -14832,8 +14757,6 @@ class ChatModal {
    * @returns {Promise<void>}
    */
   async submitReclaimToll(contactAddress) {
-    assert(contactAddress, 'Missing contact address for reclaim submit');
-
     if (!this.isActive() || this.address !== contactAddress) {
       return;
     }

--- a/index.html
+++ b/index.html
@@ -1641,7 +1641,7 @@
             <li>Half the toll is given to the recipient if they reply to your message</li>
             <li>Any toll that was not given to the recipient can be reclaimed</li>
             <li>To reclaim the toll you must not send more messages to the recipient for 7 days</li>
-            <li>After 7 days just open and close the chat session with the recipient to reclaim any remaining toll</li>
+            <li>After 7 days, open the chat session with the recipient to reclaim any remaining toll</li>
           </ul>
         </div>
       </template>


### PR DESCRIPTION
## Summary
- remove automatic `reclaim_toll` submission from `ChatModal.close()`
- check reclaim eligibility when a chat opens, after `appendChatModal()` refreshes the current chat state
- prompt the user with an explicit browser confirmation before any reclaim action
- submit `reclaim_toll` only from that explicit user action and track pending reclaim transactions by contact
- surface reclaim success and failure feedback from both submit-time and pending-transaction processing
- update the toll help copy to match the explicit reclaim flow

## Why
Reclaim was previously coupled to backing out of a chat, which made it implicit and created unnecessary no-op and failure paths during normal navigation. This change makes reclaim user-driven instead.

Closes #1250

## Sequence Diagram
```mermaid
sequenceDiagram
  participant U as User
  participant CL as Chat List
  participant CM as ChatModal.open
  participant AC as appendChatModal
  participant RP as maybePromptReclaimToll
  participant RS as getReclaimStatus
  participant API as Network /inject + /transaction

  U->>CL: Open chat
  CL->>CM: open(address)
  CM->>AC: appendChatModal()
  AC-->>CM: refresh newestSentMessage
  CM->>RP: maybePromptReclaimToll(address)
  RP->>RS: getReclaimStatus(address)
  RS-->>RP: eligible / offline / pending / empty / unavailable / too_soon
  alt eligible
    RP->>U: window.confirm(...)
    alt user confirms
      RP->>CM: submitReclaimToll(address)
      CM->>RS: re-check status
      RS-->>CM: eligible
      CM->>API: injectTx(reclaim_toll)
      API-->>CM: accepted or failed to submit
      API-->>CM: later pending tx result
    else user cancels
      RP-->>U: no action
    end
  else not eligible
    RP-->>U: no prompt
  end
```

## Screenshots
on desktop

<img width="570" height="1157" alt="Image" src="https://github.com/user-attachments/assets/3d06787f-ea91-4b11-9b46-1288b76127e0" />

on mobile

<img width="476" height="1030" alt="Image" src="https://github.com/user-attachments/assets/0097cb12-8dea-42b5-842a-62a1a382d2c7" />

<img width="476" height="1030" alt="Image" src="https://github.com/user-attachments/assets/3dadcffc-28ab-4f3e-be89-3ca9b1b7d516" />