### PR TITLE
Determine reclaim availability from confirmed outbound message activity

### DIFF
--- a/app.js
+++ b/app.js
@@ -6319,6 +6319,9 @@ async function processChats(chats, keys) {
           if (useTxTimestamp || !payload.sent_timestamp) {
             payload.sent_timestamp = tx.timestamp;
           }
+          if (mine && (typeof contact.latestOutboundMessageTimestamp !== 'number' || tx.timestamp > contact.latestOutboundMessageTimestamp)) {
+            contact.latestOutboundMessageTimestamp = tx.timestamp;
+          }
           if (mine){
             // console.warn('my message tx', tx)
           }
@@ -14684,14 +14687,21 @@ class ChatModal {
     await getNetworkParams();
     assert(parameters.current.tollTimeout, 'Missing toll timeout');
 
+    const contact = myData.contacts[contactAddress];
+    assert(contact, `Missing contact for reclaim status: ${contactAddress}`);
+    const latestOutboundMessageTimestamp =
+      typeof contact.latestOutboundMessageTimestamp === 'number'
+        ? contact.latestOutboundMessageTimestamp
+        : contact.messages.find((item) => item.my)?.timestamp;
+
     const currentTime = getCorrectedTimestamp();
     const networkTollTimeoutInMs = parameters.current.tollTimeout;
-    const timeSinceNewestSentMessage = currentTime - this.newestSentMessage?.timestamp;
-    if (!this.newestSentMessage) {
+    if (typeof latestOutboundMessageTimestamp !== 'number') {
       return { kind: 'empty' };
     }
-    if (timeSinceNewestSentMessage < networkTollTimeoutInMs) {
-      return { kind: 'too_soon', retryAfterTimestamp: this.newestSentMessage.timestamp + networkTollTimeoutInMs };
+    const timeSinceLatestOutboundMessage = currentTime - latestOutboundMessageTimestamp;
+    if (timeSinceLatestOutboundMessage < networkTollTimeoutInMs) {
+      return { kind: 'too_soon', retryAfterTimestamp: latestOutboundMessageTimestamp + networkTollTimeoutInMs };
     }
 
     const sortedAddresses = [longAddress(myData.account.keys.address), longAddress(contactAddress)].sort();


### PR DESCRIPTION
## Summary
- cache `latestOutboundMessageTimestamp` from confirmed outbound `message` transactions during chat processing
- use that cached timestamp when deciding reclaim availability on chat open
- fall back to `messages.find((item) => item.my)` when the cache is not present

## Why
Issue #1251 needs reclaim availability to track outbound chat activity more accurately than the current modal-local `newestSentMessage` check.

This change keeps the implementation client-only and simple:
- no backend/API changes
- no extra lookup when opening chat
- no new broad reconciliation pass

## Tradeoff
Accepted for now: the cache is written only when an outbound `message` transaction is later observed in `processChats()`.

That means there is still a restart gap for outbound control-message transactions if the app closes before the next chat sync. In that case the client falls back to the latest sent chat row, which cannot recover control-message activity that is intentionally not rendered as a chat bubble. We are accepting that gap for now and relying on `latestOutboundMessageTimestamp` to exist going forward once outbound activity has been processed.

## Validation
- `node --check app.js`

## Sequence Diagram
```mermaid
sequenceDiagram
    participant U as User
    participant C as ChatModal
    participant N as Network
    participant P as processChats
    participant S as Local State

    U->>C: Open chat
    C->>S: Read contact.latestOutboundMessageTimestamp
    alt cache present
        C->>C: Compare cached timestamp to tollTimeout
    else cache missing
        C->>S: Fallback to messages.find((item) => item.my)
        C->>C: Compare fallback timestamp to tollTimeout
    end
    C->>N: Query toll pool state
    alt toll exists and cooldown expired
        C->>U: Show reclaim prompt
    else toll missing or cooldown active
        C->>U: Hide reclaim prompt
    end

    Note over U,N: Later, after any outbound message/edit/delete/reaction message tx succeeds on network
    N-->>P: Return outbound message tx in chat history
    P->>S: Set latestOutboundMessageTimestamp = tx.timestamp if newer
    S-->>C: Future chat opens use cached outbound timestamp first
```

## Notes
- Covers any outbound transaction with `type === 'message'`, including edits, delete-for-all, reaction set, and reaction remove.
- Leaves unrelated untracked `data_structures_flow/` files out of scope for this PR.