### PR TITLE
Handle pending edit rollback

### DIFF
--- a/app.js
+++ b/app.js
@@ -6195,113 +6195,75 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
 }
 
 /**
- * Restores wallet history memo/edited fields captured before an optimistic edit.
- * @param {string} txid
- * @param {{memo?: string, edited?: number, edited_timestamp?: number}|undefined} originalHistory
- * @returns {boolean}
- */
-function restoreWalletHistoryEditSnapshot(txid, originalHistory) {
-  try {
-    if (!originalHistory) return false;
-    if (!(myData?.wallet?.history) || !Array.isArray(myData.wallet.history)) return false;
-
-    const hIdx = myData.wallet.history.findIndex((h) => h.txid === txid);
-    if (hIdx === -1) return false;
-
-    if (typeof originalHistory.memo !== 'undefined') {
-      myData.wallet.history[hIdx].memo = originalHistory.memo;
-    } else {
-      delete myData.wallet.history[hIdx].memo;
-    }
-    if (typeof originalHistory.edited !== 'undefined') {
-      myData.wallet.history[hIdx].edited = originalHistory.edited;
-    } else {
-      delete myData.wallet.history[hIdx].edited;
-    }
-    if (typeof originalHistory.edited_timestamp !== 'undefined') {
-      myData.wallet.history[hIdx].edited_timestamp = originalHistory.edited_timestamp;
-    } else {
-      delete myData.wallet.history[hIdx].edited_timestamp;
-    }
-
-    return true;
-  } catch (e) {
-    console.error('Failed to restore wallet history edit snapshot', e);
-    return false;
-  }
-}
-
-/**
- * Restores the previous chat-list entry after an optimistic edit fails.
+ * Restores local state captured before an optimistic message edit.
  * @param {string} contactAddress
- * @param {{address: string, timestamp: number, txid?: string}|null|undefined} previousChat
- * @returns {boolean}
+ * @param {{
+ *   targetTxid: string,
+ *   previousMessage: { message: string, edited?: number, edited_timestamp?: number },
+ *   previousHistory: null | { memo?: string, edited?: number, edited_timestamp?: number },
+ *   previousChat: { address: string, timestamp: number, txid?: string }
+ * }} editPending
+ * @returns {void}
  */
-function restoreChatListEntryAfterFailedEdit(contactAddress, previousChat) {
-  if (!contactAddress || !Array.isArray(myData?.chats)) {
-    return false;
+function restorePendingMessageEdit(contactAddress, editPending) {
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for pending edit: ${contactAddress}`);
+  assert(editPending.previousChat, `Missing chat snapshot for pending edit: ${editPending.targetTxid}`);
+
+  const message = contact.messages.find((item) => item.txid === editPending.targetTxid);
+  assert(message, `Missing message for pending edit: ${editPending.targetTxid}`);
+
+  message.message = editPending.previousMessage.message;
+  if (typeof editPending.previousMessage.edited !== 'undefined') {
+    message.edited = editPending.previousMessage.edited;
+  } else {
+    delete message.edited;
+  }
+  if (typeof editPending.previousMessage.edited_timestamp !== 'undefined') {
+    message.edited_timestamp = editPending.previousMessage.edited_timestamp;
+  } else {
+    delete message.edited_timestamp;
   }
 
   const existingChatIndex = myData.chats.findIndex((chat) => chat.address === contactAddress);
   if (existingChatIndex !== -1) {
     myData.chats.splice(existingChatIndex, 1);
   }
+  insertSorted(myData.chats, { ...editPending.previousChat }, 'timestamp');
 
-  if (!previousChat) {
-    return existingChatIndex !== -1;
+  if (editPending.previousHistory === null) {
+    return;
   }
 
-  insertSorted(myData.chats, { ...previousChat }, 'timestamp');
-  return true;
+  const historyIndex = myData.wallet.history.findIndex((item) => item.txid === editPending.targetTxid);
+  assert(historyIndex !== -1, `Missing wallet history for pending edit: ${editPending.targetTxid}`);
+
+  if (typeof editPending.previousHistory.memo !== 'undefined') {
+    myData.wallet.history[historyIndex].memo = editPending.previousHistory.memo;
+  } else {
+    delete myData.wallet.history[historyIndex].memo;
+  }
+  if (typeof editPending.previousHistory.edited !== 'undefined') {
+    myData.wallet.history[historyIndex].edited = editPending.previousHistory.edited;
+  } else {
+    delete myData.wallet.history[historyIndex].edited;
+  }
+  if (typeof editPending.previousHistory.edited_timestamp !== 'undefined') {
+    myData.wallet.history[historyIndex].edited_timestamp = editPending.previousHistory.edited_timestamp;
+  } else {
+    delete myData.wallet.history[historyIndex].edited_timestamp;
+  }
 }
 
 /**
- * Finalizes or reverts a pending optimistic message edit that stored rollback metadata.
+ * Reverts a pending optimistic message edit that stored rollback metadata.
  * @param {Object} pendingTxInfo
- * @param {'success' | 'failure'} result
  * @returns {boolean}
  */
-function reconcilePendingMessageEdit(pendingTxInfo, result) {
-  if (!pendingTxInfo.editPending) {
-    return false;
-  }
-
-  if (result === 'success') {
-    return false;
-  }
-
-  if (result !== 'failure') {
-    throw new Error(`Unknown pending message edit result: ${result}`);
-  }
-
+function reconcilePendingMessageEdit(pendingTxInfo) {
   const { editPending } = pendingTxInfo;
-  const contact = myData?.contacts?.[pendingTxInfo.to];
-  if (!contact) {
-    console.warn('Missing contact for pending message edit revert', pendingTxInfo);
-    return false;
-  }
-
-  let didChange = false;
-  const messageToRestore = contact.messages?.find((msg) => msg.txid === editPending.targetTxid);
-  if (messageToRestore) {
-    messageToRestore.message = editPending.previousMessage.message;
-    if (typeof editPending.previousMessage.edited !== 'undefined') {
-      messageToRestore.edited = editPending.previousMessage.edited;
-    } else {
-      delete messageToRestore.edited;
-    }
-    if (typeof editPending.previousMessage.edited_timestamp !== 'undefined') {
-      messageToRestore.edited_timestamp = editPending.previousMessage.edited_timestamp;
-    } else {
-      delete messageToRestore.edited_timestamp;
-    }
-    didChange = true;
-  } else {
-    console.warn('Missing message for pending message edit revert', pendingTxInfo);
-  }
-
-  didChange = restoreWalletHistoryEditSnapshot(editPending.targetTxid, editPending.previousHistory) || didChange;
-  didChange = restoreChatListEntryAfterFailedEdit(pendingTxInfo.to, editPending.previousChat) || didChange;
+  assert(editPending, `Missing pending message edit metadata for ${pendingTxInfo.txid}`);
+  restorePendingMessageEdit(pendingTxInfo.to, editPending);
 
   if (historyModal.isActive()) {
     historyModal.refresh();
@@ -6313,7 +6275,7 @@ function reconcilePendingMessageEdit(pendingTxInfo, result) {
     chatModal.appendChatModal();
   }
 
-  return didChange;
+  return true;
 }
 
 /**
@@ -15032,12 +14994,12 @@ class ChatModal {
 
     // Declare edit-related state outside try so catch can access
     let isEdit = false;
-    let originalMsg = null;
-    let originalMsgState = null;
-    let originalChatState = null;
+    let editMessage = null;
+    let editPending = null;
     let editInput = null;
     let editTargetTxId = '';
     let currentAddress = '';
+    let existingChatIndex = -1;
 
     try {
       this.messageInput.focus(); // Add focus back to keep keyboard open
@@ -15100,15 +15062,15 @@ class ChatModal {
       if (editTargetTxId) {
         // Validate we still can edit
         const contactMsgs = myData.contacts[currentAddress].messages;
-        originalMsg = contactMsgs.find(m => m.txid === editTargetTxId);
-        if (!originalMsg) {
+        editMessage = contactMsgs.find((item) => item.txid === editTargetTxId);
+        if (!editMessage) {
           // Original disappeared; fallback to normal send
           console.warn('Edit target message not found locally; sending as new message');
-        } else if (!originalMsg.my) {
+        } else if (!editMessage.my) {
           console.warn('Attempt to edit a message not owned by user');
-        } else if (isDeleted(originalMsg)) {
+        } else if (isDeleted(editMessage)) {
           console.warn('Attempt to edit a deleted message');
-        } else if ((Date.now() - Number(originalMsg.timestamp || 0)) > EDIT_WINDOW_MS) {
+        } else if ((Date.now() - Number(editMessage.timestamp || 0)) > EDIT_WINDOW_MS) {
           showToast('Edit window expired', 3000, 'info');
         } else {
           isEdit = true;
@@ -15183,33 +15145,39 @@ class ChatModal {
       let newMessage;
       if (isEdit) {
         // Optimistic update of original message (record original so we can revert on failure)
-        const contactMsgs = chatsData.contacts[currentAddress].messages;
-        originalMsg = contactMsgs.find(m => m.txid === editTargetTxId);
-        if (originalMsg) {
-          originalMsgState = {
-            message: originalMsg.message,
-            edited: originalMsg.edited,
-            edited_timestamp: originalMsg.edited_timestamp
+        assert(editMessage, `Missing edit message for ${editTargetTxId}`);
+        editPending = {
+          targetTxid: editTargetTxId,
+          previousMessage: {
+            message: editMessage.message,
+            edited: editMessage.edited,
+            edited_timestamp: editMessage.edited_timestamp
+          },
+          previousHistory: null,
+          previousChat: null
+        };
+
+        existingChatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
+        assert(existingChatIndex !== -1, `Missing chat list entry for pending edit: ${currentAddress}`);
+        editPending.previousChat = { ...chatsData.chats[existingChatIndex] };
+
+        editMessage.message = message;
+        editMessage.edited = 1;
+        editMessage.edited_timestamp = payload.sent_timestamp;
+
+        const historyIndex = myData.wallet.history.findIndex((item) => item.txid === editTargetTxId);
+        if (historyIndex !== -1) {
+          editPending.previousHistory = {
+            memo: myData.wallet.history[historyIndex].memo,
+            edited: myData.wallet.history[historyIndex].edited,
+            edited_timestamp: myData.wallet.history[historyIndex].edited_timestamp
           };
-          originalMsg.message = message;
-          originalMsg.edited = 1;
-          originalMsg.edited_timestamp = payload.sent_timestamp;
-          // Also update wallet history memo if this was a payment we sent
-          if (myData?.wallet?.history && Array.isArray(myData.wallet.history)) {
-            const hIdx = myData.wallet.history.findIndex((h) => h.txid === editTargetTxId);
-            if (hIdx !== -1) {
-              // Preserve prior state for potential revert
-              if (!originalMsgState.history) originalMsgState.history = {};
-              originalMsgState.history.memo = myData.wallet.history[hIdx].memo;
-              originalMsgState.history.edited = myData.wallet.history[hIdx].edited;
-              originalMsgState.history.edited_timestamp = myData.wallet.history[hIdx].edited_timestamp;
-              myData.wallet.history[hIdx].memo = message;
-              myData.wallet.history[hIdx].edited = 1;
-              myData.wallet.history[hIdx].edited_timestamp = payload.sent_timestamp;
-            }
-          }
-          this.appendChatModal();
+          myData.wallet.history[historyIndex].memo = message;
+          myData.wallet.history[historyIndex].edited = 1;
+          myData.wallet.history[historyIndex].edited_timestamp = payload.sent_timestamp;
         }
+
+        this.appendChatModal();
         // Clear edit marker only after capturing state and hide cancel button
         editInput.value = '';
         this.cancelEditButton.style.display = 'none';
@@ -15250,11 +15218,10 @@ class ChatModal {
       };
 
       // Remove existing chat for this contact if it exists. Not handling in removeFailedTx anymore.
-      const existingChatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
+      if (!isEdit) {
+        existingChatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
+      }
       if (existingChatIndex !== -1) {
-        if (isEdit) {
-          originalChatState = { ...chatsData.chats[existingChatIndex] };
-        }
         chatsData.chats.splice(existingChatIndex, 1);
       }
 
@@ -15315,21 +15282,9 @@ class ChatModal {
           this.appendChatModal();
         } else {
           showToast('Edit failed to send', 0, 'error');
-          // Revert optimistic edit
-          if (originalMsg && originalMsgState) {
-            originalMsg.message = originalMsgState.message;
-            if (originalMsgState.edited) {
-              originalMsg.edited = originalMsgState.edited;
-              originalMsg.edited_timestamp = originalMsgState.edited_timestamp;
-            } else {
-              delete originalMsg.edited;
-              delete originalMsg.edited_timestamp;
-            }
-            // Revert wallet history memo if we changed it optimistically
-            this.revertWalletHistoryEdit(editTargetTxId, originalMsgState.history);
-            restoreChatListEntryAfterFailedEdit(currentAddress, originalChatState);
-            this.appendChatModal();
-          }
+          assert(editPending, `Missing edit snapshot for ${editTargetTxId}`);
+          restorePendingMessageEdit(currentAddress, editPending);
+          this.appendChatModal();
           // Restore edit UI state to allow user to retry or cancel
           editInput.value = editTargetTxId;
           this.cancelEditButton.style.display = '';
@@ -15348,16 +15303,8 @@ class ChatModal {
         if (isEdit) {
           const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
           assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
-          pendingTxInfo.editPending = {
-            targetTxid: editTargetTxId,
-            previousMessage: {
-              message: originalMsgState.message,
-              edited: originalMsgState.edited,
-              edited_timestamp: originalMsgState.edited_timestamp
-            },
-            previousHistory: originalMsgState.history ? { ...originalMsgState.history } : undefined,
-            previousChat: originalChatState ? { ...originalChatState } : null
-          };
+          assert(editPending, `Missing edit snapshot for ${editTargetTxId}`);
+          pendingTxInfo.editPending = editPending;
           saveState();
           showToast('Message edited', 2000, 'success');
           this.addAttachmentButton.disabled = this.blockedByRecipient;
@@ -15367,18 +15314,8 @@ class ChatModal {
       console.error('Message error:', error);
       showToast('Failed to send message. Please try again.', 0, 'error');
       // Revert optimistic edit on exception
-      if (isEdit && originalMsg && originalMsgState) {
-        originalMsg.message = originalMsgState.message;
-        if (originalMsgState.edited) {
-          originalMsg.edited = originalMsgState.edited;
-          originalMsg.edited_timestamp = originalMsgState.edited_timestamp;
-        } else {
-          delete originalMsg.edited;
-          delete originalMsg.edited_timestamp;
-        }
-        // Revert wallet history memo if we changed it optimistically
-        this.revertWalletHistoryEdit(editTargetTxId, originalMsgState.history);
-        restoreChatListEntryAfterFailedEdit(currentAddress, originalChatState);
+      if (isEdit && editPending) {
+        restorePendingMessageEdit(currentAddress, editPending);
         this.appendChatModal();
       }
     } finally {
@@ -15412,15 +15349,6 @@ class ChatModal {
     } catch (e) {
       console.error('Failed to cancel edit', e);
     }
-  }
-
-  /**
-   * Revert wallet history memo/edited fields for a given txid using the provided originalHistory snapshot
-   * @param {string} txid - Transaction id to locate in myData.wallet.history
-   * @param {{memo?: string, edited?: number, edited_timestamp?: number}} originalHistory - Original values to restore
-   */
-  revertWalletHistoryEdit(txid, originalHistory) {
-    restoreWalletHistoryEditSnapshot(txid, originalHistory);
   }
 
   /**
@@ -27536,7 +27464,7 @@ async function checkPendingTransactions() {
           showToast('Reaction timed out and was reverted', 0, 'error');
         }
         if (pendingTxInfo.editPending) {
-          const didRevertEdit = reconcilePendingMessageEdit(pendingTxInfo, 'failure');
+          const didRevertEdit = reconcilePendingMessageEdit(pendingTxInfo);
           showToast(didRevertEdit ? 'Edit timed out and was reverted' : 'Edit timed out', 0, 'error');
         }
         // remove the pending tx from the pending array
@@ -27613,7 +27541,7 @@ async function checkPendingTransactions() {
               ? `Reaction failed and was reverted: ${userFailureReason}`
               : userFailureReason, 0, 'error');
           } else if (pendingTxInfo.editPending) {
-            const didRevert = reconcilePendingMessageEdit(pendingTxInfo, 'failure');
+            const didRevert = reconcilePendingMessageEdit(pendingTxInfo);
             showToast(didRevert
               ? `Edit failed and was reverted: ${userFailureReason}`
               : userFailureReason, 0, 'error');

--- a/app.js
+++ b/app.js
@@ -6182,14 +6182,14 @@ function syncReactionUiState(contactAddress, contact, targetTxid) {
  * @param {string} targetTxid
  * @returns {boolean}
  */
+const inFlightPendingEditTargets = new Set();
+
 function hasPendingEditForTarget(contactAddress, targetTxid) {
   if (!contactAddress || !targetTxid) {
     return false;
   }
 
-  const contact = myData?.contacts?.[contactAddress];
-  const message = contact?.messages?.find((item) => item.txid === targetTxid);
-  if (message?.pendingEditTxid) {
+  if (inFlightPendingEditTargets.has(targetTxid)) {
     return true;
   }
 
@@ -6234,9 +6234,6 @@ function restorePendingMessageEdit(contactAddress, editPending) {
     message.edited_timestamp = editPending.previousMessage.edited_timestamp;
   } else {
     delete message.edited_timestamp;
-  }
-  if (message.pendingEditTxid === editPending.pendingTxid) {
-    delete message.pendingEditTxid;
   }
 
   const existingChatIndex = myData.chats.findIndex((chat) => chat.address === contactAddress);
@@ -15176,7 +15173,7 @@ class ChatModal {
         assert(existingChatIndex !== -1, `Missing chat list entry for pending edit: ${currentAddress}`);
         editPending.previousChat = { ...chatsData.chats[existingChatIndex] };
 
-        editMessage.pendingEditTxid = txid;
+        inFlightPendingEditTargets.add(editTargetTxId);
         editMessage.message = message;
         editMessage.edited = 1;
         editMessage.edited_timestamp = payload.sent_timestamp;
@@ -15297,6 +15294,7 @@ class ChatModal {
           updateTransactionStatus(txid, currentAddress, 'failed', 'message');
           this.appendChatModal();
         } else {
+          inFlightPendingEditTargets.delete(editTargetTxId);
           showToast('Edit failed to send', 0, 'error');
           assert(editPending, `Missing edit snapshot for ${editTargetTxId}`);
           restorePendingMessageEdit(currentAddress, editPending);
@@ -15320,6 +15318,7 @@ class ChatModal {
           const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
           assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
           assert(editPending, `Missing edit snapshot for ${editTargetTxId}`);
+          inFlightPendingEditTargets.delete(editTargetTxId);
           pendingTxInfo.editPending = editPending;
           saveState();
           showToast('Message edited', 2000, 'success');
@@ -15331,6 +15330,7 @@ class ChatModal {
       showToast('Failed to send message. Please try again.', 0, 'error');
       // Revert optimistic edit on exception
       if (isEdit && editPending) {
+        inFlightPendingEditTargets.delete(editTargetTxId);
         restorePendingMessageEdit(currentAddress, editPending);
         this.appendChatModal();
       }
@@ -27492,13 +27492,6 @@ async function checkPendingTransactions() {
         // comment out to test the pending txs removal logic
         myData.pending.splice(i, 1);
         reconcilePendingReactionSet(pendingTxInfo, 'success');
-        if (pendingTxInfo.editPending) {
-          const contact = myData.contacts[pendingTxInfo.to];
-          const message = contact?.messages?.find((item) => item.txid === pendingTxInfo.editPending.targetTxid);
-          if (message?.pendingEditTxid === pendingTxInfo.txid) {
-            delete message.pendingEditTxid;
-          }
-        }
 
         if (type === 'register') {
           pendingPromiseService.resolve(txid, {

--- a/app.js
+++ b/app.js
@@ -17142,9 +17142,7 @@ class ChatModal {
         const hasMemo = !!messageEl.querySelector('.payment-memo');
         const isVoice = !!messageEl.querySelector('.voice-message');
         const allowedType = !isPayment || (isPayment && hasMemo);
-        const targetTxid = messageEl.dataset.txid;
-        const hasPendingEdit = isMine && !!targetTxid && hasPendingEditForTarget(this.address, targetTxid);
-        const show = isMine && !isDeleted && allowedType && !isVoice && !isFailedPayment && ageOk && !hasPendingEdit;
+        const show = isMine && !isDeleted && allowedType && !isVoice && !isFailedPayment && ageOk;
         editOption.style.display = show ? 'flex' : 'none';
       }
     }

--- a/app.js
+++ b/app.js
@@ -6305,7 +6305,6 @@ function trackPendingMessageEditBeforeInject(txid, contactAddress, editPending) 
   if (pendingTxInfo) {
     pendingTxInfo.to = normalizeAddress(contactAddress);
     pendingTxInfo.editPending = editPending;
-    pendingTxInfo.awaitingInject = true;
     return;
   }
 
@@ -6316,7 +6315,6 @@ function trackPendingMessageEditBeforeInject(txid, contactAddress, editPending) 
     checkedts: 0,
     to: normalizeAddress(contactAddress),
     editPending,
-    awaitingInject: true,
   });
 }
 
@@ -15355,11 +15353,6 @@ class ChatModal {
       } else {
         // Success: for normal message nothing extra; for edit we already updated locally
         if (isEdit) {
-          const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-          assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
-          assert(pendingTxInfo.editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
-          delete pendingTxInfo.awaitingInject;
-          saveState();
           showToast('Message edited', 2000, 'success');
           this.addAttachmentButton.disabled = this.blockedByRecipient;
         }
@@ -27504,16 +27497,6 @@ async function checkPendingTransactions() {
   for (let i = myData.pending.length - 1; i >= 0; i--) {
     const pendingTxInfo = myData.pending[i];
     const { txid, type, submittedts } = pendingTxInfo;
-
-    if (pendingTxInfo.awaitingInject) {
-      if (submittedts < thirtySecondsAgo && pendingTxInfo.editPending) {
-        console.error(`DEBUG: txid ${txid} inject timed out before pending tracking was established`);
-        reconcilePendingMessageEdit(pendingTxInfo);
-        showToast('Edit failed to send and was reverted', 0, 'error');
-        myData.pending.splice(i, 1);
-      }
-      continue;
-    }
 
     if (submittedts < eightSecondsAgo) {
 

--- a/app.js
+++ b/app.js
@@ -6242,31 +6242,32 @@ function restorePendingMessageEdit(contactAddress, editPending) {
   }
   syncChatLatestActivityTimestamp(contactAddress, contact);
 
-  if (previousHistory.kind === 'none') {
-    return;
-  }
+  switch (previousHistory.kind) {
+    case 'none':
+      return;
+    case 'payment': {
+      const historyIndex = myData.wallet.history.findIndex((item) => item.txid === targetTxid);
+      assert(historyIndex !== -1, `Missing wallet history for pending edit: ${targetTxid}`);
 
-  if (previousHistory.kind !== 'payment') {
-    assert(false, `Unknown pending edit history kind: ${previousHistory.kind}`);
-  }
-
-  const historyIndex = myData.wallet.history.findIndex((item) => item.txid === targetTxid);
-  assert(historyIndex !== -1, `Missing wallet history for pending edit: ${targetTxid}`);
-
-  if (typeof previousHistory.memo !== 'undefined') {
-    myData.wallet.history[historyIndex].memo = previousHistory.memo;
-  } else {
-    delete myData.wallet.history[historyIndex].memo;
-  }
-  if (typeof previousHistory.edited !== 'undefined') {
-    myData.wallet.history[historyIndex].edited = previousHistory.edited;
-  } else {
-    delete myData.wallet.history[historyIndex].edited;
-  }
-  if (typeof previousHistory.edited_timestamp !== 'undefined') {
-    myData.wallet.history[historyIndex].edited_timestamp = previousHistory.edited_timestamp;
-  } else {
-    delete myData.wallet.history[historyIndex].edited_timestamp;
+      if (typeof previousHistory.memo !== 'undefined') {
+        myData.wallet.history[historyIndex].memo = previousHistory.memo;
+      } else {
+        delete myData.wallet.history[historyIndex].memo;
+      }
+      if (typeof previousHistory.edited !== 'undefined') {
+        myData.wallet.history[historyIndex].edited = previousHistory.edited;
+      } else {
+        delete myData.wallet.history[historyIndex].edited;
+      }
+      if (typeof previousHistory.edited_timestamp !== 'undefined') {
+        myData.wallet.history[historyIndex].edited_timestamp = previousHistory.edited_timestamp;
+      } else {
+        delete myData.wallet.history[historyIndex].edited_timestamp;
+      }
+      return;
+    }
+    default:
+      assert(false, `Unknown pending edit history kind: ${previousHistory.kind}`);
   }
 }
 
@@ -6297,22 +6298,22 @@ function reconcilePendingMessageEdit(pendingTxInfo) {
  * @param {string} txid
  * @param {string} contactAddress
  * @param {Object} editPending
- * @returns {Object}
+ * @returns {void}
  */
 function trackPendingMessageEditBeforeInject(txid, contactAddress, editPending) {
   if (!myData.pending) {
     myData.pending = [];
   }
 
-  const existingPending = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-  if (existingPending) {
-    existingPending.to = normalizeAddress(contactAddress);
-    existingPending.editPending = editPending;
-    existingPending.awaitingInject = true;
-    return existingPending;
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+  if (pendingTxInfo) {
+    pendingTxInfo.to = normalizeAddress(contactAddress);
+    pendingTxInfo.editPending = editPending;
+    pendingTxInfo.awaitingInject = true;
+    return;
   }
 
-  const pendingTxData = {
+  myData.pending.push({
     txid,
     type: 'message',
     submittedts: getCorrectedTimestamp(),
@@ -6320,9 +6321,7 @@ function trackPendingMessageEditBeforeInject(txid, contactAddress, editPending) 
     to: normalizeAddress(contactAddress),
     editPending,
     awaitingInject: true,
-  };
-  myData.pending.push(pendingTxData);
-  return pendingTxData;
+  });
 }
 
 /**
@@ -17145,7 +17144,8 @@ class ChatModal {
         const hasMemo = !!messageEl.querySelector('.payment-memo');
         const isVoice = !!messageEl.querySelector('.voice-message');
         const allowedType = !isPayment || (isPayment && hasMemo);
-        const hasPendingEdit = isMine && hasPendingEditForTarget(this.address, messageEl.dataset.txid || '');
+        const targetTxid = messageEl.dataset.txid;
+        const hasPendingEdit = isMine && !!targetTxid && hasPendingEditForTarget(this.address, targetTxid);
         const show = isMine && !isDeleted && allowedType && !isVoice && !isFailedPayment && ageOk && !hasPendingEdit;
         editOption.style.display = show ? 'flex' : 'none';
       }

--- a/app.js
+++ b/app.js
@@ -6189,18 +6189,11 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
     return false;
   }
 
-  if (pendingEditByTargetTxid.has(targetTxid)) {
-    return true;
-  }
-
-  if (!Array.isArray(myData?.pending)) {
-    return false;
-  }
-
-  return myData.pending.some((pendingTx) =>
-    pendingTx?.type === 'message' &&
-    pendingTx?.to === contactAddress &&
-    pendingTx?.editPending?.targetTxid === targetTxid
+  return pendingEditByTargetTxid.has(targetTxid) || myData.pending.some((pendingTx) =>
+    pendingTx.type === 'message' &&
+    pendingTx.to === contactAddress &&
+    pendingTx.editPending &&
+    pendingTx.editPending.targetTxid === targetTxid
   );
 }
 
@@ -6211,56 +6204,68 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
  *   pendingTxid: string,
  *   targetTxid: string,
  *   previousMessage: { message: string, edited?: number, edited_timestamp?: number },
- *   previousHistory: null | { memo?: string, edited?: number, edited_timestamp?: number },
+ *   previousHistory:
+ *     | { kind: 'none' }
+ *     | { kind: 'payment', memo?: string, edited?: number, edited_timestamp?: number },
  *   previousChat: { address: string, timestamp: number, txid?: string }
  * }} editPending
  * @returns {void}
  */
 function restorePendingMessageEdit(contactAddress, editPending) {
+  const {
+    pendingTxid,
+    targetTxid,
+    previousMessage,
+    previousHistory,
+    previousChat,
+  } = editPending;
   const contact = myData.contacts[contactAddress];
   assert(contact, `Missing contact for pending edit: ${contactAddress}`);
-  assert(editPending.previousChat, `Missing chat snapshot for pending edit: ${editPending.targetTxid}`);
 
-  const message = contact.messages.find((item) => item.txid === editPending.targetTxid);
-  assert(message, `Missing message for pending edit: ${editPending.targetTxid}`);
+  const message = contact.messages.find((item) => item.txid === targetTxid);
+  assert(message, `Missing message for pending edit: ${targetTxid}`);
 
-  message.message = editPending.previousMessage.message;
-  if (typeof editPending.previousMessage.edited !== 'undefined') {
-    message.edited = editPending.previousMessage.edited;
+  message.message = previousMessage.message;
+  if (typeof previousMessage.edited !== 'undefined') {
+    message.edited = previousMessage.edited;
   } else {
     delete message.edited;
   }
-  if (typeof editPending.previousMessage.edited_timestamp !== 'undefined') {
-    message.edited_timestamp = editPending.previousMessage.edited_timestamp;
+  if (typeof previousMessage.edited_timestamp !== 'undefined') {
+    message.edited_timestamp = previousMessage.edited_timestamp;
   } else {
     delete message.edited_timestamp;
   }
 
   const existingChatIndex = myData.chats.findIndex((chat) => chat.address === contactAddress);
-  if (existingChatIndex !== -1 && myData.chats[existingChatIndex].txid === editPending.pendingTxid) {
+  if (existingChatIndex !== -1 && myData.chats[existingChatIndex].txid === pendingTxid) {
     myData.chats.splice(existingChatIndex, 1);
-    insertSorted(myData.chats, { ...editPending.previousChat }, 'timestamp');
+    insertSorted(myData.chats, { ...previousChat }, 'timestamp');
   }
 
-  if (editPending.previousHistory === null) {
+  if (previousHistory.kind === 'none') {
     return;
   }
 
-  const historyIndex = myData.wallet.history.findIndex((item) => item.txid === editPending.targetTxid);
-  assert(historyIndex !== -1, `Missing wallet history for pending edit: ${editPending.targetTxid}`);
+  if (previousHistory.kind !== 'payment') {
+    assert(false, `Unknown pending edit history kind: ${previousHistory.kind}`);
+  }
 
-  if (typeof editPending.previousHistory.memo !== 'undefined') {
-    myData.wallet.history[historyIndex].memo = editPending.previousHistory.memo;
+  const historyIndex = myData.wallet.history.findIndex((item) => item.txid === targetTxid);
+  assert(historyIndex !== -1, `Missing wallet history for pending edit: ${targetTxid}`);
+
+  if (typeof previousHistory.memo !== 'undefined') {
+    myData.wallet.history[historyIndex].memo = previousHistory.memo;
   } else {
     delete myData.wallet.history[historyIndex].memo;
   }
-  if (typeof editPending.previousHistory.edited !== 'undefined') {
-    myData.wallet.history[historyIndex].edited = editPending.previousHistory.edited;
+  if (typeof previousHistory.edited !== 'undefined') {
+    myData.wallet.history[historyIndex].edited = previousHistory.edited;
   } else {
     delete myData.wallet.history[historyIndex].edited;
   }
-  if (typeof editPending.previousHistory.edited_timestamp !== 'undefined') {
-    myData.wallet.history[historyIndex].edited_timestamp = editPending.previousHistory.edited_timestamp;
+  if (typeof previousHistory.edited_timestamp !== 'undefined') {
+    myData.wallet.history[historyIndex].edited_timestamp = previousHistory.edited_timestamp;
   } else {
     delete myData.wallet.history[historyIndex].edited_timestamp;
   }
@@ -6269,7 +6274,7 @@ function restorePendingMessageEdit(contactAddress, editPending) {
 /**
  * Reverts a pending optimistic message edit that stored rollback metadata.
  * @param {Object} pendingTxInfo
- * @returns {boolean}
+ * @returns {void}
  */
 function reconcilePendingMessageEdit(pendingTxInfo) {
   const { editPending } = pendingTxInfo;
@@ -6285,8 +6290,6 @@ function reconcilePendingMessageEdit(pendingTxInfo) {
   if (chatModal.isActive() && chatModal.address === pendingTxInfo.to) {
     chatModal.appendChatModal();
   }
-
-  return true;
 }
 
 /**
@@ -15009,7 +15012,7 @@ class ChatModal {
     let editInput = null;
     let editTargetTxId = '';
     let currentAddress = '';
-    let existingChatIndex = -1;
+    let chatIndex = -1;
 
     try {
       this.messageInput.focus(); // Add focus back to keep keyboard open
@@ -15156,6 +15159,18 @@ class ChatModal {
       if (isEdit) {
         // Optimistic update of original message (record original so we can revert on failure)
         assert(editMessage, `Missing edit message for ${editTargetTxId}`);
+        chatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
+        assert(chatIndex !== -1, `Missing chat list entry for pending edit: ${currentAddress}`);
+
+        const previousHistoryIndex = myData.wallet.history.findIndex((item) => item.txid === editTargetTxId);
+        const previousHistory = previousHistoryIndex === -1
+          ? { kind: 'none' }
+          : {
+              kind: 'payment',
+              memo: myData.wallet.history[previousHistoryIndex].memo,
+              edited: myData.wallet.history[previousHistoryIndex].edited,
+              edited_timestamp: myData.wallet.history[previousHistoryIndex].edited_timestamp
+            };
         const editPending = {
           pendingTxid: txid,
           targetTxid: editTargetTxId,
@@ -15164,29 +15179,19 @@ class ChatModal {
             edited: editMessage.edited,
             edited_timestamp: editMessage.edited_timestamp
           },
-          previousHistory: null,
-          previousChat: null
+          previousHistory,
+          previousChat: { ...chatsData.chats[chatIndex] }
         };
-
-        existingChatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
-        assert(existingChatIndex !== -1, `Missing chat list entry for pending edit: ${currentAddress}`);
-        editPending.previousChat = { ...chatsData.chats[existingChatIndex] };
 
         pendingEditByTargetTxid.set(editTargetTxId, editPending);
         editMessage.message = message;
         editMessage.edited = 1;
         editMessage.edited_timestamp = payload.sent_timestamp;
 
-        const historyIndex = myData.wallet.history.findIndex((item) => item.txid === editTargetTxId);
-        if (historyIndex !== -1) {
-          editPending.previousHistory = {
-            memo: myData.wallet.history[historyIndex].memo,
-            edited: myData.wallet.history[historyIndex].edited,
-            edited_timestamp: myData.wallet.history[historyIndex].edited_timestamp
-          };
-          myData.wallet.history[historyIndex].memo = message;
-          myData.wallet.history[historyIndex].edited = 1;
-          myData.wallet.history[historyIndex].edited_timestamp = payload.sent_timestamp;
+        if (previousHistory.kind === 'payment') {
+          myData.wallet.history[previousHistoryIndex].memo = message;
+          myData.wallet.history[previousHistoryIndex].edited = 1;
+          myData.wallet.history[previousHistoryIndex].edited_timestamp = payload.sent_timestamp;
         }
 
         this.appendChatModal();
@@ -15231,10 +15236,10 @@ class ChatModal {
 
       // Remove existing chat for this contact if it exists. Not handling in removeFailedTx anymore.
       if (!isEdit) {
-        existingChatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
+        chatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
       }
-      if (existingChatIndex !== -1) {
-        chatsData.chats.splice(existingChatIndex, 1);
+      if (chatIndex !== -1) {
+        chatsData.chats.splice(chatIndex, 1);
       }
 
       insertSorted(chatsData.chats, chatUpdate, 'timestamp');
@@ -27484,8 +27489,8 @@ async function checkPendingTransactions() {
           showToast('Reaction timed out and was reverted', 0, 'error');
         }
         if (pendingTxInfo.editPending) {
-          const didRevertEdit = reconcilePendingMessageEdit(pendingTxInfo);
-          showToast(didRevertEdit ? 'Edit timed out and was reverted' : 'Edit timed out', 0, 'error');
+          reconcilePendingMessageEdit(pendingTxInfo);
+          showToast('Edit timed out and was reverted', 0, 'error');
         }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
@@ -27561,10 +27566,8 @@ async function checkPendingTransactions() {
               ? `Reaction failed and was reverted: ${userFailureReason}`
               : userFailureReason, 0, 'error');
           } else if (pendingTxInfo.editPending) {
-            const didRevert = reconcilePendingMessageEdit(pendingTxInfo);
-            showToast(didRevert
-              ? `Edit failed and was reverted: ${userFailureReason}`
-              : userFailureReason, 0, 'error');
+            reconcilePendingMessageEdit(pendingTxInfo);
+            showToast(`Edit failed and was reverted: ${userFailureReason}`, 0, 'error');
           } else if (type === 'withdraw_stake') {
             showToast(`Unstake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'deposit_stake') {

--- a/app.js
+++ b/app.js
@@ -6182,14 +6182,14 @@ function syncReactionUiState(contactAddress, contact, targetTxid) {
  * @param {string} targetTxid
  * @returns {boolean}
  */
-const inFlightPendingEditTargets = new Set();
+const pendingEditByTargetTxid = new Map();
 
 function hasPendingEditForTarget(contactAddress, targetTxid) {
   if (!contactAddress || !targetTxid) {
     return false;
   }
 
-  if (inFlightPendingEditTargets.has(targetTxid)) {
+  if (pendingEditByTargetTxid.has(targetTxid)) {
     return true;
   }
 
@@ -15006,7 +15006,6 @@ class ChatModal {
     // Declare edit-related state outside try so catch can access
     let isEdit = false;
     let editMessage = null;
-    let editPending = null;
     let editInput = null;
     let editTargetTxId = '';
     let currentAddress = '';
@@ -15157,7 +15156,7 @@ class ChatModal {
       if (isEdit) {
         // Optimistic update of original message (record original so we can revert on failure)
         assert(editMessage, `Missing edit message for ${editTargetTxId}`);
-        editPending = {
+        const editPending = {
           pendingTxid: txid,
           targetTxid: editTargetTxId,
           previousMessage: {
@@ -15173,7 +15172,7 @@ class ChatModal {
         assert(existingChatIndex !== -1, `Missing chat list entry for pending edit: ${currentAddress}`);
         editPending.previousChat = { ...chatsData.chats[existingChatIndex] };
 
-        inFlightPendingEditTargets.add(editTargetTxId);
+        pendingEditByTargetTxid.set(editTargetTxId, editPending);
         editMessage.message = message;
         editMessage.edited = 1;
         editMessage.edited_timestamp = payload.sent_timestamp;
@@ -15294,9 +15293,10 @@ class ChatModal {
           updateTransactionStatus(txid, currentAddress, 'failed', 'message');
           this.appendChatModal();
         } else {
-          inFlightPendingEditTargets.delete(editTargetTxId);
+          const editPending = pendingEditByTargetTxid.get(editTargetTxId);
+          pendingEditByTargetTxid.delete(editTargetTxId);
           showToast('Edit failed to send', 0, 'error');
-          assert(editPending, `Missing edit snapshot for ${editTargetTxId}`);
+          assert(editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
           restorePendingMessageEdit(currentAddress, editPending);
           this.appendChatModal();
           // Restore edit UI state to allow user to retry or cancel
@@ -15317,9 +15317,10 @@ class ChatModal {
         if (isEdit) {
           const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
           assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
-          assert(editPending, `Missing edit snapshot for ${editTargetTxId}`);
-          inFlightPendingEditTargets.delete(editTargetTxId);
+          const editPending = pendingEditByTargetTxid.get(editTargetTxId);
+          assert(editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
           pendingTxInfo.editPending = editPending;
+          pendingEditByTargetTxid.delete(editTargetTxId);
           saveState();
           showToast('Message edited', 2000, 'success');
           this.addAttachmentButton.disabled = this.blockedByRecipient;
@@ -15329,10 +15330,13 @@ class ChatModal {
       console.error('Message error:', error);
       showToast('Failed to send message. Please try again.', 0, 'error');
       // Revert optimistic edit on exception
-      if (isEdit && editPending) {
-        inFlightPendingEditTargets.delete(editTargetTxId);
-        restorePendingMessageEdit(currentAddress, editPending);
-        this.appendChatModal();
+      if (isEdit && editTargetTxId) {
+        const editPending = pendingEditByTargetTxid.get(editTargetTxId);
+        pendingEditByTargetTxid.delete(editTargetTxId);
+        if (editPending) {
+          restorePendingMessageEdit(currentAddress, editPending);
+          this.appendChatModal();
+        }
       }
     } finally {
       // Cooldown and re-enable handled by withButtonCooldown wrapper

--- a/app.js
+++ b/app.js
@@ -419,7 +419,6 @@ function newDataRecord(myAccount) {
  * This function centralizes the clearing of user data to ensure consistency
  */
 function clearMyData() {
-  pendingEditByTargetTxid.clear();
   myData = null;
   myAccount = null;
 }
@@ -6183,14 +6182,12 @@ function syncReactionUiState(contactAddress, contact, targetTxid) {
  * @param {string} targetTxid
  * @returns {boolean}
  */
-const pendingEditByTargetTxid = new Map();
-
 function hasPendingEditForTarget(contactAddress, targetTxid) {
   if (!contactAddress || !targetTxid) {
     return false;
   }
 
-  return pendingEditByTargetTxid.has(targetTxid) || myData.pending.some((pendingTx) =>
+  return myData.pending.some((pendingTx) =>
     pendingTx.type === 'message' &&
     pendingTx.to === contactAddress &&
     pendingTx.editPending &&
@@ -15220,7 +15217,6 @@ class ChatModal {
           previousHistory
         };
 
-        pendingEditByTargetTxid.set(editTargetTxId, editPending);
         trackPendingMessageEditBeforeInject(txid, currentAddress, editPending);
         editMessage.message = message;
         editMessage.edited = 1;
@@ -15337,12 +15333,11 @@ class ChatModal {
           updateTransactionStatus(txid, currentAddress, 'failed', 'message');
           this.appendChatModal();
         } else {
-          const editPending = pendingEditByTargetTxid.get(editTargetTxId);
-          pendingEditByTargetTxid.delete(editTargetTxId);
+          const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
           myData.pending = myData.pending.filter((pendingTx) => pendingTx.txid !== txid);
           showToast('Edit failed to send', 0, 'error');
-          assert(editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
-          restorePendingMessageEdit(txid, currentAddress, editPending);
+          assert(pendingTxInfo?.editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
+          restorePendingMessageEdit(txid, currentAddress, pendingTxInfo.editPending);
           this.appendChatModal();
           // Restore edit UI state to allow user to retry or cancel
           editInput.value = editTargetTxId;
@@ -15362,11 +15357,8 @@ class ChatModal {
         if (isEdit) {
           const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
           assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
-          const editPending = pendingEditByTargetTxid.get(editTargetTxId);
-          assert(editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
-          pendingTxInfo.editPending = editPending;
+          assert(pendingTxInfo.editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
           delete pendingTxInfo.awaitingInject;
-          pendingEditByTargetTxid.delete(editTargetTxId);
           saveState();
           showToast('Message edited', 2000, 'success');
           this.addAttachmentButton.disabled = this.blockedByRecipient;
@@ -15377,11 +15369,10 @@ class ChatModal {
       showToast('Failed to send message. Please try again.', 0, 'error');
       // Revert optimistic edit on exception
       if (isEdit && editTargetTxId) {
-        const editPending = pendingEditByTargetTxid.get(editTargetTxId);
-        pendingEditByTargetTxid.delete(editTargetTxId);
+        const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
         myData.pending = myData.pending.filter((pendingTx) => pendingTx.txid !== txid);
-        if (editPending) {
-          restorePendingMessageEdit(txid, currentAddress, editPending);
+        if (pendingTxInfo?.editPending) {
+          restorePendingMessageEdit(txid, currentAddress, pendingTxInfo.editPending);
           this.appendChatModal();
         }
       }

--- a/app.js
+++ b/app.js
@@ -6177,6 +6177,146 @@ function syncReactionUiState(contactAddress, contact, targetTxid) {
 }
 
 /**
+ * Returns whether a specific message already has a pending optimistic edit in flight.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {boolean}
+ */
+function hasPendingEditForTarget(contactAddress, targetTxid) {
+  if (!contactAddress || !targetTxid || !Array.isArray(myData?.pending)) {
+    return false;
+  }
+
+  return myData.pending.some((pendingTx) =>
+    pendingTx?.type === 'message' &&
+    pendingTx?.to === contactAddress &&
+    pendingTx?.editPending?.targetTxid === targetTxid
+  );
+}
+
+/**
+ * Restores wallet history memo/edited fields captured before an optimistic edit.
+ * @param {string} txid
+ * @param {{memo?: string, edited?: number, edited_timestamp?: number}|undefined} originalHistory
+ * @returns {boolean}
+ */
+function restoreWalletHistoryEditSnapshot(txid, originalHistory) {
+  try {
+    if (!originalHistory) return false;
+    if (!(myData?.wallet?.history) || !Array.isArray(myData.wallet.history)) return false;
+
+    const hIdx = myData.wallet.history.findIndex((h) => h.txid === txid);
+    if (hIdx === -1) return false;
+
+    if (typeof originalHistory.memo !== 'undefined') {
+      myData.wallet.history[hIdx].memo = originalHistory.memo;
+    } else {
+      delete myData.wallet.history[hIdx].memo;
+    }
+    if (typeof originalHistory.edited !== 'undefined') {
+      myData.wallet.history[hIdx].edited = originalHistory.edited;
+    } else {
+      delete myData.wallet.history[hIdx].edited;
+    }
+    if (typeof originalHistory.edited_timestamp !== 'undefined') {
+      myData.wallet.history[hIdx].edited_timestamp = originalHistory.edited_timestamp;
+    } else {
+      delete myData.wallet.history[hIdx].edited_timestamp;
+    }
+
+    return true;
+  } catch (e) {
+    console.error('Failed to restore wallet history edit snapshot', e);
+    return false;
+  }
+}
+
+/**
+ * Restores the previous chat-list entry after an optimistic edit fails.
+ * @param {string} contactAddress
+ * @param {{address: string, timestamp: number, txid?: string}|null|undefined} previousChat
+ * @returns {boolean}
+ */
+function restoreChatListEntryAfterFailedEdit(contactAddress, previousChat) {
+  if (!contactAddress || !Array.isArray(myData?.chats)) {
+    return false;
+  }
+
+  const existingChatIndex = myData.chats.findIndex((chat) => chat.address === contactAddress);
+  if (existingChatIndex !== -1) {
+    myData.chats.splice(existingChatIndex, 1);
+  }
+
+  if (!previousChat) {
+    return existingChatIndex !== -1;
+  }
+
+  insertSorted(myData.chats, { ...previousChat }, 'timestamp');
+  return true;
+}
+
+/**
+ * Finalizes or reverts a pending optimistic message edit that stored rollback metadata.
+ * @param {Object} pendingTxInfo
+ * @param {'success' | 'failure'} result
+ * @returns {boolean}
+ */
+function reconcilePendingMessageEdit(pendingTxInfo, result) {
+  if (!pendingTxInfo.editPending) {
+    return false;
+  }
+
+  if (result === 'success') {
+    return false;
+  }
+
+  if (result !== 'failure') {
+    throw new Error(`Unknown pending message edit result: ${result}`);
+  }
+
+  const { editPending } = pendingTxInfo;
+  const contact = myData?.contacts?.[pendingTxInfo.to];
+  if (!contact) {
+    console.warn('Missing contact for pending message edit revert', pendingTxInfo);
+    return false;
+  }
+
+  let didChange = false;
+  const messageToRestore = contact.messages?.find((msg) => msg.txid === editPending.targetTxid);
+  if (messageToRestore) {
+    messageToRestore.message = editPending.previousMessage.message;
+    if (typeof editPending.previousMessage.edited !== 'undefined') {
+      messageToRestore.edited = editPending.previousMessage.edited;
+    } else {
+      delete messageToRestore.edited;
+    }
+    if (typeof editPending.previousMessage.edited_timestamp !== 'undefined') {
+      messageToRestore.edited_timestamp = editPending.previousMessage.edited_timestamp;
+    } else {
+      delete messageToRestore.edited_timestamp;
+    }
+    didChange = true;
+  } else {
+    console.warn('Missing message for pending message edit revert', pendingTxInfo);
+  }
+
+  didChange = restoreWalletHistoryEditSnapshot(editPending.targetTxid, editPending.previousHistory) || didChange;
+  didChange = restoreChatListEntryAfterFailedEdit(pendingTxInfo.to, editPending.previousChat) || didChange;
+
+  if (historyModal.isActive()) {
+    historyModal.refresh();
+  }
+  if (chatsScreen.isActive()) {
+    chatsScreen.updateChatList();
+  }
+  if (chatModal.isActive() && chatModal.address === pendingTxInfo.to) {
+    chatModal.appendChatModal();
+  }
+
+  return didChange;
+}
+
+/**
  * Finalizes or reverts a pending optimistic reaction set that stored fallback metadata.
  * @param {Object} pendingTxInfo
  * @param {'success' | 'failure'} result
@@ -14894,8 +15034,10 @@ class ChatModal {
     let isEdit = false;
     let originalMsg = null;
     let originalMsgState = null;
+    let originalChatState = null;
     let editInput = null;
     let editTargetTxId = '';
+    let currentAddress = '';
 
     try {
       this.messageInput.focus(); // Add focus back to keep keyboard open
@@ -14922,7 +15064,7 @@ class ChatModal {
                 modalTitle.textContent === (contact.name || contact.username || `${contact.address.slice(0,8)}...${contact.address.slice(-6)}`)
             )?.address;
             */
-      const currentAddress = this.address;
+      currentAddress = this.address;
       if (!currentAddress) return;
       const contact = chatsData.contacts[currentAddress];
 
@@ -15110,6 +15252,9 @@ class ChatModal {
       // Remove existing chat for this contact if it exists. Not handling in removeFailedTx anymore.
       const existingChatIndex = chatsData.chats.findIndex((chat) => chat.address === currentAddress);
       if (existingChatIndex !== -1) {
+        if (isEdit) {
+          originalChatState = { ...chatsData.chats[existingChatIndex] };
+        }
         chatsData.chats.splice(existingChatIndex, 1);
       }
 
@@ -15182,6 +15327,7 @@ class ChatModal {
             }
             // Revert wallet history memo if we changed it optimistically
             this.revertWalletHistoryEdit(editTargetTxId, originalMsgState.history);
+            restoreChatListEntryAfterFailedEdit(currentAddress, originalChatState);
             this.appendChatModal();
           }
           // Restore edit UI state to allow user to retry or cancel
@@ -15200,6 +15346,19 @@ class ChatModal {
       } else {
         // Success: for normal message nothing extra; for edit we already updated locally
         if (isEdit) {
+          const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+          assert(pendingTxInfo, `Pending edit metadata missing for ${txid}`);
+          pendingTxInfo.editPending = {
+            targetTxid: editTargetTxId,
+            previousMessage: {
+              message: originalMsgState.message,
+              edited: originalMsgState.edited,
+              edited_timestamp: originalMsgState.edited_timestamp
+            },
+            previousHistory: originalMsgState.history ? { ...originalMsgState.history } : undefined,
+            previousChat: originalChatState ? { ...originalChatState } : null
+          };
+          saveState();
           showToast('Message edited', 2000, 'success');
           this.addAttachmentButton.disabled = this.blockedByRecipient;
         }
@@ -15219,6 +15378,7 @@ class ChatModal {
         }
         // Revert wallet history memo if we changed it optimistically
         this.revertWalletHistoryEdit(editTargetTxId, originalMsgState.history);
+        restoreChatListEntryAfterFailedEdit(currentAddress, originalChatState);
         this.appendChatModal();
       }
     } finally {
@@ -15260,30 +15420,7 @@ class ChatModal {
    * @param {{memo?: string, edited?: number, edited_timestamp?: number}} originalHistory - Original values to restore
    */
   revertWalletHistoryEdit(txid, originalHistory) {
-    try {
-      if (!originalHistory) return; // nothing captured, nothing to revert
-      if (!(myData?.wallet?.history) || !Array.isArray(myData.wallet.history)) return;
-      const hIdx = myData.wallet.history.findIndex((h) => h.txid === txid);
-      if (hIdx === -1) return;
-
-      if (typeof originalHistory.memo !== 'undefined') {
-        myData.wallet.history[hIdx].memo = originalHistory.memo;
-      } else {
-        delete myData.wallet.history[hIdx].memo;
-      }
-      if (typeof originalHistory.edited !== 'undefined') {
-        myData.wallet.history[hIdx].edited = originalHistory.edited;
-      } else {
-        delete myData.wallet.history[hIdx].edited;
-      }
-      if (typeof originalHistory.edited_timestamp !== 'undefined') {
-        myData.wallet.history[hIdx].edited_timestamp = originalHistory.edited_timestamp;
-      } else {
-        delete myData.wallet.history[hIdx].edited_timestamp;
-      }
-    } catch (e) {
-      console.error('Failed to revert wallet history edit', e);
-    }
+    restoreWalletHistoryEditSnapshot(txid, originalHistory);
   }
 
   /**
@@ -17010,7 +17147,8 @@ class ChatModal {
         const hasMemo = !!messageEl.querySelector('.payment-memo');
         const isVoice = !!messageEl.querySelector('.voice-message');
         const allowedType = !isPayment || (isPayment && hasMemo);
-        const show = isMine && !isDeleted && allowedType && !isVoice && !isFailedPayment && ageOk;
+        const hasPendingEdit = isMine && hasPendingEditForTarget(this.address, messageEl.dataset.txid || '');
+        const show = isMine && !isDeleted && allowedType && !isVoice && !isFailedPayment && ageOk && !hasPendingEdit;
         editOption.style.display = show ? 'flex' : 'none';
       }
     }
@@ -18456,6 +18594,9 @@ class ChatModal {
       const txid = messageEl.dataset.txid;
       const timestamp = parseInt(messageEl.dataset.messageTimestamp || '0', 10);
       if (!txid) return;
+      if (hasPendingEditForTarget(this.address, txid)) {
+        return showToast('This message already has a pending edit.', 3000, 'info');
+      }
       // Enforce edit window in case UI got out of sync
       if (timestamp && (Date.now() - timestamp) > EDIT_WINDOW_MS) {
         return showToast('Edit window expired', 3000, 'info');
@@ -27394,6 +27535,10 @@ async function checkPendingTransactions() {
         if (didRevert) {
           showToast('Reaction timed out and was reverted', 0, 'error');
         }
+        if (pendingTxInfo.editPending) {
+          const didRevertEdit = reconcilePendingMessageEdit(pendingTxInfo, 'failure');
+          showToast(didRevertEdit ? 'Edit timed out and was reverted' : 'Edit timed out', 0, 'error');
+        }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
         continue;
@@ -27467,6 +27612,11 @@ async function checkPendingTransactions() {
             showToast(didRevert
               ? `Reaction failed and was reverted: ${userFailureReason}`
               : userFailureReason, 0, 'error');
+          } else if (pendingTxInfo.editPending) {
+            const didRevert = reconcilePendingMessageEdit(pendingTxInfo, 'failure');
+            showToast(didRevert
+              ? `Edit failed and was reverted: ${userFailureReason}`
+              : userFailureReason, 0, 'error');
           } else if (type === 'withdraw_stake') {
             showToast(`Unstake failed: ${userFailureReason}`, 0, 'error');
           } else if (type === 'deposit_stake') {
@@ -27519,7 +27669,7 @@ async function checkPendingTransactions() {
             showToast(userFailureReason, 0, 'error');
           }
 
-          if (!pendingTxInfo.reactionPending) {
+          if (!pendingTxInfo.reactionPending && !pendingTxInfo.editPending) {
             const toAddress = pendingTxInfo.to;
             updateTransactionStatus(txid, toAddress, 'failed', type);
             chatModal.refreshCurrentView(txid);

--- a/app.js
+++ b/app.js
@@ -6200,9 +6200,9 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
 
 /**
  * Restores local state captured before an optimistic message edit.
+ * @param {string} pendingTxid
  * @param {string} contactAddress
  * @param {{
- *   pendingTxid: string,
  *   targetTxid: string,
  *   previousMessage: { message: string, edited?: number, edited_timestamp?: number },
  *   previousHistory:
@@ -6211,9 +6211,8 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
  * }} editPending
  * @returns {void}
  */
-function restorePendingMessageEdit(contactAddress, editPending) {
+function restorePendingMessageEdit(pendingTxid, contactAddress, editPending) {
   const {
-    pendingTxid,
     targetTxid,
     previousMessage,
     previousHistory,
@@ -6279,7 +6278,7 @@ function restorePendingMessageEdit(contactAddress, editPending) {
 function reconcilePendingMessageEdit(pendingTxInfo) {
   const { editPending } = pendingTxInfo;
   assert(editPending, `Missing pending message edit metadata for ${pendingTxInfo.txid}`);
-  restorePendingMessageEdit(pendingTxInfo.to, editPending);
+  restorePendingMessageEdit(pendingTxInfo.txid, pendingTxInfo.to, editPending);
 
   if (historyModal.isActive()) {
     historyModal.refresh();
@@ -15212,7 +15211,6 @@ class ChatModal {
               edited_timestamp: myData.wallet.history[previousHistoryIndex].edited_timestamp
             };
         const editPending = {
-          pendingTxid: txid,
           targetTxid: editTargetTxId,
           previousMessage: {
             message: editMessage.message,
@@ -15344,7 +15342,7 @@ class ChatModal {
           myData.pending = myData.pending.filter((pendingTx) => pendingTx.txid !== txid);
           showToast('Edit failed to send', 0, 'error');
           assert(editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
-          restorePendingMessageEdit(currentAddress, editPending);
+          restorePendingMessageEdit(txid, currentAddress, editPending);
           this.appendChatModal();
           // Restore edit UI state to allow user to retry or cancel
           editInput.value = editTargetTxId;
@@ -15383,7 +15381,7 @@ class ChatModal {
         pendingEditByTargetTxid.delete(editTargetTxId);
         myData.pending = myData.pending.filter((pendingTx) => pendingTx.txid !== txid);
         if (editPending) {
-          restorePendingMessageEdit(currentAddress, editPending);
+          restorePendingMessageEdit(txid, currentAddress, editPending);
           this.appendChatModal();
         }
       }

--- a/app.js
+++ b/app.js
@@ -419,6 +419,7 @@ function newDataRecord(myAccount) {
  * This function centralizes the clearing of user data to ensure consistency
  */
 function clearMyData() {
+  pendingEditByTargetTxid.clear();
   myData = null;
   myAccount = null;
 }
@@ -6207,7 +6208,6 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
  *   previousHistory:
  *     | { kind: 'none' }
  *     | { kind: 'payment', memo?: string, edited?: number, edited_timestamp?: number },
- *   previousChat: { address: string, timestamp: number, txid?: string }
  * }} editPending
  * @returns {void}
  */
@@ -6217,7 +6217,6 @@ function restorePendingMessageEdit(contactAddress, editPending) {
     targetTxid,
     previousMessage,
     previousHistory,
-    previousChat,
   } = editPending;
   const contact = myData.contacts[contactAddress];
   assert(contact, `Missing contact for pending edit: ${contactAddress}`);
@@ -6240,8 +6239,8 @@ function restorePendingMessageEdit(contactAddress, editPending) {
   const existingChatIndex = myData.chats.findIndex((chat) => chat.address === contactAddress);
   if (existingChatIndex !== -1 && myData.chats[existingChatIndex].txid === pendingTxid) {
     myData.chats.splice(existingChatIndex, 1);
-    insertSorted(myData.chats, { ...previousChat }, 'timestamp');
   }
+  syncChatLatestActivityTimestamp(contactAddress, contact);
 
   if (previousHistory.kind === 'none') {
     return;
@@ -6290,6 +6289,40 @@ function reconcilePendingMessageEdit(pendingTxInfo) {
   if (chatModal.isActive() && chatModal.address === pendingTxInfo.to) {
     chatModal.appendChatModal();
   }
+}
+
+/**
+ * Creates or updates the provisional pending entry used to persist optimistic edit rollback data
+ * before `/inject` confirms the transaction was accepted for receipt tracking.
+ * @param {string} txid
+ * @param {string} contactAddress
+ * @param {Object} editPending
+ * @returns {Object}
+ */
+function trackPendingMessageEditBeforeInject(txid, contactAddress, editPending) {
+  if (!myData.pending) {
+    myData.pending = [];
+  }
+
+  const existingPending = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+  if (existingPending) {
+    existingPending.to = normalizeAddress(contactAddress);
+    existingPending.editPending = editPending;
+    existingPending.awaitingInject = true;
+    return existingPending;
+  }
+
+  const pendingTxData = {
+    txid,
+    type: 'message',
+    submittedts: getCorrectedTimestamp(),
+    checkedts: 0,
+    to: normalizeAddress(contactAddress),
+    editPending,
+    awaitingInject: true,
+  };
+  myData.pending.push(pendingTxData);
+  return pendingTxData;
 }
 
 /**
@@ -7504,7 +7537,15 @@ async function injectTx(tx, txid) {
       } else if (tx.type === 'deposit_stake' || tx.type === 'withdraw_stake') {
         pendingTxData.to = tx.nominee; // Store 64-character address as-is for stake transactions
       }
-      myData.pending.push(pendingTxData);
+      const existingPendingIndex = myData.pending.findIndex((pendingTx) => pendingTx.txid === txid);
+      if (existingPendingIndex === -1) {
+        myData.pending.push(pendingTxData);
+      } else {
+        myData.pending[existingPendingIndex] = {
+          ...myData.pending[existingPendingIndex],
+          ...pendingTxData
+        };
+      }
 
       if (tx.type !== 'register') {
         // After submitting a transaction, warn if user is low on LIB.
@@ -15179,11 +15220,11 @@ class ChatModal {
             edited: editMessage.edited,
             edited_timestamp: editMessage.edited_timestamp
           },
-          previousHistory,
-          previousChat: { ...chatsData.chats[chatIndex] }
+          previousHistory
         };
 
         pendingEditByTargetTxid.set(editTargetTxId, editPending);
+        trackPendingMessageEditBeforeInject(txid, currentAddress, editPending);
         editMessage.message = message;
         editMessage.edited = 1;
         editMessage.edited_timestamp = payload.sent_timestamp;
@@ -15195,6 +15236,7 @@ class ChatModal {
         }
 
         this.appendChatModal();
+        saveState();
         // Clear edit marker only after capturing state and hide cancel button
         editInput.value = '';
         this.cancelEditButton.style.display = 'none';
@@ -15300,6 +15342,7 @@ class ChatModal {
         } else {
           const editPending = pendingEditByTargetTxid.get(editTargetTxId);
           pendingEditByTargetTxid.delete(editTargetTxId);
+          myData.pending = myData.pending.filter((pendingTx) => pendingTx.txid !== txid);
           showToast('Edit failed to send', 0, 'error');
           assert(editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
           restorePendingMessageEdit(currentAddress, editPending);
@@ -15325,6 +15368,7 @@ class ChatModal {
           const editPending = pendingEditByTargetTxid.get(editTargetTxId);
           assert(editPending, `Missing pending edit snapshot for ${editTargetTxId}`);
           pendingTxInfo.editPending = editPending;
+          delete pendingTxInfo.awaitingInject;
           pendingEditByTargetTxid.delete(editTargetTxId);
           saveState();
           showToast('Message edited', 2000, 'success');
@@ -15338,6 +15382,7 @@ class ChatModal {
       if (isEdit && editTargetTxId) {
         const editPending = pendingEditByTargetTxid.get(editTargetTxId);
         pendingEditByTargetTxid.delete(editTargetTxId);
+        myData.pending = myData.pending.filter((pendingTx) => pendingTx.txid !== txid);
         if (editPending) {
           restorePendingMessageEdit(currentAddress, editPending);
           this.appendChatModal();
@@ -27472,6 +27517,16 @@ async function checkPendingTransactions() {
   for (let i = myData.pending.length - 1; i >= 0; i--) {
     const pendingTxInfo = myData.pending[i];
     const { txid, type, submittedts } = pendingTxInfo;
+
+    if (pendingTxInfo.awaitingInject) {
+      if (submittedts < thirtySecondsAgo && pendingTxInfo.editPending) {
+        console.error(`DEBUG: txid ${txid} inject timed out before pending tracking was established`);
+        reconcilePendingMessageEdit(pendingTxInfo);
+        showToast('Edit failed to send and was reverted', 0, 'error');
+        myData.pending.splice(i, 1);
+      }
+      continue;
+    }
 
     if (submittedts < eightSecondsAgo) {
 

--- a/app.js
+++ b/app.js
@@ -6183,7 +6183,17 @@ function syncReactionUiState(contactAddress, contact, targetTxid) {
  * @returns {boolean}
  */
 function hasPendingEditForTarget(contactAddress, targetTxid) {
-  if (!contactAddress || !targetTxid || !Array.isArray(myData?.pending)) {
+  if (!contactAddress || !targetTxid) {
+    return false;
+  }
+
+  const contact = myData?.contacts?.[contactAddress];
+  const message = contact?.messages?.find((item) => item.txid === targetTxid);
+  if (message?.pendingEditTxid) {
+    return true;
+  }
+
+  if (!Array.isArray(myData?.pending)) {
     return false;
   }
 
@@ -6198,6 +6208,7 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
  * Restores local state captured before an optimistic message edit.
  * @param {string} contactAddress
  * @param {{
+ *   pendingTxid: string,
  *   targetTxid: string,
  *   previousMessage: { message: string, edited?: number, edited_timestamp?: number },
  *   previousHistory: null | { memo?: string, edited?: number, edited_timestamp?: number },
@@ -6224,12 +6235,15 @@ function restorePendingMessageEdit(contactAddress, editPending) {
   } else {
     delete message.edited_timestamp;
   }
+  if (message.pendingEditTxid === editPending.pendingTxid) {
+    delete message.pendingEditTxid;
+  }
 
   const existingChatIndex = myData.chats.findIndex((chat) => chat.address === contactAddress);
-  if (existingChatIndex !== -1) {
+  if (existingChatIndex !== -1 && myData.chats[existingChatIndex].txid === editPending.pendingTxid) {
     myData.chats.splice(existingChatIndex, 1);
+    insertSorted(myData.chats, { ...editPending.previousChat }, 'timestamp');
   }
-  insertSorted(myData.chats, { ...editPending.previousChat }, 'timestamp');
 
   if (editPending.previousHistory === null) {
     return;
@@ -15147,6 +15161,7 @@ class ChatModal {
         // Optimistic update of original message (record original so we can revert on failure)
         assert(editMessage, `Missing edit message for ${editTargetTxId}`);
         editPending = {
+          pendingTxid: txid,
           targetTxid: editTargetTxId,
           previousMessage: {
             message: editMessage.message,
@@ -15161,6 +15176,7 @@ class ChatModal {
         assert(existingChatIndex !== -1, `Missing chat list entry for pending edit: ${currentAddress}`);
         editPending.previousChat = { ...chatsData.chats[existingChatIndex] };
 
+        editMessage.pendingEditTxid = txid;
         editMessage.message = message;
         editMessage.edited = 1;
         editMessage.edited_timestamp = payload.sent_timestamp;
@@ -27476,6 +27492,13 @@ async function checkPendingTransactions() {
         // comment out to test the pending txs removal logic
         myData.pending.splice(i, 1);
         reconcilePendingReactionSet(pendingTxInfo, 'success');
+        if (pendingTxInfo.editPending) {
+          const contact = myData.contacts[pendingTxInfo.to];
+          const message = contact?.messages?.find((item) => item.txid === pendingTxInfo.editPending.targetTxid);
+          if (message?.pendingEditTxid === pendingTxInfo.txid) {
+            delete message.pendingEditTxid;
+          }
+        }
 
         if (type === 'register') {
           pendingPromiseService.resolve(txid, {


### PR DESCRIPTION
## Summary
- add rollback metadata for optimistic message edits so failed edit submissions can restore prior message state
- block duplicate pending edits on the same message and route failures through shared reconciliation logic
- simplify pending edit tracking by using `myData.pending` as the source of truth and removing the extra `awaitingInject` flow

## Why
Edits were applied optimistically, but if inject failed or the pending transaction later failed/timed out, the client could leave the edited text, wallet memo state, or chat ordering in the wrong local state.

## Impact
- failed edit injects now restore the original message state immediately
- pending edit failures/timeouts now restore message, payment memo, and chat activity consistently
- users cannot start a second pending edit on the same message

## Validation
- `node --check app.js`

Closes #1249
