### PR TITLE
Prevent reaction sends in tolled and blocked chats

### DIFF
--- a/app.js
+++ b/app.js
@@ -18399,6 +18399,22 @@ class ChatModal {
     if (!messageEl || !selectedReaction) return;
     assert(typeof closeUi === 'function', 'Reaction close callback is required');
 
+    const contact = myData.contacts[this.address];
+    const required = contact?.tollRequiredToSend;
+    if (required === 2) {
+      showToast('You are blocked by this user', 0, 'error');
+      return;
+    }
+    if (required !== undefined && required !== 0) {
+      const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
+      showToast(
+        `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`,
+        0,
+        'info'
+      );
+      return;
+    }
+
     const txid = messageEl.dataset.txid;
     assert(txid, 'Reaction target txid is required');
     const currentReaction = this.getCurrentUserReactionForMessage(messageEl);


### PR DESCRIPTION
## Summary
- stop reaction clicks from attempting to send when the chat is tolled
- show the blocked-user toast when reactions are attempted in blocked chats
- fail fast in the picker instead of falling through to generic send errors

## Why
Reactions were bypassing the chat eligibility check used by the main composer flow. In tolled chats that meant a click could continue into the send path and surface the wrong error handling. Blocked chats needed the same early stop behavior.

## Impact
Users now get an immediate explanation for why the reaction cannot be sent, and no reaction send is attempted in tolled or blocked chats.

## Validation
- `node --check app.js`

Closes #1255
Closes #1257
