### PR TITLE
Show active emoji in reaction context menus

### DIFF
--- a/app.js
+++ b/app.js
@@ -17063,6 +17063,10 @@ class ChatModal {
 
     if (this.contextMenuReactions) {
       this.contextMenuReactions.style.display = canShowReactionRow ? 'flex' : 'none';
+      this.syncContextReactionTrayDisplay(
+        this.contextMenuReactions,
+        canShowReactionRow ? messageEl : null
+      );
       this.syncReactionPickerActiveState(this.contextMenuReactions, canShowReactionRow ? messageEl : null);
     }
 
@@ -17387,6 +17391,41 @@ class ChatModal {
     const contact = myData.contacts[this.address];
     const reaction = getEffectiveReactionForSenderTarget(contact, targetTxid, currentUserAddress);
     return reaction ? reaction.emoji : '';
+  }
+
+  /**
+   * Ensures context-menu reaction trays surface the active reaction even when it
+   * was chosen from the expanded picker.
+   * @param {HTMLElement} reactionTray
+   * @param {HTMLElement | null} messageEl
+   * @returns {void}
+   */
+  syncContextReactionTrayDisplay(reactionTray, messageEl) {
+    const reactionButtons = [...reactionTray.querySelectorAll('.message-context-reaction-button')]
+      .filter((button) => button.dataset.reactionPickerTrigger !== 'true');
+    assert(reactionButtons.length > 0, 'Reaction tray requires quick reaction buttons');
+
+    for (const button of reactionButtons) {
+      const { defaultEmoji, defaultAriaLabel } = button.dataset;
+      assert(defaultEmoji, 'Reaction button emoji is required');
+      assert(defaultAriaLabel, 'Reaction button aria-label is required');
+      button.dataset.emoji = defaultEmoji;
+      button.textContent = defaultEmoji;
+      button.setAttribute('aria-label', defaultAriaLabel);
+    }
+
+    const activeEmoji = this.getCurrentUserReactionForMessage(messageEl);
+
+    if (!activeEmoji) return;
+
+    for (const button of reactionButtons) {
+      if (button.dataset.defaultEmoji === activeEmoji) return;
+    }
+
+    const customReactionButton = reactionButtons[reactionButtons.length - 1];
+    customReactionButton.dataset.emoji = activeEmoji;
+    customReactionButton.textContent = activeEmoji;
+    customReactionButton.setAttribute('aria-label', `React with ${activeEmoji}`);
   }
 
   /**
@@ -18162,6 +18201,11 @@ class ChatModal {
       importContactsOpt.style.display = isVcf ? '' : 'none';
     }
 
+    assert(this.imageAttachmentContextMenuReactions, 'Image attachment reaction tray is required');
+    this.syncContextReactionTrayDisplay(
+      this.imageAttachmentContextMenuReactions,
+      messageEl
+    );
     this.syncReactionPickerActiveState(this.imageAttachmentContextMenuReactions, messageEl);
 
     this.positionContextMenu(this.imageAttachmentContextMenu, attachmentRow);

--- a/index.html
+++ b/index.html
@@ -1370,11 +1370,11 @@
       <!-- Message Context Menu -->
       <div class="message-context-menu" id="messageContextMenu" style="display: none;">
         <div class="message-context-reactions" id="messageContextReactions" aria-label="Quick reactions">
-          <button class="message-context-reaction-button" type="button" data-emoji="👍" aria-label="React with thumbs up">👍</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="❤️" aria-label="React with heart">❤️</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="😂" aria-label="React with tears of joy">😂</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="😮" aria-label="React with surprised face">😮</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="👎" aria-label="React with thumbs down">👎</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="👍" data-default-emoji="👍" data-default-aria-label="React with thumbs up" aria-label="React with thumbs up">👍</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="❤️" data-default-emoji="❤️" data-default-aria-label="React with heart" aria-label="React with heart">❤️</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="😂" data-default-emoji="😂" data-default-aria-label="React with tears of joy" aria-label="React with tears of joy">😂</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="😮" data-default-emoji="😮" data-default-aria-label="React with surprised face" aria-label="React with surprised face">😮</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="👎" data-default-emoji="👎" data-default-aria-label="React with thumbs down" aria-label="React with thumbs down">👎</button>
           <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction">+</button>
         </div>
         <!-- Voice message specific action: Save -->
@@ -1424,11 +1424,11 @@
       <!-- Image Attachment Context Menu -->
       <div class="message-context-menu" id="imageAttachmentContextMenu" style="display: none;">
         <div class="message-context-reactions" aria-label="Quick reactions">
-          <button class="message-context-reaction-button" type="button" data-emoji="👍" aria-label="React with thumbs up">👍</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="❤️" aria-label="React with heart">❤️</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="😂" aria-label="React with tears of joy">😂</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="😮" aria-label="React with surprised face">😮</button>
-          <button class="message-context-reaction-button" type="button" data-emoji="👎" aria-label="React with thumbs down">👎</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="👍" data-default-emoji="👍" data-default-aria-label="React with thumbs up" aria-label="React with thumbs up">👍</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="❤️" data-default-emoji="❤️" data-default-aria-label="React with heart" aria-label="React with heart">❤️</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="😂" data-default-emoji="😂" data-default-aria-label="React with tears of joy" aria-label="React with tears of joy">😂</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="😮" data-default-emoji="😮" data-default-aria-label="React with surprised face" aria-label="React with surprised face">😮</button>
+          <button class="message-context-reaction-button" type="button" data-emoji="👎" data-default-emoji="👎" data-default-aria-label="React with thumbs down" aria-label="React with thumbs down">👎</button>
           <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction">+</button>
         </div>
         <div class="context-menu-option" data-action="import-contacts" data-icon="contacts" style="display: none;">


### PR DESCRIPTION
## Summary
- reset each quick reaction tray from explicit default emoji metadata
- when a message or attachment context menu opens, read the current user reaction for that message
- if that emoji came from the expanded picker, swap it into the quick row so the same emoji is visible and removable