### PR TITLE
Refactor optimistic reaction set into pending chain

### DIFF
--- a/app.js
+++ b/app.js
@@ -5844,12 +5844,32 @@ async function ensureContactKeys(address) {
  */
 
 /**
- * @typedef {{ targetTxid: string, previousReactionTxId: string | null }} PendingReactionSet
+ * @typedef {{
+ *   sender: string,
+ *   targetTxid: string,
+ *   emoji: string,
+ *   timestamp: number,
+ *   reactionTxId?: string
+ * }} ReactionSnapshot
+ */
+
+/**
+ * @typedef {{
+ *   targetTxid: string,
+ *   localOrder: number,
+ *   status: 'pending' | 'success' | 'failure',
+ *   baseReaction: ReactionSnapshot | null
+ * } & ({
+ *   kind: 'set',
+ *   visibleResult: ReactionSnapshot
+ * } | {
+ *   kind: 'remove',
+ *   visibleResult: null
+ * })} PendingReactionMutation
  */
 
 /**
  * Returns the newest effective reaction for a specific sender and target message.
- * The raw reaction array may contain older fallback entries behind the newest one.
  * @param {Object} contact
  * @param {string} targetTxid
  * @param {string} sender
@@ -5870,7 +5890,6 @@ function getEffectiveReactionForSenderTarget(contact, targetTxid, sender) {
 
 /**
  * Returns the effective reactions for a specific target message.
- * Older duplicate entries for the same sender are hidden fallback state.
  * @param {Object} contact
  * @param {string} targetTxid
  * @returns {Array<Object>}
@@ -5938,6 +5957,173 @@ function removeReactionByReactionTxId(contact, reactionTxId) {
 }
 
 /**
+ * Returns a normalized copy of a reaction snapshot or null.
+ * @param {ReactionSnapshot | null} reaction
+ * @returns {ReactionSnapshot | null}
+ */
+function copyReactionSnapshot(reaction) {
+  if (!reaction) {
+    return null;
+  }
+
+  return {
+    sender: normalizeAddress(reaction.sender),
+    targetTxid: reaction.targetTxid,
+    emoji: reaction.emoji,
+    timestamp: Number(reaction.timestamp),
+    reactionTxId: reaction.reactionTxId
+  };
+}
+
+/**
+ * Returns whether two reaction snapshots describe the same visible reaction.
+ * @param {ReactionSnapshot | null} left
+ * @param {ReactionSnapshot | null} right
+ * @returns {boolean}
+ */
+function areReactionSnapshotsEqual(left, right) {
+  if (!left && !right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+
+  return normalizeAddress(left.sender) === normalizeAddress(right.sender) &&
+    left.targetTxid === right.targetTxid &&
+    left.emoji === right.emoji &&
+    Number(left.timestamp) === Number(right.timestamp) &&
+    left.reactionTxId === right.reactionTxId;
+}
+
+/**
+ * Replaces the visible reaction for one sender+target pair with the provided snapshot.
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @param {string} sender
+ * @param {ReactionSnapshot | null} reaction
+ * @returns {void}
+ */
+function setMaterializedReactionForSenderTarget(contact, targetTxid, sender, reaction) {
+  contact.reactions ??= [];
+  purgeReactionStackForSenderTarget(contact, targetTxid, sender);
+
+  if (!reaction) {
+    return;
+  }
+
+  insertSorted(contact.reactions, {
+    sender: normalizeAddress(reaction.sender),
+    targetTxid: reaction.targetTxid,
+    emoji: reaction.emoji,
+    timestamp: Number(reaction.timestamp),
+    reactionTxId: reaction.reactionTxId
+  }, 'timestamp');
+}
+
+/**
+ * Returns the pending reaction chain entries for one contact+target pair.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {Array<Object>}
+ */
+function getPendingReactionChainEntries(contactAddress, targetTxid) {
+  assert(contactAddress, 'Reaction contact address is required');
+  assert(targetTxid, 'Reaction target txid is required');
+  myData.pending ??= [];
+  const normalizedContactAddress = normalizeAddress(contactAddress);
+  return myData.pending
+    .filter((pendingTx) =>
+      pendingTx.type === 'message' &&
+      pendingTx.to === normalizedContactAddress &&
+      pendingTx.reactionPending &&
+      pendingTx.reactionPending.targetTxid === targetTxid
+    )
+    .sort((left, right) => left.reactionPending.localOrder - right.reactionPending.localOrder);
+}
+
+/**
+ * Computes the visible reaction for a pending reaction chain by replaying successful/pending
+ * mutations in client order on top of the chain base reaction.
+ * @param {Array<Object>} chainEntries
+ * @returns {ReactionSnapshot | null}
+ */
+function computePendingReactionChainVisibleReaction(chainEntries) {
+  if (chainEntries.length === 0) {
+    return null;
+  }
+
+  let effectiveReaction = copyReactionSnapshot(chainEntries[0].reactionPending.baseReaction);
+  for (const entry of chainEntries) {
+    switch (entry.reactionPending.status) {
+      case 'failure':
+        continue;
+      case 'pending':
+      case 'success':
+        effectiveReaction = copyReactionSnapshot(entry.reactionPending.visibleResult);
+        continue;
+      default:
+        assert(false, `Unknown pending reaction status: ${entry.reactionPending.status}`);
+    }
+  }
+
+  return effectiveReaction;
+}
+
+/**
+ * Materializes the current visible reaction state for one pending reaction chain.
+ * @param {string} contactAddress
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @returns {{ didChange: boolean, hasPending: boolean }}
+ */
+function syncPendingReactionChainState(contactAddress, contact, targetTxid) {
+  const currentUserAddress = normalizeAddress(myAccount.keys.address);
+  const chainEntries = getPendingReactionChainEntries(contactAddress, targetTxid);
+  if (chainEntries.length === 0) {
+    return { didChange: false, hasPending: false };
+  }
+
+  const previousVisibleReaction = copyReactionSnapshot(
+    getEffectiveReactionForSenderTarget(contact, targetTxid, currentUserAddress)
+  );
+  const nextVisibleReaction = computePendingReactionChainVisibleReaction(chainEntries);
+  const didChange = !areReactionSnapshotsEqual(previousVisibleReaction, nextVisibleReaction);
+
+  setMaterializedReactionForSenderTarget(contact, targetTxid, currentUserAddress, nextVisibleReaction);
+  if (didChange) {
+    syncReactionUiState(contactAddress, contact, targetTxid);
+  }
+
+  return {
+    didChange,
+    hasPending: chainEntries.some((entry) => entry.reactionPending.status === 'pending')
+  };
+}
+
+/**
+ * Removes all retained pending reaction chain entries for one contact+target pair.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {void}
+ */
+function removePendingReactionChainEntries(contactAddress, targetTxid) {
+  assert(contactAddress, 'Reaction contact address is required');
+  assert(targetTxid, 'Reaction target txid is required');
+  myData.pending ??= [];
+  const normalizedContactAddress = normalizeAddress(contactAddress);
+  myData.pending = myData.pending.filter((pendingTx) => {
+    return !(
+      pendingTx.type === 'message' &&
+      pendingTx.to === normalizedContactAddress &&
+      pendingTx.reactionPending &&
+      pendingTx.reactionPending.targetTxid === targetTxid &&
+      pendingTx.reactionPending.status !== 'pending'
+    );
+  });
+}
+
+/**
  * Removes all active reactions that target a specific message.
  * @param {Object} contact
  * @param {string} targetTxid
@@ -5951,48 +6137,6 @@ function purgeContactReactionsForTarget(contact, targetTxid) {
   const initialLength = contact.reactions.length;
   contact.reactions = contact.reactions.filter((reaction) => reaction.targetTxid !== targetTxid);
   return contact.reactions.length !== initialLength;
-}
-
-/**
- * Applies an optimistic outgoing reaction set while keeping the prior reaction as fallback.
- * @param {Object} contact
- * @param {Extract<ReactionUpdate, { action: 'set' }>} reaction
- * @returns {{ didApply: false } | { didApply: true, previousReactionTxId: string | null }}
- */
-function applyOptimisticReactionSet(contact, reaction) {
-  const targetMessage = contact.messages.find((message) => message.txid === reaction.reactId);
-  if (!targetMessage || isDeleted(targetMessage)) {
-    console.warn('Reaction target not found locally', reaction);
-    return { didApply: false };
-  }
-
-  if (!Array.isArray(contact.reactions)) {
-    contact.reactions = [];
-  }
-
-  const sender = normalizeAddress(reaction.sender);
-  const previousReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
-  const emoji = reaction.emoji.trim();
-
-  if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
-    return { didApply: false };
-  }
-
-  if (previousReaction && previousReaction.emoji === emoji) {
-    return { didApply: false };
-  }
-
-  const previousReactionTxId = previousReaction ? previousReaction.reactionTxId : null;
-  assert(previousReaction === null || previousReactionTxId, 'Previous reaction txid is required');
-
-  insertSorted(contact.reactions, {
-    sender,
-    targetTxid: reaction.reactId,
-    emoji,
-    timestamp: reaction.timestamp,
-    reactionTxId: reaction.reactionTxId
-  }, 'timestamp');
-  return { didApply: true, previousReactionTxId };
 }
 
 /**
@@ -6331,46 +6475,60 @@ function trackPendingMessageEditBeforeInject(txid, contactAddress, editPending) 
 }
 
 /**
- * Finalizes or reverts a pending optimistic reaction set that stored fallback metadata.
+ * Creates the provisional pending entry used to persist optimistic reaction chain metadata
+ * before `/inject` confirms the transaction was accepted for receipt tracking.
+ * @param {string} txid
+ * @param {string} contactAddress
+ * @param {PendingReactionMutation} reactionPending
+ * @returns {void}
+ */
+function trackPendingReactionBeforeInject(txid, contactAddress, reactionPending) {
+  assert(txid, 'Pending reaction txid is required');
+  assert(contactAddress, 'Pending reaction contact address is required');
+  myData.pending ??= [];
+
+  assert(
+    !myData.pending.some((pendingTx) => pendingTx.txid === txid),
+    `Duplicate pending reaction txid: ${txid}`
+  );
+
+  myData.pending.push({
+    txid,
+    type: 'message',
+    submittedts: getCorrectedTimestamp(),
+    checkedts: 0,
+    to: normalizeAddress(contactAddress),
+    reactionPending,
+  });
+}
+
+/**
+ * Applies a success/failure result to one pending reaction chain entry and recomputes
+ * the materialized visible reaction for that target.
  * @param {Object} pendingTxInfo
  * @param {'success' | 'failure'} result
- * @returns {boolean}
+ * @returns {{ didChange: boolean, hasPending: boolean, targetTxid: string }}
  */
-function reconcilePendingReactionSet(pendingTxInfo, result) {
-  if (!pendingTxInfo.reactionPending) {
-    return false;
+function reconcilePendingReaction(pendingTxInfo, result) {
+  assert(pendingTxInfo.reactionPending, `Missing pending reaction metadata for ${pendingTxInfo.txid}`);
+  switch (result) {
+    case 'success':
+    case 'failure':
+      break;
+    default:
+      assert(false, `Unknown pending reaction result: ${result}`);
   }
 
-  /** @type {PendingReactionSet} */
+  /** @type {PendingReactionMutation} */
   const { reactionPending } = pendingTxInfo;
-
   const contact = myData.contacts[pendingTxInfo.to];
   assert(contact, `Missing contact for pending reaction: ${pendingTxInfo.to}`);
 
-  switch (result) {
-    case 'success': {
-      if (!reactionPending.previousReactionTxId) {
-        return false;
-      }
-
-      const didChange = removeReactionByReactionTxId(contact, reactionPending.previousReactionTxId);
-      if (didChange) {
-        syncReactionUiState(pendingTxInfo.to, contact, reactionPending.targetTxid);
-      }
-      return didChange;
-    }
-
-    case 'failure': {
-      const didChange = removeReactionByReactionTxId(contact, pendingTxInfo.txid);
-      if (didChange) {
-        syncReactionUiState(pendingTxInfo.to, contact, reactionPending.targetTxid);
-      }
-      return didChange;
-    }
-
-    default:
-      throw new Error(`Unknown pending reaction result: ${result}`);
-  }
+  reactionPending.status = result;
+  return {
+    ...syncPendingReactionChainState(pendingTxInfo.to, contact, reactionPending.targetTxid),
+    targetTxid: reactionPending.targetTxid
+  };
 }
 
 /**
@@ -18588,40 +18746,61 @@ class ChatModal {
       reactAction: reaction.reactAction
     });
 
+    const targetMessage = contact.messages.find((message) => message.txid === reaction.reactId);
+    if (!targetMessage || isDeleted(targetMessage)) {
+      console.warn('Reaction send skipped: local target message missing', reaction);
+      return false;
+    }
+
+    const sender = normalizeAddress(keys.address);
+    assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
+    const chainEntries = getPendingReactionChainEntries(currentAddress, reaction.reactId);
+    const activeChainEntries = chainEntries.some((entry) => entry.reactionPending.status === 'pending')
+      ? chainEntries
+      : [];
+    const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
+    const baseReaction = copyReactionSnapshot(
+      activeChainEntries.length > 0
+        ? activeChainEntries[0].reactionPending.baseReaction
+        : currentReaction
+    );
+    const localOrder = activeChainEntries.reduce((maxOrder, entry) => {
+      return Math.max(maxOrder, entry.reactionPending.localOrder);
+    }, 0) + 1;
+
+    /** @type {PendingReactionMutation | null} */
     let reactionPendingState = null;
     if (reaction.reactAction === 'set') {
-      const sender = normalizeAddress(keys.address);
-      assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
-      const localReaction = {
-        sender,
-        reactId: reaction.reactId,
-        action: 'set',
-        emoji: reaction.reactMessage,
-        timestamp: payload.sent_timestamp,
-        reactionTxId: txid
-      };
-      const optimisticApply = applyOptimisticReactionSet(contact, localReaction);
-      if (optimisticApply.didApply) {
-        reactionPendingState = {
+      reactionPendingState = {
+        kind: 'set',
+        targetTxid: reaction.reactId,
+        localOrder,
+        status: 'pending',
+        baseReaction,
+        visibleResult: {
+          sender,
           targetTxid: reaction.reactId,
-          previousReactionTxId: optimisticApply.previousReactionTxId
-        };
-        syncReactionUiState(currentAddress, contact, reaction.reactId);
-      } else {
-        console.warn('Reaction sent but local optimistic apply was skipped', localReaction);
-      }
+          emoji: reaction.reactMessage.trim(),
+          timestamp: payload.sent_timestamp,
+          reactionTxId: txid
+        }
+      };
+      trackPendingReactionBeforeInject(txid, currentAddress, reactionPendingState);
+      syncPendingReactionChainState(currentAddress, contact, reaction.reactId);
     }
 
     const response = await injectTx(chatMessageObj, txid);
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
       if (reactionPendingState) {
-        const didRevert = reconcilePendingReactionSet({
-          txid,
-          to: currentAddress,
-          reactionPending: reactionPendingState
-        }, 'failure');
-        if (didRevert) {
+        const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+        assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
+
+        const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
+        if (!outcome.hasPending) {
+          removePendingReactionChainEntries(currentAddress, outcome.targetTxid);
+        }
+        if (outcome.didChange) {
           showToast('Reaction failed to send and was reverted', 0, 'error');
         }
         saveState();
@@ -18630,9 +18809,10 @@ class ChatModal {
     }
 
     if (reactionPendingState) {
-      const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-      assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
-      pendingTxInfo.reactionPending = reactionPendingState;
+      assert(
+        myData.pending.some((pendingTx) => pendingTx.txid === txid),
+        `Pending reaction metadata missing for ${txid}`
+      );
       saveState();
     }
 
@@ -27561,14 +27741,12 @@ async function checkPendingTransactions() {
     return;
   }
 
-  // initialize the pending array if it is not already initialized
-  if (!myData.pending) {
-    myData.pending = [];
-  }
-
+  myData.pending ??= [];
   if (myData.pending.length === 0) return; // No pending transactions to check
 
   const startingPendingCount = myData.pending.length;
+  let didMutatePendingState = false;
+  const resolvedReactionChains = [];
 
   const now = getCorrectedTimestamp();
   const eightSecondsAgo = now - 8000;
@@ -27578,6 +27756,10 @@ async function checkPendingTransactions() {
   for (let i = myData.pending.length - 1; i >= 0; i--) {
     const pendingTxInfo = myData.pending[i];
     const { txid, type, submittedts } = pendingTxInfo;
+    const reactionPending = pendingTxInfo.reactionPending;
+    if (reactionPending && reactionPending.status !== 'pending') {
+      continue;
+    }
 
     if (submittedts < eightSecondsAgo) {
 
@@ -27590,9 +27772,19 @@ async function checkPendingTransactions() {
       //console.log(`DEBUG: txid ${txid} res: ${JSON.stringify(res)}`);
       if (submittedts < thirtySecondsAgo && (res.transaction === null || Object.keys(res.transaction).length === 0)) {
         console.error(`DEBUG: txid ${txid} timed out, removing completely`);
-        const didRevert = reconcilePendingReactionSet(pendingTxInfo, 'failure');
-        if (didRevert) {
-          showToast('Reaction timed out and was reverted', 0, 'error');
+        if (reactionPending) {
+          const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
+          didMutatePendingState = true;
+          if (!outcome.hasPending) {
+            resolvedReactionChains.push({
+              contactAddress: pendingTxInfo.to,
+              targetTxid: outcome.targetTxid
+            });
+          }
+          if (outcome.didChange) {
+            showToast('Reaction timed out and was reverted', 0, 'error');
+          }
+          continue;
         }
         if (pendingTxInfo.editPending) {
           reconcilePendingMessageEdit(pendingTxInfo);
@@ -27600,13 +27792,25 @@ async function checkPendingTransactions() {
         }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
+        didMutatePendingState = true;
         continue;
       }
 
       if (res?.transaction?.success === true) {
-        // comment out to test the pending txs removal logic
-        myData.pending.splice(i, 1);
-        reconcilePendingReactionSet(pendingTxInfo, 'success');
+        if (reactionPending) {
+          const outcome = reconcilePendingReaction(pendingTxInfo, 'success');
+          didMutatePendingState = true;
+          if (!outcome.hasPending) {
+            resolvedReactionChains.push({
+              contactAddress: pendingTxInfo.to,
+              targetTxid: outcome.targetTxid
+            });
+          }
+        } else {
+          // comment out to test the pending txs removal logic
+          myData.pending.splice(i, 1);
+          didMutatePendingState = true;
+        }
 
         if (type === 'register') {
           pendingPromiseService.resolve(txid, {
@@ -27666,11 +27870,20 @@ async function checkPendingTransactions() {
           pendingPromiseService.reject(txid, new Error(userFailureReason));
         } else {
           // Show toast notification with the failure reason
-          if (pendingTxInfo.reactionPending) {
-            const didRevert = reconcilePendingReactionSet(pendingTxInfo, 'failure');
-            showToast(didRevert
-              ? `Reaction failed and was reverted: ${userFailureReason}`
-              : userFailureReason, 0, 'error');
+          if (reactionPending) {
+            const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
+            didMutatePendingState = true;
+            if (!outcome.hasPending) {
+              resolvedReactionChains.push({
+                contactAddress: pendingTxInfo.to,
+                targetTxid: outcome.targetTxid
+              });
+            }
+            if (outcome.didChange) {
+              showToast(`Reaction failed and was reverted: ${userFailureReason}`, 0, 'error');
+            } else if (!outcome.hasPending) {
+              showToast(userFailureReason, 0, 'error');
+            }
           } else if (pendingTxInfo.editPending) {
             reconcilePendingMessageEdit(pendingTxInfo);
             showToast(`Edit failed and was reverted: ${userFailureReason}`, 0, 'error');
@@ -27726,14 +27939,17 @@ async function checkPendingTransactions() {
             showToast(userFailureReason, 0, 'error');
           }
 
-          if (!pendingTxInfo.reactionPending && !pendingTxInfo.editPending) {
+          if (!reactionPending && !pendingTxInfo.editPending) {
             const toAddress = pendingTxInfo.to;
             updateTransactionStatus(txid, toAddress, 'failed', type);
             chatModal.refreshCurrentView(txid);
           }
         }
-        // Remove from pending array
-        myData.pending.splice(i, 1);
+        if (!reactionPending) {
+          // Remove from pending array
+          myData.pending.splice(i, 1);
+          didMutatePendingState = true;
+        }
 
         // refresh the validator modal if this is a withdraw_stake/deposit_stake and validator modal is open
         if (type === 'withdraw_stake' || type === 'deposit_stake') {
@@ -27751,13 +27967,16 @@ async function checkPendingTransactions() {
       }
     }
   }
+  for (const chain of resolvedReactionChains) {
+    removePendingReactionChainEntries(chain.contactAddress, chain.targetTxid);
+  }
   // if createAccountModal is open, skip balance change
   if (!createAccountModal.isActive()) {
     walletScreen.updateWalletBalances();
   }
 
   // save state if pending transactions were processed
-  if (startingPendingCount !== myData.pending.length) {
+  if (startingPendingCount !== myData.pending.length || didMutatePendingState) {
     saveState();
   }
 }


### PR DESCRIPTION
## Stack

```mermaid
flowchart TD
  A[phase 1: reaction set pending chain] --> B[phase 2: optimistic remove]
  B --> C[phase 3: incoming ordering]
```

## Summary

Refactors optimistic reaction `set` handling to use a replayable pending reaction chain.

- Replaces the previous `previousReactionTxId` rollback model with `reactionPending` entries that store `baseReaction`, `visibleResult`, `localOrder`, and `status`.
- Materializes the current visible reaction by replaying pending/successful mutations and skipping failed mutations.
- Keeps resolved reaction entries while later same-target entries are still pending, then removes resolved entries once the chain is complete.
- Preserves existing set behavior while making rollback work when multiple local set operations overlap.

## Validation

- `node --check app.js`
