### PR TITLE
Add optimistic reaction remove handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -6073,12 +6073,14 @@ function computePendingReactionChainVisibleReaction(chainEntries) {
 /**
  * Materializes the current visible reaction state for one pending reaction chain.
  * @param {string} contactAddress
- * @param {Object} contact
  * @param {string} targetTxid
  * @returns {{ didChange: boolean, hasPending: boolean }}
  */
-function syncPendingReactionChainState(contactAddress, contact, targetTxid) {
+function syncPendingReactionChainState(contactAddress, targetTxid) {
   const currentUserAddress = normalizeAddress(myAccount.keys.address);
+  const contact = myData.contacts[contactAddress];
+  assert(contact, `Missing contact for pending reaction chain: ${contactAddress}`);
+
   const chainEntries = getPendingReactionChainEntries(contactAddress, targetTxid);
   if (chainEntries.length === 0) {
     return { didChange: false, hasPending: false };
@@ -6533,7 +6535,7 @@ function reconcilePendingReaction(pendingTxInfo, result) {
 
   reactionPending.status = result;
   return {
-    ...syncPendingReactionChainState(pendingTxInfo.to, contact, reactionPending.targetTxid),
+    ...syncPendingReactionChainState(pendingTxInfo.to, reactionPending.targetTxid),
     targetTxid: reactionPending.targetTxid
   };
 }
@@ -18816,7 +18818,7 @@ class ChatModal {
     }
 
     trackPendingReactionBeforeInject(txid, currentAddress, reactionPendingState);
-    syncPendingReactionChainState(currentAddress, contact, reaction.reactId);
+    syncPendingReactionChainState(currentAddress, reaction.reactId);
 
     const response = await injectTx(chatMessageObj, txid);
     if (!response?.result?.success) {
@@ -27773,6 +27775,17 @@ async function checkPendingTransactions() {
   const startingPendingCount = myData.pending.length;
   let didMutatePendingState = false;
   const resolvedReactionChains = [];
+  const settlePendingReaction = (pendingTxInfo, result) => {
+    const outcome = reconcilePendingReaction(pendingTxInfo, result);
+    didMutatePendingState = true;
+    if (!outcome.hasPending) {
+      resolvedReactionChains.push({
+        contactAddress: pendingTxInfo.to,
+        targetTxid: outcome.targetTxid
+      });
+    }
+    return outcome;
+  };
 
   const now = getCorrectedTimestamp();
   const eightSecondsAgo = now - 8000;
@@ -27799,14 +27812,7 @@ async function checkPendingTransactions() {
       if (submittedts < thirtySecondsAgo && (res.transaction === null || Object.keys(res.transaction).length === 0)) {
         console.error(`DEBUG: txid ${txid} timed out, removing completely`);
         if (reactionPending) {
-          const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
-          didMutatePendingState = true;
-          if (!outcome.hasPending) {
-            resolvedReactionChains.push({
-              contactAddress: pendingTxInfo.to,
-              targetTxid: outcome.targetTxid
-            });
-          }
+          const outcome = settlePendingReaction(pendingTxInfo, 'failure');
           if (outcome.didChange) {
             showToast('Reaction timed out and was reverted', 0, 'error');
           }
@@ -27824,14 +27830,7 @@ async function checkPendingTransactions() {
 
       if (res?.transaction?.success === true) {
         if (reactionPending) {
-          const outcome = reconcilePendingReaction(pendingTxInfo, 'success');
-          didMutatePendingState = true;
-          if (!outcome.hasPending) {
-            resolvedReactionChains.push({
-              contactAddress: pendingTxInfo.to,
-              targetTxid: outcome.targetTxid
-            });
-          }
+          settlePendingReaction(pendingTxInfo, 'success');
         } else {
           // comment out to test the pending txs removal logic
           myData.pending.splice(i, 1);
@@ -27897,14 +27896,7 @@ async function checkPendingTransactions() {
         } else {
           // Show toast notification with the failure reason
           if (reactionPending) {
-            const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
-            didMutatePendingState = true;
-            if (!outcome.hasPending) {
-              resolvedReactionChains.push({
-                contactAddress: pendingTxInfo.to,
-                targetTxid: outcome.targetTxid
-              });
-            }
+            const outcome = settlePendingReaction(pendingTxInfo, 'failure');
             if (outcome.didChange) {
               showToast(`Reaction failed and was reverted: ${userFailureReason}`, 0, 'error');
             } else if (!outcome.hasPending) {

--- a/app.js
+++ b/app.js
@@ -6043,35 +6043,6 @@ function getPendingReactionChainEntries(contactAddress, targetTxid) {
 }
 
 /**
- * Returns the next client-side local order for a pending reaction chain entry.
- * @param {Array<Object>} chainEntries
- * @returns {number}
- */
-function getPendingReactionNextLocalOrder(chainEntries) {
-  if (chainEntries.length === 0) {
-    return 1;
-  }
-
-  return chainEntries.reduce((maxOrder, entry) => {
-    return Math.max(maxOrder, entry.reactionPending.localOrder);
-  }, 0) + 1;
-}
-
-/**
- * Returns the chain base reaction for a new pending reaction mutation.
- * @param {Array<Object>} chainEntries
- * @param {ReactionSnapshot | null} fallbackBaseReaction
- * @returns {ReactionSnapshot | null}
- */
-function getPendingReactionChainBase(chainEntries, fallbackBaseReaction) {
-  if (chainEntries.length > 0) {
-    return copyReactionSnapshot(chainEntries[0].reactionPending.baseReaction);
-  }
-
-  return copyReactionSnapshot(fallbackBaseReaction);
-}
-
-/**
  * Computes the visible reaction for a pending reaction chain by replaying successful/pending
  * mutations in client order on top of the chain base reaction.
  * @param {Array<Object>} chainEntries
@@ -6523,12 +6494,10 @@ function trackPendingReactionBeforeInject(txid, contactAddress, reactionPending)
   assert(contactAddress, 'Pending reaction contact address is required');
   myData.pending ??= [];
 
-  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-  if (pendingTxInfo) {
-    pendingTxInfo.to = normalizeAddress(contactAddress);
-    pendingTxInfo.reactionPending = reactionPending;
-    return;
-  }
+  assert(
+    !myData.pending.some((pendingTx) => pendingTx.txid === txid),
+    `Duplicate pending reaction txid: ${txid}`
+  );
 
   myData.pending.push({
     txid,
@@ -18803,11 +18772,15 @@ class ChatModal {
     const activeChainEntries = chainEntries.some((entry) => entry.reactionPending.status === 'pending')
       ? chainEntries
       : [];
-    const baseReaction = getPendingReactionChainBase(
-      activeChainEntries,
-      getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender)
+    const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
+    const baseReaction = copyReactionSnapshot(
+      activeChainEntries.length > 0
+        ? activeChainEntries[0].reactionPending.baseReaction
+        : currentReaction
     );
-    const localOrder = getPendingReactionNextLocalOrder(activeChainEntries);
+    const localOrder = activeChainEntries.reduce((maxOrder, entry) => {
+      return Math.max(maxOrder, entry.reactionPending.localOrder);
+    }, 0) + 1;
 
     /** @type {PendingReactionMutation} */
     let reactionPendingState;

--- a/app.js
+++ b/app.js
@@ -5861,10 +5861,10 @@ async function ensureContactKeys(address) {
  *   baseReaction: ReactionSnapshot | null
  * } & ({
  *   kind: 'set',
- *   optimisticResult: ReactionSnapshot
+ *   visibleResult: ReactionSnapshot
  * } | {
  *   kind: 'remove',
- *   optimisticResult: null
+ *   visibleResult: null
  * })} PendingReactionMutation
  */
 
@@ -6089,7 +6089,7 @@ function computePendingReactionChainVisibleReaction(chainEntries) {
         continue;
       case 'pending':
       case 'success':
-        effectiveReaction = copyReactionSnapshot(entry.reactionPending.optimisticResult);
+        effectiveReaction = copyReactionSnapshot(entry.reactionPending.visibleResult);
         continue;
       default:
         assert(false, `Unknown pending reaction status: ${entry.reactionPending.status}`);
@@ -18819,7 +18819,7 @@ class ChatModal {
           localOrder,
           status: 'pending',
           baseReaction,
-          optimisticResult: {
+          visibleResult: {
             sender,
             targetTxid: reaction.reactId,
             emoji: reaction.reactMessage.trim(),
@@ -18835,7 +18835,7 @@ class ChatModal {
           localOrder,
           status: 'pending',
           baseReaction,
-          optimisticResult: null
+          visibleResult: null
         };
         break;
       default:

--- a/app.js
+++ b/app.js
@@ -6004,7 +6004,7 @@ function areReactionSnapshotsEqual(left, right) {
  * @param {ReactionSnapshot | null} reaction
  * @returns {void}
  */
-function replaceVisibleReactionForSenderTarget(contact, targetTxid, sender, reaction) {
+function setVisibleReaction(contact, targetTxid, sender, reaction) {
   contact.reactions ??= [];
   purgeReactionStackForSenderTarget(contact, targetTxid, sender);
 
@@ -6048,7 +6048,7 @@ function getPendingReactionChainEntries(contactAddress, targetTxid) {
  * @param {Array<Object>} chainEntries
  * @returns {ReactionSnapshot | null}
  */
-function computePendingReactionChainVisibleReaction(chainEntries) {
+function replayPendingReactionChain(chainEntries) {
   if (chainEntries.length === 0) {
     return null;
   }
@@ -6089,10 +6089,10 @@ function syncPendingReactionChainState(contactAddress, targetTxid) {
   const previousVisibleReaction = copyReactionSnapshot(
     getEffectiveReactionForSenderTarget(contact, targetTxid, currentUserAddress)
   );
-  const nextVisibleReaction = computePendingReactionChainVisibleReaction(chainEntries);
+  const nextVisibleReaction = replayPendingReactionChain(chainEntries);
   const didChange = !areReactionSnapshotsEqual(previousVisibleReaction, nextVisibleReaction);
 
-  replaceVisibleReactionForSenderTarget(contact, targetTxid, currentUserAddress, nextVisibleReaction);
+  setVisibleReaction(contact, targetTxid, currentUserAddress, nextVisibleReaction);
   if (didChange) {
     syncReactionUiState(contactAddress, contact, targetTxid);
   }
@@ -6109,7 +6109,7 @@ function syncPendingReactionChainState(contactAddress, targetTxid) {
  * @param {string} targetTxid
  * @returns {void}
  */
-function removePendingReactionChainEntries(contactAddress, targetTxid) {
+function cleanupResolvedReactionChain(contactAddress, targetTxid) {
   assert(contactAddress, 'Reaction contact address is required');
   assert(targetTxid, 'Reaction target txid is required');
   myData.pending ??= [];
@@ -6518,7 +6518,7 @@ function trackPendingReactionBeforeInject(txid, contactAddress, reactionPending)
  * @param {'success' | 'failure'} result
  * @returns {{ didChange: boolean, hasPending: boolean, targetTxid: string }}
  */
-function reconcilePendingReaction(pendingTxInfo, result) {
+function settlePendingReaction(pendingTxInfo, result) {
   assert(pendingTxInfo.reactionPending, `Missing pending reaction metadata for ${pendingTxInfo.txid}`);
   switch (result) {
     case 'success':
@@ -18818,9 +18818,9 @@ class ChatModal {
       const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
       assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
 
-      const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
+      const outcome = settlePendingReaction(pendingTxInfo, 'failure');
       if (!outcome.hasPending) {
-        removePendingReactionChainEntries(currentAddress, outcome.targetTxid);
+        cleanupResolvedReactionChain(currentAddress, outcome.targetTxid);
       }
       if (outcome.didChange) {
         showToast('Reaction failed to send and was reverted', 0, 'error');
@@ -27763,8 +27763,8 @@ async function checkPendingTransactions() {
   const startingPendingCount = myData.pending.length;
   let didMutatePendingState = false;
   const resolvedReactionChains = [];
-  const settlePendingReaction = (pendingTxInfo, result) => {
-    const outcome = reconcilePendingReaction(pendingTxInfo, result);
+  const settleAndQueueReactionCleanup = (pendingTxInfo, result) => {
+    const outcome = settlePendingReaction(pendingTxInfo, result);
     didMutatePendingState = true;
     if (!outcome.hasPending) {
       resolvedReactionChains.push({
@@ -27800,7 +27800,7 @@ async function checkPendingTransactions() {
       if (submittedts < thirtySecondsAgo && (res.transaction === null || Object.keys(res.transaction).length === 0)) {
         console.error(`DEBUG: txid ${txid} timed out, removing completely`);
         if (reactionPending) {
-          const outcome = settlePendingReaction(pendingTxInfo, 'failure');
+          const outcome = settleAndQueueReactionCleanup(pendingTxInfo, 'failure');
           if (outcome.didChange) {
             showToast('Reaction timed out and was reverted', 0, 'error');
           }
@@ -27818,7 +27818,7 @@ async function checkPendingTransactions() {
 
       if (res?.transaction?.success === true) {
         if (reactionPending) {
-          settlePendingReaction(pendingTxInfo, 'success');
+          settleAndQueueReactionCleanup(pendingTxInfo, 'success');
         } else {
           // comment out to test the pending txs removal logic
           myData.pending.splice(i, 1);
@@ -27884,7 +27884,7 @@ async function checkPendingTransactions() {
         } else {
           // Show toast notification with the failure reason
           if (reactionPending) {
-            const outcome = settlePendingReaction(pendingTxInfo, 'failure');
+            const outcome = settleAndQueueReactionCleanup(pendingTxInfo, 'failure');
             if (outcome.didChange) {
               showToast(`Reaction failed and was reverted: ${userFailureReason}`, 0, 'error');
             } else if (!outcome.hasPending) {
@@ -27975,7 +27975,7 @@ async function checkPendingTransactions() {
   }
 
   for (const chain of resolvedReactionChains) {
-    removePendingReactionChainEntries(chain.contactAddress, chain.targetTxid);
+    cleanupResolvedReactionChain(chain.contactAddress, chain.targetTxid);
   }
   // if createAccountModal is open, skip balance change
   if (!createAccountModal.isActive()) {

--- a/app.js
+++ b/app.js
@@ -6004,7 +6004,7 @@ function areReactionSnapshotsEqual(left, right) {
  * @param {ReactionSnapshot | null} reaction
  * @returns {void}
  */
-function setMaterializedReactionForSenderTarget(contact, targetTxid, sender, reaction) {
+function replaceVisibleReactionForSenderTarget(contact, targetTxid, sender, reaction) {
   contact.reactions ??= [];
   purgeReactionStackForSenderTarget(contact, targetTxid, sender);
 
@@ -6090,7 +6090,7 @@ function syncPendingReactionChainState(contactAddress, contact, targetTxid) {
   const nextVisibleReaction = computePendingReactionChainVisibleReaction(chainEntries);
   const didChange = !areReactionSnapshotsEqual(previousVisibleReaction, nextVisibleReaction);
 
-  setMaterializedReactionForSenderTarget(contact, targetTxid, currentUserAddress, nextVisibleReaction);
+  replaceVisibleReactionForSenderTarget(contact, targetTxid, currentUserAddress, nextVisibleReaction);
   if (didChange) {
     syncReactionUiState(contactAddress, contact, targetTxid);
   }

--- a/app.js
+++ b/app.js
@@ -6530,9 +6530,6 @@ function reconcilePendingReaction(pendingTxInfo, result) {
 
   /** @type {PendingReactionMutation} */
   const { reactionPending } = pendingTxInfo;
-  const contact = myData.contacts[pendingTxInfo.to];
-  assert(contact, `Missing contact for pending reaction: ${pendingTxInfo.to}`);
-
   reactionPending.status = result;
   return {
     ...syncPendingReactionChainState(pendingTxInfo.to, reactionPending.targetTxid),

--- a/app.js
+++ b/app.js
@@ -18657,11 +18657,6 @@ class ChatModal {
 
     const isRemovingCurrentReaction = !!currentReaction && selectedReaction === currentReaction.emoji;
     if (isRemovingCurrentReaction) {
-      const confirmed = confirm('Remove your reaction?');
-      if (!confirmed) {
-        return;
-      }
-
       assert(currentReaction.reactionTxId, 'Reaction txid is required for remove');
       closeUi();
       await this.sendReactionMessage({
@@ -18839,10 +18834,6 @@ class ChatModal {
       `Pending reaction metadata missing for ${txid}`
     );
     saveState();
-
-    if (reaction.reactAction === 'remove') {
-      showToast('Reaction remove request sent', 5000, 'loading');
-    }
 
     return true;
   }

--- a/app.js
+++ b/app.js
@@ -27766,6 +27766,7 @@ async function checkPendingTransactions() {
     return;
   }
 
+  // initialize the pending array if it is not already initialized
   myData.pending ??= [];
   if (myData.pending.length === 0) return; // No pending transactions to check
 

--- a/app.js
+++ b/app.js
@@ -18800,11 +18800,14 @@ class ChatModal {
     const sender = normalizeAddress(keys.address);
     assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
     const chainEntries = getPendingReactionChainEntries(currentAddress, reaction.reactId);
+    const activeChainEntries = chainEntries.some((entry) => entry.reactionPending.status === 'pending')
+      ? chainEntries
+      : [];
     const baseReaction = getPendingReactionChainBase(
-      chainEntries,
+      activeChainEntries,
       getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender)
     );
-    const localOrder = getPendingReactionNextLocalOrder(chainEntries);
+    const localOrder = getPendingReactionNextLocalOrder(activeChainEntries);
 
     /** @type {PendingReactionMutation} */
     let reactionPendingState;

--- a/app.js
+++ b/app.js
@@ -5844,12 +5844,32 @@ async function ensureContactKeys(address) {
  */
 
 /**
- * @typedef {{ targetTxid: string, previousReactionTxId: string | null }} PendingReactionSet
+ * @typedef {{
+ *   sender: string,
+ *   targetTxid: string,
+ *   emoji: string,
+ *   timestamp: number,
+ *   reactionTxId?: string
+ * }} ReactionSnapshot
+ */
+
+/**
+ * @typedef {{
+ *   targetTxid: string,
+ *   localOrder: number,
+ *   status: 'pending' | 'success' | 'failure',
+ *   baseReaction: ReactionSnapshot | null
+ * } & ({
+ *   kind: 'set',
+ *   optimisticResult: ReactionSnapshot
+ * } | {
+ *   kind: 'remove',
+ *   optimisticResult: null
+ * })} PendingReactionMutation
  */
 
 /**
  * Returns the newest effective reaction for a specific sender and target message.
- * The raw reaction array may contain older fallback entries behind the newest one.
  * @param {Object} contact
  * @param {string} targetTxid
  * @param {string} sender
@@ -5870,7 +5890,6 @@ function getEffectiveReactionForSenderTarget(contact, targetTxid, sender) {
 
 /**
  * Returns the effective reactions for a specific target message.
- * Older duplicate entries for the same sender are hidden fallback state.
  * @param {Object} contact
  * @param {string} targetTxid
  * @returns {Array<Object>}
@@ -5938,6 +5957,202 @@ function removeReactionByReactionTxId(contact, reactionTxId) {
 }
 
 /**
+ * Returns a normalized copy of a reaction snapshot or null.
+ * @param {ReactionSnapshot | null} reaction
+ * @returns {ReactionSnapshot | null}
+ */
+function copyReactionSnapshot(reaction) {
+  if (!reaction) {
+    return null;
+  }
+
+  return {
+    sender: normalizeAddress(reaction.sender),
+    targetTxid: reaction.targetTxid,
+    emoji: reaction.emoji,
+    timestamp: Number(reaction.timestamp),
+    reactionTxId: reaction.reactionTxId
+  };
+}
+
+/**
+ * Returns whether two reaction snapshots describe the same visible reaction.
+ * @param {ReactionSnapshot | null} left
+ * @param {ReactionSnapshot | null} right
+ * @returns {boolean}
+ */
+function areReactionSnapshotsEqual(left, right) {
+  if (!left && !right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+
+  return normalizeAddress(left.sender) === normalizeAddress(right.sender) &&
+    left.targetTxid === right.targetTxid &&
+    left.emoji === right.emoji &&
+    Number(left.timestamp) === Number(right.timestamp) &&
+    left.reactionTxId === right.reactionTxId;
+}
+
+/**
+ * Replaces the visible reaction for one sender+target pair with the provided snapshot.
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @param {string} sender
+ * @param {ReactionSnapshot | null} reaction
+ * @returns {void}
+ */
+function setMaterializedReactionForSenderTarget(contact, targetTxid, sender, reaction) {
+  contact.reactions ??= [];
+  purgeReactionStackForSenderTarget(contact, targetTxid, sender);
+
+  if (!reaction) {
+    return;
+  }
+
+  insertSorted(contact.reactions, {
+    sender: normalizeAddress(reaction.sender),
+    targetTxid: reaction.targetTxid,
+    emoji: reaction.emoji,
+    timestamp: Number(reaction.timestamp),
+    reactionTxId: reaction.reactionTxId
+  }, 'timestamp');
+}
+
+/**
+ * Returns the pending reaction chain entries for one contact+target pair.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {Array<Object>}
+ */
+function getPendingReactionChainEntries(contactAddress, targetTxid) {
+  assert(contactAddress, 'Reaction contact address is required');
+  assert(targetTxid, 'Reaction target txid is required');
+  myData.pending ??= [];
+  const normalizedContactAddress = normalizeAddress(contactAddress);
+  return myData.pending
+    .filter((pendingTx) =>
+      pendingTx.type === 'message' &&
+      pendingTx.to === normalizedContactAddress &&
+      pendingTx.reactionPending &&
+      pendingTx.reactionPending.targetTxid === targetTxid
+    )
+    .sort((left, right) => left.reactionPending.localOrder - right.reactionPending.localOrder);
+}
+
+/**
+ * Returns the next client-side local order for a pending reaction chain entry.
+ * @param {Array<Object>} chainEntries
+ * @returns {number}
+ */
+function getPendingReactionNextLocalOrder(chainEntries) {
+  if (chainEntries.length === 0) {
+    return 1;
+  }
+
+  return chainEntries.reduce((maxOrder, entry) => {
+    return Math.max(maxOrder, entry.reactionPending.localOrder);
+  }, 0) + 1;
+}
+
+/**
+ * Returns the chain base reaction for a new pending reaction mutation.
+ * @param {Array<Object>} chainEntries
+ * @param {ReactionSnapshot | null} fallbackBaseReaction
+ * @returns {ReactionSnapshot | null}
+ */
+function getPendingReactionChainBase(chainEntries, fallbackBaseReaction) {
+  if (chainEntries.length > 0) {
+    return copyReactionSnapshot(chainEntries[0].reactionPending.baseReaction);
+  }
+
+  return copyReactionSnapshot(fallbackBaseReaction);
+}
+
+/**
+ * Computes the visible reaction for a pending reaction chain by replaying successful/pending
+ * mutations in client order on top of the chain base reaction.
+ * @param {Array<Object>} chainEntries
+ * @returns {ReactionSnapshot | null}
+ */
+function computePendingReactionChainVisibleReaction(chainEntries) {
+  if (chainEntries.length === 0) {
+    return null;
+  }
+
+  let effectiveReaction = copyReactionSnapshot(chainEntries[0].reactionPending.baseReaction);
+  for (const entry of chainEntries) {
+    switch (entry.reactionPending.status) {
+      case 'failure':
+        continue;
+      case 'pending':
+      case 'success':
+        effectiveReaction = copyReactionSnapshot(entry.reactionPending.optimisticResult);
+        continue;
+      default:
+        assert(false, `Unknown pending reaction status: ${entry.reactionPending.status}`);
+    }
+  }
+
+  return effectiveReaction;
+}
+
+/**
+ * Materializes the current visible reaction state for one pending reaction chain.
+ * @param {string} contactAddress
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @returns {{ didChange: boolean, hasPending: boolean }}
+ */
+function syncPendingReactionChainState(contactAddress, contact, targetTxid) {
+  const currentUserAddress = normalizeAddress(myAccount.keys.address);
+  const chainEntries = getPendingReactionChainEntries(contactAddress, targetTxid);
+  if (chainEntries.length === 0) {
+    return { didChange: false, hasPending: false };
+  }
+
+  const previousVisibleReaction = copyReactionSnapshot(
+    getEffectiveReactionForSenderTarget(contact, targetTxid, currentUserAddress)
+  );
+  const nextVisibleReaction = computePendingReactionChainVisibleReaction(chainEntries);
+  const didChange = !areReactionSnapshotsEqual(previousVisibleReaction, nextVisibleReaction);
+
+  setMaterializedReactionForSenderTarget(contact, targetTxid, currentUserAddress, nextVisibleReaction);
+  if (didChange) {
+    syncReactionUiState(contactAddress, contact, targetTxid);
+  }
+
+  return {
+    didChange,
+    hasPending: chainEntries.some((entry) => entry.reactionPending.status === 'pending')
+  };
+}
+
+/**
+ * Removes all retained pending reaction chain entries for one contact+target pair.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {void}
+ */
+function removePendingReactionChainEntries(contactAddress, targetTxid) {
+  assert(contactAddress, 'Reaction contact address is required');
+  assert(targetTxid, 'Reaction target txid is required');
+  myData.pending ??= [];
+  const normalizedContactAddress = normalizeAddress(contactAddress);
+  myData.pending = myData.pending.filter((pendingTx) => {
+    return !(
+      pendingTx.type === 'message' &&
+      pendingTx.to === normalizedContactAddress &&
+      pendingTx.reactionPending &&
+      pendingTx.reactionPending.targetTxid === targetTxid &&
+      pendingTx.reactionPending.status !== 'pending'
+    );
+  });
+}
+
+/**
  * Removes all active reactions that target a specific message.
  * @param {Object} contact
  * @param {string} targetTxid
@@ -5951,48 +6166,6 @@ function purgeContactReactionsForTarget(contact, targetTxid) {
   const initialLength = contact.reactions.length;
   contact.reactions = contact.reactions.filter((reaction) => reaction.targetTxid !== targetTxid);
   return contact.reactions.length !== initialLength;
-}
-
-/**
- * Applies an optimistic outgoing reaction set while keeping the prior reaction as fallback.
- * @param {Object} contact
- * @param {Extract<ReactionUpdate, { action: 'set' }>} reaction
- * @returns {{ didApply: false } | { didApply: true, previousReactionTxId: string | null }}
- */
-function applyOptimisticReactionSet(contact, reaction) {
-  const targetMessage = contact.messages.find((message) => message.txid === reaction.reactId);
-  if (!targetMessage || isDeleted(targetMessage)) {
-    console.warn('Reaction target not found locally', reaction);
-    return { didApply: false };
-  }
-
-  if (!Array.isArray(contact.reactions)) {
-    contact.reactions = [];
-  }
-
-  const sender = normalizeAddress(reaction.sender);
-  const previousReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
-  const emoji = reaction.emoji.trim();
-
-  if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
-    return { didApply: false };
-  }
-
-  if (previousReaction && previousReaction.emoji === emoji) {
-    return { didApply: false };
-  }
-
-  const previousReactionTxId = previousReaction ? previousReaction.reactionTxId : null;
-  assert(previousReaction === null || previousReactionTxId, 'Previous reaction txid is required');
-
-  insertSorted(contact.reactions, {
-    sender,
-    targetTxid: reaction.reactId,
-    emoji,
-    timestamp: reaction.timestamp,
-    reactionTxId: reaction.reactionTxId
-  }, 'timestamp');
-  return { didApply: true, previousReactionTxId };
 }
 
 /**
@@ -6017,6 +6190,7 @@ function applyIncomingReaction(contact, reaction) {
 
   const sender = normalizeAddress(reaction.sender);
   const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
+  const isIncomingOlderThanCurrent = !!currentReaction && currentReaction.timestamp > reaction.timestamp;
 
   switch (reaction.action) {
     case 'remove': {
@@ -6031,6 +6205,9 @@ function applyIncomingReaction(contact, reaction) {
         }
         return removeReactionByReactionTxId(contact, targetReaction.reactionTxId);
       }
+      if (isIncomingOlderThanCurrent) {
+        return false;
+      }
       return purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
     }
 
@@ -6038,6 +6215,9 @@ function applyIncomingReaction(contact, reaction) {
       const emoji = reaction.emoji.trim();
       // don't allow duplicate reactions
       if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
+        return false;
+      }
+      if (isIncomingOlderThanCurrent) {
         return false;
       }
       if (currentReaction && currentReaction.emoji === emoji) {
@@ -6331,46 +6511,62 @@ function trackPendingMessageEditBeforeInject(txid, contactAddress, editPending) 
 }
 
 /**
- * Finalizes or reverts a pending optimistic reaction set that stored fallback metadata.
- * @param {Object} pendingTxInfo
- * @param {'success' | 'failure'} result
- * @returns {boolean}
+ * Creates or updates the provisional pending entry used to persist optimistic reaction chain metadata
+ * before `/inject` confirms the transaction was accepted for receipt tracking.
+ * @param {string} txid
+ * @param {string} contactAddress
+ * @param {PendingReactionMutation} reactionPending
+ * @returns {void}
  */
-function reconcilePendingReactionSet(pendingTxInfo, result) {
-  if (!pendingTxInfo.reactionPending) {
-    return false;
+function trackPendingReactionBeforeInject(txid, contactAddress, reactionPending) {
+  assert(txid, 'Pending reaction txid is required');
+  assert(contactAddress, 'Pending reaction contact address is required');
+  myData.pending ??= [];
+
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+  if (pendingTxInfo) {
+    pendingTxInfo.to = normalizeAddress(contactAddress);
+    pendingTxInfo.reactionPending = reactionPending;
+    return;
   }
 
-  /** @type {PendingReactionSet} */
-  const { reactionPending } = pendingTxInfo;
+  myData.pending.push({
+    txid,
+    type: 'message',
+    submittedts: getCorrectedTimestamp(),
+    checkedts: 0,
+    to: normalizeAddress(contactAddress),
+    reactionPending,
+  });
+}
 
+/**
+ * Applies a success/failure result to one pending reaction chain entry and recomputes
+ * the materialized visible reaction for that target.
+ * @param {Object} pendingTxInfo
+ * @param {'success' | 'failure'} result
+ * @returns {{ didChange: boolean, hasPending: boolean, targetTxid: string }}
+ */
+function reconcilePendingReaction(pendingTxInfo, result) {
+  assert(pendingTxInfo.reactionPending, `Missing pending reaction metadata for ${pendingTxInfo.txid}`);
+  switch (result) {
+    case 'success':
+    case 'failure':
+      break;
+    default:
+      assert(false, `Unknown pending reaction result: ${result}`);
+  }
+
+  /** @type {PendingReactionMutation} */
+  const { reactionPending } = pendingTxInfo;
   const contact = myData.contacts[pendingTxInfo.to];
   assert(contact, `Missing contact for pending reaction: ${pendingTxInfo.to}`);
 
-  switch (result) {
-    case 'success': {
-      if (!reactionPending.previousReactionTxId) {
-        return false;
-      }
-
-      const didChange = removeReactionByReactionTxId(contact, reactionPending.previousReactionTxId);
-      if (didChange) {
-        syncReactionUiState(pendingTxInfo.to, contact, reactionPending.targetTxid);
-      }
-      return didChange;
-    }
-
-    case 'failure': {
-      const didChange = removeReactionByReactionTxId(contact, pendingTxInfo.txid);
-      if (didChange) {
-        syncReactionUiState(pendingTxInfo.to, contact, reactionPending.targetTxid);
-      }
-      return didChange;
-    }
-
-    default:
-      throw new Error(`Unknown pending reaction result: ${result}`);
-  }
+  reactionPending.status = result;
+  return {
+    ...syncPendingReactionChainState(pendingTxInfo.to, contact, reactionPending.targetTxid),
+    targetTxid: reactionPending.targetTxid
+  };
 }
 
 /**
@@ -6411,6 +6607,7 @@ async function processChats(chats, keys) {
   const messageQueryTimestamp = Math.max(0, timestamp+1);
   let hasAnyTransfer = false;
   let needsUpcomingCallsUiRefresh = false;
+  const currentUserAddress = normalizeAddress(keys.address);
 
   for (let sender in chats) {
     // Fetch messages using the adjusted timestamp
@@ -7029,6 +7226,12 @@ async function processChats(chats, keys) {
         });
 
         for (const pendingReaction of pendingReactionControls) {
+          if (
+            pendingReaction.sender === currentUserAddress &&
+            getPendingReactionChainEntries(from, pendingReaction.reactId).length > 0
+          ) {
+            continue;
+          }
           if (applyIncomingReaction(contact, pendingReaction)) {
             didApplyPendingReaction = true;
             syncChatLatestActivityTimestamp(from, contact);
@@ -18588,53 +18791,79 @@ class ChatModal {
       reactAction: reaction.reactAction
     });
 
-    let reactionPendingState = null;
-    if (reaction.reactAction === 'set') {
-      const sender = normalizeAddress(keys.address);
-      assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
-      const localReaction = {
-        sender,
-        reactId: reaction.reactId,
-        action: 'set',
-        emoji: reaction.reactMessage,
-        timestamp: payload.sent_timestamp,
-        reactionTxId: txid
-      };
-      const optimisticApply = applyOptimisticReactionSet(contact, localReaction);
-      if (optimisticApply.didApply) {
-        reactionPendingState = {
-          targetTxid: reaction.reactId,
-          previousReactionTxId: optimisticApply.previousReactionTxId
-        };
-        syncReactionUiState(currentAddress, contact, reaction.reactId);
-      } else {
-        console.warn('Reaction sent but local optimistic apply was skipped', localReaction);
-      }
+    const targetMessage = contact.messages.find((message) => message.txid === reaction.reactId);
+    if (!targetMessage || isDeleted(targetMessage)) {
+      console.warn('Reaction send skipped: local target message missing', reaction);
+      return false;
     }
+
+    const sender = normalizeAddress(keys.address);
+    assert(payload.sent_timestamp, 'Reaction sent_timestamp is required');
+    const chainEntries = getPendingReactionChainEntries(currentAddress, reaction.reactId);
+    const baseReaction = getPendingReactionChainBase(
+      chainEntries,
+      getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender)
+    );
+    const localOrder = getPendingReactionNextLocalOrder(chainEntries);
+
+    /** @type {PendingReactionMutation} */
+    let reactionPendingState;
+    switch (reaction.reactAction) {
+      case 'set':
+        reactionPendingState = {
+          kind: 'set',
+          targetTxid: reaction.reactId,
+          localOrder,
+          status: 'pending',
+          baseReaction,
+          optimisticResult: {
+            sender,
+            targetTxid: reaction.reactId,
+            emoji: reaction.reactMessage.trim(),
+            timestamp: payload.sent_timestamp,
+            reactionTxId: txid
+          }
+        };
+        break;
+      case 'remove':
+        reactionPendingState = {
+          kind: 'remove',
+          targetTxid: reaction.reactId,
+          localOrder,
+          status: 'pending',
+          baseReaction,
+          optimisticResult: null
+        };
+        break;
+      default:
+        assert(false, `Unknown reaction action: ${reaction.reactAction}`);
+    }
+
+    trackPendingReactionBeforeInject(txid, currentAddress, reactionPendingState);
+    syncPendingReactionChainState(currentAddress, contact, reaction.reactId);
 
     const response = await injectTx(chatMessageObj, txid);
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
-      if (reactionPendingState) {
-        const didRevert = reconcilePendingReactionSet({
-          txid,
-          to: currentAddress,
-          reactionPending: reactionPendingState
-        }, 'failure');
-        if (didRevert) {
-          showToast('Reaction failed to send and was reverted', 0, 'error');
-        }
-        saveState();
+      const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+      assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
+
+      const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
+      if (!outcome.hasPending) {
+        removePendingReactionChainEntries(currentAddress, outcome.targetTxid);
       }
+      if (outcome.didChange) {
+        showToast('Reaction failed to send and was reverted', 0, 'error');
+      }
+      saveState();
       return false;
     }
 
-    if (reactionPendingState) {
-      const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-      assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
-      pendingTxInfo.reactionPending = reactionPendingState;
-      saveState();
-    }
+    assert(
+      myData.pending.some((pendingTx) => pendingTx.txid === txid),
+      `Pending reaction metadata missing for ${txid}`
+    );
+    saveState();
 
     if (reaction.reactAction === 'remove') {
       showToast('Reaction remove request sent', 5000, 'loading');
@@ -27561,14 +27790,12 @@ async function checkPendingTransactions() {
     return;
   }
 
-  // initialize the pending array if it is not already initialized
-  if (!myData.pending) {
-    myData.pending = [];
-  }
-
+  myData.pending ??= [];
   if (myData.pending.length === 0) return; // No pending transactions to check
 
   const startingPendingCount = myData.pending.length;
+  let didMutatePendingState = false;
+  const resolvedReactionChains = [];
 
   const now = getCorrectedTimestamp();
   const eightSecondsAgo = now - 8000;
@@ -27578,6 +27805,10 @@ async function checkPendingTransactions() {
   for (let i = myData.pending.length - 1; i >= 0; i--) {
     const pendingTxInfo = myData.pending[i];
     const { txid, type, submittedts } = pendingTxInfo;
+    const reactionPending = pendingTxInfo.reactionPending;
+    if (reactionPending && reactionPending.status !== 'pending') {
+      continue;
+    }
 
     if (submittedts < eightSecondsAgo) {
 
@@ -27590,9 +27821,19 @@ async function checkPendingTransactions() {
       //console.log(`DEBUG: txid ${txid} res: ${JSON.stringify(res)}`);
       if (submittedts < thirtySecondsAgo && (res.transaction === null || Object.keys(res.transaction).length === 0)) {
         console.error(`DEBUG: txid ${txid} timed out, removing completely`);
-        const didRevert = reconcilePendingReactionSet(pendingTxInfo, 'failure');
-        if (didRevert) {
-          showToast('Reaction timed out and was reverted', 0, 'error');
+        if (reactionPending) {
+          const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
+          didMutatePendingState = true;
+          if (!outcome.hasPending) {
+            resolvedReactionChains.push({
+              contactAddress: pendingTxInfo.to,
+              targetTxid: outcome.targetTxid
+            });
+          }
+          if (outcome.didChange) {
+            showToast('Reaction timed out and was reverted', 0, 'error');
+          }
+          continue;
         }
         if (pendingTxInfo.editPending) {
           reconcilePendingMessageEdit(pendingTxInfo);
@@ -27600,13 +27841,25 @@ async function checkPendingTransactions() {
         }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
+        didMutatePendingState = true;
         continue;
       }
 
       if (res?.transaction?.success === true) {
-        // comment out to test the pending txs removal logic
-        myData.pending.splice(i, 1);
-        reconcilePendingReactionSet(pendingTxInfo, 'success');
+        if (reactionPending) {
+          const outcome = reconcilePendingReaction(pendingTxInfo, 'success');
+          didMutatePendingState = true;
+          if (!outcome.hasPending) {
+            resolvedReactionChains.push({
+              contactAddress: pendingTxInfo.to,
+              targetTxid: outcome.targetTxid
+            });
+          }
+        } else {
+          // comment out to test the pending txs removal logic
+          myData.pending.splice(i, 1);
+          didMutatePendingState = true;
+        }
 
         if (type === 'register') {
           pendingPromiseService.resolve(txid, {
@@ -27666,11 +27919,20 @@ async function checkPendingTransactions() {
           pendingPromiseService.reject(txid, new Error(userFailureReason));
         } else {
           // Show toast notification with the failure reason
-          if (pendingTxInfo.reactionPending) {
-            const didRevert = reconcilePendingReactionSet(pendingTxInfo, 'failure');
-            showToast(didRevert
-              ? `Reaction failed and was reverted: ${userFailureReason}`
-              : userFailureReason, 0, 'error');
+          if (reactionPending) {
+            const outcome = reconcilePendingReaction(pendingTxInfo, 'failure');
+            didMutatePendingState = true;
+            if (!outcome.hasPending) {
+              resolvedReactionChains.push({
+                contactAddress: pendingTxInfo.to,
+                targetTxid: outcome.targetTxid
+              });
+            }
+            if (outcome.didChange) {
+              showToast(`Reaction failed and was reverted: ${userFailureReason}`, 0, 'error');
+            } else if (!outcome.hasPending) {
+              showToast(userFailureReason, 0, 'error');
+            }
           } else if (pendingTxInfo.editPending) {
             reconcilePendingMessageEdit(pendingTxInfo);
             showToast(`Edit failed and was reverted: ${userFailureReason}`, 0, 'error');
@@ -27726,14 +27988,17 @@ async function checkPendingTransactions() {
             showToast(userFailureReason, 0, 'error');
           }
 
-          if (!pendingTxInfo.reactionPending && !pendingTxInfo.editPending) {
+          if (!reactionPending && !pendingTxInfo.editPending) {
             const toAddress = pendingTxInfo.to;
             updateTransactionStatus(txid, toAddress, 'failed', type);
             chatModal.refreshCurrentView(txid);
           }
         }
-        // Remove from pending array
-        myData.pending.splice(i, 1);
+        if (!reactionPending) {
+          // Remove from pending array
+          myData.pending.splice(i, 1);
+          didMutatePendingState = true;
+        }
 
         // refresh the validator modal if this is a withdraw_stake/deposit_stake and validator modal is open
         if (type === 'withdraw_stake' || type === 'deposit_stake') {
@@ -27751,13 +28016,17 @@ async function checkPendingTransactions() {
       }
     }
   }
+
+  for (const chain of resolvedReactionChains) {
+    removePendingReactionChainEntries(chain.contactAddress, chain.targetTxid);
+  }
   // if createAccountModal is open, skip balance change
   if (!createAccountModal.isActive()) {
     walletScreen.updateWalletBalances();
   }
 
   // save state if pending transactions were processed
-  if (startingPendingCount !== myData.pending.length) {
+  if (startingPendingCount !== myData.pending.length || didMutatePendingState) {
     saveState();
   }
 }


### PR DESCRIPTION
## Short Summary

This branch changes reactions from a one-off optimistic insert into an ordered pending mutation chain stored in `myData.pending`.

The UI now updates immediately for both reaction sets and reaction removes. Each outgoing reaction creates a `reactionPending` entry, the pending chain is replayed into `contact.reactions`, and the entry later settles to `success` or `failure` after inject or receipt polling.

```text
send click
  -> load same-target chain entries
  -> reuse them only if any entry is still pending
  -> create reactionPending(status: pending)
  -> add to myData.pending
  -> replay chain into contact.reactions
  -> injectTx

inject failure
  -> status: failure
  -> replay chain
  -> cleanup resolved entries if no pending remains

inject success
  -> leave status: pending
  -> receipt polling continues

receipt success
  -> status: success
  -> replay chain
  -> cleanup resolved entries if no pending remains

receipt failure or timeout
  -> status: failure
  -> replay chain
  -> cleanup resolved entries if no pending remains
```

## Main Objects

### Pending reaction entry

Each optimistic reaction lives inside a normal `myData.pending` transaction entry:

```js
{
  txid: "reactionTx1",
  type: "message",
  submittedts: 1710000000000,
  checkedts: 0,
  to: "contactAddress",
  reactionPending: {
    kind: "set",              // "set" or "remove"
    targetTxid: "messageTx1",
    localOrder: 1,
    status: "pending",        // "pending", "success", or "failure"
    baseReaction: null,       // visible reaction before this chain started
    visibleResult: {
      sender: "myAddress",
      targetTxid: "messageTx1",
      emoji: "👍",
      timestamp: 1710000000000,
      reactionTxId: "reactionTx1"
    }
  }
}
```

For a remove mutation, `visibleResult` is `null`:

```js
reactionPending: {
  kind: "remove",
  targetTxid: "messageTx1",
  localOrder: 2,
  status: "pending",
  baseReaction: {
    sender: "myAddress",
    targetTxid: "messageTx1",
    emoji: "👍",
    timestamp: 1710000000000,
    reactionTxId: "reactionTx1"
  },
  visibleResult: null
}
```

## Lifecycle Examples

### Sending a reaction

`sendReactionMessage()` loads existing same-target entries with `getPendingReactionChainEntries()`. If any entry is still `pending`, the new mutation joins that chain and reuses the first entry's `baseReaction`; otherwise it starts a fresh chain from the current `contact.reactions` state.

The send path then creates a `reactionPending` mutation, stores it with `trackPendingReactionBeforeInject()`, and calls `syncPendingReactionChainState()` so the visible chip updates before the network result arrives.

### Replaying the chain

`syncPendingReactionChainState()` calls `replayPendingReactionChain()`, which starts from `baseReaction` and walks entries by `localOrder`:

```text
failure -> skip mutation
pending -> apply visibleResult
success -> apply visibleResult
```

The replay result is written back to `contact.reactions` with `setVisibleReaction()`, keeping reaction chips backed by the same materialized state they already use.

### Settling receipts

When inject fails, receipt polling fails, or receipt polling succeeds, the code calls `settlePendingReaction(pendingTxInfo, "failure" | "success")`. That updates `reactionPending.status`, replays the chain, and returns whether the visible reaction changed and whether anything is still pending.

Successful entries stay in `myData.pending` while later same-target entries are still pending. This lets a later failed mutation fall back to the latest successful mutation instead of falling back all the way to the original base.

### Cleaning up

Once a chain has no remaining `pending` entries, `cleanupResolvedReactionChain(contactAddress, targetTxid)` removes the resolved bookkeeping from `myData.pending`.

The final visible reaction remains in `contact.reactions`; cleanup only removes pending-chain metadata.

## Validation

- `node --check app.js`
- `node --test tests-local/*.js`
