### PR TITLE
Track reaction removals in chat previews

### DIFF
--- a/app.js
+++ b/app.js
@@ -5882,11 +5882,10 @@ function getEffectiveReactionForSenderTarget(contact, targetTxid, sender) {
   const normalizedSender = normalizeAddress(sender);
 
   for (const reaction of reactions) {
-    if (
-      reaction.emoji &&
-      reaction.targetTxid === targetTxid &&
-      normalizeAddress(reaction.sender) === normalizedSender
-    ) {
+    if (!reaction.emoji) {
+      continue;
+    }
+    if (reaction.targetTxid === targetTxid && normalizeAddress(reaction.sender) === normalizedSender) {
       return reaction;
     }
   }
@@ -5906,10 +5905,10 @@ function getContactReactionsForTarget(contact, targetTxid) {
   const effectiveReactions = [];
 
   for (const reaction of reactions) {
-    if (reaction.targetTxid !== targetTxid) {
+    if (!reaction.emoji) {
       continue;
     }
-    if (!reaction.emoji) {
+    if (reaction.targetTxid !== targetTxid) {
       continue;
     }
 
@@ -5968,7 +5967,7 @@ function removeReactionByReactionTxId(contact, reactionTxId) {
 /**
  * Records a reaction removal as chat-list activity without creating a visible chip.
  * @param {Object} contact
- * @param {ReactionUpdate} reaction
+ * @param {Extract<ReactionUpdate, { action: 'remove' }>} reaction
  * @returns {void}
  */
 function recordReactionRemovalActivity(contact, reaction) {
@@ -17663,9 +17662,6 @@ class ChatModal {
     const otherChips = [];
 
     for (const reaction of reactionsForTarget) {
-      if (!reaction.emoji) {
-        continue;
-      }
       const sender = reaction.sender;
       const emoji = reaction.emoji;
 

--- a/app.js
+++ b/app.js
@@ -18820,7 +18820,7 @@ class ChatModal {
     const activeChainEntries = chainEntries.some((entry) => entry.reactionPending.status === 'pending')
       ? chainEntries
       : [];
-    const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
+    const currentReaction = getLatestReactionStateForSenderTarget(contact, reaction.reactId, sender);
     const baseReaction = copyReactionSnapshot(
       activeChainEntries.length > 0
         ? activeChainEntries[0].reactionPending.baseReaction

--- a/app.js
+++ b/app.js
@@ -5866,7 +5866,7 @@ async function ensureContactKeys(address) {
  *   visibleResult: ReactionSnapshot
  * } | {
  *   kind: 'remove',
- *   visibleResult: null
+ *   visibleResult: ReactionSnapshot
  * })} PendingReactionMutation
  */
 
@@ -5885,6 +5885,26 @@ function getEffectiveReactionForSenderTarget(contact, targetTxid, sender) {
     if (!reaction.emoji) {
       continue;
     }
+    if (reaction.targetTxid === targetTxid && normalizeAddress(reaction.sender) === normalizedSender) {
+      return reaction;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns the newest reaction state, including empty-emoji removal markers.
+ * @param {Object} contact
+ * @param {string} targetTxid
+ * @param {string} sender
+ * @returns {Object|null}
+ */
+function getLatestReactionStateForSenderTarget(contact, targetTxid, sender) {
+  const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
+  const normalizedSender = normalizeAddress(sender);
+
+  for (const reaction of reactions) {
     if (reaction.targetTxid === targetTxid && normalizeAddress(reaction.sender) === normalizedSender) {
       return reaction;
     }
@@ -6187,7 +6207,8 @@ function applyIncomingReaction(contact, reaction) {
 
   const sender = normalizeAddress(reaction.sender);
   const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
-  const isIncomingOlderThanCurrent = !!currentReaction && currentReaction.timestamp > reaction.timestamp;
+  const latestReactionState = getLatestReactionStateForSenderTarget(contact, reaction.reactId, sender);
+  const isIncomingOlderThanCurrent = !!latestReactionState && latestReactionState.timestamp > reaction.timestamp;
 
   switch (reaction.action) {
     case 'remove': {
@@ -18835,7 +18856,13 @@ class ChatModal {
           localOrder,
           status: 'pending',
           baseReaction,
-          visibleResult: null
+          visibleResult: {
+            sender,
+            targetTxid: reaction.reactId,
+            emoji: '',
+            timestamp: payload.sent_timestamp,
+            reactionTxId: txid
+          }
         };
         break;
       default:

--- a/app.js
+++ b/app.js
@@ -5866,7 +5866,7 @@ async function ensureContactKeys(address) {
  *   visibleResult: ReactionSnapshot
  * } | {
  *   kind: 'remove',
- *   visibleResult: ReactionSnapshot
+ *   visibleResult: ReactionSnapshot & { emoji: '' }
  * })} PendingReactionMutation
  */
 
@@ -6206,7 +6206,6 @@ function applyIncomingReaction(contact, reaction) {
   }
 
   const sender = normalizeAddress(reaction.sender);
-  const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
   const latestReactionState = getLatestReactionStateForSenderTarget(contact, reaction.reactId, sender);
   const isIncomingOlderThanCurrent = !!latestReactionState && latestReactionState.timestamp > reaction.timestamp;
 
@@ -6228,15 +6227,16 @@ function applyIncomingReaction(contact, reaction) {
       if (isIncomingOlderThanCurrent) {
         return false;
       }
-      const didRemove = purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
-      if (didRemove) {
-        recordReactionRemovalActivity(contact, reaction);
+      if (!purgeReactionStackForSenderTarget(contact, reaction.reactId, sender)) {
+        return false;
       }
-      return didRemove;
+      recordReactionRemovalActivity(contact, reaction);
+      return true;
     }
 
     case 'set': {
       const emoji = reaction.emoji.trim();
+      const currentReaction = getEffectiveReactionForSenderTarget(contact, reaction.reactId, sender);
       // don't allow duplicate reactions
       if (reaction.reactionTxId && contact.reactions.some((entry) => entry.reactionTxId === reaction.reactionTxId)) {
         return false;

--- a/app.js
+++ b/app.js
@@ -1583,7 +1583,9 @@ class ChatsScreen {
       if (isShowingReactionPreview) {
         const reactionActor = reactionPreview.my ? 'You' : contactName;
         const reactionTarget = reactionPreview.target;
-        const reactionText = `${reactionActor} reacted ${reactionPreview.emoji} to "${reactionTarget}"`;
+        const reactionText = reactionPreview.emoji
+          ? `${reactionActor} reacted ${reactionPreview.emoji} to "${reactionTarget}"`
+          : `${reactionActor} removed a reaction from "${reactionTarget}"`;
         previewHTML = truncateMessage(escapeHtml(reactionText), 50);
       } else if (typeof latestActivity.amount === 'bigint') {
         // Latest item is a payment/transfer
@@ -5880,7 +5882,11 @@ function getEffectiveReactionForSenderTarget(contact, targetTxid, sender) {
   const normalizedSender = normalizeAddress(sender);
 
   for (const reaction of reactions) {
-    if (reaction.targetTxid === targetTxid && normalizeAddress(reaction.sender) === normalizedSender) {
+    if (
+      reaction.emoji &&
+      reaction.targetTxid === targetTxid &&
+      normalizeAddress(reaction.sender) === normalizedSender
+    ) {
       return reaction;
     }
   }
@@ -5901,6 +5907,9 @@ function getContactReactionsForTarget(contact, targetTxid) {
 
   for (const reaction of reactions) {
     if (reaction.targetTxid !== targetTxid) {
+      continue;
+    }
+    if (!reaction.emoji) {
       continue;
     }
 
@@ -5954,6 +5963,22 @@ function removeReactionByReactionTxId(contact, reactionTxId) {
 
   contact.reactions.splice(index, 1);
   return true;
+}
+
+/**
+ * Records a reaction removal as chat-list activity without creating a visible chip.
+ * @param {Object} contact
+ * @param {ReactionUpdate} reaction
+ * @returns {void}
+ */
+function recordReactionRemovalActivity(contact, reaction) {
+  insertSorted(contact.reactions, {
+    sender: normalizeAddress(reaction.sender),
+    targetTxid: reaction.reactId,
+    emoji: '',
+    timestamp: reaction.timestamp,
+    reactionTxId: reaction.reactionTxId
+  }, 'timestamp');
 }
 
 /**
@@ -6176,12 +6201,18 @@ function applyIncomingReaction(contact, reaction) {
         if (!targetReaction) {
           return false;
         }
-        return removeReactionByReactionTxId(contact, targetReaction.reactionTxId);
+        removeReactionByReactionTxId(contact, targetReaction.reactionTxId);
+        recordReactionRemovalActivity(contact, reaction);
+        return true;
       }
       if (isIncomingOlderThanCurrent) {
         return false;
       }
-      return purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
+      const didRemove = purgeReactionStackForSenderTarget(contact, reaction.reactId, sender);
+      if (didRemove) {
+        recordReactionRemovalActivity(contact, reaction);
+      }
+      return didRemove;
     }
 
     case 'set': {
@@ -17632,6 +17663,9 @@ class ChatModal {
     const otherChips = [];
 
     for (const reaction of reactionsForTarget) {
+      if (!reaction.emoji) {
+        continue;
+      }
       const sender = reaction.sender;
       const emoji = reaction.emoji;
 
@@ -17690,6 +17724,9 @@ class ChatModal {
     const reactions = Array.isArray(contact.reactions) ? contact.reactions : [];
     const seen = new Set();
     for (const reaction of reactions) {
+      if (!reaction.emoji) {
+        continue;
+      }
       const reactionKey = `${reaction.targetTxid}:${normalizeAddress(reaction.sender)}`;
       if (seen.has(reactionKey)) {
         continue;


### PR DESCRIPTION
## Summary

Adds removal-aware reaction activity on top of the optimistic reaction remove branch.

- Records successful reaction removals as empty-emoji reaction activity so the chat list can show that a reaction was removed without rendering an empty reaction chip.
- Keeps two reaction lookup functions because they answer different questions:
  - `getEffectiveReactionForSenderTarget` ignores empty-emoji removal markers and returns only the visible reaction state used by chips, picker active state, and duplicate visible-reaction checks.
  - `getLatestReactionStateForSenderTarget` includes empty-emoji removal markers so timestamp ordering, incoming replay, and optimistic rollback can see that a remove is newer than an older set.
- Preserves removal markers in pending remove mutations, allowing optimistic remove chains to replay cleanly and keep chat previews accurate.
- Updates reaction rendering paths to skip empty-emoji entries.

## Validation

- `node --check app.js`
- `git diff --check issue-1264-optimistic-reaction-remove -- app.js`