### PR TITLE
DAO: Prevent proposal field overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6124,6 +6124,11 @@ small {
   color: var(--button-text);
 }
 
+#proposalInfoFields {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 #lockModal p {
   font-family: var(--font-primary);
   font-size: var(--font-size-base);


### PR DESCRIPTION
## Summary
- Add a targeted wrapping rule for proposal info fields so long values stay inside the modal on narrow widths.

## Root Cause
Long unbroken field values, such as Ethereum-style addresses, rendered without a wrapping rule in `#proposalInfoFields`.

<img width="383" height="768" alt="image" src="https://github.com/user-attachments/assets/eebf958f-66cc-48f6-9b42-a5c7cf144772" />


Fixes #1276