### PR TITLE
Allow zero-toll reactions for tolled chats

### DIFF
--- a/app.js
+++ b/app.js
@@ -18689,12 +18689,13 @@ class ChatModal {
     assert(typeof closeUi === 'function', 'Reaction close callback is required');
 
     const contact = myData.contacts[this.address];
-    const required = contact?.tollRequiredToSend;
+    const required = contact.tollRequiredToSend;
     if (required === 2) {
       showToast('You are blocked by this user', 0, 'error');
       return;
     }
-    if (required !== undefined && required !== 0) {
+    const tollInLib = required === 0 ? 0n : getEffectiveTollLibWei(this.toll);
+    if (required !== 0 && tollInLib > 0n) {
       const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
       showToast(
         `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`,
@@ -18751,12 +18752,13 @@ class ChatModal {
       return false;
     }
 
-    if (contact.tollRequiredToSend == 2) {
+    const required = contact.tollRequiredToSend;
+    if (required === 2) {
       console.warn('Reaction send skipped because sender is blocked by recipient');
       return false;
     }
 
-    const tollInLib = contact.tollRequiredToSend == 0 ? 0n : getEffectiveTollLibWei(this.toll);
+    const tollInLib = required === 0 ? 0n : getEffectiveTollLibWei(this.toll);
     const sufficientBalance = await validateBalance(tollInLib);
     if (!sufficientBalance) {
       console.warn('Reaction send skipped due to insufficient balance', reaction);

--- a/app.js
+++ b/app.js
@@ -18689,7 +18689,7 @@ class ChatModal {
     assert(typeof closeUi === 'function', 'Reaction close callback is required');
 
     const contact = myData.contacts[this.address];
-    const required = contact.tollRequiredToSend;
+    const required = contact?.tollRequiredToSend ?? 1;
     if (required === 2) {
       showToast('You are blocked by this user', 0, 'error');
       return;


### PR DESCRIPTION
## Summary

Fixes #1292 by allowing reactions when the recipient still has the sender marked as tolled, but the effective toll amount is zero. Blocked recipients still block reactions, and tolled recipients with a nonzero effective toll still require being added as a connection.

Core fix logic:

```js
const required = contact?.tollRequiredToSend ?? 1;
if (required === 2) {
  showToast('You are blocked by this user', 0, 'error');
  return;
}

const tollInLib = required === 0 ? 0n : getEffectiveTollLibWei(this.toll);
if (required !== 0 && tollInLib > 0n) {
  // Require connection only when there is a real toll cost.
  return;
}
```

## Root Cause

The reaction picker previously blocked every known non-connection state (`tollRequiredToSend !== 0`) before checking whether that tolled state actually had a payable toll. That made zero-toll tolled chats behave like nonzero-toll chats.

## Validation

- `node --check app.js`
- `git diff --check`

Note: `git diff --check` only reported Git's LF-to-CRLF working-copy warning.