### PR TITLE
Allow zero-toll chat actions (reactions, delete-for-all, and calls)

### DIFF
--- a/app.js
+++ b/app.js
@@ -17908,11 +17908,7 @@ class ChatModal {
    */
   canDeleteMessageForAll(messageEl, messageRecord = null) {
     const isMine = !!messageEl?.classList?.contains('sent');
-    if (!isMine) {
-      return false;
-    }
-
-    if (!this.canSendWithZeroToll()) {
+    if (!isMine || !this.canSendWithZeroToll()) {
       return false;
     }
 

--- a/app.js
+++ b/app.js
@@ -18805,7 +18805,7 @@ class ChatModal {
     const tollInLib = 0n;
     const sufficientBalance = await validateBalance(tollInLib);
     if (!sufficientBalance) {
-      const feeInLIB = big2str(getTransactionFeeWei(), 18);
+      const feeInLIB = big2str(getTransactionFeeWei(), 18).slice(0, -16);
       showToast(`Insufficient balance for fee of ${feeInLIB} LIB. Go to the wallet to add more LIB.`, 0, 'error');
       console.warn('Reaction send skipped due to insufficient balance', reaction);
       return false;

--- a/app.js
+++ b/app.js
@@ -18712,12 +18712,13 @@ class ChatModal {
     assert(typeof closeUi === 'function', 'Reaction close callback is required');
 
     const contact = myData.contacts[this.address];
-    const required = contact?.tollRequiredToSend;
+    const required = contact.tollRequiredToSend;
     if (required === 2) {
       showToast('You are blocked by this user', 0, 'error');
       return;
     }
-    if (required !== undefined && required !== 0) {
+    const tollInLib = required === 0 ? 0n : getEffectiveTollLibWei(this.toll);
+    if (required !== 0 && tollInLib > 0n) {
       const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
       showToast(
         `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`,
@@ -18774,12 +18775,13 @@ class ChatModal {
       return false;
     }
 
-    if (contact.tollRequiredToSend == 2) {
+    const required = contact.tollRequiredToSend;
+    if (required === 2) {
       console.warn('Reaction send skipped because sender is blocked by recipient');
       return false;
     }
 
-    const tollInLib = contact.tollRequiredToSend == 0 ? 0n : getEffectiveTollLibWei(this.toll);
+    const tollInLib = required === 0 ? 0n : getEffectiveTollLibWei(this.toll);
     const sufficientBalance = await validateBalance(tollInLib);
     if (!sufficientBalance) {
       console.warn('Reaction send skipped due to insufficient balance', reaction);

--- a/app.js
+++ b/app.js
@@ -18797,13 +18797,16 @@ class ChatModal {
       return false;
     }
 
-    const required = contact.tollRequiredToSend;
-    if (required === 2) {
+    if (!this.canSendWithZeroToll()) {
+      if (contact.tollRequiredToSend !== 2) {
+        console.warn('Reaction send skipped because recipient requires a nonzero toll');
+        return false;
+      }
       console.warn('Reaction send skipped because sender is blocked by recipient');
       return false;
     }
 
-    const tollInLib = required === 0 ? 0n : getEffectiveTollLibWei(this.toll);
+    const tollInLib = 0n;
     const sufficientBalance = await validateBalance(tollInLib);
     if (!sufficientBalance) {
       console.warn('Reaction send skipped due to insufficient balance', reaction);
@@ -19645,7 +19648,7 @@ class ChatModal {
   async handleCallUser() {
     try {
       // Synchronous eligibility based on cached value fetched on ChatModal open
-      const contact = myData.contacts[this.address];
+      const contact = myData.contacts[this.address] || {};
       if (!this.canSendWithZeroToll()) {
         const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
         if (contact.tollRequiredToSend === 2) {

--- a/app.js
+++ b/app.js
@@ -17912,7 +17912,7 @@ class ChatModal {
       return false;
     }
 
-    if (!this.canUseConnectionGatedChatAction()) {
+    if (!this.canSendWithZeroToll()) {
       return false;
     }
 
@@ -18685,10 +18685,10 @@ class ChatModal {
   }
 
   /**
-   * Returns whether the active chat can use actions normally limited to connections.
+   * Returns whether the active chat can send actions with no payable toll.
    * @returns {boolean}
    */
-  canUseConnectionGatedChatAction() {
+  canSendWithZeroToll() {
     const contact = myData.contacts[this.address];
 
     switch (contact.tollRequiredToSend) {
@@ -18740,7 +18740,7 @@ class ChatModal {
       showToast('You are blocked by this user', 0, 'error');
       return;
     }
-    if (!this.canUseConnectionGatedChatAction()) {
+    if (!this.canSendWithZeroToll()) {
       const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
       showToast(
         `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`,
@@ -19646,7 +19646,7 @@ class ChatModal {
     try {
       // Synchronous eligibility based on cached value fetched on ChatModal open
       const contact = myData.contacts[this.address];
-      if (!this.canUseConnectionGatedChatAction()) {
+      if (!this.canSendWithZeroToll()) {
         const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
         if (contact.tollRequiredToSend === 2) {
           showToast('You are blocked by this user', 0, 'error');

--- a/app.js
+++ b/app.js
@@ -17912,7 +17912,7 @@ class ChatModal {
       return false;
     }
 
-    if (!this.canUseConnectionGatedChatAction(myData.contacts[this.address])) {
+    if (!this.canUseConnectionGatedChatAction()) {
       return false;
     }
 
@@ -18686,10 +18686,11 @@ class ChatModal {
 
   /**
    * Returns whether the active chat can use actions normally limited to connections.
-   * @param {Object} contact
    * @returns {boolean}
    */
-  canUseConnectionGatedChatAction(contact) {
+  canUseConnectionGatedChatAction() {
+    const contact = myData.contacts[this.address];
+
     switch (contact.tollRequiredToSend) {
       case 0:
         return true;
@@ -18739,7 +18740,7 @@ class ChatModal {
       showToast('You are blocked by this user', 0, 'error');
       return;
     }
-    if (!this.canUseConnectionGatedChatAction(contact)) {
+    if (!this.canUseConnectionGatedChatAction()) {
       const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
       showToast(
         `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`,
@@ -19645,7 +19646,7 @@ class ChatModal {
     try {
       // Synchronous eligibility based on cached value fetched on ChatModal open
       const contact = myData.contacts[this.address];
-      if (!this.canUseConnectionGatedChatAction(contact)) {
+      if (!this.canUseConnectionGatedChatAction()) {
         const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
         if (contact.tollRequiredToSend === 2) {
           showToast('You are blocked by this user', 0, 'error');

--- a/app.js
+++ b/app.js
@@ -17908,7 +17908,11 @@ class ChatModal {
    */
   canDeleteMessageForAll(messageEl, messageRecord = null) {
     const isMine = !!messageEl?.classList?.contains('sent');
-    if (!isMine || myData.contacts[this.address]?.tollRequiredToSend != 0) {
+    if (!isMine) {
+      return false;
+    }
+
+    if (!this.canUseConnectionGatedChatAction(myData.contacts[this.address])) {
       return false;
     }
 
@@ -18681,6 +18685,24 @@ class ChatModal {
   }
 
   /**
+   * Returns whether the active chat can use actions normally limited to connections.
+   * @param {Object} contact
+   * @returns {boolean}
+   */
+  canUseConnectionGatedChatAction(contact) {
+    switch (contact.tollRequiredToSend) {
+      case 0:
+        return true;
+      case 1:
+        return getEffectiveTollLibWei(this.toll) === 0n;
+      case 2:
+        return false;
+      default:
+        assert(false, `Unknown tollRequiredToSend: ${contact.tollRequiredToSend}`);
+    }
+  }
+
+  /**
    * Resolves a quick reaction picker press into a target txid and a minimal send flow.
    * @param {HTMLElement} reactionButton
    * @param {HTMLElement | null} messageEl
@@ -18717,8 +18739,7 @@ class ChatModal {
       showToast('You are blocked by this user', 0, 'error');
       return;
     }
-    const tollInLib = required === 0 ? 0n : getEffectiveTollLibWei(this.toll);
-    if (required !== 0 && tollInLib > 0n) {
+    if (!this.canUseConnectionGatedChatAction(contact)) {
       const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
       showToast(
         `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`,
@@ -19623,11 +19644,10 @@ class ChatModal {
   async handleCallUser() {
     try {
       // Synchronous eligibility based on cached value fetched on ChatModal open
-      const contact = myData.contacts[this.address] || {};
-      const required = contact.tollRequiredToSend;
-      if (required !== 0) {
+      const contact = myData.contacts[this.address];
+      if (!this.canUseConnectionGatedChatAction(contact)) {
         const username = contact.username || `${this.address.slice(0, 8)}...${this.address.slice(-6)}`;
-        if (required === 2) {
+        if (contact.tollRequiredToSend === 2) {
           showToast('You are blocked by this user', 0, 'error');
         } else {
           showToast(

--- a/app.js
+++ b/app.js
@@ -18735,7 +18735,7 @@ class ChatModal {
     assert(typeof closeUi === 'function', 'Reaction close callback is required');
 
     const contact = myData.contacts[this.address];
-    const required = contact.tollRequiredToSend;
+    const required = contact?.tollRequiredToSend;
     if (required === 2) {
       showToast('You are blocked by this user', 0, 'error');
       return;

--- a/app.js
+++ b/app.js
@@ -18805,6 +18805,8 @@ class ChatModal {
     const tollInLib = 0n;
     const sufficientBalance = await validateBalance(tollInLib);
     if (!sufficientBalance) {
+      const feeInLIB = big2str(getTransactionFeeWei(), 18);
+      showToast(`Insufficient balance for fee of ${feeInLIB} LIB. Go to the wallet to add more LIB.`, 0, 'error');
       console.warn('Reaction send skipped due to insufficient balance', reaction);
       return false;
     }


### PR DESCRIPTION
## Summary

Fixes #1292 and #1294 by treating tolled chats with an effective zero toll as eligible for actions that are normally limited to connections.

## Behavior

- Connections remain eligible.
- Blocked chats remain ineligible.
- Tolled chats with a nonzero effective toll still require being added as a connection.
- Tolled chats with an effective zero toll are eligible for reactions, delete-for-all, and calls.

## Root Cause

Reaction handling and other connection-gated chat actions previously treated every tolled state as ineligible before checking whether the effective toll was actually payable. That made zero-toll tolled chats behave like nonzero-toll chats.

## Validation

- `node --check app.js`
- `git diff --check`

Closes #1292
Closes #1294