### PR TITLE
[codex] Remove redundant username in reaction previews

### DIFF
--- a/app.js
+++ b/app.js
@@ -1603,9 +1603,10 @@ class ChatsScreen {
       let previewHTML = '';
       if (isShowingReactionPreview) {
         const reactionTarget = reactionPreview.target;
+        const reactionActor = reactionPreview.my ? 'You ' : '';
         const reactionText = reactionPreview.emoji
-          ? `reacted ${reactionPreview.emoji} to "${reactionTarget}"`
-          : `removed a reaction from "${reactionTarget}"`;
+          ? `${reactionActor}reacted ${reactionPreview.emoji} to "${reactionTarget}"`
+          : `${reactionActor}removed a reaction from "${reactionTarget}"`;
         previewHTML = truncateMessage(escapeHtml(reactionText), 50);
       } else if (typeof latestActivity.amount === 'bigint') {
         // Latest item is a payment/transfer

--- a/app.js
+++ b/app.js
@@ -1602,11 +1602,10 @@ class ChatsScreen {
 
       let previewHTML = '';
       if (isShowingReactionPreview) {
-        const reactionActor = reactionPreview.my ? 'You ' : '';
         const reactionTarget = reactionPreview.target;
         const reactionText = reactionPreview.emoji
-          ? `${reactionActor}reacted ${reactionPreview.emoji} to "${reactionTarget}"`
-          : `${reactionActor}removed a reaction from "${reactionTarget}"`;
+          ? `reacted ${reactionPreview.emoji} to "${reactionTarget}"`
+          : `removed a reaction from "${reactionTarget}"`;
         previewHTML = truncateMessage(escapeHtml(reactionText), 50);
       } else if (typeof latestActivity.amount === 'bigint') {
         // Latest item is a payment/transfer
@@ -1651,7 +1650,8 @@ class ChatsScreen {
       // Determine what to show in the preview
 
       let displayPreview = previewHTML;
-      let displayPrefix = isShowingReactionPreview ? (reactionPreview.my ? '' : '> ') : (latestActivity.my ? '< ' : '> ');
+      const isOutgoingPreview = isShowingReactionPreview ? reactionPreview.my : latestActivity.my;
+      let displayPrefix = isOutgoingPreview ? '< ' : '> ';
       let hasDraftAttachment = false;
 
       // Check for draft attachments

--- a/app.js
+++ b/app.js
@@ -1602,11 +1602,11 @@ class ChatsScreen {
 
       let previewHTML = '';
       if (isShowingReactionPreview) {
-        const reactionActor = reactionPreview.my ? 'You' : contactName;
+        const reactionActor = reactionPreview.my ? 'You ' : '';
         const reactionTarget = reactionPreview.target;
         const reactionText = reactionPreview.emoji
-          ? `${reactionActor} reacted ${reactionPreview.emoji} to "${reactionTarget}"`
-          : `${reactionActor} removed a reaction from "${reactionTarget}"`;
+          ? `${reactionActor}reacted ${reactionPreview.emoji} to "${reactionTarget}"`
+          : `${reactionActor}removed a reaction from "${reactionTarget}"`;
         previewHTML = truncateMessage(escapeHtml(reactionText), 50);
       } else if (typeof latestActivity.amount === 'bigint') {
         // Latest item is a payment/transfer
@@ -1651,7 +1651,7 @@ class ChatsScreen {
       // Determine what to show in the preview
 
       let displayPreview = previewHTML;
-      let displayPrefix = isShowingReactionPreview ? '' : (latestActivity.my ? '< ' : '> ');
+      let displayPrefix = isShowingReactionPreview ? (reactionPreview.my ? '' : '> ') : (latestActivity.my ? '< ' : '> ');
       let hasDraftAttachment = false;
 
       // Check for draft attachments


### PR DESCRIPTION
## Summary

- Remove the contact name from incoming reaction preview text in the chat list.
- Keep the incoming direction marker (`>`) for incoming reaction previews while leaving outgoing reaction previews as `You reacted...`.

## Issue

Closes #1295

## Validation

- `node --check app.js`