### PR TITLE
Add recent emoji reaction category

### DIFF
--- a/app.js
+++ b/app.js
@@ -18853,14 +18853,12 @@ class ChatModal {
     }
 
     closeUi();
-    const didSend = await this.sendReactionMessage({
+    this.recordRecentReactionEmoji(selectedReaction);
+    await this.sendReactionMessage({
       reactId: txid,
       reactMessage: selectedReaction,
       reactAction: 'set'
     });
-    if (didSend) {
-      this.recordRecentReactionEmoji(selectedReaction);
-    }
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -136,7 +136,11 @@ import {
   EthNum,
 } from './lib.js';
 
-import { CHAT_REACTION_SHEET_CATEGORIES } from './data/emoji-picker-data.js';
+import {
+  CHAT_REACTION_SHEET_CATEGORIES,
+  CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS,
+  CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY,
+} from './data/emoji-picker-data.js';
 
 const weiDigits = 18;
 const wei = 10n ** BigInt(weiDigits);
@@ -2949,6 +2953,9 @@ class SettingsModal {
     
     this.secretButton = document.getElementById('openSecretModal');
     this.secretButton.addEventListener('click', () => secretModal.open());
+
+    this.resetRecentEmojisButton = document.getElementById('resetRecentEmojis');
+    this.resetRecentEmojisButton.addEventListener('click', () => this.handleResetRecentEmojis());
     
     this.signOutButton = document.getElementById('handleSignOutSettings');
     this.signOutHeaderButton = document.getElementById('signOutSettingsHeader');
@@ -2966,6 +2973,33 @@ class SettingsModal {
         this.signOutHeaderButton.classList.add('active');
       }
     }, 400); // 400ms = modal animation (300ms) + 100ms buffer
+  }
+
+  handleResetRecentEmojis() {
+    if (!myData?.account) {
+      return;
+    }
+
+    const hasRecentEmojiOverrides = Object.prototype.hasOwnProperty.call(
+      myData.account,
+      CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY
+    );
+    if (!hasRecentEmojiOverrides) {
+      showToast('Recent emojis are already reset', 2000, 'info');
+      return;
+    }
+
+    const confirmed = confirm('Reset recent emojis to the default set?');
+    if (!confirmed) {
+      return;
+    }
+
+    delete myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY];
+    saveState();
+    if (chatModal?.reactionSheetActiveCategory === CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY) {
+      chatModal.setReactionSheetCategory(CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY);
+    }
+    showToast('Recent emojis reset', 2000, 'success');
   }
 
   open() {
@@ -13816,9 +13850,13 @@ const stakeValidatorModal = new StakeValidatorModal();
 const CHAT_REACTION_SHEET_CATEGORY_MAP = new Map(
   CHAT_REACTION_SHEET_CATEGORIES.map((category) => [category.key, category])
 );
-const CHAT_REACTION_SHEET_DEFAULT_CATEGORY = CHAT_REACTION_SHEET_CATEGORIES[0].key;
+const CHAT_REACTION_SHEET_DEFAULT_CATEGORY = CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY;
+const CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY = 'recentReactionEmojis';
+const CHAT_REACTION_SHEET_RECENT_LIMIT = CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.length;
+const CHAT_REACTION_SHEET_PROMOTION_RATIO = 0.5;
 const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
 const CHAT_REACTION_SHEET_TAB_ICONS = {
+  recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
   people: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><path d="M16 3.128a4 4 0 0 1 0 7.744"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><circle cx="9" cy="7" r="4"/></svg>',
   nature: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z"/><path d="M2 21c0-3 1.85-5.36 5.08-6C9.5 14.52 12 13 13 12"/></svg>',
@@ -14022,6 +14060,70 @@ class ChatModal {
     return this.dropOverlay;
   }
 
+  normalizeRecentReactionEmojiList(emojis) {
+    if (!Array.isArray(emojis)) {
+      return [];
+    }
+
+    const normalizedEmojis = [];
+    const seen = new Set();
+    for (const entry of emojis) {
+      const emoji = typeof entry === 'string' ? entry.trim() : '';
+      if (!emoji || seen.has(emoji)) {
+        continue;
+      }
+      seen.add(emoji);
+      normalizedEmojis.push(emoji);
+    }
+
+    return normalizedEmojis;
+  }
+
+  getRecentReactionAccountEmojis() {
+    return this.normalizeRecentReactionEmojiList(myData?.account?.[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY]);
+  }
+
+  getRecentReactionSheetEmojis() {
+    const rankedEmojis = [];
+    const seen = new Set();
+    const addEmoji = (emoji) => {
+      if (!emoji || seen.has(emoji)) {
+        return;
+      }
+      seen.add(emoji);
+      rankedEmojis.push(emoji);
+    };
+
+    this.getRecentReactionAccountEmojis().forEach(addEmoji);
+    CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.forEach(addEmoji);
+
+    return rankedEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+  }
+
+  recordRecentReactionEmoji(emoji) {
+    const selectedEmoji = typeof emoji === 'string' ? emoji.trim() : '';
+    if (!selectedEmoji || !myData?.account) {
+      return;
+    }
+
+    const rankedEmojis = this.getRecentReactionSheetEmojis();
+    const currentIndex = rankedEmojis.indexOf(selectedEmoji);
+    const remainingEmojis = rankedEmojis.filter((entry) => entry !== selectedEmoji);
+    const targetIndex = currentIndex === -1
+      ? CHAT_REACTION_SHEET_RECENT_LIMIT - 1
+      : Math.max(
+          0,
+          currentIndex - Math.max(1, Math.ceil((currentIndex + 1) * CHAT_REACTION_SHEET_PROMOTION_RATIO))
+        );
+
+    remainingEmojis.splice(targetIndex, 0, selectedEmoji);
+    myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY] = remainingEmojis.slice(
+      0,
+      CHAT_REACTION_SHEET_RECENT_LIMIT
+    );
+    saveState();
+  }
+
   /**
    * Returns the active reaction sheet category config.
    * @param {string} categoryKey
@@ -14030,6 +14132,9 @@ class ChatModal {
   getReactionSheetCategory(categoryKey) {
     const category = CHAT_REACTION_SHEET_CATEGORY_MAP.get(categoryKey);
     assert(category, `Unknown reaction sheet category: ${categoryKey}`);
+    if (category.key === CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY) {
+      return { ...category, emojis: this.getRecentReactionSheetEmojis() };
+    }
     return category;
   }
 
@@ -14041,7 +14146,10 @@ class ChatModal {
   getReactionSheetCategoryKeyForEmoji(emoji) {
     if (!emoji) return '';
 
-    const category = CHAT_REACTION_SHEET_CATEGORIES.find((entry) => entry.emojis.includes(emoji));
+    const category = CHAT_REACTION_SHEET_CATEGORIES.find((entry) => (
+      entry.key !== CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY &&
+      entry.emojis.includes(emoji)
+    ));
     return category?.key || '';
   }
 
@@ -18738,11 +18846,14 @@ class ChatModal {
     }
 
     closeUi();
-    await this.sendReactionMessage({
+    const didSend = await this.sendReactionMessage({
       reactId: txid,
       reactMessage: selectedReaction,
       reactAction: 'set'
     });
+    if (didSend) {
+      this.recordRecentReactionEmoji(selectedReaction);
+    }
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -2996,9 +2996,6 @@ class SettingsModal {
 
     delete myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY];
     saveState();
-    if (chatModal?.reactionSheetActiveCategory === CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY) {
-      chatModal.setReactionSheetCategory(CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY);
-    }
     showToast('Recent emojis reset', 2000, 'success');
   }
 
@@ -13855,6 +13852,63 @@ const CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY = 'recentReactionEmojis';
 const CHAT_REACTION_SHEET_RECENT_LIMIT = CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.length;
 const CHAT_REACTION_SHEET_PROMOTION_RATIO = 0.5;
 const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
+
+function normalizeRecentReactionEmojiList(emojis) {
+  if (!Array.isArray(emojis)) {
+    return [];
+  }
+
+  const normalizedEmojis = [];
+  const seen = new Set();
+  for (const entry of emojis) {
+    const emoji = typeof entry === 'string' ? entry.trim() : '';
+    if (!emoji || seen.has(emoji)) {
+      continue;
+    }
+    seen.add(emoji);
+    normalizedEmojis.push(emoji);
+  }
+
+  return normalizedEmojis;
+}
+
+function getRecentReactionSheetEmojis(accountEmojis) {
+  const rankedEmojis = [];
+  const seen = new Set();
+  const addEmoji = (emoji) => {
+    if (!emoji || seen.has(emoji)) {
+      return;
+    }
+    seen.add(emoji);
+    rankedEmojis.push(emoji);
+  };
+
+  normalizeRecentReactionEmojiList(accountEmojis).forEach(addEmoji);
+  CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.forEach(addEmoji);
+
+  return rankedEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+}
+
+function promoteRecentReactionEmoji(recentEmojis, selectedEmoji) {
+  const emoji = typeof selectedEmoji === 'string' ? selectedEmoji.trim() : '';
+  if (!emoji) {
+    return normalizeRecentReactionEmojiList(recentEmojis).slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+  }
+
+  const currentEmojis = normalizeRecentReactionEmojiList(recentEmojis).slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+  const currentIndex = currentEmojis.indexOf(emoji);
+  const remainingEmojis = currentEmojis.filter((entry) => entry !== emoji);
+  const targetIndex = currentIndex === -1
+    ? CHAT_REACTION_SHEET_RECENT_LIMIT - 1
+    : Math.max(
+        0,
+        currentIndex - Math.max(1, Math.ceil((currentIndex + 1) * CHAT_REACTION_SHEET_PROMOTION_RATIO))
+      );
+
+  remainingEmojis.splice(targetIndex, 0, emoji);
+  return remainingEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+}
+
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
@@ -14060,44 +14114,8 @@ class ChatModal {
     return this.dropOverlay;
   }
 
-  normalizeRecentReactionEmojiList(emojis) {
-    if (!Array.isArray(emojis)) {
-      return [];
-    }
-
-    const normalizedEmojis = [];
-    const seen = new Set();
-    for (const entry of emojis) {
-      const emoji = typeof entry === 'string' ? entry.trim() : '';
-      if (!emoji || seen.has(emoji)) {
-        continue;
-      }
-      seen.add(emoji);
-      normalizedEmojis.push(emoji);
-    }
-
-    return normalizedEmojis;
-  }
-
-  getRecentReactionAccountEmojis() {
-    return this.normalizeRecentReactionEmojiList(myData?.account?.[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY]);
-  }
-
   getRecentReactionSheetEmojis() {
-    const rankedEmojis = [];
-    const seen = new Set();
-    const addEmoji = (emoji) => {
-      if (!emoji || seen.has(emoji)) {
-        return;
-      }
-      seen.add(emoji);
-      rankedEmojis.push(emoji);
-    };
-
-    this.getRecentReactionAccountEmojis().forEach(addEmoji);
-    CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.forEach(addEmoji);
-
-    return rankedEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+    return getRecentReactionSheetEmojis(myData?.account?.[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY]);
   }
 
   recordRecentReactionEmoji(emoji) {
@@ -14106,20 +14124,9 @@ class ChatModal {
       return;
     }
 
-    const rankedEmojis = this.getRecentReactionSheetEmojis();
-    const currentIndex = rankedEmojis.indexOf(selectedEmoji);
-    const remainingEmojis = rankedEmojis.filter((entry) => entry !== selectedEmoji);
-    const targetIndex = currentIndex === -1
-      ? CHAT_REACTION_SHEET_RECENT_LIMIT - 1
-      : Math.max(
-          0,
-          currentIndex - Math.max(1, Math.ceil((currentIndex + 1) * CHAT_REACTION_SHEET_PROMOTION_RATIO))
-        );
-
-    remainingEmojis.splice(targetIndex, 0, selectedEmoji);
-    myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY] = remainingEmojis.slice(
-      0,
-      CHAT_REACTION_SHEET_RECENT_LIMIT
+    myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY] = promoteRecentReactionEmoji(
+      this.getRecentReactionSheetEmojis(),
+      selectedEmoji
     );
     saveState();
   }

--- a/app.js
+++ b/app.js
@@ -2953,9 +2953,6 @@ class SettingsModal {
     
     this.secretButton = document.getElementById('openSecretModal');
     this.secretButton.addEventListener('click', () => secretModal.open());
-
-    this.resetRecentEmojisButton = document.getElementById('resetRecentEmojis');
-    this.resetRecentEmojisButton.addEventListener('click', () => this.handleResetRecentEmojis());
     
     this.signOutButton = document.getElementById('handleSignOutSettings');
     this.signOutHeaderButton = document.getElementById('signOutSettingsHeader');
@@ -2973,30 +2970,6 @@ class SettingsModal {
         this.signOutHeaderButton.classList.add('active');
       }
     }, 400); // 400ms = modal animation (300ms) + 100ms buffer
-  }
-
-  handleResetRecentEmojis() {
-    if (!myData?.account) {
-      return;
-    }
-
-    const hasRecentEmojiOverrides = Object.prototype.hasOwnProperty.call(
-      myData.account,
-      CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY
-    );
-    if (!hasRecentEmojiOverrides) {
-      showToast('Recent emojis are already reset', 2000, 'info');
-      return;
-    }
-
-    const confirmed = confirm('Reset recent emojis to the default set?');
-    if (!confirmed) {
-      return;
-    }
-
-    delete myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY];
-    saveState();
-    showToast('Recent emojis reset', 2000, 'success');
   }
 
   open() {
@@ -14131,6 +14104,44 @@ class ChatModal {
     saveState();
   }
 
+  hasRecentReactionEmojiOverrides() {
+    return !!myData?.account && Object.prototype.hasOwnProperty.call(
+      myData.account,
+      CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY
+    );
+  }
+
+  updateReactionSheetResetButtonVisibility() {
+    if (!this.resetReactionSheetRecentButton) {
+      return;
+    }
+
+    this.resetReactionSheetRecentButton.hidden = (
+      this.reactionSheetActiveCategory !== CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY
+    );
+  }
+
+  handleResetRecentReactionEmojis() {
+    if (!myData?.account) {
+      return;
+    }
+
+    if (!this.hasRecentReactionEmojiOverrides()) {
+      showToast('Recent emojis are already reset', 2000, 'info');
+      return;
+    }
+
+    const confirmed = confirm('Reset recent emojis to the default set?');
+    if (!confirmed) {
+      return;
+    }
+
+    delete myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY];
+    saveState();
+    this.setReactionSheetCategory(CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY);
+    showToast('Recent emojis reset', 2000, 'success');
+  }
+
   /**
    * Returns the active reaction sheet category config.
    * @param {string} categoryKey
@@ -14192,6 +14203,7 @@ class ChatModal {
     const category = this.getReactionSheetCategory(categoryKey);
     this.reactionSheetActiveCategory = category.key;
     this.renderReactionSheetTabs();
+    this.updateReactionSheetResetButtonVisibility();
 
     this.reactionSheetGrid.innerHTML = category.emojis.map((emoji) => `
       <button class="chat-reaction-sheet-button message-context-reaction-button" type="button" data-emoji="${emoji}" aria-label="React with ${emoji}">${emoji}</button>
@@ -14331,6 +14343,7 @@ class ChatModal {
     this.reactionSheetDragRegion = document.getElementById('chatReactionSheetDragRegion');
     this.reactionSheetTabs = document.getElementById('chatReactionSheetTabs');
     this.reactionSheetGrid = document.getElementById('chatReactionSheetGrid');
+    this.resetReactionSheetRecentButton = document.getElementById('resetChatReactionSheetRecent');
     this.closeReactionSheetButton = document.getElementById('closeChatReactionSheet');
     this.renderReactionSheetTabs();
     this.setReactionSheetCategory(this.reactionSheetActiveCategory);
@@ -14431,6 +14444,7 @@ class ChatModal {
       }
     });
     this.closeReactionSheetButton.addEventListener('click', () => this.closeReactionSheet());
+    this.resetReactionSheetRecentButton.addEventListener('click', () => this.handleResetRecentReactionEmojis());
     this.reactionSheetDragRegion.addEventListener('pointerdown', this.handleReactionSheetDragStart.bind(this));
     this.reactionSheetDragRegion.addEventListener('pointermove', this.handleReactionSheetDragMove.bind(this));
     this.reactionSheetDragRegion.addEventListener('pointerup', this.handleReactionSheetDragEnd.bind(this));
@@ -17640,7 +17654,7 @@ class ChatModal {
   handleReactionSheetDragStart(event) {
     if (!this.reactionSheetOverlay.classList.contains('active')) return;
     if (event.button !== undefined && event.button !== 0) return;
-    if (event.target?.closest?.('.chat-reaction-sheet-close')) return;
+    if (event.target?.closest?.('.chat-reaction-sheet-close, .chat-reaction-sheet-reset')) return;
 
     event.stopPropagation();
     this.reactionSheetDragStartY = event.clientY;

--- a/app.js
+++ b/app.js
@@ -13852,63 +13852,6 @@ const CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY = 'recentReactionEmojis';
 const CHAT_REACTION_SHEET_RECENT_LIMIT = CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.length;
 const CHAT_REACTION_SHEET_PROMOTION_RATIO = 0.5;
 const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
-
-function normalizeRecentReactionEmojiList(emojis) {
-  if (!Array.isArray(emojis)) {
-    return [];
-  }
-
-  const normalizedEmojis = [];
-  const seen = new Set();
-  for (const entry of emojis) {
-    const emoji = typeof entry === 'string' ? entry.trim() : '';
-    if (!emoji || seen.has(emoji)) {
-      continue;
-    }
-    seen.add(emoji);
-    normalizedEmojis.push(emoji);
-  }
-
-  return normalizedEmojis;
-}
-
-function getRecentReactionSheetEmojis(accountEmojis) {
-  const rankedEmojis = [];
-  const seen = new Set();
-  const addEmoji = (emoji) => {
-    if (!emoji || seen.has(emoji)) {
-      return;
-    }
-    seen.add(emoji);
-    rankedEmojis.push(emoji);
-  };
-
-  normalizeRecentReactionEmojiList(accountEmojis).forEach(addEmoji);
-  CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.forEach(addEmoji);
-
-  return rankedEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
-}
-
-function promoteRecentReactionEmoji(recentEmojis, selectedEmoji) {
-  const emoji = typeof selectedEmoji === 'string' ? selectedEmoji.trim() : '';
-  if (!emoji) {
-    return normalizeRecentReactionEmojiList(recentEmojis).slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
-  }
-
-  const currentEmojis = normalizeRecentReactionEmojiList(recentEmojis).slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
-  const currentIndex = currentEmojis.indexOf(emoji);
-  const remainingEmojis = currentEmojis.filter((entry) => entry !== emoji);
-  const targetIndex = currentIndex === -1
-    ? CHAT_REACTION_SHEET_RECENT_LIMIT - 1
-    : Math.max(
-        0,
-        currentIndex - Math.max(1, Math.ceil((currentIndex + 1) * CHAT_REACTION_SHEET_PROMOTION_RATIO))
-      );
-
-  remainingEmojis.splice(targetIndex, 0, emoji);
-  return remainingEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
-}
-
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
@@ -14114,8 +14057,65 @@ class ChatModal {
     return this.dropOverlay;
   }
 
+  normalizeRecentReactionEmojiList(emojis) {
+    if (!Array.isArray(emojis)) {
+      return [];
+    }
+
+    const normalizedEmojis = [];
+    const seen = new Set();
+    for (const entry of emojis) {
+      const emoji = typeof entry === 'string' ? entry.trim() : '';
+      if (!emoji || seen.has(emoji)) {
+        continue;
+      }
+      seen.add(emoji);
+      normalizedEmojis.push(emoji);
+    }
+
+    return normalizedEmojis;
+  }
+
   getRecentReactionSheetEmojis() {
-    return getRecentReactionSheetEmojis(myData?.account?.[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY]);
+    const rankedEmojis = [];
+    const seen = new Set();
+    const addEmoji = (emoji) => {
+      if (!emoji || seen.has(emoji)) {
+        return;
+      }
+      seen.add(emoji);
+      rankedEmojis.push(emoji);
+    };
+
+    this.normalizeRecentReactionEmojiList(
+      myData?.account?.[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY]
+    ).forEach(addEmoji);
+    CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.forEach(addEmoji);
+
+    return rankedEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+  }
+
+  promoteRecentReactionEmoji(recentEmojis, selectedEmoji) {
+    const emoji = typeof selectedEmoji === 'string' ? selectedEmoji.trim() : '';
+    if (!emoji) {
+      return this.normalizeRecentReactionEmojiList(recentEmojis).slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
+    }
+
+    const currentEmojis = this.normalizeRecentReactionEmojiList(recentEmojis).slice(
+      0,
+      CHAT_REACTION_SHEET_RECENT_LIMIT
+    );
+    const currentIndex = currentEmojis.indexOf(emoji);
+    const remainingEmojis = currentEmojis.filter((entry) => entry !== emoji);
+    const targetIndex = currentIndex === -1
+      ? CHAT_REACTION_SHEET_RECENT_LIMIT - 1
+      : Math.max(
+          0,
+          currentIndex - Math.max(1, Math.ceil((currentIndex + 1) * CHAT_REACTION_SHEET_PROMOTION_RATIO))
+        );
+
+    remainingEmojis.splice(targetIndex, 0, emoji);
+    return remainingEmojis.slice(0, CHAT_REACTION_SHEET_RECENT_LIMIT);
   }
 
   recordRecentReactionEmoji(emoji) {
@@ -14124,7 +14124,7 @@ class ChatModal {
       return;
     }
 
-    myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY] = promoteRecentReactionEmoji(
+    myData.account[CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY] = this.promoteRecentReactionEmoji(
       this.getRecentReactionSheetEmojis(),
       selectedEmoji
     );

--- a/data/emoji-picker-data.js
+++ b/data/emoji-picker-data.js
@@ -10,6 +10,14 @@ const flagFromCode = (code) => {
 
 const regionFlags = (codes) => emojiWords(codes).map(flagFromCode);
 
+export const CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY = 'recent';
+
+export const CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS = emojiWords(`
+👍 ❤️ 😂 😮 🙏 👏 🎉 ✅ 💯 🔥
+👎 😢 🤔 😍 😡 🥳 ✨ 🚀 🙌 🤝
+👀 😎 🤩 🫶 💪 🤯 😭 🙂 😁 🤣
+`);
+
 const countryFlagCodes = `
 AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ
 CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO
@@ -21,6 +29,11 @@ TV TW TZ UA UG US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW
 `;
 
 export const CHAT_REACTION_SHEET_CATEGORIES = [
+  {
+    key: CHAT_REACTION_SHEET_RECENT_CATEGORY_KEY,
+    label: 'Recent',
+    emojis: CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS
+  },
   {
     key: 'smileys',
     label: 'Smileys',

--- a/index.html
+++ b/index.html
@@ -434,6 +434,7 @@
             <li class="menu-item" id="openToll" data-icon="dollar-sign">Toll</li>
             <li class="menu-item" id="openLockModal" data-icon="lock">Lock</li>
             <li class="menu-item" id="openSecretModal" data-icon="key">Secret</li>
+            <li class="menu-item" id="resetRecentEmojis" data-icon="rotate-ccw">Reset Recent Emojis</li>
             <li class="menu-item" id="openBackupForm" data-icon="download">Backup</li>
             <li class="menu-item" id="openRemoveAccount" data-icon="trash-2">Remove</li>
             <li class="menu-item" id="openLaunchUrl" data-icon="launch" style="display: none;">Launch</li>

--- a/index.html
+++ b/index.html
@@ -434,7 +434,6 @@
             <li class="menu-item" id="openToll" data-icon="dollar-sign">Toll</li>
             <li class="menu-item" id="openLockModal" data-icon="lock">Lock</li>
             <li class="menu-item" id="openSecretModal" data-icon="key">Secret</li>
-            <li class="menu-item" id="resetRecentEmojis" data-icon="rotate-ccw">Reset Recent Emojis</li>
             <li class="menu-item" id="openBackupForm" data-icon="download">Backup</li>
             <li class="menu-item" id="openRemoveAccount" data-icon="trash-2">Remove</li>
             <li class="menu-item" id="openLaunchUrl" data-icon="launch" style="display: none;">Launch</li>
@@ -1228,7 +1227,10 @@
               <div class="chat-reaction-sheet-handle" aria-hidden="true"></div>
               <div class="chat-reaction-sheet-header">
                 <div class="chat-reaction-sheet-title">Choose reaction</div>
-                <button class="chat-reaction-sheet-close" id="closeChatReactionSheet" type="button" aria-label="Close reaction picker">Close</button>
+                <div class="chat-reaction-sheet-actions">
+                  <button class="chat-reaction-sheet-reset" id="resetChatReactionSheetRecent" type="button" aria-label="Reset recent emojis" hidden>Reset</button>
+                  <button class="chat-reaction-sheet-close" id="closeChatReactionSheet" type="button" aria-label="Close reaction picker">Close</button>
+                </div>
               </div>
             </div>
             <div class="chat-reaction-sheet-body">

--- a/styles.css
+++ b/styles.css
@@ -1958,6 +1958,13 @@ input[type='file'].form-control::file-selector-button {
   color: var(--text-color);
 }
 
+.chat-reaction-sheet-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-reaction-sheet-reset,
 .chat-reaction-sheet-close {
   border: 0;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- Add a first/default Recent category to the expanded emoji reaction picker.
- Seed Recent with common reaction emojis, then let account-specific usage replace/reorder that list over time.
- Store the ordered recent emoji list in `myData.account.recentReactionEmojis` and persist through the existing account `saveState()` path.
- Add a Reset button inside the reaction sheet header that only appears on the Recent category.

## Behavior
- New off-list emojis enter at the end of the Recent list.
- Existing emojis move halfway toward the front on each attempted set reaction.
- Reaction attempts are recorded before the send completes, so failed sends still make the selected emoji easy to retry.
- Reset clears the account-level recent emoji override and immediately restores the default common set.

Closes #1296.

## Validation
- `node --check app.js`
- `node --check data\emoji-picker-data.js`
- `git diff --check`
- Static wiring check for the reaction sheet reset action