### PR TITLE
Refresh chat toll state after recipient send failures

### DIFF
--- a/app.js
+++ b/app.js
@@ -2076,7 +2076,7 @@ class WalletScreen {
 
   /**
    * Request funds from the faucet for normal users
-   * @returns {Promise<void>}
+   * @returns {void}
    */
   async requestFromFaucet() {
     if (this.isFaucetRequestInProgress) {
@@ -4648,7 +4648,7 @@ class FriendModal {
   * Handle friend form submission
   * 0 = blocked, 1 = Other, 2 = Connection
    * @param {Event} event
-   * @returns {Promise<void>}
+   * @returns {void}
    */
   async handleFriendSubmit(event) {
     event.preventDefault();
@@ -4736,7 +4736,7 @@ class FriendModal {
    * Update the friend button based on the contact's friend status
    * @param {Object} contact - The contact object
    * @param {string} buttonId - The ID of the button to update
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   updateFriendButton(contact, buttonId) {
     const button = document.getElementById(buttonId);
@@ -5263,7 +5263,7 @@ class ClockTimer {
 
   /**
    * Starts the ticking clock timer
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   start() {
     // Clear any existing timer

--- a/app.js
+++ b/app.js
@@ -2076,7 +2076,7 @@ class WalletScreen {
 
   /**
    * Request funds from the faucet for normal users
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   async requestFromFaucet() {
     if (this.isFaucetRequestInProgress) {
@@ -4648,7 +4648,7 @@ class FriendModal {
   * Handle friend form submission
   * 0 = blocked, 1 = Other, 2 = Connection
    * @param {Event} event
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   async handleFriendSubmit(event) {
     event.preventDefault();

--- a/app.js
+++ b/app.js
@@ -7642,6 +7642,11 @@ function getUserFacingTxFailureReason(reason, feeMismatchStatus = null) {
   return typeof reason === 'string' && reason.length > 0 ? reason : 'Transaction failed';
 }
 
+function isRecipientTollStateFailure(reason) {
+  assert(typeof reason === 'string', 'Transaction failure reason must be a string');
+  return /toll|blocked by the receiver|chat is blocked/i.test(reason);
+}
+
 /**
  * Attempts to refresh network params when a tx fails due to fee mismatch.
  * @param {string} reason
@@ -15667,11 +15672,9 @@ class ChatModal {
 
       if (!response || !response.result || !response.result.success) {
         console.error('message failed to send', response);
-        const str = response.result.reason;
-        const regex = /toll/i;
-  
-        if (str.match(regex)) {
-          await this.reopen();
+        const reason = response?.result?.reason;
+        if (reason && isRecipientTollStateFailure(reason)) {
+          await this.refreshRecipientTollState(currentAddress);
         }
         //let userMessage = 'Message failed to send. Please try again.';
         //const reason = response.result?.reason || '';
@@ -19038,6 +19041,10 @@ class ChatModal {
       if (outcome.didChange) {
         showToast('Reaction failed to send and was reverted', 0, 'error');
       }
+      const reason = response?.result?.reason;
+      if (reason && isRecipientTollStateFailure(reason)) {
+        await this.refreshRecipientTollState(currentAddress);
+      }
       saveState();
       return false;
     }
@@ -19718,6 +19725,29 @@ class ChatModal {
     }
   }
 
+  async refreshRecipientTollState(address) {
+    assert(address, 'Recipient address is required to refresh toll state');
+    const contact = myData.contacts[address];
+    assert(contact, `Contact is required to refresh toll state: ${address}`);
+
+    await this.updateTollValue(address);
+    await this.updateTollRequired(address);
+
+    if (!this.isActive() || this.address !== address) {
+      saveState();
+      return;
+    }
+
+    this.blockedByRecipient = Number(contact.tollRequiredToSend) === 2;
+    this.updateTollAmountUI(address);
+    this.addAttachmentButton.disabled = this.isEncrypting || this.isEditingMessage() || this.blockedByRecipient;
+    if (this.voiceRecordButton) {
+      this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
+    }
+
+    saveState();
+  }
+
   /**
    * Opens a lightweight chooser to select calling now or scheduling for later.
    * Returns 0 for immediate call or a corrected future timestamp (ms since epoch) using timeSkew.
@@ -20116,9 +20146,9 @@ class ChatModal {
       if (!response || !response.result || !response.result.success) {
         console.error('voice message failed to send', response);
 
-        const reason = response?.result?.reason || '';
-        if (/toll/i.test(reason)) {
-          await this.reopen();
+        const reason = response?.result?.reason;
+        if (reason && isRecipientTollStateFailure(reason)) {
+          await this.refreshRecipientTollState(this.address);
         }
 
         newMessage.status = 'failed';

--- a/app.js
+++ b/app.js
@@ -19651,7 +19651,7 @@ class ChatModal {
   /**
    * updateTollRequired queries contact object and updates the tollRequiredByMe and tollRequiredByOther fields
    * @param {string} address - the address of the contact
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   async updateTollRequired(address) {
     const myAddr = longAddress(myAccount.keys.address);
@@ -19704,7 +19704,7 @@ class ChatModal {
    * Invoked when opening chatModal. In the background, it will query the contact's toll field from the network.
    * If the queried toll value is different from the toll field in localStorage, it will update the toll field in localStorage and update the UI element that displays the toll field value.
    * @param {string} address - the address of the contact
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   async updateTollValue(address) {
     // query the contact's toll field from the network

--- a/app.js
+++ b/app.js
@@ -7642,6 +7642,11 @@ function getUserFacingTxFailureReason(reason, feeMismatchStatus = null) {
   return typeof reason === 'string' && reason.length > 0 ? reason : 'Transaction failed';
 }
 
+/**
+ * Returns true when the transaction failure reason indicates a recipient toll state failure.
+ * @param {string} reason
+ * @returns {boolean}
+ */
 function isRecipientTollStateFailure(reason) {
   assert(typeof reason === 'string', 'Transaction failure reason must be a string');
   return /toll|blocked by the receiver|chat is blocked/i.test(reason);
@@ -19725,6 +19730,11 @@ class ChatModal {
     }
   }
 
+  /**
+   * Refreshes the toll state for the given address
+   * @param {string} address - The address of the contact to refresh the toll state for
+   * @returns {Promise<void>}
+   */
   async refreshRecipientTollState(address) {
     assert(address, 'Recipient address is required to refresh toll state');
     const contact = myData.contacts[address];
@@ -20146,7 +20156,7 @@ class ChatModal {
       if (!response || !response.result || !response.result.success) {
         console.error('voice message failed to send', response);
 
-        const reason = response?.result?.reason;
+        const reason = response?.result?.reason || '';
         if (reason && isRecipientTollStateFailure(reason)) {
           await this.refreshRecipientTollState(this.address);
         }

--- a/app.js
+++ b/app.js
@@ -19751,9 +19751,7 @@ class ChatModal {
     this.blockedByRecipient = Number(contact.tollRequiredToSend) === 2;
     this.updateTollAmountUI(address);
     this.addAttachmentButton.disabled = this.isEncrypting || this.isEditingMessage() || this.blockedByRecipient;
-    if (this.voiceRecordButton) {
-      this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
-    }
+    this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
 
     saveState();
   }

--- a/app.js
+++ b/app.js
@@ -7649,7 +7649,7 @@ function getUserFacingTxFailureReason(reason, feeMismatchStatus = null) {
  */
 function isRecipientTollStateFailure(reason) {
   assert(typeof reason === 'string', 'Transaction failure reason must be a string');
-  return /toll|blocked by the receiver|chat is blocked/i.test(reason);
+  return /required toll|blocked by the receiver|chat is blocked/i.test(reason);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add recipient toll-state failure detection for failed text/edit, reaction, and voice-message sends.
- Replace full chat modal reopen behavior on toll-related failures with `refreshRecipientTollState(address)`, which refreshes the recipient toll amount and chat toll-required/block state in place.
- Keep the existing cached-first modal open behavior: the chat opens immediately from `myData.contacts[address]`, while `updateTollValue(address)` and `updateTollRequired(address)` continue refreshing network-backed toll values asynchronously.
- Ensure the footer toll display under the composer is covered by the refresh path: after the network calls update cached contact fields, `updateTollAmountUI(address)` rerenders `#tollLabel` and `#tollValue` for the active chat.
- Update composer controls after refresh so attachment and voice recording availability reflect the latest blocked/toll state without rebuilding the whole modal.

## Notes

- The header friend-status color is intentionally unchanged by this path. It is based on `contact.friend`, while this refresh handles recipient send eligibility via `tollRequiredToSend` and footer toll UI state.

## Validation

- Reviewed the diff against `origin/main` / merge base `3520877dca3a79f4207340ebd37f3de46a860047`.
- No code changes were made while updating this PR description.