### PR TITLE
Combine reaction pre-crack failure toasts

### DIFF
--- a/app.js
+++ b/app.js
@@ -2084,7 +2084,7 @@ class WalletScreen {
 
   /**
    * Request funds from the faucet for normal users
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   async requestFromFaucet() {
     if (this.isFaucetRequestInProgress) {
@@ -4656,7 +4656,7 @@ class FriendModal {
   * Handle friend form submission
   * 0 = blocked, 1 = Other, 2 = Connection
    * @param {Event} event
-   * @returns {void}
+   * @returns {Promise<void>}
    */
   async handleFriendSubmit(event) {
     event.preventDefault();

--- a/app.js
+++ b/app.js
@@ -7709,7 +7709,7 @@ function getUserFacingTxFailureReason(reason, feeMismatchStatus = null) {
  */
 function isRecipientTollStateFailure(reason) {
   assert(typeof reason === 'string', 'Transaction failure reason must be a string');
-  return /toll|blocked by the receiver|chat is blocked/i.test(reason);
+  return /required toll|blocked by the receiver|chat is blocked/i.test(reason);
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -7741,16 +7741,6 @@ function getRecipientTollPrecrackFailureReason(reason, contact = null, address =
 }
 
 /**
- * Returns true when the transaction failure reason indicates a recipient toll state failure.
- * @param {string} reason
- * @returns {boolean}
- */
-function isRecipientTollStateFailure(reason) {
-  assert(typeof reason === 'string', 'Transaction failure reason must be a string');
-  return /required toll|blocked by the receiver|chat is blocked/i.test(reason);
-}
-
-/**
  * Attempts to refresh network params when a tx fails due to fee mismatch.
  * @param {string} reason
  * @returns {Promise<{detected: boolean, refreshed: boolean}>}
@@ -19789,32 +19779,6 @@ class ChatModal {
     } else {
       return;
     }
-  }
-
-  /**
-   * Refreshes the toll state for the given address
-   * @param {string} address - The address of the contact to refresh the toll state for
-   * @returns {Promise<void>}
-   */
-  async refreshRecipientTollState(address) {
-    assert(address, 'Recipient address is required to refresh toll state');
-    const contact = myData.contacts[address];
-    assert(contact, `Contact is required to refresh toll state: ${address}`);
-
-    await this.updateTollValue(address);
-    await this.updateTollRequired(address);
-
-    if (!this.isActive() || this.address !== address) {
-      saveState();
-      return;
-    }
-
-    this.blockedByRecipient = Number(contact.tollRequiredToSend) === 2;
-    this.updateTollAmountUI(address);
-    this.addAttachmentButton.disabled = this.isEncrypting || this.isEditingMessage() || this.blockedByRecipient;
-    this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
-
-    saveState();
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -7702,6 +7702,11 @@ function getUserFacingTxFailureReason(reason, feeMismatchStatus = null) {
   return typeof reason === 'string' && reason.length > 0 ? reason : 'Transaction failed';
 }
 
+/**
+ * Returns true when the transaction failure reason indicates a recipient toll state failure.
+ * @param {string} reason
+ * @returns {boolean}
+ */
 function isRecipientTollStateFailure(reason) {
   assert(typeof reason === 'string', 'Transaction failure reason must be a string');
   return /toll|blocked by the receiver|chat is blocked/i.test(reason);
@@ -19749,6 +19754,11 @@ class ChatModal {
     }
   }
 
+  /**
+   * Refreshes the toll state for the given address
+   * @param {string} address - The address of the contact to refresh the toll state for
+   * @returns {Promise<void>}
+   */
   async refreshRecipientTollState(address) {
     assert(address, 'Recipient address is required to refresh toll state');
     const contact = myData.contacts[address];
@@ -20196,7 +20206,7 @@ class ChatModal {
       if (!response || !response.result || !response.result.success) {
         console.error('voice message failed to send', response);
 
-        const reason = response?.result?.reason;
+        const reason = response?.result?.reason || '';
         if (reason && isRecipientTollStateFailure(reason)) {
           await this.refreshRecipientTollState(this.address);
         }

--- a/app.js
+++ b/app.js
@@ -7712,28 +7712,22 @@ function isRecipientTollStateFailure(reason) {
   return /required toll|blocked by the receiver|chat is blocked/i.test(reason);
 }
 
-const REACTION_REVERTED_TOAST = 'Reaction failed to send and was reverted';
-
 /**
  * Extracts the actionable one-line recipient toll/block reason from a pre-crack message.
  * @param {string} reason
- * @param {Object | null} contact
- * @param {string} address
+ * @param {Object} contact
  * @returns {string}
  */
-function getRecipientTollPrecrackFailureReason(reason, contact = null, address = '') {
+function getRecipientTollPrecrackFailureReason(reason, contact) {
   assert(typeof reason === 'string', 'Pre-crack failure reason must be a string');
+  assert(contact, 'Contact is required for reaction pre-crack failure copy');
 
-  const blockedReason = 'Chat is blocked by the receiver.';
-  if (reason.includes(blockedReason)) return 'You are blocked by this user';
+  if (reason.includes('Chat is blocked by the receiver.')) {
+    return 'You are blocked by this user';
+  }
 
-  const tollMatch = reason.match(/Message amount \(([0-9]+)\) is less than required toll \(([0-9]+)\)\./);
-  if (tollMatch) {
-    const displayContact = {
-      ...(contact || {}),
-      address: contact?.address || address
-    };
-    const username = (contact || address) ? getContactDisplayName(displayContact) : 'this contact';
+  if (/less than required toll/i.test(reason)) {
+    const username = getContactDisplayName(contact);
     return `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`;
   }
 
@@ -7880,11 +7874,13 @@ async function injectTx(tx, txid) {
         timeDifference()
         toastMessage += ' (Please try again)';
       }
-      const isReactionPrecrackFailure = getRecipientTollPrecrackFailureReason(failureReason) !== ''
-        && myData.pending.some((pendingTx) => pendingTx.txid === txid && pendingTx.reactionPending);
-      if (!isReactionPrecrackFailure) {
-        showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
+      if (
+        isRecipientTollStateFailure(failureReason)
+        && myData.pending.some((pendingTx) => pendingTx.txid === txid && pendingTx.reactionPending)
+      ) {
+        return data;
       }
+      showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
     }
     return data;
   } catch (error) {
@@ -19091,11 +19087,11 @@ class ChatModal {
       }
       const reason = response?.result?.reason || '';
       if (outcome.didChange) {
-        const precrackReason = getRecipientTollPrecrackFailureReason(reason, contact, currentAddress);
+        const precrackReason = getRecipientTollPrecrackFailureReason(reason, contact);
         if (precrackReason) {
           showToast(precrackReason, 0, 'error');
         } else {
-          showToast(REACTION_REVERTED_TOAST, 0, 'error');
+          showToast('Reaction failed to send and was reverted', 0, 'error');
         }
       }
       if (reason && isRecipientTollStateFailure(reason)) {

--- a/app.js
+++ b/app.js
@@ -19096,7 +19096,13 @@ class ChatModal {
       if (outcome.didChange) {
         const precrackReason = getRecipientTollPrecrackFailureReason(reason);
         if (precrackReason) {
-          showToast(`${escapeHtml(REACTION_REVERTED_TOAST)}<br>${escapeHtml(precrackReason)}`, 0, 'error', true);
+          const message = [
+            '<div class="toast-reaction-failure">',
+            `<div class="toast-reaction-title">${escapeHtml(REACTION_REVERTED_TOAST)}</div>`,
+            `<div class="toast-reaction-detail">${escapeHtml(precrackReason)}</div>`,
+            '</div>'
+          ].join('');
+          showToast(message, 0, 'error', true);
         } else {
           showToast(REACTION_REVERTED_TOAST, 0, 'error');
         }

--- a/app.js
+++ b/app.js
@@ -2084,7 +2084,7 @@ class WalletScreen {
 
   /**
    * Request funds from the faucet for normal users
-   * @returns {Promise<void>}
+   * @returns {void}
    */
   async requestFromFaucet() {
     if (this.isFaucetRequestInProgress) {
@@ -4656,7 +4656,7 @@ class FriendModal {
   * Handle friend form submission
   * 0 = blocked, 1 = Other, 2 = Connection
    * @param {Event} event
-   * @returns {Promise<void>}
+   * @returns {void}
    */
   async handleFriendSubmit(event) {
     event.preventDefault();

--- a/app.js
+++ b/app.js
@@ -19775,9 +19775,7 @@ class ChatModal {
     this.blockedByRecipient = Number(contact.tollRequiredToSend) === 2;
     this.updateTollAmountUI(address);
     this.addAttachmentButton.disabled = this.isEncrypting || this.isEditingMessage() || this.blockedByRecipient;
-    if (this.voiceRecordButton) {
-      this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
-    }
+    this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
 
     saveState();
   }

--- a/app.js
+++ b/app.js
@@ -7717,9 +7717,11 @@ const REACTION_REVERTED_TOAST = 'Reaction failed to send and was reverted';
 /**
  * Extracts the actionable one-line recipient toll/block reason from a pre-crack message.
  * @param {string} reason
+ * @param {Object | null} contact
+ * @param {string} address
  * @returns {string}
  */
-function getRecipientTollPrecrackFailureReason(reason) {
+function getRecipientTollPrecrackFailureReason(reason, contact = null, address = '') {
   assert(typeof reason === 'string', 'Pre-crack failure reason must be a string');
 
   const blockedReason = 'Chat is blocked by the receiver.';
@@ -7727,7 +7729,12 @@ function getRecipientTollPrecrackFailureReason(reason) {
 
   const tollMatch = reason.match(/Message amount \(([0-9]+)\) is less than required toll \(([0-9]+)\)\./);
   if (tollMatch) {
-    return 'You can only send reactions to people who have added you as a connection';
+    const displayContact = {
+      ...(contact || {}),
+      address: contact?.address || address
+    };
+    const username = (contact || address) ? getContactDisplayName(displayContact) : 'this contact';
+    return `You can only send reactions to people who have added you as a connection. Ask ${username} to add you as a connection`;
   }
 
   return '';
@@ -19094,7 +19101,7 @@ class ChatModal {
       }
       const reason = response?.result?.reason || '';
       if (outcome.didChange) {
-        const precrackReason = getRecipientTollPrecrackFailureReason(reason);
+        const precrackReason = getRecipientTollPrecrackFailureReason(reason, contact, currentAddress);
         if (precrackReason) {
           showToast(precrackReason, 0, 'error');
         } else {

--- a/app.js
+++ b/app.js
@@ -7702,6 +7702,11 @@ function getUserFacingTxFailureReason(reason, feeMismatchStatus = null) {
   return typeof reason === 'string' && reason.length > 0 ? reason : 'Transaction failed';
 }
 
+function isRecipientTollStateFailure(reason) {
+  assert(typeof reason === 'string', 'Transaction failure reason must be a string');
+  return /toll|blocked by the receiver|chat is blocked/i.test(reason);
+}
+
 /**
  * Returns true when the transaction failure reason indicates a recipient toll state failure.
  * @param {string} reason
@@ -19744,6 +19749,29 @@ class ChatModal {
     }
   }
 
+  async refreshRecipientTollState(address) {
+    assert(address, 'Recipient address is required to refresh toll state');
+    const contact = myData.contacts[address];
+    assert(contact, `Contact is required to refresh toll state: ${address}`);
+
+    await this.updateTollValue(address);
+    await this.updateTollRequired(address);
+
+    if (!this.isActive() || this.address !== address) {
+      saveState();
+      return;
+    }
+
+    this.blockedByRecipient = Number(contact.tollRequiredToSend) === 2;
+    this.updateTollAmountUI(address);
+    this.addAttachmentButton.disabled = this.isEncrypting || this.isEditingMessage() || this.blockedByRecipient;
+    if (this.voiceRecordButton) {
+      this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
+    }
+
+    saveState();
+  }
+
   /**
    * Refreshes the toll state for the given address
    * @param {string} address - The address of the contact to refresh the toll state for
@@ -20168,7 +20196,7 @@ class ChatModal {
       if (!response || !response.result || !response.result.success) {
         console.error('voice message failed to send', response);
 
-        const reason = response?.result?.reason || '';
+        const reason = response?.result?.reason;
         if (reason && isRecipientTollStateFailure(reason)) {
           await this.refreshRecipientTollState(this.address);
         }

--- a/app.js
+++ b/app.js
@@ -7727,7 +7727,7 @@ function getRecipientTollPrecrackFailureReason(reason) {
 
   const tollMatch = reason.match(/Message amount \(([0-9]+)\) is less than required toll \(([0-9]+)\)\./);
   if (tollMatch) {
-    return `Toll sent (${EthNum.toStr(BigInt(tollMatch[1]))} LIB) is less than required toll (${EthNum.toStr(BigInt(tollMatch[2]))} LIB).`;
+    return `The contact may have changed your status. Ask them to add you as a connection. Toll sent: ${EthNum.toStr(BigInt(tollMatch[1]))} LIB; required toll: ${EthNum.toStr(BigInt(tollMatch[2]))} LIB.`;
   }
 
   return '';

--- a/app.js
+++ b/app.js
@@ -7712,6 +7712,25 @@ function isRecipientTollStateFailure(reason) {
   return /required toll|blocked by the receiver|chat is blocked/i.test(reason);
 }
 
+const REACTION_REVERTED_TOAST = 'Reaction failed to send and was reverted';
+
+/**
+ * Extracts the actionable recipient toll/block reason from a pre-crack message.
+ * @param {string} reason
+ * @returns {string}
+ */
+function getRecipientTollPrecrackFailureReason(reason) {
+  assert(typeof reason === 'string', 'Pre-crack failure reason must be a string');
+
+  const blockedReason = 'Chat is blocked by the receiver.';
+  if (reason.includes(blockedReason)) return blockedReason;
+
+  const tollMatch = reason.match(/Message amount \([^)]+\) is less than required toll \([^)]+\)\./);
+  if (tollMatch) return tollMatch[0];
+
+  return '';
+}
+
 /**
  * Returns true when the transaction failure reason indicates a recipient toll state failure.
  * @param {string} reason
@@ -7862,7 +7881,11 @@ async function injectTx(tx, txid) {
         timeDifference()
         toastMessage += ' (Please try again)';
       }
-      showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
+      const isReactionPrecrackFailure = getRecipientTollPrecrackFailureReason(failureReason) !== ''
+        && myData.pending.some((pendingTx) => pendingTx.txid === txid && pendingTx.reactionPending);
+      if (!isReactionPrecrackFailure) {
+        showToast(toastMessage, 0, feeMismatchStatus.detected ? 'warning' : 'error');
+      }
     }
     return data;
   } catch (error) {
@@ -19067,10 +19090,15 @@ class ChatModal {
       if (!outcome.hasPending) {
         cleanupResolvedReactionChain(currentAddress, outcome.targetTxid);
       }
+      const reason = response?.result?.reason || '';
       if (outcome.didChange) {
-        showToast('Reaction failed to send and was reverted', 0, 'error');
+        const precrackReason = getRecipientTollPrecrackFailureReason(reason);
+        if (precrackReason) {
+          showToast(`${escapeHtml(REACTION_REVERTED_TOAST)}<br>${escapeHtml(precrackReason)}`, 0, 'error', true);
+        } else {
+          showToast(REACTION_REVERTED_TOAST, 0, 'error');
+        }
       }
-      const reason = response?.result?.reason;
       if (reason && isRecipientTollStateFailure(reason)) {
         await this.refreshRecipientTollState(currentAddress);
       }

--- a/app.js
+++ b/app.js
@@ -7725,8 +7725,10 @@ function getRecipientTollPrecrackFailureReason(reason) {
   const blockedReason = 'Chat is blocked by the receiver.';
   if (reason.includes(blockedReason)) return blockedReason;
 
-  const tollMatch = reason.match(/Message amount \([^)]+\) is less than required toll \([^)]+\)\./);
-  if (tollMatch) return tollMatch[0];
+  const tollMatch = reason.match(/Message amount \(([0-9]+)\) is less than required toll \(([0-9]+)\)\./);
+  if (tollMatch) {
+    return `Toll sent (${EthNum.toStr(BigInt(tollMatch[1]))} LIB) is less than required toll (${EthNum.toStr(BigInt(tollMatch[2]))} LIB).`;
+  }
 
   return '';
 }

--- a/app.js
+++ b/app.js
@@ -7715,7 +7715,7 @@ function isRecipientTollStateFailure(reason) {
 const REACTION_REVERTED_TOAST = 'Reaction failed to send and was reverted';
 
 /**
- * Extracts the actionable recipient toll/block reason from a pre-crack message.
+ * Extracts the actionable one-line recipient toll/block reason from a pre-crack message.
  * @param {string} reason
  * @returns {string}
  */
@@ -7723,11 +7723,11 @@ function getRecipientTollPrecrackFailureReason(reason) {
   assert(typeof reason === 'string', 'Pre-crack failure reason must be a string');
 
   const blockedReason = 'Chat is blocked by the receiver.';
-  if (reason.includes(blockedReason)) return blockedReason;
+  if (reason.includes(blockedReason)) return 'You are blocked by this user';
 
   const tollMatch = reason.match(/Message amount \(([0-9]+)\) is less than required toll \(([0-9]+)\)\./);
   if (tollMatch) {
-    return `The contact may have changed your status. Ask them to add you as a connection.\nToll sent: ${EthNum.toStr(BigInt(tollMatch[1]))} LIB; required toll: ${EthNum.toStr(BigInt(tollMatch[2]))} LIB.`;
+    return 'You can only send reactions to people who have added you as a connection';
   }
 
   return '';
@@ -19096,13 +19096,7 @@ class ChatModal {
       if (outcome.didChange) {
         const precrackReason = getRecipientTollPrecrackFailureReason(reason);
         if (precrackReason) {
-          const message = [
-            '<div class="toast-reaction-failure">',
-            `<div class="toast-reaction-title">${escapeHtml(REACTION_REVERTED_TOAST)}</div>`,
-            `<div class="toast-reaction-detail">${escapeHtml(precrackReason)}</div>`,
-            '</div>'
-          ].join('');
-          showToast(message, 0, 'error', true);
+          showToast(precrackReason, 0, 'error');
         } else {
           showToast(REACTION_REVERTED_TOAST, 0, 'error');
         }

--- a/app.js
+++ b/app.js
@@ -7727,7 +7727,7 @@ function getRecipientTollPrecrackFailureReason(reason) {
 
   const tollMatch = reason.match(/Message amount \(([0-9]+)\) is less than required toll \(([0-9]+)\)\./);
   if (tollMatch) {
-    return `The contact may have changed your status. Ask them to add you as a connection. Toll sent: ${EthNum.toStr(BigInt(tollMatch[1]))} LIB; required toll: ${EthNum.toStr(BigInt(tollMatch[2]))} LIB.`;
+    return `The contact may have changed your status. Ask them to add you as a connection.\nToll sent: ${EthNum.toStr(BigInt(tollMatch[1]))} LIB; required toll: ${EthNum.toStr(BigInt(tollMatch[2]))} LIB.`;
   }
 
   return '';

--- a/styles.css
+++ b/styles.css
@@ -4067,21 +4067,6 @@ mark {
   margin-bottom: 6px;
 }
 
-.toast-reaction-failure {
-  text-align: left;
-  line-height: 1.3;
-}
-
-.toast-reaction-title {
-  font-weight: 700;
-  margin-bottom: 8px;
-}
-
-.toast-reaction-detail {
-  font-weight: var(--font-weight-normal);
-  white-space: pre-line;
-}
-
 .toast-list-title-centered {
   text-align: center;
 }

--- a/styles.css
+++ b/styles.css
@@ -4079,6 +4079,7 @@ mark {
 
 .toast-reaction-detail {
   font-weight: var(--font-weight-normal);
+  white-space: pre-line;
 }
 
 .toast-list-title-centered {

--- a/styles.css
+++ b/styles.css
@@ -4067,6 +4067,20 @@ mark {
   margin-bottom: 6px;
 }
 
+.toast-reaction-failure {
+  text-align: left;
+  line-height: 1.3;
+}
+
+.toast-reaction-title {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.toast-reaction-detail {
+  font-weight: var(--font-weight-normal);
+}
+
 .toast-list-title-centered {
   text-align: center;
 }


### PR DESCRIPTION
Fixes #1307

## Summary
- Show one simple reaction failure toast for recipient toll/block pre-crack failures.
- Use the relevant user-facing line: blocked users see the standard blocked message, and tolled users are asked to have the contact add them as a connection.
- Suppress the raw inject error toast only when the failed transaction is a pending reaction pre-crack failure.

## Why
Reaction sends could show both the raw `Error injecting transaction: PreCrack has failed...` toast and the generic revert toast. This keeps the reaction revert handling while making the visible toast short and actionable.

## Validation
- `node --check app.js`
- `node --test tests-local/reaction-precrack-toast-copy.test.js tests-local/reaction-send-restrictions.test.js`

<img width="501" height="1006" alt="image" src="https://github.com/user-attachments/assets/e2c7ea11-19c6-4a24-a3fb-e0e0c2b3ff65" />

<img width="501" height="1006" alt="image" src="https://github.com/user-attachments/assets/99db5225-9f3c-4dcd-9001-66183fb388a5" />

