### PR TITLE
Improve chat modal open performance on iPhone WebView

### DIFF
--- a/app.js
+++ b/app.js
@@ -15097,12 +15097,21 @@ class ChatModal {
     this.isExpandingChatRenderWindow = true;
     this.chatRenderedOldestIndex = nextOldestIndex;
     this.messagesList.insertAdjacentHTML('afterbegin', range.html);
+    const prependedThumbnailRows = range.renderedTxids.flatMap((txid) => {
+      const messageEl = this.messagesList.querySelector(`.message[data-txid="${CSS.escape(txid)}"]`);
+      return messageEl
+        ? [...messageEl.querySelectorAll('[data-image-attachment="true"], [data-video-attachment="true"]')]
+        : [];
+    });
 
     this.syncRenderedReactionTargets(range.renderedTxids);
-    this.loadThumbnailsForAttachments();
 
     const insertedHeight = this.messagesContainer.scrollHeight - oldScrollHeight;
     this.messagesContainer.scrollTop = oldScrollTop + insertedHeight;
+    this.loadThumbnailsForAttachments({
+      attachmentRows: prependedThumbnailRows,
+      preserveScrollAnchor: true
+    });
     this.chatExpansionRearmDistanceFromBottom = beforeSnapshot.distanceFromBottom + this.getChatLoadAheadThreshold();
     this.isExpandingChatRenderWindow = false;
     this.stopChatTopBoundaryScrollHold();
@@ -17322,21 +17331,34 @@ class ChatModal {
   /**
    * Load thumbnails for image and video attachments asynchronously
    * Only loads from local IndexedDB cache - pUrl downloads happen on user action (Preview)
+   * @param {{ attachmentRows?: Iterable<HTMLElement>, preserveScrollAnchor?: boolean }} options
    * @returns {void}
    */
-  async loadThumbnailsForAttachments() {
-    const thumbnailAttachments = this.messagesList.querySelectorAll(
-      '[data-image-attachment="true"], [data-video-attachment="true"]'
-    );
+  async loadThumbnailsForAttachments({ attachmentRows = null, preserveScrollAnchor = false } = {}) {
+    const thumbnailAttachments = attachmentRows
+      ? [...attachmentRows]
+      : [...this.messagesList.querySelectorAll(
+          '[data-image-attachment="true"], [data-video-attachment="true"]'
+        )];
     
     for (const attachmentRow of thumbnailAttachments) {
+      if (!attachmentRow?.isConnected) continue;
       const url = attachmentRow.dataset.url;
       if (!url || url === '#') continue;
 
       try {
         const thumbnailBlob = await thumbnailCache.get(url);
-        if (thumbnailBlob) {
-          this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
+        if (thumbnailBlob && attachmentRow.isConnected) {
+          const oldScrollHeight = preserveScrollAnchor && this.messagesContainer
+            ? this.messagesContainer.scrollHeight
+            : null;
+          const didUpdate = this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
+          if (didUpdate && Number.isFinite(oldScrollHeight) && this.messagesContainer) {
+            const heightDelta = this.messagesContainer.scrollHeight - oldScrollHeight;
+            if (heightDelta !== 0) {
+              this.messagesContainer.scrollTop = Math.max(0, this.messagesContainer.scrollTop + heightDelta);
+            }
+          }
         }
       } catch (error) {
         console.warn('Failed to load thumbnail for', url, error);

--- a/app.js
+++ b/app.js
@@ -13947,7 +13947,7 @@ class ChatModal {
 
     this.chatInitialRenderCount = 50;
     this.chatFirstOlderRenderBatchSize = 25;
-    this.chatOlderRenderBatchSize = 50;
+    this.chatOlderRenderBatchSize = 25;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
@@ -13961,10 +13961,12 @@ class ChatModal {
     this.chatRenderWindowDrainFrame = null;
     this.chatRenderWindowDrainAddress = null;
     this.chatRenderWindowDrainStartedAt = 0;
+    this.chatSpacerCatchupTimer = null;
     this.chatRenderSequence = 0;
     this.lastChatTouchLogAt = 0;
     this.chatTouchStartY = null;
     this.chatExpansionRearmDistanceFromBottom = null;
+    this.chatHistorySpacerHeight = 0;
   }
 
   /**
@@ -15027,14 +15029,94 @@ class ChatModal {
     };
   }
 
+  getChatHistorySpacerElement() {
+    const firstChild = this.messagesList?.firstElementChild;
+    return firstChild?.classList?.contains('chat-history-spacer') ? firstChild : null;
+  }
+
+  getChatHistorySpacerHeight() {
+    const spacer = this.getChatHistorySpacerElement();
+    if (spacer) {
+      const styleHeight = Number.parseFloat(spacer.style.height);
+      if (Number.isFinite(styleHeight)) {
+        return Math.max(0, styleHeight);
+      }
+    }
+    return Number.isFinite(this.chatHistorySpacerHeight)
+      ? Math.max(0, this.chatHistorySpacerHeight)
+      : 0;
+  }
+
+  setChatHistorySpacerHeight(height) {
+    const nextHeight = Math.max(0, Math.round(height || 0));
+    this.chatHistorySpacerHeight = nextHeight;
+    const spacer = this.getChatHistorySpacerElement();
+    if (!spacer) return;
+    if (nextHeight <= 0) {
+      spacer.remove();
+      return;
+    }
+    spacer.style.height = `${nextHeight}px`;
+    spacer.dataset.estimatedHeight = String(nextHeight);
+  }
+
+  estimateChatMessageHeight(item) {
+    if (!item) return 104;
+
+    let height = 92;
+    if (item.replyId) height += 56;
+
+    if (typeof item.amount === 'bigint') {
+      if (typeof item.message === 'string' && item.message.trim()) height += 28;
+      return Math.min(260, height);
+    }
+
+    if (isDeleted(item)) {
+      return Math.min(180, height + 20);
+    }
+
+    const attachments = Array.isArray(item.xattach) ? item.xattach : [];
+    attachments.forEach((attachment) => {
+      const type = attachment?.type || '';
+      height += type.startsWith('image/') || type.startsWith('video/') ? 148 : 132;
+    });
+
+    if (item.type === 'vm') {
+      height += 104;
+    } else if (item.type === 'call') {
+      height += 72;
+    } else if (typeof item.message === 'string' && item.message.trim()) {
+      const textLength = item.message.length;
+      const estimatedLines = Math.max(1, Math.ceil(textLength / 28));
+      height += Math.min(220, estimatedLines * 22);
+    }
+
+    return Math.min(520, Math.max(104, height));
+  }
+
+  estimateChatMessagesHeight(messages, oldestIndex, newestIndex) {
+    if (!Array.isArray(messages) || messages.length === 0) return 0;
+    const clampedOldestIndex = Math.min(messages.length - 1, oldestIndex);
+    const clampedNewestIndex = Math.max(0, newestIndex);
+    if (clampedOldestIndex < clampedNewestIndex) return 0;
+
+    let estimatedHeight = 0;
+    for (let i = clampedOldestIndex; i >= clampedNewestIndex; i--) {
+      estimatedHeight += this.estimateChatMessageHeight(messages[i]);
+    }
+    return Math.round(estimatedHeight);
+  }
+
   resetChatRenderWindow(address = null) {
     this.cancelChatRenderWindowDrain();
+    this.cancelChatSpacerCatchup();
     this.clearPendingChatScrollExpand();
     this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
     this.chatForceFullRenderOnce = false;
     this.isExpandingChatRenderWindow = false;
     this.chatExpansionRearmDistanceFromBottom = null;
+    this.chatHistorySpacerHeight = 0;
   }
 
   getChatRenderRange(messages, currentAddress, forceFullRender = false) {
@@ -15107,14 +15189,18 @@ class ChatModal {
   getChatScrollSnapshot() {
     const container = this.messagesContainer || this.messagesList?.parentElement;
     if (!container) return null;
+    const topSpacerHeight = this.getChatHistorySpacerHeight();
     const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    const scrollTop = Math.round(container.scrollTop);
     return {
-      scrollTop: Math.round(container.scrollTop),
+      scrollTop,
       maxScrollTop: Math.round(maxScrollTop),
       distanceFromBottom: Math.round(Math.max(0, maxScrollTop - container.scrollTop)),
       scrollHeight: Math.round(container.scrollHeight),
       clientHeight: Math.round(container.clientHeight),
-      messageListHeight: this.messagesList ? Math.round(this.messagesList.scrollHeight) : 'n/a'
+      messageListHeight: this.messagesList ? Math.round(this.messagesList.scrollHeight) : 'n/a',
+      topSpacerHeight: Math.round(topSpacerHeight),
+      distanceToRenderedTop: Math.round(Math.max(0, scrollTop - topSpacerHeight))
     };
   }
 
@@ -15163,6 +15249,8 @@ class ChatModal {
       scrollTop: snapshot ? snapshot.scrollTop : 'n/a',
       maxScrollTop: snapshot ? snapshot.maxScrollTop : 'n/a',
       distanceFromBottom: snapshot ? snapshot.distanceFromBottom : 'n/a',
+      distanceToRenderedTop: snapshot ? snapshot.distanceToRenderedTop : 'n/a',
+      topSpacerHeight: snapshot ? snapshot.topSpacerHeight : 'n/a',
       containerOverflowY: containerStyle.overflowY,
       containerTouchAction: containerStyle.touchAction,
       containerWebkitOverflow: containerStyle.webkitOverflowScrolling || 'n/a',
@@ -15205,6 +15293,8 @@ class ChatModal {
         reason,
         scrollTop: scrollSnapshot ? scrollSnapshot.scrollTop : 'n/a',
         distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
+        distanceToRenderedTop: scrollSnapshot ? scrollSnapshot.distanceToRenderedTop : 'n/a',
+        topSpacerHeight: scrollSnapshot ? scrollSnapshot.topSpacerHeight : 'n/a',
         loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
         touchActive: this.isChatTouchActive
       });
@@ -15315,7 +15405,15 @@ class ChatModal {
     if (shouldPrependOlderMessages) {
       const prependPerfStart = this.getChatPerfTime();
       const oldScrollTop = this.messagesContainer.scrollTop;
-      const oldScrollHeight = this.messagesContainer.scrollHeight;
+      const spacer = this.getChatHistorySpacerElement();
+      const oldSpacerHeight = this.getChatHistorySpacerHeight();
+      const useEstimatedSpacerPreserve = !!spacer && oldSpacerHeight > 0;
+      const oldScrollHeight = useEstimatedSpacerPreserve ? null : this.messagesContainer.scrollHeight;
+      const estimatedInsertedHeight = this.estimateChatMessagesHeight(
+        messages,
+        nextOldestIndex,
+        currentOldestIndex + 1
+      );
       const range = this.buildChatMessageRangeHTML(
         messages,
         contact,
@@ -15323,7 +15421,11 @@ class ChatModal {
         currentOldestIndex + 1
       );
       const domWritePerfStart = this.getChatPerfTime();
-      this.messagesList.insertAdjacentHTML('afterbegin', range.html);
+      if (useEstimatedSpacerPreserve) {
+        spacer.insertAdjacentHTML('afterend', range.html);
+      } else {
+        this.messagesList.insertAdjacentHTML('afterbegin', range.html);
+      }
       const domWriteMs = this.formatChatPerfMs(domWritePerfStart);
       const reactionsPerfStart = this.getChatPerfTime();
       if (range.renderedTxids.length > 0) {
@@ -15331,15 +15433,22 @@ class ChatModal {
       }
       const reactionsMs = this.formatChatPerfMs(reactionsPerfStart);
       const preservePerfStart = this.getChatPerfTime();
-      const newScrollHeight = this.messagesContainer.scrollHeight;
-      const scrollDelta = newScrollHeight - oldScrollHeight;
-      this.messagesContainer.scrollTop = oldScrollTop + scrollDelta;
+      let scrollDelta = estimatedInsertedHeight;
+      let nextSpacerHeight = oldSpacerHeight;
+      if (useEstimatedSpacerPreserve) {
+        nextSpacerHeight = Math.max(0, oldSpacerHeight - estimatedInsertedHeight);
+        this.setChatHistorySpacerHeight(nextSpacerHeight);
+      } else {
+        const newScrollHeight = this.messagesContainer.scrollHeight;
+        scrollDelta = newScrollHeight - oldScrollHeight;
+        this.messagesContainer.scrollTop = oldScrollTop + scrollDelta;
+      }
       const preserveMs = this.formatChatPerfMs(preservePerfStart);
       this.chatRenderedOldestIndex = nextOldestIndex;
       this.isExpandingChatRenderWindow = false;
 
       const rearmDistance = (beforeSnapshot?.distanceFromBottom || 0) + Math.max(
-        this.messagesContainer.clientHeight || 0,
+        beforeSnapshot?.clientHeight || this.messagesContainer.clientHeight || 0,
         this.getChatLoadAheadThreshold() * 2
       );
       this.chatExpansionRearmDistanceFromBottom = rearmDistance;
@@ -15352,15 +15461,28 @@ class ChatModal {
         join: range.joinMs,
         domWrite: domWriteMs,
         reactions: reactionsMs,
+        preserveStrategy: useEstimatedSpacerPreserve ? 'estimatedSpacer' : 'scrollHeightDelta',
         preserve: preserveMs,
         oldScrollTop: Math.round(oldScrollTop),
-        oldScrollHeight: Math.round(oldScrollHeight),
+        oldScrollHeight: useEstimatedSpacerPreserve ? 'skipped' : Math.round(oldScrollHeight),
+        oldSpacerHeight: Math.round(oldSpacerHeight),
+        estimatedHeight: Math.round(estimatedInsertedHeight),
+        nextSpacerHeight: Math.round(nextSpacerHeight),
         scrollDelta: Math.round(scrollDelta),
         nextScrollTop: Math.round(this.messagesContainer.scrollTop),
         rearmDistance: Math.round(rearmDistance),
         children: this.messagesList.children.length,
         total: this.formatChatPerfMs(prependPerfStart)
       });
+      if (useEstimatedSpacerPreserve && nextOldestIndex < messages.length - 1) {
+        const distanceToRenderedTop = Math.max(
+          0,
+          this.messagesContainer.scrollTop - this.getChatHistorySpacerHeight()
+        );
+        if (distanceToRenderedTop <= this.getChatLoadAheadThreshold()) {
+          this.scheduleChatSpacerCatchup('afterPrepend');
+        }
+      }
       return true;
     }
 
@@ -15407,6 +15529,9 @@ class ChatModal {
     const renderedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
       : 'n/a';
+    const remainingOlder = Number.isInteger(renderedOldestIndex)
+      ? Math.max(0, totalMessages - 1 - renderedOldestIndex)
+      : 0;
     const now = this.getChatPerfTime();
     if (now - this.lastChatScrollLogAt > 750) {
       this.lastChatScrollLogAt = now;
@@ -15418,10 +15543,10 @@ class ChatModal {
         clientHeight: scrollSnapshot.clientHeight,
         messageListHeight: scrollSnapshot.messageListHeight,
         loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
+        topSpacerHeight: scrollSnapshot.topSpacerHeight,
+        distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
         renderedOldestIndex,
-        remainingOlder: Number.isInteger(renderedOldestIndex)
-          ? Math.max(0, totalMessages - 1 - renderedOldestIndex)
-          : 'n/a',
+        remainingOlder: Number.isInteger(renderedOldestIndex) ? remainingOlder : 'n/a',
         isExpanding: this.isExpandingChatRenderWindow,
         modalScrollTop: this.modal ? Math.round(this.modal.scrollTop || 0) : 'n/a',
         bodyScrollY: Math.round(window.scrollY || 0)
@@ -15436,14 +15561,22 @@ class ChatModal {
     }
     const isExpansionRearmed = !Number.isFinite(this.chatExpansionRearmDistanceFromBottom) ||
       scrollSnapshot.distanceFromBottom >= this.chatExpansionRearmDistanceFromBottom;
-    if (scrollSnapshot.distanceFromBottom >= loadAheadThreshold && isExpansionRearmed) {
-      this.queueChatScrollExpand('scrollDistance', scrollSnapshot);
+    if (
+      remainingOlder > 0 &&
+      scrollSnapshot.distanceToRenderedTop <= loadAheadThreshold &&
+      isExpansionRearmed
+    ) {
+      if (scrollSnapshot.topSpacerHeight > 0) {
+        this.expandChatRenderWindow('scrollDistance');
+      } else {
+        this.queueChatScrollExpand('scrollDistance', scrollSnapshot);
+      }
     }
   }
 
   getChatLoadAheadThreshold() {
     const containerHeight = this.messagesContainer?.clientHeight || 0;
-    return Math.max(240, containerHeight * 0.35);
+    return Math.max(1200, containerHeight * 3);
   }
 
   getChatOlderRenderBatchSize() {
@@ -15455,12 +15588,44 @@ class ChatModal {
     if (currentOldestIndex <= this.chatInitialRenderCount - 1) {
       return this.chatFirstOlderRenderBatchSize;
     }
-    const scrollSnapshot = this.getChatScrollSnapshot();
-    const distanceFromBottom = scrollSnapshot ? scrollSnapshot.distanceFromBottom : 0;
-    const urgentThreshold = (container.clientHeight || 0) * 3;
-    return distanceFromBottom >= urgentThreshold
-      ? this.chatOlderRenderBatchSize * 2
-      : this.chatOlderRenderBatchSize;
+    return this.chatOlderRenderBatchSize;
+  }
+
+  cancelChatSpacerCatchup() {
+    if (!this.chatSpacerCatchupTimer) return;
+    clearTimeout(this.chatSpacerCatchupTimer);
+    this.chatSpacerCatchupTimer = null;
+  }
+
+  scheduleChatSpacerCatchup(reason) {
+    if (this.chatSpacerCatchupTimer || this.isExpandingChatRenderWindow) return;
+    this.chatSpacerCatchupTimer = setTimeout(() => {
+      this.chatSpacerCatchupTimer = null;
+      if (!this.isActive() || !this.messagesContainer || !this.messagesList || !this.address) return;
+      const contact = myData.contacts[this.address];
+      const messages = contact?.messages;
+      if (!Array.isArray(messages) || messages.length === 0) return;
+      const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+        ? this.chatRenderedOldestIndex
+        : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
+      if (currentOldestIndex >= messages.length - 1) return;
+
+      const topSpacerHeight = this.getChatHistorySpacerHeight();
+      const distanceToRenderedTop = Math.max(0, this.messagesContainer.scrollTop - topSpacerHeight);
+      const loadAheadThreshold = this.getChatLoadAheadThreshold();
+      if (topSpacerHeight <= 0 || distanceToRenderedTop > loadAheadThreshold) return;
+
+      this.logChatPerf('window:spacerCatchup', {
+        contact: this.formatChatPerfAddress(this.address, contact),
+        reason,
+        scrollTop: Math.round(this.messagesContainer.scrollTop),
+        topSpacerHeight: Math.round(topSpacerHeight),
+        distanceToRenderedTop: Math.round(distanceToRenderedTop),
+        loadAheadThreshold: Math.round(loadAheadThreshold),
+        remainingOlder: Math.max(0, messages.length - 1 - currentOldestIndex)
+      });
+      this.expandChatRenderWindow('scrollDistance');
+    }, 16);
   }
 
   cancelChatRenderWindowDrain() {
@@ -17165,11 +17330,16 @@ class ChatModal {
       // The newest received element will be found after the loop completes
     }
     const renderLoopMs = this.formatChatPerfMs(renderLoopPerfStart);
-    const topSpacerHeight = 0;
+    const topSpacerHeight = renderRange.isWindowed
+      ? this.estimateChatMessagesHeight(messages, messages.length - 1, renderRange.oldestIndex + 1)
+      : 0;
+    this.chatHistorySpacerHeight = topSpacerHeight;
 
     // Replace the list once to avoid one DOM mutation per message.
     const joinPerfStart = this.getChatPerfTime();
-    const renderedHTML = renderedMessages.join('');
+    const renderedHTML = `${topSpacerHeight > 0
+      ? `<div class="chat-history-spacer" aria-hidden="true" data-estimated-height="${Math.round(topSpacerHeight)}" style="height:${Math.round(topSpacerHeight)}px"></div>`
+      : ''}${renderedMessages.join('')}`;
     const joinMs = this.formatChatPerfMs(joinPerfStart);
     const domWritePerfStart = this.getChatPerfTime();
     this.messagesList.innerHTML = renderedHTML;

--- a/app.js
+++ b/app.js
@@ -15046,8 +15046,15 @@ class ChatModal {
     for (const messageEl of messageEls) {
       const rect = messageEl.getBoundingClientRect();
       if (rect.bottom >= containerTop) {
+        const txid = messageEl.dataset.txid;
+        const timestamp = messageEl.dataset.messageTimestamp;
+        const selector = txid
+          ? `.message[data-txid="${CSS.escape(txid)}"]`
+          : timestamp
+            ? `.message[data-message-timestamp="${CSS.escape(timestamp)}"]`
+            : null;
         return {
-          element: messageEl,
+          selector,
           offsetTop: rect.top - containerTop
         };
       }
@@ -15057,9 +15064,11 @@ class ChatModal {
   }
 
   restoreVisibleMessageAnchor(anchor) {
-    if (!anchor?.element || !this.messagesContainer) return;
+    if (!anchor?.selector || !this.messagesContainer || !this.messagesList) return;
+    const anchorElement = this.messagesList.querySelector(anchor.selector);
+    if (!anchorElement) return;
     const containerTop = this.messagesContainer.getBoundingClientRect().top;
-    const nextTop = anchor.element.getBoundingClientRect().top - containerTop;
+    const nextTop = anchorElement.getBoundingClientRect().top - containerTop;
     this.messagesContainer.scrollTop += nextTop - anchor.offsetTop;
   }
 

--- a/app.js
+++ b/app.js
@@ -13948,7 +13948,7 @@ class ChatModal {
 
     this.chatInitialRenderCount = 50;
     this.chatFirstOlderRenderBatchSize = 10;
-    this.chatOlderRenderBatchSize = 25;
+    this.chatOlderRenderBatchSize = 10;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;

--- a/app.js
+++ b/app.js
@@ -13946,11 +13946,16 @@ class ChatModal {
     this.chatPerfLogFlushTimer = null;
 
     this.chatInitialRenderCount = 50;
-    this.chatOlderRenderBatchSize = 75;
+    this.chatFirstOlderRenderBatchSize = 25;
+    this.chatOlderRenderBatchSize = 50;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
     this.isExpandingChatRenderWindow = false;
+    this.isChatTouchActive = false;
+    this.chatPendingScrollExpand = false;
+    this.chatPendingScrollExpandReason = null;
+    this.chatScrollEndFallbackTimer = null;
     this.lastChatScrollLogAt = 0;
     this.chatRenderWindowDrainTimer = null;
     this.chatRenderWindowDrainFrame = null;
@@ -14472,8 +14477,11 @@ class ChatModal {
     });
     // Close all context menus when messages container scrolls
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
-    this.messagesContainer.addEventListener('touchstart', (e) => this.logChatTouchDiagnostics(e, 'messagesStart'), { passive: true });
+    this.messagesContainer.addEventListener('scrollend', () => this.handleMessagesContainerScrollEnd('scrollend'), { passive: true });
+    this.messagesContainer.addEventListener('touchstart', (e) => this.handleMessagesTouchStart(e), { passive: true });
     this.messagesContainer.addEventListener('touchmove', (e) => this.logChatTouchDiagnostics(e, 'messagesMove'), { passive: true });
+    this.messagesContainer.addEventListener('touchend', (e) => this.handleMessagesTouchEnd(e), { passive: true });
+    this.messagesContainer.addEventListener('touchcancel', (e) => this.handleMessagesTouchEnd(e), { passive: true });
     this.modal.addEventListener('touchmove', (e) => this.logChatTouchDiagnostics(e, 'modalMove'), { passive: true });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
@@ -15021,6 +15029,7 @@ class ChatModal {
 
   resetChatRenderWindow(address = null) {
     this.cancelChatRenderWindowDrain();
+    this.clearPendingChatScrollExpand();
     this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
     this.chatForceFullRenderOnce = false;
@@ -15167,13 +15176,105 @@ class ChatModal {
     });
   }
 
+  handleMessagesTouchStart(event) {
+    this.isChatTouchActive = true;
+    this.logChatTouchDiagnostics(event, 'messagesStart');
+  }
+
+  handleMessagesTouchEnd(event) {
+    this.isChatTouchActive = false;
+    this.logChatTouchDiagnostics(event, 'messagesEnd');
+    this.schedulePendingChatScrollExpand('touchEnd');
+  }
+
+  clearPendingChatScrollExpand() {
+    this.chatPendingScrollExpand = false;
+    this.chatPendingScrollExpandReason = null;
+    if (this.chatScrollEndFallbackTimer) {
+      clearTimeout(this.chatScrollEndFallbackTimer);
+      this.chatScrollEndFallbackTimer = null;
+    }
+  }
+
+  queueChatScrollExpand(reason, scrollSnapshot) {
+    const wasPending = this.chatPendingScrollExpand;
+    this.chatPendingScrollExpand = true;
+    this.chatPendingScrollExpandReason = reason;
+    if (!wasPending) {
+      this.logChatPerf('window:expandQueued', {
+        reason,
+        scrollTop: scrollSnapshot ? scrollSnapshot.scrollTop : 'n/a',
+        distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
+        loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
+        touchActive: this.isChatTouchActive
+      });
+    }
+    this.schedulePendingChatScrollExpand('scrollIdleFallback');
+  }
+
+  schedulePendingChatScrollExpand(trigger) {
+    if (!this.chatPendingScrollExpand) return;
+    if (this.chatScrollEndFallbackTimer) {
+      clearTimeout(this.chatScrollEndFallbackTimer);
+    }
+    this.chatScrollEndFallbackTimer = setTimeout(() => {
+      this.chatScrollEndFallbackTimer = null;
+      this.flushPendingChatScrollExpand(trigger);
+    }, 220);
+  }
+
+  handleMessagesContainerScrollEnd(trigger = 'scrollend') {
+    this.flushPendingChatScrollExpand(trigger);
+  }
+
+  flushPendingChatScrollExpand(trigger) {
+    if (!this.chatPendingScrollExpand || this.isExpandingChatRenderWindow || !this.isActive()) return;
+    if (this.isChatTouchActive && trigger !== 'scrollend') {
+      this.schedulePendingChatScrollExpand('touchStillActive');
+      return;
+    }
+
+    const scrollSnapshot = this.getChatScrollSnapshot();
+    const loadAheadThreshold = this.getChatLoadAheadThreshold();
+    const rearmDistance = this.chatExpansionRearmDistanceFromBottom;
+    const isExpansionRearmed = !Number.isFinite(rearmDistance) ||
+      (scrollSnapshot && scrollSnapshot.distanceFromBottom >= rearmDistance);
+
+    if (!scrollSnapshot || scrollSnapshot.distanceFromBottom < loadAheadThreshold || !isExpansionRearmed) {
+      this.logChatPerf('window:expandAborted', {
+        trigger,
+        reason: !scrollSnapshot
+          ? 'missingSnapshot'
+          : scrollSnapshot.distanceFromBottom < loadAheadThreshold
+            ? 'belowThreshold'
+            : 'notRearmed',
+        distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
+        loadAheadThreshold: Math.round(loadAheadThreshold),
+        rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
+      });
+      this.clearPendingChatScrollExpand();
+      return;
+    }
+
+    const queuedReason = this.chatPendingScrollExpandReason || 'scrollDistance';
+    this.clearPendingChatScrollExpand();
+    this.logChatPerf('window:expandFlushed', {
+      trigger,
+      queuedReason,
+      distanceFromBottom: scrollSnapshot.distanceFromBottom,
+      loadAheadThreshold: Math.round(loadAheadThreshold),
+      rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
+    });
+    this.expandChatRenderWindow('scrollIdle');
+  }
+
   expandChatRenderWindow(reason = 'scroll') {
     if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) return false;
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
     if (!Array.isArray(messages) || messages.length === 0) return false;
     const isOpenDrain = reason === 'openDrain';
-    const shouldPrependOlderMessages = reason === 'scrollDistance' && this.messagesContainer;
+    const shouldPrependOlderMessages = (reason === 'scrollDistance' || reason === 'scrollIdle') && this.messagesContainer;
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
@@ -15336,7 +15437,7 @@ class ChatModal {
     const isExpansionRearmed = !Number.isFinite(this.chatExpansionRearmDistanceFromBottom) ||
       scrollSnapshot.distanceFromBottom >= this.chatExpansionRearmDistanceFromBottom;
     if (scrollSnapshot.distanceFromBottom >= loadAheadThreshold && isExpansionRearmed) {
-      this.expandChatRenderWindow('scrollDistance');
+      this.queueChatScrollExpand('scrollDistance', scrollSnapshot);
     }
   }
 
@@ -15348,6 +15449,12 @@ class ChatModal {
   getChatOlderRenderBatchSize() {
     const container = this.messagesContainer;
     if (!container) return this.chatOlderRenderBatchSize;
+    const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+      ? this.chatRenderedOldestIndex
+      : this.chatInitialRenderCount - 1;
+    if (currentOldestIndex <= this.chatInitialRenderCount - 1) {
+      return this.chatFirstOlderRenderBatchSize;
+    }
     const scrollSnapshot = this.getChatScrollSnapshot();
     const distanceFromBottom = scrollSnapshot ? scrollSnapshot.distanceFromBottom : 0;
     const urgentThreshold = (container.clientHeight || 0) * 3;

--- a/app.js
+++ b/app.js
@@ -17096,9 +17096,9 @@ class ChatModal {
    * Update an attachment row with a thumbnail image
    * @param {HTMLElement} attachmentRow - The attachment row element
    * @param {Blob} thumbnailBlob - The thumbnail blob to display
-   * @returns {boolean} True if update was successful, false otherwise
+   * @returns {Promise<boolean>} True if update was successful, false otherwise
    */
-  updateThumbnailInPlace(attachmentRow, thumbnailBlob) {
+  async updateThumbnailInPlace(attachmentRow, thumbnailBlob) {
     if (!attachmentRow || !attachmentRow.parentNode || !thumbnailBlob) {
       return false;
     }
@@ -17112,10 +17112,34 @@ class ChatModal {
       if (oldThumbnailUrl) {
         URL.revokeObjectURL(oldThumbnailUrl);
       }
-      
+
+      const thumbnailImage = new Image();
+      thumbnailImage.alt = 'Thumbnail';
+      thumbnailImage.className = 'attachment-thumbnail';
+      thumbnailImage.src = thumbnailUrl;
+
+      try {
+        if (typeof thumbnailImage.decode === 'function') {
+          await thumbnailImage.decode();
+        } else if (!thumbnailImage.complete) {
+          await new Promise((resolve, reject) => {
+            thumbnailImage.onload = resolve;
+            thumbnailImage.onerror = reject;
+          });
+        }
+      } catch (error) {
+        URL.revokeObjectURL(thumbnailUrl);
+        throw error;
+      }
+
+      if (!attachmentRow.isConnected || !iconContainer.isConnected) {
+        URL.revokeObjectURL(thumbnailUrl);
+        return false;
+      }
+
       // Replace icon with thumbnail image
-      iconContainer.innerHTML = `<img src="${thumbnailUrl}" alt="Thumbnail" class="attachment-thumbnail">`;
-      
+      iconContainer.replaceChildren(thumbnailImage);
+
       // Store blob URL for cleanup
       attachmentRow.dataset.thumbnailUrl = thumbnailUrl;
       return true;
@@ -17373,7 +17397,7 @@ class ChatModal {
             if (attachmentRow) {
               const thumbnailBlob = await thumbnailCache.get(attachmentUrl);
               if (thumbnailBlob) {
-                this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
+                await this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
               }
             }
           })
@@ -18843,7 +18867,7 @@ class ChatModal {
       
       // Cache and display thumbnail
       await thumbnailCache.save(url, thumbnailBlob, 'image/jpeg');
-      this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
+      await this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
       
       hideToast(loadingToastId);
     } catch (err) {

--- a/app.js
+++ b/app.js
@@ -13947,23 +13947,14 @@ class ChatModal {
     this.chatOlderRenderBatchSize = 50;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
-    this.chatForceFullRenderOnce = false;
     this.isExpandingChatRenderWindow = false;
     this.isChatTouchActive = false;
     this.chatPendingScrollExpand = false;
-    this.chatPendingScrollExpandReason = null;
     this.chatScrollEndFallbackTimer = null;
-    this.chatRenderWindowDrainTimer = null;
-    this.chatRenderWindowDrainFrame = null;
-    this.chatRenderWindowDrainAddress = null;
-    this.chatSpacerCatchupTimer = null;
     this.chatRenderSequence = 0;
     this.chatTouchStartY = null;
     this.chatExpansionRearmDistanceFromBottom = null;
-    this.chatHistorySpacerHeight = 0;
     this.chatHistoryLoadingToastId = null;
-    this.chatTopBoundaryScrollHoldActive = false;
-    this.chatTopBoundaryScrollHoldTop = 0;
   }
 
   /**
@@ -14473,11 +14464,11 @@ class ChatModal {
     });
     // Close all context menus when messages container scrolls
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
-    this.messagesContainer.addEventListener('scrollend', () => this.handleMessagesContainerScrollEnd('scrollend'), { passive: true });
+    this.messagesContainer.addEventListener('scrollend', () => this.handleMessagesContainerScrollEnd(), { passive: true });
     this.messagesContainer.addEventListener('touchstart', (e) => this.handleMessagesTouchStart(e), { passive: true });
     this.messagesContainer.addEventListener('touchmove', (e) => this.handleMessagesTouchMove(e), { passive: false });
-    this.messagesContainer.addEventListener('touchend', (e) => this.handleMessagesTouchEnd(e), { passive: true });
-    this.messagesContainer.addEventListener('touchcancel', (e) => this.handleMessagesTouchEnd(e), { passive: true });
+    this.messagesContainer.addEventListener('touchend', () => this.handleMessagesTouchEnd(), { passive: true });
+    this.messagesContainer.addEventListener('touchcancel', () => this.handleMessagesTouchEnd(), { passive: true });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
       const reactionButton = e.target.closest('.message-context-reaction-button');
@@ -14911,131 +14902,27 @@ class ChatModal {
     return !!(editInput?.value?.trim?.());
   }
 
-  isMessagesContainerNearBottom(thresholdPx = 50) {
-    const container = this.messagesContainer || this.messagesList?.parentElement;
-    if (!container) return false;
-    return container.scrollHeight - container.scrollTop - container.clientHeight <= thresholdPx;
-  }
-
-  scrollMessagesToBottom({ readMetrics = true } = {}) {
-    const container = this.messagesContainer || this.messagesList?.parentElement;
-    if (!container) return null;
-    container.scrollTop = 1000000000;
-    if (!readMetrics) return null;
-    return {
-      scrollTop: Math.round(container.scrollTop),
-      scrollHeight: Math.round(container.scrollHeight),
-      clientHeight: Math.round(container.clientHeight)
-    };
-  }
-
-  getChatHistorySpacerElement() {
-    const firstChild = this.messagesList?.firstElementChild;
-    return firstChild?.classList?.contains('chat-history-spacer') ? firstChild : null;
-  }
-
-  getChatHistorySpacerHeight() {
-    const spacer = this.getChatHistorySpacerElement();
-    if (spacer) {
-      const styleHeight = Number.parseFloat(spacer.style.height);
-      if (Number.isFinite(styleHeight)) {
-        return Math.max(0, styleHeight);
-      }
-    }
-    return Number.isFinite(this.chatHistorySpacerHeight)
-      ? Math.max(0, this.chatHistorySpacerHeight)
-      : 0;
-  }
-
-  setChatHistorySpacerHeight(height) {
-    const nextHeight = Math.max(0, Math.round(height || 0));
-    this.chatHistorySpacerHeight = nextHeight;
-    const spacer = this.getChatHistorySpacerElement();
-    if (!spacer) return;
-    if (nextHeight <= 0) {
-      spacer.remove();
-      return;
-    }
-    spacer.style.height = `${nextHeight}px`;
-    spacer.dataset.estimatedHeight = String(nextHeight);
-  }
-
-  estimateChatMessageHeight(item) {
-    if (!item) return 104;
-
-    let height = 92;
-    if (item.replyId) height += 56;
-
-    if (typeof item.amount === 'bigint') {
-      if (typeof item.message === 'string' && item.message.trim()) height += 28;
-      return Math.min(260, height);
-    }
-
-    if (isDeleted(item)) {
-      return Math.min(180, height + 20);
-    }
-
-    const attachments = Array.isArray(item.xattach) ? item.xattach : [];
-    attachments.forEach((attachment) => {
-      const type = attachment?.type || '';
-      height += type.startsWith('image/') || type.startsWith('video/') ? 148 : 132;
-    });
-
-    if (item.type === 'vm') {
-      height += 104;
-    } else if (item.type === 'call') {
-      height += 72;
-    } else if (typeof item.message === 'string' && item.message.trim()) {
-      const textLength = item.message.length;
-      const estimatedLines = Math.max(1, Math.ceil(textLength / 28));
-      height += Math.min(220, estimatedLines * 22);
-    }
-
-    return Math.min(520, Math.max(104, height));
-  }
-
-  estimateChatMessagesHeight(messages, oldestIndex, newestIndex) {
-    if (!Array.isArray(messages) || messages.length === 0) return 0;
-    const clampedOldestIndex = Math.min(messages.length - 1, oldestIndex);
-    const clampedNewestIndex = Math.max(0, newestIndex);
-    if (clampedOldestIndex < clampedNewestIndex) return 0;
-
-    let estimatedHeight = 0;
-    for (let i = clampedOldestIndex; i >= clampedNewestIndex; i--) {
-      estimatedHeight += this.estimateChatMessageHeight(messages[i]);
-    }
-    return Math.round(estimatedHeight);
-  }
-
-  resetChatRenderWindow(address = null) {
-    this.cancelChatRenderWindowDrain();
-    this.cancelChatSpacerCatchup();
+  resetChatRenderWindow(address) {
     this.clearPendingChatScrollExpand();
-    this.stopChatTopBoundaryScrollHold('reset');
+    this.stopChatTopBoundaryScrollHold();
     this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
-    this.chatForceFullRenderOnce = false;
     this.isExpandingChatRenderWindow = false;
     this.chatExpansionRearmDistanceFromBottom = null;
-    this.chatHistorySpacerHeight = 0;
   }
 
-  getChatRenderRange(messages, currentAddress, forceFullRender = false) {
-    const totalMessages = Array.isArray(messages) ? messages.length : 0;
+  getChatRenderRange(messages, currentAddress, renderAll) {
+    assert(Array.isArray(messages), 'Chat messages are required');
+    const totalMessages = messages.length;
     if (totalMessages === 0) {
-      return { newestIndex: 0, oldestIndex: -1, totalMessages, isWindowed: false };
+      return { newestIndex: 0, oldestIndex: -1 };
     }
 
-    if (
-      forceFullRender ||
-      this.chatForceFullRenderOnce ||
-      this.chatRenderedWindowAddress !== currentAddress
-    ) {
+    if (renderAll || this.chatRenderedWindowAddress !== currentAddress) {
       this.chatRenderedWindowAddress = currentAddress;
-      this.chatRenderedOldestIndex = forceFullRender || this.chatForceFullRenderOnce
+      this.chatRenderedOldestIndex = renderAll
         ? totalMessages - 1
         : Math.min(totalMessages - 1, this.chatInitialRenderCount - 1);
-      this.chatForceFullRenderOnce = false;
     }
 
     if (!Number.isInteger(this.chatRenderedOldestIndex)) {
@@ -15046,69 +14933,25 @@ class ChatModal {
 
     return {
       newestIndex: 0,
-      oldestIndex: this.chatRenderedOldestIndex,
-      totalMessages,
-      isWindowed: this.chatRenderedOldestIndex < totalMessages - 1
+      oldestIndex: this.chatRenderedOldestIndex
     };
   }
 
-  getFirstVisibleMessageAnchor() {
-    const container = this.messagesContainer;
-    if (!container || !this.messagesList) return null;
-
-    const containerTop = container.getBoundingClientRect().top;
-    const messageEls = [...this.messagesList.querySelectorAll('.message')];
-    for (const messageEl of messageEls) {
-      const rect = messageEl.getBoundingClientRect();
-      if (rect.bottom >= containerTop) {
-        const txid = messageEl.dataset.txid;
-        const timestamp = messageEl.dataset.messageTimestamp;
-        const selector = txid
-          ? `.message[data-txid="${CSS.escape(txid)}"]`
-          : timestamp
-            ? `.message[data-message-timestamp="${CSS.escape(timestamp)}"]`
-            : null;
-        return {
-          selector,
-          offsetTop: rect.top - containerTop
-        };
-      }
-    }
-
-    return null;
-  }
-
-  restoreVisibleMessageAnchor(anchor) {
-    if (!anchor?.selector || !this.messagesContainer || !this.messagesList) return;
-    const anchorElement = this.messagesList.querySelector(anchor.selector);
-    if (!anchorElement) return;
-    const containerTop = this.messagesContainer.getBoundingClientRect().top;
-    const nextTop = anchorElement.getBoundingClientRect().top - containerTop;
-    this.messagesContainer.scrollTop += nextTop - anchor.offsetTop;
-  }
-
   getChatScrollSnapshot() {
-    const container = this.messagesContainer || this.messagesList?.parentElement;
-    if (!container) return null;
-    const topSpacerHeight = this.getChatHistorySpacerHeight();
-    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    const container = this.messagesContainer;
+    assert(container, 'Messages container is required');
+    const maxScrollTop = container.scrollHeight - container.clientHeight;
     const scrollTop = Math.round(container.scrollTop);
     return {
       scrollTop,
-      maxScrollTop: Math.round(maxScrollTop),
       distanceFromBottom: Math.round(Math.max(0, maxScrollTop - container.scrollTop)),
-      scrollHeight: Math.round(container.scrollHeight),
       clientHeight: Math.round(container.clientHeight),
-      messageListHeight: this.messagesList ? Math.round(this.messagesList.scrollHeight) : 'n/a',
-      topSpacerHeight: Math.round(topSpacerHeight),
-      distanceToRenderedTop: Math.round(Math.max(0, scrollTop - topSpacerHeight))
+      distanceToRenderedTop: Math.max(0, scrollTop)
     };
   }
 
   showChatHistoryLoadingToast() {
-    if (this.chatHistoryLoadingToastId && document.getElementById(this.chatHistoryLoadingToastId)) {
-      return;
-    }
+    if (this.chatHistoryLoadingToastId) return;
     this.chatHistoryLoadingToastId = showToast('Loading messages', 0, 'loading', false, { dedupe: false });
   }
 
@@ -15118,30 +14961,25 @@ class ChatModal {
     this.chatHistoryLoadingToastId = null;
   }
 
-  startChatTopBoundaryScrollHold(scrollSnapshot) {
-    this.chatTopBoundaryScrollHoldActive = true;
-    this.chatTopBoundaryScrollHoldTop = Math.max(0, Math.round(scrollSnapshot?.topSpacerHeight || 0));
+  startChatTopBoundaryScrollHold() {
     this.showChatHistoryLoadingToast();
     this.clampChatTopBoundaryScrollHold();
   }
 
-  stopChatTopBoundaryScrollHold(reason = 'rendered') {
-    if (!this.chatTopBoundaryScrollHoldActive && !this.chatHistoryLoadingToastId) return;
-    this.chatTopBoundaryScrollHoldActive = false;
-    this.chatTopBoundaryScrollHoldTop = 0;
+  stopChatTopBoundaryScrollHold() {
+    if (!this.chatHistoryLoadingToastId) return;
     this.hideChatHistoryLoadingToast();
   }
 
   clampChatTopBoundaryScrollHold() {
-    if (!this.chatTopBoundaryScrollHoldActive || !this.messagesContainer) return false;
-    const holdTop = Math.max(0, Math.round(this.chatTopBoundaryScrollHoldTop || 0));
-    if (this.messagesContainer.scrollTop >= holdTop) return false;
-    this.messagesContainer.scrollTop = holdTop;
+    if (!this.chatHistoryLoadingToastId || !this.messagesContainer) return false;
+    if (this.messagesContainer.scrollTop >= 0) return false;
+    this.messagesContainer.scrollTop = 0;
     return true;
   }
 
   shouldBlockChatTopBoundaryTouchMove(event) {
-    if (!this.chatTopBoundaryScrollHoldActive || !this.messagesContainer) return false;
+    if (!this.chatHistoryLoadingToastId || !this.messagesContainer) return false;
     const touch = event.touches?.[0] || null;
     const y = touch ? Math.round(touch.clientY) : null;
     const deltaY = typeof y === 'number' && typeof this.chatTouchStartY === 'number'
@@ -15150,8 +14988,7 @@ class ChatModal {
     if (deltaY <= 0) return false;
 
     const snapshot = this.getChatScrollSnapshot();
-    const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(snapshot);
-    return !snapshot || snapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
+    return snapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(snapshot);
   }
 
   handleMessagesTouchStart(event) {
@@ -15170,45 +15007,43 @@ class ChatModal {
     event.stopPropagation();
   }
 
-  handleMessagesTouchEnd(event) {
+  handleMessagesTouchEnd() {
     this.isChatTouchActive = false;
-    this.schedulePendingChatScrollExpand('touchEnd');
+    this.schedulePendingChatScrollExpand();
   }
 
   clearPendingChatScrollExpand() {
     this.chatPendingScrollExpand = false;
-    this.chatPendingScrollExpandReason = null;
     if (this.chatScrollEndFallbackTimer) {
       clearTimeout(this.chatScrollEndFallbackTimer);
       this.chatScrollEndFallbackTimer = null;
     }
   }
 
-  queueChatScrollExpand(reason, scrollSnapshot) {
+  queueChatScrollExpand() {
     this.chatPendingScrollExpand = true;
-    this.chatPendingScrollExpandReason = reason;
-    this.schedulePendingChatScrollExpand('scrollIdleFallback');
+    this.schedulePendingChatScrollExpand();
   }
 
-  schedulePendingChatScrollExpand(trigger) {
+  schedulePendingChatScrollExpand() {
     if (!this.chatPendingScrollExpand) return;
     if (this.chatScrollEndFallbackTimer) {
       clearTimeout(this.chatScrollEndFallbackTimer);
     }
     this.chatScrollEndFallbackTimer = setTimeout(() => {
       this.chatScrollEndFallbackTimer = null;
-      this.flushPendingChatScrollExpand(trigger);
+      this.flushPendingChatScrollExpand();
     }, 220);
   }
 
-  handleMessagesContainerScrollEnd(trigger = 'scrollend') {
-    this.flushPendingChatScrollExpand(trigger);
+  handleMessagesContainerScrollEnd() {
+    this.flushPendingChatScrollExpand();
   }
 
-  flushPendingChatScrollExpand(trigger) {
+  flushPendingChatScrollExpand() {
     if (!this.chatPendingScrollExpand || this.isExpandingChatRenderWindow || !this.isActive()) return;
-    if (this.isChatTouchActive && trigger !== 'scrollend') {
-      this.schedulePendingChatScrollExpand('touchStillActive');
+    if (this.isChatTouchActive) {
+      this.schedulePendingChatScrollExpand();
       return;
     }
 
@@ -15216,161 +15051,72 @@ class ChatModal {
     const loadAheadThreshold = this.getChatLoadAheadThreshold();
     const rearmDistance = this.chatExpansionRearmDistanceFromBottom;
     const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(scrollSnapshot);
-    const isAtRenderedBoundary = !!scrollSnapshot &&
-      scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
+    const isAtRenderedBoundary = scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
     const isExpansionRearmed = !Number.isFinite(rearmDistance) ||
-      (scrollSnapshot && scrollSnapshot.distanceFromBottom >= rearmDistance);
+      scrollSnapshot.distanceFromBottom >= rearmDistance;
 
     if (
-      !scrollSnapshot ||
       scrollSnapshot.distanceFromBottom < loadAheadThreshold ||
       (!isExpansionRearmed && !isAtRenderedBoundary)
     ) {
       this.clearPendingChatScrollExpand();
-      this.stopChatTopBoundaryScrollHold('expandAborted');
+      this.stopChatTopBoundaryScrollHold();
       return;
     }
 
     if (isAtRenderedBoundary) {
-      this.startChatTopBoundaryScrollHold(scrollSnapshot, 'expandFlush');
+      this.startChatTopBoundaryScrollHold();
     }
     this.clearPendingChatScrollExpand();
-    const expanded = this.expandChatRenderWindow('scrollIdle');
+    const expanded = this.expandChatRenderWindow();
     if (!expanded) {
-      this.stopChatTopBoundaryScrollHold('expandSkipped');
+      this.stopChatTopBoundaryScrollHold();
     }
   }
 
-  expandChatRenderWindow(reason = 'scroll') {
-    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) {
-      this.stopChatTopBoundaryScrollHold('expandUnavailable');
-      return false;
-    }
+  expandChatRenderWindow() {
+    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesContainer || !this.messagesList) return false;
+
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
-    if (!Array.isArray(messages) || messages.length === 0) {
-      this.stopChatTopBoundaryScrollHold('expandNoMessages');
-      return false;
-    }
-    const isOpenDrain = reason === 'openDrain';
-    const shouldPrependOlderMessages = (
-      reason === 'scrollDistance' ||
-      reason === 'scrollIdle'
-    ) && this.messagesContainer;
+    assert(Array.isArray(messages), `Missing messages for chat: ${this.address}`);
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
       : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
     if (currentOldestIndex >= messages.length - 1) {
-      this.stopChatTopBoundaryScrollHold('expandComplete');
+      this.stopChatTopBoundaryScrollHold();
       return false;
     }
 
-    const renderBatchSize = isOpenDrain
-      ? this.chatOlderRenderBatchSize
-      : this.getChatOlderRenderBatchSize();
     const nextOldestIndex = Math.min(
       messages.length - 1,
-      currentOldestIndex + renderBatchSize
+      currentOldestIndex + this.getChatOlderRenderBatchSize()
     );
-    const anchor = isOpenDrain || shouldPrependOlderMessages ? null : this.getFirstVisibleMessageAnchor();
-    const beforeSnapshot = isOpenDrain
-      ? {
-          scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
-          maxScrollTop: 'skipped',
-          distanceFromBottom: 'skipped'
-        }
-      : this.getChatScrollSnapshot();
+
+    const beforeSnapshot = this.getChatScrollSnapshot();
+    const oldScrollTop = beforeSnapshot.scrollTop;
+    const oldScrollHeight = this.messagesContainer.scrollHeight;
+    const range = this.buildChatMessageRangeHTML(
+      messages,
+      contact,
+      nextOldestIndex,
+      currentOldestIndex + 1
+    );
+
     this.isExpandingChatRenderWindow = true;
     this.chatRenderedOldestIndex = nextOldestIndex;
+    this.messagesList.insertAdjacentHTML('afterbegin', range.html);
 
-    if (shouldPrependOlderMessages) {
-      const cachedClientHeight = Number.isFinite(beforeSnapshot?.clientHeight)
-        ? beforeSnapshot.clientHeight
-        : (this.messagesContainer?.clientHeight || 0);
-      const cachedLoadAheadThreshold = Math.max(1200, cachedClientHeight * 3);
-      const snapshotScrollTop = Number.isFinite(beforeSnapshot?.scrollTop)
-        ? beforeSnapshot.scrollTop
-        : null;
-      const oldScrollTop = snapshotScrollTop ?? this.messagesContainer.scrollTop;
-      const spacer = this.getChatHistorySpacerElement();
-      const oldSpacerHeight = this.getChatHistorySpacerHeight();
-      const useEstimatedSpacerPreserve = !!spacer && oldSpacerHeight > 0;
-      const oldScrollHeight = useEstimatedSpacerPreserve ? null : this.messagesContainer.scrollHeight;
-      const estimatedInsertedHeight = this.estimateChatMessagesHeight(
-        messages,
-        nextOldestIndex,
-        currentOldestIndex + 1
-      );
-      const range = this.buildChatMessageRangeHTML(
-        messages,
-        contact,
-        nextOldestIndex,
-        currentOldestIndex + 1
-      );
-      if (useEstimatedSpacerPreserve) {
-        spacer.insertAdjacentHTML('afterend', range.html);
-      } else {
-        this.messagesList.insertAdjacentHTML('afterbegin', range.html);
-      }
-      if (range.renderedTxids.length > 0) {
-        this.syncRenderedReactionTargets(range.renderedTxids);
-      }
-      let scrollDelta = estimatedInsertedHeight;
-      let nextSpacerHeight = oldSpacerHeight;
-      if (useEstimatedSpacerPreserve) {
-        nextSpacerHeight = Math.max(0, oldSpacerHeight - estimatedInsertedHeight);
-        this.setChatHistorySpacerHeight(nextSpacerHeight);
-      } else {
-        const newScrollHeight = this.messagesContainer.scrollHeight;
-        scrollDelta = newScrollHeight - oldScrollHeight;
-        this.messagesContainer.scrollTop = oldScrollTop + scrollDelta;
-      }
-      this.chatRenderedOldestIndex = nextOldestIndex;
-      this.isExpandingChatRenderWindow = false;
-
-      const expectedScrollTop = useEstimatedSpacerPreserve
-        ? oldScrollTop
-        : oldScrollTop + scrollDelta;
-      const afterDistanceToRenderedTop = Math.max(0, expectedScrollTop - nextSpacerHeight);
-      const afterSnapshotEstimate = beforeSnapshot && useEstimatedSpacerPreserve
-        ? {
-            ...beforeSnapshot,
-            topSpacerHeight: Math.round(nextSpacerHeight),
-            distanceToRenderedTop: Math.round(afterDistanceToRenderedTop)
-          }
-        : null;
-      const rearmDistance = (beforeSnapshot?.distanceFromBottom || 0) + Math.max(
-        cachedClientHeight,
-        cachedLoadAheadThreshold
-      );
-      this.chatExpansionRearmDistanceFromBottom = rearmDistance;
-      if (useEstimatedSpacerPreserve && nextOldestIndex < messages.length - 1) {
-        const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(afterSnapshotEstimate);
-        const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(afterSnapshotEstimate);
-        const shouldCatchUp = afterDistanceToRenderedTop <= renderedTopThreshold &&
-          (
-            beforeSnapshot?.distanceFromBottom >= rearmDistance ||
-            afterDistanceToRenderedTop <= renderedBoundaryThreshold
-        );
-        if (shouldCatchUp) {
-          this.scheduleChatSpacerCatchup('afterPrepend');
-        }
-      }
-      this.stopChatTopBoundaryScrollHold('rendered');
-      return true;
+    if (range.renderedTxids.length > 0) {
+      this.syncRenderedReactionTargets(range.renderedTxids);
     }
 
-    this.chatRenderedOldestIndex = nextOldestIndex;
-    this.appendChatModal(false, true, { skipDeferredWork: isOpenDrain });
-    if (isOpenDrain) {
-      this.scrollMessagesToBottom({ readMetrics: false });
-      this.isExpandingChatRenderWindow = false;
-      return true;
-    }
-
-    this.restoreVisibleMessageAnchor(anchor);
+    const insertedHeight = this.messagesContainer.scrollHeight - oldScrollHeight;
+    this.messagesContainer.scrollTop = oldScrollTop + insertedHeight;
+    this.chatExpansionRearmDistanceFromBottom = beforeSnapshot.distanceFromBottom + this.getChatLoadAheadThreshold();
     this.isExpandingChatRenderWindow = false;
+    this.stopChatTopBoundaryScrollHold();
     return true;
   }
 
@@ -15378,15 +15124,12 @@ class ChatModal {
     this.closeAllContextMenus();
     if (!this.messagesContainer || !this.isActive()) return;
     const scrollSnapshot = this.getChatScrollSnapshot();
-    if (!scrollSnapshot) return;
     const contact = this.address ? myData.contacts[this.address] : null;
     const totalMessages = Array.isArray(contact?.messages) ? contact.messages.length : 0;
     const renderedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
-      : 'n/a';
-    const remainingOlder = Number.isInteger(renderedOldestIndex)
-      ? Math.max(0, totalMessages - 1 - renderedOldestIndex)
-      : 0;
+      : this.chatInitialRenderCount - 1;
+    const remainingOlder = Math.max(0, totalMessages - 1 - renderedOldestIndex);
     const loadAheadThreshold = this.getChatLoadAheadThreshold();
     const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
     if (
@@ -15404,52 +15147,27 @@ class ChatModal {
       scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
     const canExpandOlderWindow = isExpansionRearmed || isAtRenderedBoundary;
     if (isNearRenderedTop && canExpandOlderWindow) {
-      if (scrollSnapshot.topSpacerHeight > 0) {
-        this.expandChatRenderWindow('scrollDistance');
-      } else {
-        if (isAtRenderedBoundary) {
-          this.startChatTopBoundaryScrollHold(scrollSnapshot, 'scrollBoundary');
-        }
-        this.queueChatScrollExpand('scrollDistance', scrollSnapshot);
+      if (isAtRenderedBoundary) {
+        this.startChatTopBoundaryScrollHold();
       }
+      this.queueChatScrollExpand();
     }
   }
 
   getChatLoadAheadThreshold() {
-    const containerHeight = this.messagesContainer?.clientHeight || 0;
-    return Math.max(1200, containerHeight * 3);
+    assert(this.messagesContainer, 'Messages container is required');
+    return Math.max(1200, this.messagesContainer.clientHeight * 3);
   }
 
-  getChatRenderedTopLoadAheadThreshold(scrollSnapshot = null) {
-    const snapshot = scrollSnapshot || this.getChatScrollSnapshot();
-    const baseThreshold = Number.isFinite(snapshot?.clientHeight)
-      ? Math.max(1200, snapshot.clientHeight * 3)
-      : this.getChatLoadAheadThreshold();
-    if (
-      !snapshot ||
-      !Number.isFinite(snapshot.maxScrollTop) ||
-      !Number.isFinite(snapshot.topSpacerHeight)
-    ) {
-      return baseThreshold;
-    }
-
-    if (snapshot.topSpacerHeight <= 0) {
-      return Math.max(420, Math.min(900, (snapshot.clientHeight || 0) * 1.25));
-    }
-
-    const renderedRunway = Math.max(0, snapshot.maxScrollTop - snapshot.topSpacerHeight);
-    return Math.max(baseThreshold, renderedRunway * 0.5);
+  getChatRenderedTopLoadAheadThreshold(scrollSnapshot) {
+    return Math.max(420, Math.min(900, scrollSnapshot.clientHeight * 1.25));
   }
 
-  getChatRenderedBoundaryThreshold(scrollSnapshot = null) {
-    const snapshot = scrollSnapshot || this.getChatScrollSnapshot();
-    const containerHeight = snapshot?.clientHeight || this.messagesContainer?.clientHeight || 0;
-    return Math.max(32, Math.min(180, containerHeight * 0.2));
+  getChatRenderedBoundaryThreshold(scrollSnapshot) {
+    return Math.max(32, Math.min(180, scrollSnapshot.clientHeight * 0.2));
   }
 
   getChatOlderRenderBatchSize() {
-    const container = this.messagesContainer;
-    if (!container) return this.chatOlderRenderBatchSize;
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
       : this.chatInitialRenderCount - 1;
@@ -15457,119 +15175,6 @@ class ChatModal {
       return this.chatFirstOlderRenderBatchSize;
     }
     return this.chatOlderRenderBatchSize;
-  }
-
-  cancelChatSpacerCatchup() {
-    if (!this.chatSpacerCatchupTimer) return;
-    clearTimeout(this.chatSpacerCatchupTimer);
-    this.chatSpacerCatchupTimer = null;
-  }
-
-  scheduleChatSpacerCatchup(reason) {
-    if (this.chatSpacerCatchupTimer || this.isExpandingChatRenderWindow) return;
-    this.chatSpacerCatchupTimer = setTimeout(() => {
-      this.chatSpacerCatchupTimer = null;
-      if (!this.isActive() || !this.messagesContainer || !this.messagesList || !this.address) return;
-      const contact = myData.contacts[this.address];
-      const messages = contact?.messages;
-      if (!Array.isArray(messages) || messages.length === 0) return;
-      const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-        ? this.chatRenderedOldestIndex
-        : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
-      if (currentOldestIndex >= messages.length - 1) return;
-
-      const topSpacerHeight = this.getChatHistorySpacerHeight();
-      const distanceToRenderedTop = Math.max(0, this.messagesContainer.scrollTop - topSpacerHeight);
-      const loadAheadThreshold = this.getChatRenderedTopLoadAheadThreshold();
-      if (topSpacerHeight <= 0 || distanceToRenderedTop > loadAheadThreshold) return;
-
-      this.expandChatRenderWindow('scrollDistance');
-    }, 16);
-  }
-
-  cancelChatRenderWindowDrain() {
-    if (this.chatRenderWindowDrainTimer) {
-      clearTimeout(this.chatRenderWindowDrainTimer);
-      this.chatRenderWindowDrainTimer = null;
-    }
-    if (this.chatRenderWindowDrainFrame) {
-      if (typeof cancelAnimationFrame === 'function') {
-        cancelAnimationFrame(this.chatRenderWindowDrainFrame);
-      }
-      this.chatRenderWindowDrainFrame = null;
-    }
-    this.chatRenderWindowDrainAddress = null;
-  }
-
-  scheduleChatRenderWindowDrain(address) {
-    if (!address || this.chatRenderWindowDrainAddress === address) return;
-    const contact = myData.contacts[address];
-    const messages = contact?.messages;
-    if (!Array.isArray(messages) || messages.length === 0) return;
-
-    const getCurrentOldestIndex = () => Number.isInteger(this.chatRenderedOldestIndex)
-      ? this.chatRenderedOldestIndex
-      : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
-
-    if (getCurrentOldestIndex() >= messages.length - 1) return;
-
-    this.chatRenderWindowDrainAddress = address;
-
-    const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame
-      : (callback) => setTimeout(callback, 0);
-
-    const scheduleDrainFrame = (callback) => {
-      if (typeof requestAnimationFrame === 'function') {
-        this.chatRenderWindowDrainFrame = requestAnimationFrame(() => {
-          this.chatRenderWindowDrainFrame = null;
-          callback();
-        });
-      } else {
-        this.chatRenderWindowDrainTimer = setTimeout(() => {
-          this.chatRenderWindowDrainTimer = null;
-          callback();
-        }, 0);
-      }
-    };
-
-    const scheduleNextDrainStep = () => {
-      if (this.chatRenderWindowDrainFrame || this.chatRenderWindowDrainTimer) return;
-      scheduleDrainFrame(() => {
-        scheduleAfterPaint(() => {
-          if (!this.isActive() || this.address !== address) {
-            this.cancelChatRenderWindowDrain();
-            return;
-          }
-
-          if (this.isExpandingChatRenderWindow) {
-            scheduleNextDrainStep();
-            return;
-          }
-
-          const currentOldestIndex = getCurrentOldestIndex();
-          if (currentOldestIndex >= messages.length - 1) {
-            this.cancelChatRenderWindowDrain();
-            return;
-          }
-
-          this.expandChatRenderWindow('openDrain');
-          const nextOldestIndex = getCurrentOldestIndex();
-
-          if (nextOldestIndex < messages.length - 1) {
-            scheduleNextDrainStep();
-          } else {
-            this.cancelChatRenderWindowDrain();
-          }
-        });
-      });
-    };
-
-    scheduleAfterPaint(() => {
-      scheduleAfterPaint(() => {
-        scheduleNextDrainStep();
-      });
-    });
   }
 
   /**
@@ -15654,10 +15259,7 @@ class ChatModal {
     this.modalAvatar.innerHTML = await getContactAvatarHtml(contact, 40);
 
     // Stop and cleanup all voice messages from previous conversation
-    const previousVoiceMessages = this.messagesList
-      ? this.messagesList.querySelectorAll('.voice-message')
-      : [];
-    previousVoiceMessages.forEach(vm => this.stopVoiceMessage(vm));
+    this.messagesList?.querySelectorAll('.voice-message').forEach(vm => this.stopVoiceMessage(vm));
 
     // Clear previous messages from the UI
     this.messagesList.innerHTML = '';
@@ -15851,7 +15453,7 @@ class ChatModal {
     }
 
     this.address = null;
-    this.resetChatRenderWindow();
+    this.resetChatRenderWindow(null);
   }
 
   clearNotificationsIfAllRead() {
@@ -16828,7 +16430,6 @@ class ChatModal {
 
     return {
       html,
-      renderedCount: renderedMessages.length,
       renderedTxids
     };
   }
@@ -16837,10 +16438,9 @@ class ChatModal {
    * Appends the chat modal to the DOM
    * @param {boolean} highlightNewMessage - Whether to highlight the newest message
    * @param {boolean} skipAutoScroll - Whether to skip auto-scrolling to bottom (used when scrolling to a specific message)
-   * @param {{ skipDeferredWork?: boolean }} options - Render behavior options
    * @returns {void}
    */
-  appendChatModal(highlightNewMessage = false, skipAutoScroll = false, { skipDeferredWork = false } = {}) {
+  appendChatModal(highlightNewMessage = false, skipAutoScroll = false) {
     const currentAddress = this.address; // Use a local constant
     if (!currentAddress) {
       return;
@@ -16852,11 +16452,10 @@ class ChatModal {
       return;
     }
     const messages = contact.messages; // Already sorted descending
-    // Last time user previously had this chat open (used to mark newly edited messages)
-    const lastReadTs = contact.lastChatOpenTs || 0;
 
     if (!this.modal) return;
     if (!this.messagesList) return;
+    assert(this.messagesContainer, 'Messages container is required');
     const renderSequence = ++this.chatRenderSequence;
 
     // --- 1. Identify the actual newest received message data item ---
@@ -16865,253 +16464,42 @@ class ChatModal {
     this.newestReceivedMessage = newestReceivedItem;
     this.newestSentMessage = messages.find((item) => item.my);
 
-    const renderedMessages = [];
-    const messagesByTxid = new Map();
-    messages.forEach((message) => {
-      if (message?.txid) {
-        messagesByTxid.set(message.txid, message);
-      }
-    });
     const forceFullRender = highlightNewMessage && skipAutoScroll;
     const renderRange = this.getChatRenderRange(messages, currentAddress, forceFullRender);
-
-    // 3. Iterate backwards through messages (oldest to newest for rendering order)
-    // messages are already sorted descending (newest first) in myData
-    for (let i = renderRange.oldestIndex; i >= renderRange.newestIndex; i--) {
-      const item = messages[i];
-      let messageHTML = '';
-      const timeString = formatTime(item.timestamp);
-      // Use a consistent timestamp attribute for potential future use (e.g., message jumping)
-      const timestampAttribute = `data-message-timestamp="${item.timestamp}"`;
-      // Add txid attribute if available
-      const txidAttribute = item?.txid ? `data-txid="${item.txid}"` : '';
-      const statusAttribute = item?.status ? `data-status="${item.status}"` : '';
-
-      // Check if it's a payment based on the presence of the amount property (BigInt)
-      if (typeof item.amount === 'bigint') {
-        // Define common payment variables
-        const itemAmount = item.amount;
-        const itemMemo = item.message; // Memo is stored in the 'message' field for transfers
-
-        // Assuming LIB (18 decimals) for now. TODO: Handle different asset decimals if needed.
-        // Format amount correctly using big2str
-        const amountStr = big2str(itemAmount, 18);
-        const amountNum = parseFloat(amountStr);
-        const amountDisplay = `${amountNum.toFixed(6)} ${item.symbol || 'LIB'}`;
-
-        // Check item.my for sent/received
-
-        //console.log(`debug item: ${JSON.stringify(item, (key, value) => typeof value === 'bigint' ? big2str(value, 18) : value)}`)
-        // --- Render Payment Transaction ---
-        const directionText = item.my ? '-' : '+';
-        const messageClass = item.my ? 'sent' : 'received';
-    const showEditedDot = !item.my && item.edited && item.edited_timestamp && item.edited_timestamp > lastReadTs && !isDeleted(item);
-    messageHTML = `
-          <div class="message ${messageClass} payment-info" ${timestampAttribute} ${txidAttribute} ${statusAttribute}>
-            <div class="payment-header">
-              <span class="payment-direction">${directionText}</span>
-              <span class="payment-amount">${amountDisplay}</span>
-            </div>
-            ${itemMemo ? `<div class="payment-memo">${linkifyUrls(itemMemo)}</div>` : ''}
-            <div class="message-time">${timeString}${item.edited ? ' <span class="message-edited-label">edited</span>' : ''}${showEditedDot ? ' <span class="edited-new-dot" title="Edited since last read"></span>' : ''}</div>
-          </div>
-        `;
-      } else {
-        // --- Render Chat Message ---
-        const messageClass = item.my ? 'sent' : 'received'; // Use item.my directly
-        
-        // Initialize replyHTML at this scope so it's always defined
-        let replyHTML = '';
-        
-        // Check if message was deleted
-        if (isDeleted(item)) {
-          // Render deleted message with special styling
-          messageHTML = `
-                    <div class="message ${messageClass} deleted-message" ${timestampAttribute} ${txidAttribute} ${statusAttribute}>
-                        <div class="message-content deleted-content">${item.message}</div>
-                        <div class="message-time">${timeString}</div>
-                    </div>
-                `;
-        } else {
-          // --- Render Reply Quote if present ---
-          if (item.replyId) {
-              const replyText = escapeHtml(item.replyMessage || 'View original message');
-              // Determine owner label: "You" if the referenced message is ours, else contact name
-              const ownerIsMineHint = item.replyOwnerIsMine;
-              const hasHint = typeof ownerIsMineHint !== 'undefined';
-              let isOwnerMine = false;
-              if (hasHint) {
-                // Use both item.my and replyOwnerIsMine to determine from current viewer's perspective
-                // item.my: true if reply is from current user (viewer's perspective)
-                // replyOwnerIsMine: true if original message was from sender's perspective
-                // If they match (both true or both false), original message is from current user's perspective
-                const isSelfReply = ownerIsMineHint === true || ownerIsMineHint === '1';
-                isOwnerMine = item.my === isSelfReply;
-              } else {
-                const targetMsg = messagesByTxid.get(item.replyId);
-                isOwnerMine = !!(targetMsg && targetMsg.my);
-              }
-              const ownerText = isOwnerMine ? 'You' : (getContactDisplayName(contact) || 'Contact');
-              const ownerClass = isOwnerMine ? 'reply-owner-me' : 'reply-owner-contact';
-              const replyOwnerLabel = `<span class="reply-quote-label ${ownerClass}">${escapeHtml(ownerText)}</span>`;
-
-              replyHTML = `
-                <div class="reply-quote ${ownerClass}" data-reply-txid="${escapeHtml(item.replyId)}">
-                  ${replyOwnerLabel}
-                  <div class="reply-quote-text">${replyText}</div>
-                </div>
-              `;
-          }
-          // --- Render Attachments if present ---
-          let attachmentsHTML = '';
-          if (item.xattach && Array.isArray(item.xattach) && item.xattach.length > 0) {
-            attachmentsHTML = item.xattach.map(att => {
-              const fileUrl = att.url || '#';
-              const fileName = att.name || 'Attachment';
-              const fileSize = att.size ? this.formatFileSize(att.size) : '';
-              const fileType = att.type ? att.type.split('/').pop().toUpperCase() : '';
-              const isImage = att.type && att.type.startsWith('image/');
-              const isVideo = att.type && att.type.startsWith('video/');
-              const hasThumbnail = isImage || isVideo;
-              const fileTypeIcon = this.getFileTypeForIcon(att.type || '', fileName);
-              const paddingStyle = hasThumbnail ? 'padding: 5px 5px;' : 'padding: 10px 12px;';
-              return `
-                <div class="attachment-row" style="display: flex; ${hasThumbnail ? 'flex-direction: column;' : 'align-items: center;'} background: #f5f5f7; border-radius: 12px; ${paddingStyle} margin-bottom: 6px;"
-                  data-url="${fileUrl}"
-                  data-p-url="${att.pUrl || ''}"
-                  data-name="${encodeURIComponent(fileName)}"
-                  data-type="${att.type || ''}"
-                  data-msg-idx="${i}"
-                  ${isImage ? 'data-image-attachment="true"' : ''}
-                  ${isVideo ? 'data-video-attachment="true"' : ''}
-                >
-                  <div class="attachment-icon-container" style="${hasThumbnail ? 'margin-bottom: 10px; flex-direction: column;' : 'margin-right: 14px; flex-shrink: 0;'}">
-                    <div class="attachment-icon" data-file-type="${fileTypeIcon}"></div>
-                    ${hasThumbnail ? '<div class="attachment-preview-hint">Click for options</div>' : ''}
-                  </div>
-                  <div style="min-width:0;">
-                    <span class="attachment-label" style="font-weight:500;color:#222;font-size:0.7em;display:block;word-wrap:break-word;">
-                      ${fileName}
-                    </span><br>
-                    <span style="font-size: 0.93em; color: #888;">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
-                  </div>
-                </div>
-              `;
-            }).join('');
-          }
-          
-          // --- Render message text (if any) ---
-          let messageTextHTML = '';
-          if (item.message && item.message.trim()) {
-            // Check if this is a call message
-            if (item.type === 'call') {
-              // Determine call timing and whether join should be allowed
-              const callTimeMs = Number(item.callTime || 0);
-              const callStart = callTimeMs > 0 ? callTimeMs : Number(item.timestamp || item.sent_timestamp || 0);
-              const isExpired = this.isCallExpired(callStart);
-
-              if (isExpired) {
-                // Over 2 hours since call time: show as plain text without join button
-                const theirName = getContactDisplayName(contact);
-                const label = item.my ? `You called ${escapeHtml(theirName)}` : `${escapeHtml(theirName)} called you`;
-                messageTextHTML = `
-                  <div class="call-message">
-                    <div class="call-message-text"><i>${label}</i></div>
-                  </div>`;
-              } else {
-                // Build scheduled label if in the future
-                const scheduleHTML = this.buildCallScheduleHTML(callTimeMs);
-                // Render call message with a left circular phone icon (clickable) and plain text to the right
-                // TODO - remove the href and instead have it call a function which will open the URL and at the time of opening it adds the callUrlParam and username
-                messageTextHTML = `
-                  <div class="call-message">
-                    <a href='${item.message}${callUrlParams}"${myAccount.username}"' target="_blank" rel="noopener noreferrer" class="call-message-phone-button" aria-label="Join Video Call">
-                      <span class="sr-only">Join Video Call</span>
-                    </a>
-                    <div>
-                      <div class="call-message-text">Join Video Call</div>
-                      ${scheduleHTML}
-                    </div>
-                  </div>`;
-              }
-            } else {
-              // Regular message rendering
-              messageTextHTML = `<div class="message-content" style="white-space: pre-wrap; margin-top: ${attachmentsHTML ? '2px' : '0'};">${linkifyUrls(item.message)}</div>`;
-            }
-          }
-          
-          // Check for voice message
-          if (item.type === 'vm') {
-            const duration = this.formatDuration(item.duration);
-            // Use audio encryption keys for playback, fall back to message encryption keys if not available
-            messageTextHTML = `
-              <div class="voice-message" data-url="${item.url || ''}" data-name="voice-message" data-type="audio/webm" data-msg-idx="${i}" data-duration="${item.duration || 0}">
-                <div class="voice-message-controls">
-                  <div class="voice-message-top-row">
-                    <button class="voice-message-play-button" aria-label="Play voice message">
-                      <svg viewBox="0 0 24 24">
-                        <path d="M8 5v14l11-7z"/>
-                      </svg>
-                    </button>
-                    <div class="voice-message-text">Voice message</div>
-                    <div class="voice-message-time-display">0:00 / ${duration}</div>
-                  </div>
-                  <div class="voice-message-bottom-row">
-                    <input type="range" class="voice-message-seek" min="0" max="${item.duration || 0}" value="0" step="1" aria-label="Seek voice message">
-                    <button class="voice-message-speed-button" aria-label="Toggle playback speed" data-speed="1">1x</button>
-                  </div>
-                </div>
-              </div>`;
-          }
-          
-          const callTimeAttribute = item.type === 'call' && item.callTime ? `data-call-time="${item.callTime}"` : '';
-      const showEditedDot = !item.my && item.edited && item.edited_timestamp && item.edited_timestamp > lastReadTs && !isDeleted(item);
-      messageHTML = `
-            <div class="message ${messageClass}" ${timestampAttribute} ${txidAttribute} ${statusAttribute} ${callTimeAttribute}>
-              ${replyHTML}
-              ${attachmentsHTML}
-              ${messageTextHTML}
-              <div class="message-time">${timeString}${item.edited ? ' <span class="message-edited-label">edited</span>' : ''}${showEditedDot ? ' <span class="edited-new-dot" title="Edited since last read"></span>' : ''}</div>
-            </div>
-          `;
-        }
-      }
-
-      renderedMessages.push(messageHTML);
-      // The newest received element will be found after the loop completes
-    }
-    this.chatHistorySpacerHeight = 0;
+    const range = this.buildChatMessageRangeHTML(
+      messages,
+      contact,
+      renderRange.oldestIndex,
+      renderRange.newestIndex
+    );
 
     // Replace the list once to avoid one DOM mutation per message.
-    const renderedHTML = renderedMessages.join('');
-    this.messagesList.innerHTML = renderedHTML;
+    this.messagesList.innerHTML = range.html;
     const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
     if (shouldKeepBottomAnchored) {
-      this.scrollMessagesToBottom({ readMetrics: false });
+      this.messagesContainer.scrollTop = 1000000000;
     }
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
     this.loadThumbnailsForAttachments();
 
     const renderedAddress = currentAddress;
-    if (!skipDeferredWork) {
-      const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
-        ? requestAnimationFrame
-        : (callback) => setTimeout(callback, 0);
+    const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (callback) => setTimeout(callback, 0);
+    scheduleAfterPaint(() => {
       scheduleAfterPaint(() => {
-        scheduleAfterPaint(() => {
-          if (
-            !this.isActive() ||
-            this.address !== renderedAddress ||
-            !this.messagesList ||
-            renderSequence !== this.chatRenderSequence
-          ) {
-            return;
-          }
-          this.syncAllRenderedReactionChips();
-        });
+        if (
+          !this.isActive() ||
+          this.address !== renderedAddress ||
+          !this.messagesList ||
+          renderSequence !== this.chatRenderSequence
+        ) {
+          return;
+        }
+        this.syncAllRenderedReactionChips();
       });
-    }
+    });
 
     // --- 5. Find the corresponding DOM element after rendering ---
     // This happens inside the setTimeout to ensure elements are in the DOM
@@ -17173,7 +16561,8 @@ class ChatModal {
         // No received messages found, not highlighting, or highlightNewMessage is false,
         // just scroll to the bottom if the container exists.
         if (messageContainer) {
-          if (!shouldKeepBottomAnchored || this.isMessagesContainerNearBottom(120)) {
+          const isNearBottom = messageContainer.scrollHeight - messageContainer.scrollTop - messageContainer.clientHeight <= 120;
+          if (!shouldKeepBottomAnchored || isNearBottom) {
             messageContainer.scrollTop = messageContainer.scrollHeight;
           }
         }

--- a/app.js
+++ b/app.js
@@ -13952,6 +13952,9 @@ class ChatModal {
     this.chatForceFullRenderOnce = false;
     this.isExpandingChatRenderWindow = false;
     this.lastChatScrollLogAt = 0;
+    this.chatRenderWindowDrainTimer = null;
+    this.chatRenderWindowDrainAddress = null;
+    this.chatRenderWindowDrainStartedAt = 0;
   }
 
   /**
@@ -14375,6 +14378,7 @@ class ChatModal {
    * @returns {void}
    */
   load() {
+    const loadPerfStart = this.getChatPerfTime();
     this.modal = document.getElementById('chatModal');
     assert(this.modal, 'chatModal element is required');
     this.closeButton = document.getElementById('closeChatModal');
@@ -14443,6 +14447,8 @@ class ChatModal {
     this.contactsOpt = this.attachmentOptionsContextMenu?.querySelector('.context-menu-option[data-action="contacts"]');
     
     this.currentImageAttachmentRow = null;
+    const refsMs = this.formatChatPerfMs(loadPerfStart);
+    const listenerPerfStart = this.getChatPerfTime();
     
     // Add event delegation for message clicks (since messages are created dynamically)
     this.messagesList.addEventListener('click', this.handleMessageClick.bind(this));
@@ -14764,6 +14770,11 @@ class ChatModal {
     }
 
     this.toggleSendButtonVisibility();
+    this.logChatPerf('load:listeners', {
+      refs: refsMs,
+      listeners: this.formatChatPerfMs(listenerPerfStart),
+      total: this.formatChatPerfMs(loadPerfStart)
+    });
   }
 
     // Voice message seek slider live time display (works even before playback)
@@ -15001,6 +15012,7 @@ class ChatModal {
   }
 
   resetChatRenderWindow(address = null) {
+    this.cancelChatRenderWindowDrain();
     this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
     this.chatForceFullRenderOnce = false;
@@ -15089,15 +15101,15 @@ class ChatModal {
   }
 
   expandChatRenderWindow(reason = 'scroll') {
-    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) return;
+    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) return false;
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
-    if (!Array.isArray(messages) || messages.length === 0) return;
+    if (!Array.isArray(messages) || messages.length === 0) return false;
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
       : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
-    if (currentOldestIndex >= messages.length - 1) return;
+    if (currentOldestIndex >= messages.length - 1) return false;
 
     const renderBatchSize = this.getChatOlderRenderBatchSize();
     const nextOldestIndex = Math.min(
@@ -15137,6 +15149,7 @@ class ChatModal {
       afterRestoreDistanceFromBottom: afterRestoreSnapshot ? afterRestoreSnapshot.distanceFromBottom : 'n/a',
       afterRestoreScrollHeight: afterRestoreSnapshot ? afterRestoreSnapshot.scrollHeight : 'n/a'
     });
+    return true;
   }
 
   handleMessagesContainerScroll() {
@@ -15191,28 +15204,103 @@ class ChatModal {
       : this.chatOlderRenderBatchSize;
   }
 
-  scheduleChatRenderWindowWarmup(address) {
+  cancelChatRenderWindowDrain() {
+    if (this.chatRenderWindowDrainTimer) {
+      clearTimeout(this.chatRenderWindowDrainTimer);
+      this.chatRenderWindowDrainTimer = null;
+    }
+    this.chatRenderWindowDrainAddress = null;
+    this.chatRenderWindowDrainStartedAt = 0;
+  }
+
+  scheduleChatRenderWindowDrain(address, reason = 'afterDeferred') {
+    if (!address || this.chatRenderWindowDrainAddress === address) return;
+    const contact = myData.contacts[address];
+    const messages = contact?.messages;
+    if (!Array.isArray(messages) || messages.length === 0) return;
+
+    const getCurrentOldestIndex = () => Number.isInteger(this.chatRenderedOldestIndex)
+      ? this.chatRenderedOldestIndex
+      : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
+
+    if (getCurrentOldestIndex() >= messages.length - 1) return;
+
+    this.chatRenderWindowDrainAddress = address;
+    this.chatRenderWindowDrainStartedAt = this.getChatPerfTime();
+    this.logChatPerf('window:drainScheduled', {
+      contact: this.formatChatPerfAddress(address, contact),
+      reason,
+      currentOldestIndex: getCurrentOldestIndex(),
+      batchSize: this.chatOlderRenderBatchSize,
+      remainingOlder: Math.max(0, messages.length - 1 - getCurrentOldestIndex()),
+      totalMessages: messages.length
+    });
+
     const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
       ? requestAnimationFrame
       : (callback) => setTimeout(callback, 0);
 
+    const scheduleNextDrainStep = (delayMs) => {
+      if (this.chatRenderWindowDrainTimer) return;
+      this.chatRenderWindowDrainTimer = setTimeout(() => {
+        this.chatRenderWindowDrainTimer = null;
+        scheduleAfterPaint(() => {
+          if (!this.isActive() || this.address !== address) {
+            this.logChatPerf('window:drainAbort', {
+              contact: this.formatChatPerfAddress(address, contact),
+              reason: this.address !== address ? 'addressChanged' : 'inactive',
+              elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
+            });
+            this.cancelChatRenderWindowDrain();
+            return;
+          }
+
+          if (this.isExpandingChatRenderWindow) {
+            scheduleNextDrainStep(60);
+            return;
+          }
+
+          const currentOldestIndex = getCurrentOldestIndex();
+          if (currentOldestIndex >= messages.length - 1) {
+            this.logChatPerf('window:drainDone', {
+              contact: this.formatChatPerfAddress(address, contact),
+              currentOldestIndex,
+              totalMessages: messages.length,
+              elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
+            });
+            this.cancelChatRenderWindowDrain();
+            return;
+          }
+
+          const expanded = this.expandChatRenderWindow('openDrain');
+          const nextOldestIndex = getCurrentOldestIndex();
+          this.logChatPerf('window:drainStep', {
+            contact: this.formatChatPerfAddress(address, contact),
+            expanded,
+            previousOldestIndex: currentOldestIndex,
+            currentOldestIndex: nextOldestIndex,
+            remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
+            elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
+          });
+
+          if (nextOldestIndex < messages.length - 1) {
+            scheduleNextDrainStep(90);
+          } else {
+            this.logChatPerf('window:drainDone', {
+              contact: this.formatChatPerfAddress(address, contact),
+              currentOldestIndex: nextOldestIndex,
+              totalMessages: messages.length,
+              elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
+            });
+            this.cancelChatRenderWindowDrain();
+          }
+        });
+      });
+    };
+
     scheduleAfterPaint(() => {
       scheduleAfterPaint(() => {
-        if (!this.isActive() || this.address !== address || this.isExpandingChatRenderWindow) return;
-        const contact = myData.contacts[address];
-        const messages = contact?.messages;
-        if (!Array.isArray(messages) || messages.length === 0) return;
-        const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-          ? this.chatRenderedOldestIndex
-          : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
-        if (currentOldestIndex >= messages.length - 1) return;
-        this.logChatPerf('window:warmup', {
-          contact: this.formatChatPerfAddress(address, contact),
-          currentOldestIndex,
-          batchSize: this.chatOlderRenderBatchSize,
-          totalMessages: messages.length
-        });
-        this.expandChatRenderWindow('openWarmup');
+        scheduleNextDrainStep(0);
       });
     });
   }
@@ -15400,9 +15488,6 @@ class ChatModal {
       ms: this.formatChatPerfMs(appendPerfStart),
       total: this.formatChatPerfMs(openPerfStart)
     });
-    if (!skipAutoScroll) {
-      this.scheduleChatRenderWindowWarmup(address);
-    }
     void this.maybePromptReclaimToll(address);
   }
 
@@ -16668,6 +16753,9 @@ class ChatModal {
                 scrollHeight: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollHeight : 'n/a',
                 total: this.formatChatPerfMs(deferredStart)
               });
+              if (shouldKeepBottomAnchored && renderRange.isWindowed) {
+                this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferred');
+              }
             },
             (error) => {
               this.logChatPerf('append:deferredError', {
@@ -16677,6 +16765,9 @@ class ChatModal {
                 thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
                 error: error?.message || String(error)
               });
+              if (shouldKeepBottomAnchored && renderRange.isWindowed) {
+                this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
+              }
             }
           );
         } catch (error) {
@@ -16687,6 +16778,9 @@ class ChatModal {
             thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
             error: error?.message || String(error)
           });
+          if (shouldKeepBottomAnchored && renderRange.isWindowed) {
+            this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
+          }
         }
       });
     });

--- a/app.js
+++ b/app.js
@@ -14920,9 +14920,8 @@ class ChatModal {
     list.insertAdjacentHTML('afterbegin', range.html);
     const prependedThumbnailRows = range.renderedTxids.flatMap((txid) => {
       const messageEl = list.querySelector(`.message[data-txid="${CSS.escape(txid)}"]`);
-      return messageEl
-        ? [...messageEl.querySelectorAll('[data-image-attachment="true"], [data-video-attachment="true"]')]
-        : [];
+      assert(messageEl, `Rendered message missing for ${txid}`);
+      return [...messageEl.querySelectorAll('[data-image-attachment="true"], [data-video-attachment="true"]')];
     });
 
     this.syncRenderedReactionTargets(range.renderedTxids);
@@ -16014,8 +16013,8 @@ class ChatModal {
   renderChatMessageHTML(item, { contact, lastReadTs }) {
     const timeString = formatTime(item.timestamp);
     const timestampAttribute = `data-message-timestamp="${item.timestamp}"`;
-    const txidAttribute = item?.txid ? `data-txid="${item.txid}"` : '';
-    const statusAttribute = item?.status ? `data-status="${item.status}"` : '';
+    const txidAttribute = item.txid ? `data-txid="${item.txid}"` : '';
+    const statusAttribute = item.status ? `data-status="${item.status}"` : '';
 
     if (typeof item.amount === 'bigint') {
       const amountStr = big2str(item.amount, 18);
@@ -16184,7 +16183,6 @@ class ChatModal {
 
     for (let i = oldestIndex; i >= newestIndex; i--) {
       const item = messages[i];
-      if (!item) continue;
       renderedMessages.push(this.renderChatMessageHTML(item, { contact, lastReadTs }));
       if (item.txid) renderedTxids.push(item.txid);
     }
@@ -18736,7 +18734,7 @@ class ChatModal {
     // Show copy only if parent message has actual message text
     const copyOption = this.imageAttachmentContextMenu.querySelector('[data-action="copy"]');
     if (copyOption) {
-      const text = messageEl?.querySelector?.('.message-content')?.textContent?.trim() || '';
+      const text = messageEl.querySelector('.message-content')?.textContent?.trim() || '';
       copyOption.style.display = text ? 'flex' : 'none';
     }
 
@@ -18756,7 +18754,7 @@ class ChatModal {
     let hasThumb = true;
     if (hasThumbnailSupport) {
       hasThumb = false;
-      if (url && url !== '#') {
+      if (url !== '#') {
         try {
           const thumb = await thumbnailCache.get(url);
           hasThumb = !!thumb;
@@ -18806,19 +18804,19 @@ class ChatModal {
         void this.saveImageAttachment(row);
         break;
       case 'share':
-        if (messageEl) shareAttachmentModal.open(messageEl);
+        shareAttachmentModal.open(messageEl);
         break;
       case 'reply':
-        if (messageEl) this.startReplyToMessage(messageEl);
+        this.startReplyToMessage(messageEl);
         break;
       case 'copy':
-        if (messageEl) void this.copyMessageContent(messageEl);
+        void this.copyMessageContent(messageEl);
         break;
       case 'delete':
-        if (messageEl) this.deleteMessage(messageEl);
+        this.deleteMessage(messageEl);
         break;
       case 'delete-for-all':
-        if (messageEl) void this.deleteMessageForAll(messageEl);
+        void this.deleteMessageForAll(messageEl);
         break;
     }
 
@@ -18840,10 +18838,7 @@ class ChatModal {
 
     // Find the attachment in xattach array
     const attachment = message.xattach.find(att => att.url === url);
-    if (!attachment) {
-      showToast('Could not find attachment data', 0, 'error');
-      return;
-    }
+    assert(attachment, 'Rendered VCF attachment must exist in message data');
 
     // Open the import contacts modal with the full attachment object so
     // fields like `encKey` (new flow) are preserved for backwards compatibility.
@@ -18970,7 +18965,8 @@ class ChatModal {
    */
   async handleImageAttachmentReactionPickerClick(reactionButton) {
     const row = this.currentImageAttachmentRow;
-    const { messageEl } = row ? this.getAttachmentContextFromRow(row) : { messageEl: null };
+    assert(row, 'Image attachment reaction requires an active attachment row');
+    const { messageEl } = this.getAttachmentContextFromRow(row);
     await this.handleReactionPickerSelection(reactionButton, messageEl, () => this.closeImageAttachmentContextMenu());
   }
 
@@ -19452,12 +19448,10 @@ class ChatModal {
   scrollToMessage(txid) {
     if (!txid || !this.messagesList) return;
     let target = this.messagesList.querySelector(`[data-txid="${CSS.escape(txid)}"]`);
-    if (!target && this.address) {
+    if (!target) {
+      assert(this.address, 'Cannot scroll to a message without an active chat');
       const contact = myData.contacts[this.address];
-      const messages = contact?.messages;
-      const targetIndex = Array.isArray(messages)
-        ? messages.findIndex((message) => message?.txid === txid)
-        : -1;
+      const targetIndex = contact.messages.findIndex((message) => message.txid === txid);
       if (targetIndex !== -1) {
         this.chatRenderedOldestIndex = Math.max(
           this.chatRenderedOldestIndex,

--- a/app.js
+++ b/app.js
@@ -14911,15 +14911,13 @@ class ChatModal {
       return { newestIndex: 0, oldestIndex: -1 };
     }
 
-    if (!Number.isInteger(this.chatRenderedOldestIndex)) {
-      this.chatRenderedOldestIndex = Math.min(totalMessages - 1, CHAT_INITIAL_RENDER_COUNT - 1);
-    }
-
-    this.chatRenderedOldestIndex = Math.min(this.chatRenderedOldestIndex, totalMessages - 1);
-
+    const oldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+      ? Math.min(this.chatRenderedOldestIndex, totalMessages - 1)
+      : Math.min(totalMessages - 1, CHAT_INITIAL_RENDER_COUNT - 1);
+    this.chatRenderedOldestIndex = oldestIndex;
     return {
       newestIndex: 0,
-      oldestIndex: this.chatRenderedOldestIndex
+      oldestIndex
     };
   }
 
@@ -14953,19 +14951,21 @@ class ChatModal {
   }
 
   stopChatTopBoundaryScrollHold() {
-    if (!this.chatHistoryLoadingToastId) return;
     this.hideChatHistoryLoadingToast();
   }
 
   clampChatTopBoundaryScrollHold() {
-    if (!this.chatHistoryLoadingToastId || !this.messagesContainer) return false;
-    if (this.messagesContainer.scrollTop >= 0) return false;
-    this.messagesContainer.scrollTop = 0;
+    if (!this.chatHistoryLoadingToastId) return false;
+    const container = this.messagesContainer;
+    assert(container, 'Messages container is required');
+    if (container.scrollTop >= 0) return false;
+    container.scrollTop = 0;
     return true;
   }
 
   shouldBlockChatTopBoundaryTouchMove(event) {
-    if (!this.chatHistoryLoadingToastId || !this.messagesContainer) return false;
+    if (!this.chatHistoryLoadingToastId) return false;
+    assert(this.messagesContainer, 'Messages container is required');
     const touch = event.touches[0];
     assert(touch, 'Touch point is required');
     assert(typeof this.chatTouchStartY === 'number', 'Touch start y is required');
@@ -15003,10 +15003,6 @@ class ChatModal {
       clearTimeout(this.chatScrollExpandTimer);
       this.chatScrollExpandTimer = null;
     }
-  }
-
-  queueChatScrollExpand() {
-    this.schedulePendingChatScrollExpand();
   }
 
   schedulePendingChatScrollExpand() {
@@ -15049,7 +15045,9 @@ class ChatModal {
   }
 
   expandChatRenderWindow() {
-    if (!this.address || !this.messagesContainer || !this.messagesList) return false;
+    if (!this.address) return false;
+    assert(this.messagesContainer, 'Messages container is required');
+    assert(this.messagesList, 'Messages list is required');
 
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
@@ -15119,7 +15117,7 @@ class ChatModal {
       if (scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold) {
         this.startChatTopBoundaryScrollHold();
       }
-      this.queueChatScrollExpand();
+      this.schedulePendingChatScrollExpand();
     }
   }
 
@@ -16230,10 +16228,6 @@ class ChatModal {
     }
 
     const messageType = item.type || 'message';
-    assert(
-      messageType === 'message' || messageType === 'call' || messageType === 'vm',
-      `Unknown chat message type: ${messageType}`
-    );
 
     let replyHTML = '';
     if (item.replyId) {
@@ -16293,8 +16287,14 @@ class ChatModal {
     }
 
     let messageTextHTML = '';
-    if (item.message && item.message.trim()) {
-      if (messageType === 'call') {
+    switch (messageType) {
+      case 'message':
+        if (item.message && item.message.trim()) {
+          messageTextHTML = `<div class="message-content" style="white-space: pre-wrap; margin-top: ${attachmentsHTML ? '2px' : '0'};">${linkifyUrls(item.message)}</div>`;
+        }
+        break;
+      case 'call': {
+        if (!item.message || !item.message.trim()) break;
         const callTimeMs = Number(item.callTime || 0);
         const callStart = callTimeMs > 0 ? callTimeMs : Number(item.timestamp || item.sent_timestamp || 0);
         const isExpired = this.isCallExpired(callStart);
@@ -16319,14 +16319,11 @@ class ChatModal {
                     </div>
                   </div>`;
         }
-      } else {
-        messageTextHTML = `<div class="message-content" style="white-space: pre-wrap; margin-top: ${attachmentsHTML ? '2px' : '0'};">${linkifyUrls(item.message)}</div>`;
+        break;
       }
-    }
-
-    if (messageType === 'vm') {
-      const duration = this.formatDuration(item.duration);
-      messageTextHTML = `
+      case 'vm': {
+        const duration = this.formatDuration(item.duration);
+        messageTextHTML = `
               <div class="voice-message" data-url="${item.url || ''}" data-name="voice-message" data-type="audio/webm" data-msg-idx="${index}" data-duration="${item.duration || 0}">
                 <div class="voice-message-controls">
                   <div class="voice-message-top-row">
@@ -16344,6 +16341,10 @@ class ChatModal {
                   </div>
                 </div>
               </div>`;
+        break;
+      }
+      default:
+        assert(false, `Unknown chat message type: ${messageType}`);
     }
 
     const callTimeAttribute = messageType === 'call' && item.callTime ? `data-call-time="${item.callTime}"` : '';
@@ -16427,7 +16428,11 @@ class ChatModal {
     const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
-    this.loadThumbnailsForAttachments({ keepBottomAnchored: shouldKeepBottomAnchored });
+    if (shouldKeepBottomAnchored) {
+      this.loadThumbnailsForAttachmentsKeepingBottomAnchored();
+    } else {
+      this.loadThumbnailsForAttachments();
+    }
 
     const renderedAddress = currentAddress;
     const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
@@ -17322,19 +17327,33 @@ class ChatModal {
 
   /**
    * Load thumbnails for visible image and video attachments.
-   * @param {{ keepBottomAnchored?: boolean }} options
    * @returns {void}
    */
-  async loadThumbnailsForAttachments({ keepBottomAnchored = false } = {}) {
+  async loadThumbnailsForAttachments() {
     const thumbnailRows = this.messagesList.querySelectorAll(
       '[data-image-attachment="true"], [data-video-attachment="true"]'
     );
 
     for (const attachmentRow of thumbnailRows) {
-      const oldScrollHeight = this.messagesContainer?.scrollHeight ?? 0;
+      await this.loadThumbnailForAttachment(attachmentRow);
+    }
+  }
+
+  /**
+   * Load visible thumbnails while keeping the newest messages anchored.
+   * @returns {void}
+   */
+  async loadThumbnailsForAttachmentsKeepingBottomAnchored() {
+    const thumbnailRows = this.messagesList.querySelectorAll(
+      '[data-image-attachment="true"], [data-video-attachment="true"]'
+    );
+    assert(this.messagesContainer, 'Messages container is required');
+
+    for (const attachmentRow of thumbnailRows) {
+      const oldScrollHeight = this.messagesContainer.scrollHeight;
       const didUpdate = await this.loadThumbnailForAttachment(attachmentRow);
-      const heightDelta = (this.messagesContainer?.scrollHeight ?? 0) - oldScrollHeight;
-      if (keepBottomAnchored && didUpdate && heightDelta !== 0 && this.messagesContainer) {
+      const heightDelta = this.messagesContainer.scrollHeight - oldScrollHeight;
+      if (didUpdate && heightDelta !== 0) {
         this.messagesContainer.scrollTop = Math.max(0, this.messagesContainer.scrollTop + heightDelta);
       }
     }

--- a/app.js
+++ b/app.js
@@ -15384,10 +15384,17 @@ class ChatModal {
     const scrollSnapshot = this.getChatScrollSnapshot();
     const loadAheadThreshold = this.getChatLoadAheadThreshold();
     const rearmDistance = this.chatExpansionRearmDistanceFromBottom;
+    const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(scrollSnapshot);
+    const isAtRenderedBoundary = !!scrollSnapshot &&
+      scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
     const isExpansionRearmed = !Number.isFinite(rearmDistance) ||
       (scrollSnapshot && scrollSnapshot.distanceFromBottom >= rearmDistance);
 
-    if (!scrollSnapshot || scrollSnapshot.distanceFromBottom < loadAheadThreshold || !isExpansionRearmed) {
+    if (
+      !scrollSnapshot ||
+      scrollSnapshot.distanceFromBottom < loadAheadThreshold ||
+      (!isExpansionRearmed && !isAtRenderedBoundary)
+    ) {
       if (this.chatPerfLoggingEnabled) {
         this.logChatPerf('window:expandAborted', {
           trigger,
@@ -15398,6 +15405,8 @@ class ChatModal {
               : 'notRearmed',
           distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
           loadAheadThreshold: Math.round(loadAheadThreshold),
+          distanceToRenderedTop: scrollSnapshot ? scrollSnapshot.distanceToRenderedTop : 'n/a',
+          renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold),
           rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
         });
       }
@@ -15413,6 +15422,8 @@ class ChatModal {
         queuedReason,
         distanceFromBottom: scrollSnapshot.distanceFromBottom,
         loadAheadThreshold: Math.round(loadAheadThreshold),
+        distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
+        renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold),
         rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
       });
     }
@@ -15467,8 +15478,7 @@ class ChatModal {
         renderedTopThreshold: Math.round(this.getChatRenderedTopLoadAheadThreshold(beforeSnapshot)),
         renderedBoundaryThreshold: Math.round(this.getChatRenderedBoundaryThreshold(beforeSnapshot)),
         atRenderedBoundary: beforeSnapshot
-          ? beforeSnapshot.topSpacerHeight > 0 &&
-            beforeSnapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(beforeSnapshot)
+          ? beforeSnapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(beforeSnapshot)
           : 'n/a',
         remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
         totalMessages: messages.length
@@ -15530,11 +15540,14 @@ class ChatModal {
       const preservePerfStart = this.getChatPerfTime();
       let scrollDelta = estimatedInsertedHeight;
       let nextSpacerHeight = oldSpacerHeight;
+      let newScrollHeightMs = 'skipped';
       if (useEstimatedSpacerPreserve) {
         nextSpacerHeight = Math.max(0, oldSpacerHeight - estimatedInsertedHeight);
         this.setChatHistorySpacerHeight(nextSpacerHeight);
       } else {
+        const newScrollHeightPerfStart = this.getChatPerfTime();
         const newScrollHeight = this.messagesContainer.scrollHeight;
+        newScrollHeightMs = this.formatChatPerfMs(newScrollHeightPerfStart);
         scrollDelta = newScrollHeight - oldScrollHeight;
         this.messagesContainer.scrollTop = oldScrollTop + scrollDelta;
       }
@@ -15544,7 +15557,7 @@ class ChatModal {
 
       const expectedScrollTop = useEstimatedSpacerPreserve
         ? oldScrollTop
-        : this.messagesContainer.scrollTop;
+        : oldScrollTop + scrollDelta;
       const afterDistanceToRenderedTop = Math.max(0, expectedScrollTop - nextSpacerHeight);
       const afterSnapshotEstimate = beforeSnapshot && useEstimatedSpacerPreserve
         ? {
@@ -15583,6 +15596,7 @@ class ChatModal {
           scrollTopSource: oldScrollTopSource,
           spacerLookup: spacerLookupMs,
           oldScrollHeightRead: oldScrollHeightMs,
+          newScrollHeightRead: newScrollHeightMs,
           estimate: estimateMs,
           range: rangeMs,
           build: range.buildMs,
@@ -15713,7 +15727,6 @@ class ChatModal {
       scrollSnapshot.distanceToRenderedTop <= renderedTopThreshold;
     const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(scrollSnapshot);
     const isAtRenderedBoundary = remainingOlder > 0 &&
-      scrollSnapshot.topSpacerHeight > 0 &&
       scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
     const canExpandOlderWindow = isExpansionRearmed || isAtRenderedBoundary;
     if (isNearRenderedTop && canExpandOlderWindow) {
@@ -15760,6 +15773,10 @@ class ChatModal {
       !Number.isFinite(snapshot.topSpacerHeight)
     ) {
       return baseThreshold;
+    }
+
+    if (snapshot.topSpacerHeight <= 0) {
+      return Math.max(420, Math.min(900, (snapshot.clientHeight || 0) * 1.25));
     }
 
     const renderedRunway = Math.max(0, snapshot.maxScrollTop - snapshot.topSpacerHeight);
@@ -17558,16 +17575,12 @@ class ChatModal {
       // The newest received element will be found after the loop completes
     }
     const renderLoopMs = this.formatChatPerfMs(renderLoopPerfStart);
-    const topSpacerHeight = renderRange.isWindowed
-      ? this.estimateChatMessagesHeight(messages, messages.length - 1, renderRange.oldestIndex + 1)
-      : 0;
-    this.chatHistorySpacerHeight = topSpacerHeight;
+    const topSpacerHeight = 0;
+    this.chatHistorySpacerHeight = 0;
 
     // Replace the list once to avoid one DOM mutation per message.
     const joinPerfStart = this.getChatPerfTime();
-    const renderedHTML = `${topSpacerHeight > 0
-      ? `<div class="chat-history-spacer" aria-hidden="true" data-estimated-height="${Math.round(topSpacerHeight)}" style="height:${Math.round(topSpacerHeight)}px"></div>`
-      : ''}${renderedMessages.join('')}`;
+    const renderedHTML = renderedMessages.join('');
     const joinMs = this.formatChatPerfMs(joinPerfStart);
     const domWritePerfStart = this.getChatPerfTime();
     this.messagesList.innerHTML = renderedHTML;

--- a/app.js
+++ b/app.js
@@ -16261,11 +16261,13 @@ class ChatModal {
       }
     });
     const txidMapMs = this.formatChatPerfMs(txidMapPerfStart);
+    const forceFullRender = highlightNewMessage && skipAutoScroll;
+    const renderRange = this.getChatRenderRange(messages, currentAddress, forceFullRender);
 
     // 3. Iterate backwards through messages (oldest to newest for rendering order)
     // messages are already sorted descending (newest first) in myData
     const renderLoopPerfStart = this.getChatPerfTime();
-    for (let i = messages.length - 1; i >= 0; i--) {
+    for (let i = renderRange.oldestIndex; i >= renderRange.newestIndex; i--) {
       const item = messages[i];
       let messageHTML = '';
       const timeString = formatTime(item.timestamp);
@@ -16487,6 +16489,9 @@ class ChatModal {
     this.logChatPerf('append:sync', {
       contact: this.formatChatPerfAddress(currentAddress, contact),
       messages: messages.length,
+      rendered: renderedMessages.length,
+      oldestIndex: renderRange.oldestIndex,
+      isWindowed: renderRange.isWindowed,
       txidMap: txidMapMs,
       build: renderLoopMs,
       join: joinMs,

--- a/app.js
+++ b/app.js
@@ -13945,8 +13945,8 @@ class ChatModal {
     this.chatPerfLogBuffer = [];
     this.chatPerfLogFlushTimer = null;
 
-    this.chatInitialRenderCount = 60;
-    this.chatOlderRenderBatchSize = 60;
+    this.chatInitialRenderCount = 40;
+    this.chatOlderRenderBatchSize = 40;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
@@ -14987,10 +14987,11 @@ class ChatModal {
     return container.scrollHeight - container.scrollTop - container.clientHeight <= thresholdPx;
   }
 
-  scrollMessagesToBottom() {
+  scrollMessagesToBottom({ readMetrics = true } = {}) {
     const container = this.messagesContainer || this.messagesList?.parentElement;
     if (!container) return null;
-    container.scrollTop = container.scrollHeight;
+    container.scrollTop = 1000000000;
+    if (!readMetrics) return null;
     return {
       scrollTop: Math.round(container.scrollTop),
       scrollHeight: Math.round(container.scrollHeight),
@@ -15107,7 +15108,11 @@ class ChatModal {
   handleMessagesContainerScroll() {
     this.closeAllContextMenus();
     if (!this.messagesContainer || !this.isActive()) return;
-    if (this.messagesContainer.scrollTop <= 160) {
+    const messageListPaddingTop = this.messagesList
+      ? parseFloat(getComputedStyle(this.messagesList).paddingTop || '0')
+      : 0;
+    const loadAheadThreshold = messageListPaddingTop + (this.messagesContainer.clientHeight * 2);
+    if (this.messagesContainer.scrollTop <= loadAheadThreshold) {
       this.expandChatRenderWindow();
     }
   }
@@ -16492,7 +16497,7 @@ class ChatModal {
     const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
     if (shouldKeepBottomAnchored) {
       const immediateScrollPerfStart = this.getChatPerfTime();
-      immediateScrollMetrics = this.scrollMessagesToBottom();
+      immediateScrollMetrics = this.scrollMessagesToBottom({ readMetrics: false });
       immediateScrollMs = this.formatChatPerfMs(immediateScrollPerfStart);
     }
     this.logChatPerf('append:sync', {
@@ -16649,7 +16654,7 @@ class ChatModal {
         if (messageContainer) {
           const userStayedAtInitialBottom = immediateScrollMetrics
             ? Math.abs(messageContainer.scrollTop - immediateScrollMetrics.scrollTop) <= 2
-            : true;
+            : false;
           if (!shouldKeepBottomAnchored || userStayedAtInitialBottom || this.isMessagesContainerNearBottom(120)) {
             messageContainer.scrollTop = messageContainer.scrollHeight;
           } else {

--- a/app.js
+++ b/app.js
@@ -13959,6 +13959,7 @@ class ChatModal {
     this.chatRenderSequence = 0;
     this.lastChatTouchLogAt = 0;
     this.chatTouchStartY = null;
+    this.chatExpansionRearmDistanceFromBottom = null;
   }
 
   /**
@@ -15024,6 +15025,7 @@ class ChatModal {
     this.chatRenderedOldestIndex = null;
     this.chatForceFullRenderOnce = false;
     this.isExpandingChatRenderWindow = false;
+    this.chatExpansionRearmDistanceFromBottom = null;
   }
 
   getChatRenderRange(messages, currentAddress, forceFullRender = false) {
@@ -15171,6 +15173,7 @@ class ChatModal {
     const messages = contact?.messages;
     if (!Array.isArray(messages) || messages.length === 0) return false;
     const isOpenDrain = reason === 'openDrain';
+    const shouldPrependOlderMessages = reason === 'scrollDistance' && this.messagesContainer;
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
@@ -15184,7 +15187,7 @@ class ChatModal {
       messages.length - 1,
       currentOldestIndex + renderBatchSize
     );
-    const anchor = isOpenDrain ? null : this.getFirstVisibleMessageAnchor();
+    const anchor = isOpenDrain || shouldPrependOlderMessages ? null : this.getFirstVisibleMessageAnchor();
     const beforeSnapshot = isOpenDrain
       ? {
           scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
@@ -15208,6 +15211,59 @@ class ChatModal {
       totalMessages: messages.length
     });
 
+    if (shouldPrependOlderMessages) {
+      const prependPerfStart = this.getChatPerfTime();
+      const oldScrollTop = this.messagesContainer.scrollTop;
+      const oldScrollHeight = this.messagesContainer.scrollHeight;
+      const range = this.buildChatMessageRangeHTML(
+        messages,
+        contact,
+        nextOldestIndex,
+        currentOldestIndex + 1
+      );
+      const domWritePerfStart = this.getChatPerfTime();
+      this.messagesList.insertAdjacentHTML('afterbegin', range.html);
+      const domWriteMs = this.formatChatPerfMs(domWritePerfStart);
+      const reactionsPerfStart = this.getChatPerfTime();
+      if (range.renderedTxids.length > 0) {
+        this.syncRenderedReactionTargets(range.renderedTxids);
+      }
+      const reactionsMs = this.formatChatPerfMs(reactionsPerfStart);
+      const preservePerfStart = this.getChatPerfTime();
+      const newScrollHeight = this.messagesContainer.scrollHeight;
+      const scrollDelta = newScrollHeight - oldScrollHeight;
+      this.messagesContainer.scrollTop = oldScrollTop + scrollDelta;
+      const preserveMs = this.formatChatPerfMs(preservePerfStart);
+      this.chatRenderedOldestIndex = nextOldestIndex;
+      this.isExpandingChatRenderWindow = false;
+
+      const rearmDistance = (beforeSnapshot?.distanceFromBottom || 0) + Math.max(
+        this.messagesContainer.clientHeight || 0,
+        this.getChatLoadAheadThreshold() * 2
+      );
+      this.chatExpansionRearmDistanceFromBottom = rearmDistance;
+      this.logChatPerf('window:prepend', {
+        contact: this.formatChatPerfAddress(this.address, contact),
+        previousOldestIndex: currentOldestIndex,
+        nextOldestIndex,
+        rendered: range.renderedCount,
+        build: range.buildMs,
+        join: range.joinMs,
+        domWrite: domWriteMs,
+        reactions: reactionsMs,
+        preserve: preserveMs,
+        oldScrollTop: Math.round(oldScrollTop),
+        oldScrollHeight: Math.round(oldScrollHeight),
+        scrollDelta: Math.round(scrollDelta),
+        nextScrollTop: Math.round(this.messagesContainer.scrollTop),
+        rearmDistance: Math.round(rearmDistance),
+        children: this.messagesList.children.length,
+        total: this.formatChatPerfMs(prependPerfStart)
+      });
+      return true;
+    }
+
+    this.chatRenderedOldestIndex = nextOldestIndex;
     this.appendChatModal(false, true, { skipDeferredWork: isOpenDrain });
     if (isOpenDrain) {
       const bottomScrollPerfStart = this.getChatPerfTime();
@@ -15271,7 +15327,15 @@ class ChatModal {
       });
     }
     const loadAheadThreshold = this.getChatLoadAheadThreshold();
-    if (scrollSnapshot.distanceFromBottom >= loadAheadThreshold) {
+    if (
+      Number.isFinite(this.chatExpansionRearmDistanceFromBottom) &&
+      scrollSnapshot.distanceFromBottom < Math.max(0, loadAheadThreshold * 0.5)
+    ) {
+      this.chatExpansionRearmDistanceFromBottom = null;
+    }
+    const isExpansionRearmed = !Number.isFinite(this.chatExpansionRearmDistanceFromBottom) ||
+      scrollSnapshot.distanceFromBottom >= this.chatExpansionRearmDistanceFromBottom;
+    if (scrollSnapshot.distanceFromBottom >= loadAheadThreshold && isExpansionRearmed) {
       this.expandChatRenderWindow('scrollDistance');
     }
   }
@@ -16540,6 +16604,206 @@ class ChatModal {
       payload,
       chatMessageObj,
       txid: getTxid(chatMessageObj)
+    };
+  }
+
+  buildChatMessagesByTxid(messages) {
+    const messagesByTxid = new Map();
+    messages.forEach((message) => {
+      if (message?.txid) {
+        messagesByTxid.set(message.txid, message);
+      }
+    });
+    return messagesByTxid;
+  }
+
+  renderChatMessageHTML(item, index, { contact, messagesByTxid, lastReadTs }) {
+    const timeString = formatTime(item.timestamp);
+    const timestampAttribute = `data-message-timestamp="${item.timestamp}"`;
+    const txidAttribute = item?.txid ? `data-txid="${item.txid}"` : '';
+    const statusAttribute = item?.status ? `data-status="${item.status}"` : '';
+
+    if (typeof item.amount === 'bigint') {
+      const amountStr = big2str(item.amount, 18);
+      const amountNum = parseFloat(amountStr);
+      const amountDisplay = `${amountNum.toFixed(6)} ${item.symbol || 'LIB'}`;
+      const directionText = item.my ? '-' : '+';
+      const messageClass = item.my ? 'sent' : 'received';
+      const showEditedDot = !item.my && item.edited && item.edited_timestamp && item.edited_timestamp > lastReadTs && !isDeleted(item);
+      return `
+          <div class="message ${messageClass} payment-info" ${timestampAttribute} ${txidAttribute} ${statusAttribute}>
+            <div class="payment-header">
+              <span class="payment-direction">${directionText}</span>
+              <span class="payment-amount">${amountDisplay}</span>
+            </div>
+            ${item.message ? `<div class="payment-memo">${linkifyUrls(item.message)}</div>` : ''}
+            <div class="message-time">${timeString}${item.edited ? ' <span class="message-edited-label">edited</span>' : ''}${showEditedDot ? ' <span class="edited-new-dot" title="Edited since last read"></span>' : ''}</div>
+          </div>
+        `;
+    }
+
+    const messageClass = item.my ? 'sent' : 'received';
+    if (isDeleted(item)) {
+      return `
+                    <div class="message ${messageClass} deleted-message" ${timestampAttribute} ${txidAttribute} ${statusAttribute}>
+                        <div class="message-content deleted-content">${item.message}</div>
+                        <div class="message-time">${timeString}</div>
+                    </div>
+                `;
+    }
+
+    let replyHTML = '';
+    if (item.replyId) {
+      const replyText = escapeHtml(item.replyMessage || 'View original message');
+      const ownerIsMineHint = item.replyOwnerIsMine;
+      const hasHint = typeof ownerIsMineHint !== 'undefined';
+      let isOwnerMine = false;
+      if (hasHint) {
+        const isSelfReply = ownerIsMineHint === true || ownerIsMineHint === '1';
+        isOwnerMine = item.my === isSelfReply;
+      } else {
+        const targetMsg = messagesByTxid.get(item.replyId);
+        isOwnerMine = !!(targetMsg && targetMsg.my);
+      }
+      const ownerText = isOwnerMine ? 'You' : (getContactDisplayName(contact) || 'Contact');
+      const ownerClass = isOwnerMine ? 'reply-owner-me' : 'reply-owner-contact';
+      const replyOwnerLabel = `<span class="reply-quote-label ${ownerClass}">${escapeHtml(ownerText)}</span>`;
+
+      replyHTML = `
+                <div class="reply-quote ${ownerClass}" data-reply-txid="${escapeHtml(item.replyId)}">
+                  ${replyOwnerLabel}
+                  <div class="reply-quote-text">${replyText}</div>
+                </div>
+              `;
+    }
+
+    let attachmentsHTML = '';
+    if (item.xattach && Array.isArray(item.xattach) && item.xattach.length > 0) {
+      attachmentsHTML = item.xattach.map(att => {
+        const fileUrl = att.url || '#';
+        const fileName = att.name || 'Attachment';
+        const fileSize = att.size ? this.formatFileSize(att.size) : '';
+        const fileType = att.type ? att.type.split('/').pop().toUpperCase() : '';
+        const isImage = att.type && att.type.startsWith('image/');
+        const isVideo = att.type && att.type.startsWith('video/');
+        const hasThumbnail = isImage || isVideo;
+        const fileTypeIcon = this.getFileTypeForIcon(att.type || '', fileName);
+        const attachmentClass = hasThumbnail ? 'attachment-row attachment-row-media' : 'attachment-row attachment-row-file';
+        return `
+                <div class="${attachmentClass}"
+                  data-url="${fileUrl}"
+                  data-p-url="${att.pUrl || ''}"
+                  data-name="${encodeURIComponent(fileName)}"
+                  data-type="${att.type || ''}"
+                  data-msg-idx="${index}"
+                  ${isImage ? 'data-image-attachment="true"' : ''}
+                  ${isVideo ? 'data-video-attachment="true"' : ''}
+                >
+                  <div class="attachment-icon-container">
+                    <div class="attachment-icon" data-file-type="${fileTypeIcon}"></div>
+                  </div>
+                  <div class="attachment-details">
+                    <span class="attachment-label">
+                      ${fileName}
+                    </span>
+                    <span class="attachment-meta">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
+                  </div>
+                </div>
+              `;
+      }).join('');
+    }
+
+    let messageTextHTML = '';
+    if (item.message && item.message.trim()) {
+      if (item.type === 'call') {
+        const callTimeMs = Number(item.callTime || 0);
+        const callStart = callTimeMs > 0 ? callTimeMs : Number(item.timestamp || item.sent_timestamp || 0);
+        const isExpired = this.isCallExpired(callStart);
+
+        if (isExpired) {
+          const theirName = getContactDisplayName(contact);
+          const label = item.my ? `You called ${escapeHtml(theirName)}` : `${escapeHtml(theirName)} called you`;
+          messageTextHTML = `
+                  <div class="call-message">
+                    <div class="call-message-text"><i>${label}</i></div>
+                  </div>`;
+        } else {
+          const scheduleHTML = this.buildCallScheduleHTML(callTimeMs);
+          messageTextHTML = `
+                  <div class="call-message">
+                    <a href='${item.message}${callUrlParams}"${myAccount.username}"' target="_blank" rel="noopener noreferrer" class="call-message-phone-button" aria-label="Join Video Call">
+                      <span class="sr-only">Join Video Call</span>
+                    </a>
+                    <div>
+                      <div class="call-message-text">Join Video Call</div>
+                      ${scheduleHTML}
+                    </div>
+                  </div>`;
+        }
+      } else {
+        messageTextHTML = `<div class="message-content" style="white-space: pre-wrap; margin-top: ${attachmentsHTML ? '2px' : '0'};">${linkifyUrls(item.message)}</div>`;
+      }
+    }
+
+    if (item.type === 'vm') {
+      const duration = this.formatDuration(item.duration);
+      messageTextHTML = `
+              <div class="voice-message" data-url="${item.url || ''}" data-name="voice-message" data-type="audio/webm" data-msg-idx="${index}" data-duration="${item.duration || 0}">
+                <div class="voice-message-controls">
+                  <div class="voice-message-top-row">
+                    <button class="voice-message-play-button" aria-label="Play voice message">
+                      <svg viewBox="0 0 24 24">
+                        <path d="M8 5v14l11-7z"/>
+                      </svg>
+                    </button>
+                    <div class="voice-message-text">Voice message</div>
+                    <div class="voice-message-time-display">0:00 / ${duration}</div>
+                  </div>
+                  <div class="voice-message-bottom-row">
+                    <input type="range" class="voice-message-seek" min="0" max="${item.duration || 0}" value="0" step="1" aria-label="Seek voice message">
+                    <button class="voice-message-speed-button" aria-label="Toggle playback speed" data-speed="1">1x</button>
+                  </div>
+                </div>
+              </div>`;
+    }
+
+    const callTimeAttribute = item.type === 'call' && item.callTime ? `data-call-time="${item.callTime}"` : '';
+    const showEditedDot = !item.my && item.edited && item.edited_timestamp && item.edited_timestamp > lastReadTs && !isDeleted(item);
+    return `
+            <div class="message ${messageClass}" ${timestampAttribute} ${txidAttribute} ${statusAttribute} ${callTimeAttribute}>
+              ${replyHTML}
+              ${attachmentsHTML}
+              ${messageTextHTML}
+              <div class="message-time">${timeString}${item.edited ? ' <span class="message-edited-label">edited</span>' : ''}${showEditedDot ? ' <span class="edited-new-dot" title="Edited since last read"></span>' : ''}</div>
+            </div>
+          `;
+  }
+
+  buildChatMessageRangeHTML(messages, contact, oldestIndex, newestIndex) {
+    const buildPerfStart = this.getChatPerfTime();
+    const messagesByTxid = this.buildChatMessagesByTxid(messages);
+    const lastReadTs = contact.lastChatOpenTs || 0;
+    const renderedMessages = [];
+    const renderedTxids = [];
+
+    for (let i = oldestIndex; i >= newestIndex; i--) {
+      const item = messages[i];
+      if (!item) continue;
+      renderedMessages.push(this.renderChatMessageHTML(item, i, { contact, messagesByTxid, lastReadTs }));
+      if (item.txid) renderedTxids.push(item.txid);
+    }
+
+    const buildMs = this.formatChatPerfMs(buildPerfStart);
+    const joinPerfStart = this.getChatPerfTime();
+    const html = renderedMessages.join('');
+    const joinMs = this.formatChatPerfMs(joinPerfStart);
+
+    return {
+      html,
+      renderedCount: renderedMessages.length,
+      renderedTxids,
+      buildMs,
+      joinMs
     };
   }
 

--- a/app.js
+++ b/app.js
@@ -4749,7 +4749,7 @@ class FriendModal {
   updateFriendButton(contact, buttonId) {
     const button = document.getElementById(buttonId);
     // Remove all status classes
-    button.classList.remove('status-0', 'status-1', 'status-2');
+    button.classList.remove('status-0', 'status-1', 'status-2', 'status-3');
     // Add the current status class
     button.classList.add(`status-${contact.friend}`);
   }
@@ -13953,8 +13953,12 @@ class ChatModal {
     this.isExpandingChatRenderWindow = false;
     this.lastChatScrollLogAt = 0;
     this.chatRenderWindowDrainTimer = null;
+    this.chatRenderWindowDrainFrame = null;
     this.chatRenderWindowDrainAddress = null;
     this.chatRenderWindowDrainStartedAt = 0;
+    this.chatRenderSequence = 0;
+    this.lastChatTouchLogAt = 0;
+    this.chatTouchStartY = null;
   }
 
   /**
@@ -14467,6 +14471,9 @@ class ChatModal {
     });
     // Close all context menus when messages container scrolls
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
+    this.messagesContainer.addEventListener('touchstart', (e) => this.logChatTouchDiagnostics(e, 'messagesStart'), { passive: true });
+    this.messagesContainer.addEventListener('touchmove', (e) => this.logChatTouchDiagnostics(e, 'messagesMove'), { passive: true });
+    this.modal.addEventListener('touchmove', (e) => this.logChatTouchDiagnostics(e, 'modalMove'), { passive: true });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
       const reactionButton = e.target.closest('.message-context-reaction-button');
@@ -15100,6 +15107,64 @@ class ChatModal {
     };
   }
 
+  describeChatTouchTarget(target) {
+    if (!target || typeof target.closest !== 'function') return 'unknown';
+    if (target.closest('.message-input-container')) return 'composer';
+    if (target.closest('.modal-header')) return 'header';
+    if (target.closest('.attachment-row')) return 'attachment';
+    if (target.closest('.message')) return 'message';
+    if (target.closest('.messages-list')) return 'messages-list';
+    if (target.closest('.messages-container')) return 'messages-container';
+    if (target.closest('#chatModal')) return 'chat-modal';
+    return target.id || target.className || target.tagName || 'unknown';
+  }
+
+  logChatTouchDiagnostics(event, phase) {
+    if (!this.isActive() || !this.messagesContainer) return;
+    const now = this.getChatPerfTime();
+    if (phase !== 'messagesStart' && now - this.lastChatTouchLogAt < 350) return;
+    this.lastChatTouchLogAt = now;
+
+    const touch = event.touches?.[0] || event.changedTouches?.[0] || null;
+    const y = touch ? Math.round(touch.clientY) : 'n/a';
+    if (phase === 'messagesStart' && typeof y === 'number') {
+      this.chatTouchStartY = y;
+    }
+    const deltaY = typeof y === 'number' && typeof this.chatTouchStartY === 'number'
+      ? y - this.chatTouchStartY
+      : 'n/a';
+    const snapshot = this.getChatScrollSnapshot();
+    const containerStyle = getComputedStyle(this.messagesContainer);
+    const modalStyle = this.modal ? getComputedStyle(this.modal) : null;
+    const activeElement = document.activeElement;
+
+    this.logChatPerf(`touch:${phase}`, {
+      target: this.describeChatTouchTarget(event.target),
+      inMessagesContainer: !!event.target.closest?.('.messages-container'),
+      inMessagesList: !!event.target.closest?.('.messages-list'),
+      y,
+      deltaY,
+      cancelable: event.cancelable,
+      defaultPrevented: event.defaultPrevented,
+      canScroll: snapshot ? snapshot.scrollHeight > snapshot.clientHeight : 'n/a',
+      atTop: snapshot ? snapshot.scrollTop <= 0 : 'n/a',
+      atBottom: snapshot ? snapshot.distanceFromBottom <= 1 : 'n/a',
+      scrollTop: snapshot ? snapshot.scrollTop : 'n/a',
+      maxScrollTop: snapshot ? snapshot.maxScrollTop : 'n/a',
+      distanceFromBottom: snapshot ? snapshot.distanceFromBottom : 'n/a',
+      containerOverflowY: containerStyle.overflowY,
+      containerTouchAction: containerStyle.touchAction,
+      containerWebkitOverflow: containerStyle.webkitOverflowScrolling || 'n/a',
+      modalTouchAction: modalStyle ? modalStyle.touchAction : 'n/a',
+      modalScrollTop: this.modal ? Math.round(this.modal.scrollTop || 0) : 'n/a',
+      bodyScrollY: Math.round(window.scrollY || 0),
+      htmlOverflow: getComputedStyle(document.documentElement).overflow,
+      bodyOverflow: getComputedStyle(document.body).overflow,
+      activeElement: activeElement?.id || activeElement?.className || activeElement?.tagName || 'none',
+      scrollLocked: this.scrollLocked
+    });
+  }
+
   expandChatRenderWindow(reason = 'scroll') {
     if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) return false;
     const contact = myData.contacts[this.address];
@@ -15209,6 +15274,12 @@ class ChatModal {
       clearTimeout(this.chatRenderWindowDrainTimer);
       this.chatRenderWindowDrainTimer = null;
     }
+    if (this.chatRenderWindowDrainFrame) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(this.chatRenderWindowDrainFrame);
+      }
+      this.chatRenderWindowDrainFrame = null;
+    }
     this.chatRenderWindowDrainAddress = null;
     this.chatRenderWindowDrainStartedAt = 0;
   }
@@ -15240,10 +15311,23 @@ class ChatModal {
       ? requestAnimationFrame
       : (callback) => setTimeout(callback, 0);
 
-    const scheduleNextDrainStep = (delayMs) => {
-      if (this.chatRenderWindowDrainTimer) return;
-      this.chatRenderWindowDrainTimer = setTimeout(() => {
-        this.chatRenderWindowDrainTimer = null;
+    const scheduleDrainFrame = (callback) => {
+      if (typeof requestAnimationFrame === 'function') {
+        this.chatRenderWindowDrainFrame = requestAnimationFrame(() => {
+          this.chatRenderWindowDrainFrame = null;
+          callback();
+        });
+      } else {
+        this.chatRenderWindowDrainTimer = setTimeout(() => {
+          this.chatRenderWindowDrainTimer = null;
+          callback();
+        }, 0);
+      }
+    };
+
+    const scheduleNextDrainStep = () => {
+      if (this.chatRenderWindowDrainFrame || this.chatRenderWindowDrainTimer) return;
+      scheduleDrainFrame(() => {
         scheduleAfterPaint(() => {
           if (!this.isActive() || this.address !== address) {
             this.logChatPerf('window:drainAbort', {
@@ -15256,7 +15340,7 @@ class ChatModal {
           }
 
           if (this.isExpandingChatRenderWindow) {
-            scheduleNextDrainStep(60);
+            scheduleNextDrainStep();
             return;
           }
 
@@ -15272,7 +15356,9 @@ class ChatModal {
             return;
           }
 
+          const stepStart = this.getChatPerfTime();
           const expanded = this.expandChatRenderWindow('openDrain');
+          const stepMs = this.formatChatPerfMs(stepStart);
           const nextOldestIndex = getCurrentOldestIndex();
           this.logChatPerf('window:drainStep', {
             contact: this.formatChatPerfAddress(address, contact),
@@ -15280,11 +15366,12 @@ class ChatModal {
             previousOldestIndex: currentOldestIndex,
             currentOldestIndex: nextOldestIndex,
             remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
+            step: stepMs,
             elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
           });
 
           if (nextOldestIndex < messages.length - 1) {
-            scheduleNextDrainStep(90);
+            scheduleNextDrainStep();
           } else {
             this.logChatPerf('window:drainDone', {
               contact: this.formatChatPerfAddress(address, contact),
@@ -15300,7 +15387,7 @@ class ChatModal {
 
     scheduleAfterPaint(() => {
       scheduleAfterPaint(() => {
-        scheduleNextDrainStep(0);
+        scheduleNextDrainStep();
       });
     });
   }
@@ -15382,7 +15469,17 @@ class ChatModal {
     this.blockedByRecipient = Number(contact?.tollRequiredToSend) === 2;
     this.addAttachmentButton.disabled = this.blockedByRecipient;
     if (this.voiceRecordButton) this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
+    const friendButtonPerfStart = this.getChatPerfTime();
     friendModal.updateFriendButton(contact, 'addFriendButtonChat');
+    const friendButtonClass = this.addFriendButtonChat
+      ? [...this.addFriendButtonChat.classList].filter((className) => className.startsWith('status-')).join(',')
+      : 'missing';
+    this.logChatPerf('open:friendButton', {
+      ms: this.formatChatPerfMs(friendButtonPerfStart),
+      friend: contact?.friend,
+      class: friendButtonClass,
+      total: this.formatChatPerfMs(openPerfStart)
+    });
     // Set user info
     this.modalTitle.textContent = getContactDisplayName(contact);
 
@@ -16447,6 +16544,7 @@ class ChatModal {
 
     if (!this.modal) return;
     if (!this.messagesList) return;
+    const renderSequence = ++this.chatRenderSequence;
 
     // --- 1. Identify the actual newest received message data item ---
     // Since messages are sorted descending (newest first), the first item with my: false is the newest received.
@@ -16716,10 +16814,18 @@ class ChatModal {
     scheduleAfterPaint(() => {
       scheduleAfterPaint(() => {
         const deferredStart = this.getChatPerfTime();
-        if (!this.isActive() || this.address !== renderedAddress || !this.messagesList) {
+        if (
+          !this.isActive() ||
+          this.address !== renderedAddress ||
+          !this.messagesList ||
+          renderSequence !== this.chatRenderSequence
+        ) {
           this.logChatPerf('append:deferredSkipped', {
             contact: this.formatChatPerfAddress(renderedAddress, contact),
             delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+            reason: renderSequence !== this.chatRenderSequence ? 'staleRender' : 'inactive',
+            renderSequence,
+            currentRenderSequence: this.chatRenderSequence,
             currentAddress: this.address || 'none'
           });
           return;
@@ -16793,6 +16899,18 @@ class ChatModal {
         contact: this.formatChatPerfAddress(currentAddress, contact),
         delay: '0.0ms',
         reason: 'skipAutoScroll'
+      });
+      return;
+    }
+
+    if (shouldKeepBottomAnchored && !highlightNewMessage) {
+      this.logChatPerf('append:scrollSkipped', {
+        contact: this.formatChatPerfAddress(currentAddress, contact),
+        delay: '0.0ms',
+        reason: 'immediateBottom',
+        scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
+        scrollHeight: this.messagesContainer ? Math.round(this.messagesContainer.scrollHeight) : 'n/a',
+        clientHeight: this.messagesContainer ? Math.round(this.messagesContainer.clientHeight) : 'n/a'
       });
       return;
     }

--- a/app.js
+++ b/app.js
@@ -13951,6 +13951,7 @@ class ChatModal {
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
     this.isExpandingChatRenderWindow = false;
+    this.lastChatScrollLogAt = 0;
   }
 
   /**
@@ -15038,6 +15039,12 @@ class ChatModal {
     };
   }
 
+  getChatTopSpacerHeight(renderRange) {
+    if (!renderRange?.isWindowed) return 0;
+    const hiddenCount = Math.max(0, renderRange.totalMessages - renderRange.oldestIndex - 1);
+    return Math.min(1600, Math.max(480, hiddenCount * 28));
+  }
+
   getFirstVisibleMessageAnchor() {
     const container = this.messagesContainer;
     if (!container || !this.messagesList) return null;
@@ -15108,10 +15115,22 @@ class ChatModal {
   handleMessagesContainerScroll() {
     this.closeAllContextMenus();
     if (!this.messagesContainer || !this.isActive()) return;
-    const messageListPaddingTop = this.messagesList
-      ? parseFloat(getComputedStyle(this.messagesList).paddingTop || '0')
+    const now = this.getChatPerfTime();
+    if (now - this.lastChatScrollLogAt > 750) {
+      this.lastChatScrollLogAt = now;
+      this.logChatPerf('scroll:metrics', {
+        scrollTop: Math.round(this.messagesContainer.scrollTop),
+        scrollHeight: Math.round(this.messagesContainer.scrollHeight),
+        clientHeight: Math.round(this.messagesContainer.clientHeight),
+        messageListHeight: this.messagesList ? Math.round(this.messagesList.scrollHeight) : 'n/a',
+        modalScrollTop: this.modal ? Math.round(this.modal.scrollTop || 0) : 'n/a',
+        bodyScrollY: Math.round(window.scrollY || 0)
+      });
+    }
+    const topSpacerHeight = this.messagesList
+      ? this.messagesList.querySelector('.chat-window-top-spacer')?.offsetHeight || 0
       : 0;
-    const loadAheadThreshold = messageListPaddingTop + (this.messagesContainer.clientHeight * 2);
+    const loadAheadThreshold = topSpacerHeight + (this.messagesContainer.clientHeight * 1.5);
     if (this.messagesContainer.scrollTop <= loadAheadThreshold) {
       this.expandChatRenderWindow();
     }
@@ -16484,6 +16503,10 @@ class ChatModal {
       // The newest received element will be found after the loop completes
     }
     const renderLoopMs = this.formatChatPerfMs(renderLoopPerfStart);
+    const topSpacerHeight = this.getChatTopSpacerHeight(renderRange);
+    if (topSpacerHeight > 0) {
+      renderedMessages.unshift(`<div class="chat-window-top-spacer" style="height: ${topSpacerHeight}px;"></div>`);
+    }
 
     // Replace the list once to avoid one DOM mutation per message.
     const joinPerfStart = this.getChatPerfTime();
@@ -16506,6 +16529,7 @@ class ChatModal {
       rendered: renderedMessages.length,
       oldestIndex: renderRange.oldestIndex,
       isWindowed: renderRange.isWindowed,
+      topSpacer: topSpacerHeight,
       txidMap: txidMapMs,
       build: renderLoopMs,
       join: joinMs,

--- a/app.js
+++ b/app.js
@@ -13881,6 +13881,7 @@ const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
 const CHAT_INITIAL_RENDER_COUNT = 100;
 const CHAT_OLDER_RENDER_BATCH_SIZE = 200;
 const CHAT_SCROLL_EXPAND_DELAY_MS = 220;
+const CHAT_HISTORY_LOADING_TOAST_MIN_MS = 500;
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
@@ -13949,7 +13950,7 @@ class ChatModal {
     this.chatScrollExpandTimer = null;
     this.chatRenderSequence = 0;
     this.chatTouchStartY = null;
-    this.chatHistoryLoadingToastId = null;
+    this.chatHistoryLoadingToast = null;
   }
 
   /**
@@ -14899,7 +14900,7 @@ class ChatModal {
 
   resetChatRenderWindow() {
     this.clearPendingChatScrollExpand();
-    this.stopChatTopBoundaryScrollHold();
+    this.clearChatHistoryLoadingToast();
     this.chatRenderedOldestIndex = null;
     this.chatTouchStartY = null;
   }
@@ -14933,14 +14934,48 @@ class ChatModal {
   }
 
   showChatHistoryLoadingToast() {
-    if (this.chatHistoryLoadingToastId) return;
-    this.chatHistoryLoadingToastId = showToast('Loading messages', 0, 'loading', false, { dedupe: false });
+    const toast = this.chatHistoryLoadingToast;
+    if (toast?.hideTimer) {
+      clearTimeout(toast.hideTimer);
+      toast.hideTimer = null;
+    }
+    if (toast) return;
+
+    this.chatHistoryLoadingToast = {
+      id: showToast('Loading messages', 0, 'loading', false, { dedupe: false }),
+      shownAt: Date.now(),
+      hideTimer: null
+    };
+  }
+
+  clearChatHistoryLoadingToast() {
+    const toast = this.chatHistoryLoadingToast;
+    if (!toast) return;
+
+    if (toast.hideTimer) {
+      clearTimeout(toast.hideTimer);
+    }
+    hideToast(toast.id);
+    this.chatHistoryLoadingToast = null;
   }
 
   hideChatHistoryLoadingToast() {
-    if (!this.chatHistoryLoadingToastId) return;
-    hideToast(this.chatHistoryLoadingToastId);
-    this.chatHistoryLoadingToastId = null;
+    const toast = this.chatHistoryLoadingToast;
+    if (!toast) return;
+
+    const remainingMs = CHAT_HISTORY_LOADING_TOAST_MIN_MS - (Date.now() - toast.shownAt);
+    if (remainingMs > 0) {
+      if (toast.hideTimer) {
+        clearTimeout(toast.hideTimer);
+      }
+      toast.hideTimer = setTimeout(() => {
+        toast.hideTimer = null;
+        this.hideChatHistoryLoadingToast();
+      }, remainingMs);
+      return;
+    }
+
+    this.clearChatHistoryLoadingToast();
   }
 
   startChatTopBoundaryScrollHold() {
@@ -14953,7 +14988,7 @@ class ChatModal {
   }
 
   clampChatTopBoundaryScrollHold() {
-    if (!this.chatHistoryLoadingToastId) return false;
+    if (!this.chatHistoryLoadingToast) return false;
     const container = this.messagesContainer;
     if (container.scrollTop >= 0) return false;
     container.scrollTop = 0;
@@ -14961,7 +14996,7 @@ class ChatModal {
   }
 
   shouldBlockChatTopBoundaryTouchMove(event) {
-    if (!this.chatHistoryLoadingToastId) return false;
+    if (!this.chatHistoryLoadingToast) return false;
     const touch = event.touches[0];
     if (Math.round(touch.clientY) <= this.chatTouchStartY) return false;
 

--- a/app.js
+++ b/app.js
@@ -14462,7 +14462,6 @@ class ChatModal {
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
     this.messagesContainer.addEventListener('scrollend', () => this.handleMessagesContainerScrollEnd(), { passive: true });
     this.messagesContainer.addEventListener('touchstart', (e) => this.handleMessagesTouchStart(e), { passive: true });
-    this.messagesContainer.addEventListener('touchmove', (e) => this.handleMessagesTouchMove(e), { passive: false });
     this.messagesContainer.addEventListener('touchend', () => this.handleMessagesTouchEnd(), { passive: true });
     this.messagesContainer.addEventListener('touchcancel', () => this.handleMessagesTouchEnd(), { passive: true });
     // Add context menu option listeners
@@ -14980,43 +14979,15 @@ class ChatModal {
 
   startChatTopBoundaryScrollHold() {
     this.showChatHistoryLoadingToast();
-    this.clampChatTopBoundaryScrollHold();
   }
 
   stopChatTopBoundaryScrollHold() {
     this.hideChatHistoryLoadingToast();
   }
 
-  clampChatTopBoundaryScrollHold() {
-    if (!this.chatHistoryLoadingToast) return false;
-    const container = this.messagesContainer;
-    if (container.scrollTop >= 0) return false;
-    container.scrollTop = 0;
-    return true;
-  }
-
-  shouldBlockChatTopBoundaryTouchMove(event) {
-    if (!this.chatHistoryLoadingToast) return false;
-    const touch = event.touches[0];
-    if (Math.round(touch.clientY) <= this.chatTouchStartY) return false;
-
-    const snapshot = this.getChatScrollSnapshot();
-    return snapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(snapshot);
-  }
-
   handleMessagesTouchStart(event) {
     const touch = event.touches[0];
     this.chatTouchStartY = Math.round(touch.clientY);
-  }
-
-  handleMessagesTouchMove(event) {
-    if (!this.shouldBlockChatTopBoundaryTouchMove(event)) return;
-
-    this.clampChatTopBoundaryScrollHold();
-    if (event.cancelable) {
-      event.preventDefault();
-    }
-    event.stopPropagation();
   }
 
   handleMessagesTouchEnd() {

--- a/app.js
+++ b/app.js
@@ -13880,7 +13880,6 @@ const CHAT_REACTION_SHEET_PROMOTION_RATIO = 0.5;
 const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
 const CHAT_INITIAL_RENDER_COUNT = 100;
 const CHAT_OLDER_RENDER_BATCH_SIZE = 200;
-const CHAT_SCROLL_EXPAND_DELAY_MS = 220;
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
@@ -13946,9 +13945,7 @@ class ChatModal {
     this.dropOverlay = null;
 
     this.chatRenderedOldestIndex = null;
-    this.chatScrollExpandTimer = null;
     this.chatRenderSequence = 0;
-    this.chatTouchStartY = null;
   }
 
   /**
@@ -14458,10 +14455,6 @@ class ChatModal {
     });
     // Close all context menus when messages container scrolls
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
-    this.messagesContainer.addEventListener('scrollend', () => this.handleMessagesContainerScrollEnd(), { passive: true });
-    this.messagesContainer.addEventListener('touchstart', (e) => this.handleMessagesTouchStart(e), { passive: true });
-    this.messagesContainer.addEventListener('touchend', () => this.handleMessagesTouchEnd(), { passive: true });
-    this.messagesContainer.addEventListener('touchcancel', () => this.handleMessagesTouchEnd(), { passive: true });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
       const reactionButton = e.target.closest('.message-context-reaction-button');
@@ -14896,9 +14889,7 @@ class ChatModal {
   }
 
   resetChatRenderWindow() {
-    this.clearPendingChatScrollExpand();
     this.chatRenderedOldestIndex = null;
-    this.chatTouchStartY = null;
   }
 
   getChatRenderRange(messages) {
@@ -14919,65 +14910,12 @@ class ChatModal {
 
   getChatScrollSnapshot() {
     const container = this.messagesContainer;
-    const maxScrollTop = container.scrollHeight - container.clientHeight;
     const scrollTop = Math.round(container.scrollTop);
     return {
       scrollTop,
-      distanceFromBottom: Math.round(Math.max(0, maxScrollTop - container.scrollTop)),
       clientHeight: Math.round(container.clientHeight),
       distanceToRenderedTop: Math.max(0, scrollTop)
     };
-  }
-
-  handleMessagesTouchStart(event) {
-    const touch = event.touches[0];
-    this.chatTouchStartY = Math.round(touch.clientY);
-  }
-
-  handleMessagesTouchEnd() {
-    this.chatTouchStartY = null;
-    if (this.chatScrollExpandTimer) {
-      this.schedulePendingChatScrollExpand();
-    }
-  }
-
-  clearPendingChatScrollExpand() {
-    if (this.chatScrollExpandTimer) {
-      clearTimeout(this.chatScrollExpandTimer);
-      this.chatScrollExpandTimer = null;
-    }
-  }
-
-  schedulePendingChatScrollExpand() {
-    if (this.chatScrollExpandTimer) {
-      clearTimeout(this.chatScrollExpandTimer);
-    }
-    this.chatScrollExpandTimer = setTimeout(() => {
-      this.chatScrollExpandTimer = null;
-      this.flushPendingChatScrollExpand();
-    }, CHAT_SCROLL_EXPAND_DELAY_MS);
-  }
-
-  handleMessagesContainerScrollEnd() {
-    if (this.chatScrollExpandTimer) {
-      this.flushPendingChatScrollExpand();
-    }
-  }
-
-  flushPendingChatScrollExpand() {
-    this.clearPendingChatScrollExpand();
-    if (!this.isActive()) return;
-    if (this.chatTouchStartY !== null) {
-      this.schedulePendingChatScrollExpand();
-      return;
-    }
-
-    const scrollSnapshot = this.getChatScrollSnapshot();
-    if (scrollSnapshot.distanceToRenderedTop > this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot)) {
-      return;
-    }
-
-    this.expandChatRenderWindow();
   }
 
   expandChatRenderWindow() {
@@ -15035,13 +14973,12 @@ class ChatModal {
       : CHAT_INITIAL_RENDER_COUNT - 1;
     const remainingOlder = Math.max(0, totalMessages - 1 - renderedOldestIndex);
     if (remainingOlder === 0) {
-      this.clearPendingChatScrollExpand();
       return;
     }
 
     const isNearRenderedTop = scrollSnapshot.distanceToRenderedTop <= this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
     if (isNearRenderedTop) {
-      this.schedulePendingChatScrollExpand();
+      this.expandChatRenderWindow();
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -15170,19 +15170,28 @@ class ChatModal {
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
     if (!Array.isArray(messages) || messages.length === 0) return false;
+    const isOpenDrain = reason === 'openDrain';
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
       : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
     if (currentOldestIndex >= messages.length - 1) return false;
 
-    const renderBatchSize = this.getChatOlderRenderBatchSize();
+    const renderBatchSize = isOpenDrain
+      ? this.chatOlderRenderBatchSize
+      : this.getChatOlderRenderBatchSize();
     const nextOldestIndex = Math.min(
       messages.length - 1,
       currentOldestIndex + renderBatchSize
     );
-    const anchor = this.getFirstVisibleMessageAnchor();
-    const beforeSnapshot = this.getChatScrollSnapshot();
+    const anchor = isOpenDrain ? null : this.getFirstVisibleMessageAnchor();
+    const beforeSnapshot = isOpenDrain
+      ? {
+          scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
+          maxScrollTop: 'skipped',
+          distanceFromBottom: 'skipped'
+        }
+      : this.getChatScrollSnapshot();
     this.isExpandingChatRenderWindow = true;
     this.chatRenderedOldestIndex = nextOldestIndex;
     this.logChatPerf('window:expand', {
@@ -15199,7 +15208,21 @@ class ChatModal {
       totalMessages: messages.length
     });
 
-    this.appendChatModal(false, true);
+    this.appendChatModal(false, true, { skipDeferredWork: isOpenDrain });
+    if (isOpenDrain) {
+      const bottomScrollPerfStart = this.getChatPerfTime();
+      this.scrollMessagesToBottom({ readMetrics: false });
+      this.isExpandingChatRenderWindow = false;
+      this.logChatPerf('window:bottomRestored', {
+        contact: this.formatChatPerfAddress(this.address, contact),
+        reason,
+        beforeScrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
+        bottomScroll: this.formatChatPerfMs(bottomScrollPerfStart),
+        remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex)
+      });
+      return true;
+    }
+
     const afterWriteSnapshot = this.getChatScrollSnapshot();
     this.restoreVisibleMessageAnchor(anchor);
     const afterRestoreSnapshot = this.getChatScrollSnapshot();
@@ -16524,9 +16547,10 @@ class ChatModal {
    * Appends the chat modal to the DOM
    * @param {boolean} highlightNewMessage - Whether to highlight the newest message
    * @param {boolean} skipAutoScroll - Whether to skip auto-scrolling to bottom (used when scrolling to a specific message)
+   * @param {{ skipDeferredWork?: boolean }} options - Render behavior options
    * @returns {void}
    */
-  appendChatModal(highlightNewMessage = false, skipAutoScroll = false) {
+  appendChatModal(highlightNewMessage = false, skipAutoScroll = false, { skipDeferredWork = false } = {}) {
     const appendPerfStart = this.getChatPerfTime();
     const currentAddress = this.address; // Use a local constant
     if (!currentAddress) {
@@ -16807,89 +16831,98 @@ class ChatModal {
     });
 
     const renderedAddress = currentAddress;
-    const deferredScheduledAt = this.getChatPerfTime();
-    const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame
-      : (callback) => setTimeout(callback, 0);
-    scheduleAfterPaint(() => {
-      scheduleAfterPaint(() => {
-        const deferredStart = this.getChatPerfTime();
-        if (
-          !this.isActive() ||
-          this.address !== renderedAddress ||
-          !this.messagesList ||
-          renderSequence !== this.chatRenderSequence
-        ) {
-          this.logChatPerf('append:deferredSkipped', {
-            contact: this.formatChatPerfAddress(renderedAddress, contact),
-            delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-            reason: renderSequence !== this.chatRenderSequence ? 'staleRender' : 'inactive',
-            renderSequence,
-            currentRenderSequence: this.chatRenderSequence,
-            currentAddress: this.address || 'none'
-          });
-          return;
-        }
-        const reactionPerfStart = this.getChatPerfTime();
-        this.syncAllRenderedReactionChips();
-        const reactionsMs = this.formatChatPerfMs(reactionPerfStart);
-        const wasNearBottomBeforeThumbnails = shouldKeepBottomAnchored
-          ? this.isMessagesContainerNearBottom(80)
-          : false;
-        const thumbnailPerfStart = this.getChatPerfTime();
-        try {
-          const thumbnailResult = this.loadThumbnailsForAttachments();
-          Promise.resolve(thumbnailResult).then(
-            () => {
-              let thumbnailScrollMetrics = null;
-              let thumbnailScrollMs = 'skipped';
-              if (shouldKeepBottomAnchored && wasNearBottomBeforeThumbnails) {
-                const thumbnailScrollPerfStart = this.getChatPerfTime();
-                thumbnailScrollMetrics = this.scrollMessagesToBottom();
-                thumbnailScrollMs = this.formatChatPerfMs(thumbnailScrollPerfStart);
-              }
-              this.logChatPerf('append:deferred', {
-                contact: this.formatChatPerfAddress(renderedAddress, contact),
-                delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-                reactions: reactionsMs,
-                thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
-                thumbnailScroll: thumbnailScrollMs,
-                wasNearBottomBeforeThumbnails,
-                scrollTop: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollTop : 'n/a',
-                scrollHeight: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollHeight : 'n/a',
-                total: this.formatChatPerfMs(deferredStart)
-              });
-              if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-                this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferred');
-              }
-            },
-            (error) => {
-              this.logChatPerf('append:deferredError', {
-                contact: this.formatChatPerfAddress(renderedAddress, contact),
-                delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-                reactions: reactionsMs,
-                thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
-                error: error?.message || String(error)
-              });
-              if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-                this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
-              }
-            }
-          );
-        } catch (error) {
-          this.logChatPerf('append:deferredError', {
-            contact: this.formatChatPerfAddress(renderedAddress, contact),
-            delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-            reactions: reactionsMs,
-            thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
-            error: error?.message || String(error)
-          });
-          if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-            this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
-          }
-        }
+    if (skipDeferredWork) {
+      this.logChatPerf('append:deferredSkipped', {
+        contact: this.formatChatPerfAddress(renderedAddress, contact),
+        delay: '0.0ms',
+        reason: 'skipDeferredWork',
+        renderSequence
       });
-    });
+    } else {
+      const deferredScheduledAt = this.getChatPerfTime();
+      const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
+        ? requestAnimationFrame
+        : (callback) => setTimeout(callback, 0);
+      scheduleAfterPaint(() => {
+        scheduleAfterPaint(() => {
+          const deferredStart = this.getChatPerfTime();
+          if (
+            !this.isActive() ||
+            this.address !== renderedAddress ||
+            !this.messagesList ||
+            renderSequence !== this.chatRenderSequence
+          ) {
+            this.logChatPerf('append:deferredSkipped', {
+              contact: this.formatChatPerfAddress(renderedAddress, contact),
+              delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+              reason: renderSequence !== this.chatRenderSequence ? 'staleRender' : 'inactive',
+              renderSequence,
+              currentRenderSequence: this.chatRenderSequence,
+              currentAddress: this.address || 'none'
+            });
+            return;
+          }
+          const reactionPerfStart = this.getChatPerfTime();
+          this.syncAllRenderedReactionChips();
+          const reactionsMs = this.formatChatPerfMs(reactionPerfStart);
+          const wasNearBottomBeforeThumbnails = shouldKeepBottomAnchored
+            ? this.isMessagesContainerNearBottom(80)
+            : false;
+          const thumbnailPerfStart = this.getChatPerfTime();
+          try {
+            const thumbnailResult = this.loadThumbnailsForAttachments();
+            Promise.resolve(thumbnailResult).then(
+              () => {
+                let thumbnailScrollMetrics = null;
+                let thumbnailScrollMs = 'skipped';
+                if (shouldKeepBottomAnchored && wasNearBottomBeforeThumbnails) {
+                  const thumbnailScrollPerfStart = this.getChatPerfTime();
+                  thumbnailScrollMetrics = this.scrollMessagesToBottom();
+                  thumbnailScrollMs = this.formatChatPerfMs(thumbnailScrollPerfStart);
+                }
+                this.logChatPerf('append:deferred', {
+                  contact: this.formatChatPerfAddress(renderedAddress, contact),
+                  delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+                  reactions: reactionsMs,
+                  thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
+                  thumbnailScroll: thumbnailScrollMs,
+                  wasNearBottomBeforeThumbnails,
+                  scrollTop: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollTop : 'n/a',
+                  scrollHeight: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollHeight : 'n/a',
+                  total: this.formatChatPerfMs(deferredStart)
+                });
+                if (shouldKeepBottomAnchored && renderRange.isWindowed) {
+                  this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferred');
+                }
+              },
+              (error) => {
+                this.logChatPerf('append:deferredError', {
+                  contact: this.formatChatPerfAddress(renderedAddress, contact),
+                  delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+                  reactions: reactionsMs,
+                  thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
+                  error: error?.message || String(error)
+                });
+                if (shouldKeepBottomAnchored && renderRange.isWindowed) {
+                  this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
+                }
+              }
+            );
+          } catch (error) {
+            this.logChatPerf('append:deferredError', {
+              contact: this.formatChatPerfAddress(renderedAddress, contact),
+              delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+              reactions: reactionsMs,
+              thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
+              error: error?.message || String(error)
+            });
+            if (shouldKeepBottomAnchored && renderRange.isWindowed) {
+              this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
+            }
+          }
+        });
+      });
+    }
 
     // --- 5. Find the corresponding DOM element after rendering ---
     // This happens inside the setTimeout to ensure elements are in the DOM

--- a/app.js
+++ b/app.js
@@ -16210,7 +16210,10 @@ class ChatModal {
         break;
       }
       default:
-        assert(false, `Unknown chat message type: ${messageType}`);
+        console.warn(`Unknown chat message type: ${messageType}`);
+        if (item.message && item.message.trim()) {
+          messageTextHTML = `<div class="message-content" style="white-space: pre-wrap; margin-top: ${attachmentsHTML ? '2px' : '0'};">${linkifyUrls(item.message)}</div>`;
+        }
     }
 
     const callTimeAttribute = messageType === 'call' && item.callTime ? `data-call-time="${item.callTime}"` : '';
@@ -18893,11 +18896,19 @@ class ChatModal {
 
     // Get encryption keys from the message
     const message = this.getMessageRecordFromRenderedChild(attachmentRow);
-    assert(message.xattach, 'VCF attachment message must include attachment data');
+    if (!Array.isArray(message.xattach)) {
+      console.warn('VCF attachment message missing attachment data');
+      showToast('Import contacts is not available for this attachment', 2000, 'error');
+      return;
+    }
 
     // Find the attachment in xattach array
     const attachment = message.xattach.find(att => att.url === url);
-    assert(attachment, 'Rendered VCF attachment must exist in message data');
+    if (!attachment) {
+      console.warn('Rendered VCF attachment missing from message data');
+      showToast('Import contacts is not available for this attachment', 2000, 'error');
+      return;
+    }
 
     // Open the import contacts modal with the full attachment object so
     // fields like `encKey` (new flow) are preserved for backwards compatibility.

--- a/app.js
+++ b/app.js
@@ -13945,8 +13945,8 @@ class ChatModal {
     this.chatPerfLogBuffer = [];
     this.chatPerfLogFlushTimer = null;
 
-    this.chatInitialRenderCount = 80;
-    this.chatOlderRenderBatchSize = 80;
+    this.chatInitialRenderCount = 50;
+    this.chatOlderRenderBatchSize = 50;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;

--- a/app.js
+++ b/app.js
@@ -13942,8 +13942,8 @@ class ChatModal {
     this.dragCounter = 0;
     this.dropOverlay = null;
 
-    this.chatInitialRenderCount = 50;
-    this.chatOlderRenderBatchSize = 50;
+    this.chatInitialRenderCount = 100;
+    this.chatOlderRenderBatchSize = 200;
     this.chatRenderedOldestIndex = null;
     this.isExpandingChatRenderWindow = false;
     this.isChatTouchActive = false;
@@ -15046,8 +15046,8 @@ class ChatModal {
       scrollSnapshot.distanceFromBottom >= rearmDistance;
 
     if (
-      scrollSnapshot.distanceFromBottom < loadAheadThreshold ||
-      (!isExpansionRearmed && !isAtRenderedBoundary)
+      !isAtRenderedBoundary &&
+      (scrollSnapshot.distanceFromBottom < loadAheadThreshold || !isExpansionRearmed)
     ) {
       this.clearPendingChatScrollExpand();
       this.stopChatTopBoundaryScrollHold();
@@ -15099,6 +15099,7 @@ class ChatModal {
     this.messagesList.insertAdjacentHTML('afterbegin', range.html);
 
     this.syncRenderedReactionTargets(range.renderedTxids);
+    this.loadThumbnailsForAttachments();
 
     const insertedHeight = this.messagesContainer.scrollHeight - oldScrollHeight;
     this.messagesContainer.scrollTop = oldScrollTop + insertedHeight;

--- a/app.js
+++ b/app.js
@@ -15976,8 +15976,7 @@ class ChatModal {
     this.newestReceivedMessage = newestReceivedItem;
     this.newestSentMessage = messages.find((item) => item.my);
 
-    // 2. Clear the entire list
-    this.messagesList.innerHTML = '';
+    const renderedMessages = [];
 
     // 3. Iterate backwards through messages (oldest to newest for rendering order)
     // messages are already sorted descending (newest first) in myData
@@ -16181,11 +16180,12 @@ class ChatModal {
         }
       }
 
-      // 4. Append the constructed HTML
-      // Insert at the end of the list to maintain correct chronological order
-      this.messagesList.insertAdjacentHTML('beforeend', messageHTML);
+      renderedMessages.push(messageHTML);
       // The newest received element will be found after the loop completes
     }
+
+    // Replace the list once to avoid one DOM mutation per message.
+    this.messagesList.innerHTML = renderedMessages.join('');
 
     this.syncAllRenderedReactionChips();
 

--- a/app.js
+++ b/app.js
@@ -20624,8 +20624,7 @@ class ChatModal {
    */
   async saveVoiceMessage(messageEl) {
     const voiceEl = messageEl.querySelector('.voice-message');
-    const msgIdx = voiceEl?.dataset?.msgIdx;
-    const item = msgIdx !== undefined ? myData.contacts[this.address]?.messages?.[msgIdx] : null;
+    const item = this.getMessageRecordFromElement(messageEl);
     
     if (!voiceEl || !item || item.type !== 'vm') {
       showToast('Voice message not found', 2000, 'error');

--- a/app.js
+++ b/app.js
@@ -13963,6 +13963,7 @@ class ChatModal {
     this.chatRenderWindowDrainAddress = null;
     this.chatRenderWindowDrainStartedAt = 0;
     this.chatSpacerCatchupTimer = null;
+    this.chatSpacerPrewarmTimer = null;
     this.chatRenderSequence = 0;
     this.lastChatTouchLogAt = 0;
     this.chatTouchStartY = null;
@@ -15116,6 +15117,7 @@ class ChatModal {
   resetChatRenderWindow(address = null) {
     this.cancelChatRenderWindowDrain();
     this.cancelChatSpacerCatchup();
+    this.cancelChatSpacerPrewarm();
     this.clearPendingChatScrollExpand();
     this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
@@ -15378,7 +15380,11 @@ class ChatModal {
     const messages = contact?.messages;
     if (!Array.isArray(messages) || messages.length === 0) return false;
     const isOpenDrain = reason === 'openDrain';
-    const shouldPrependOlderMessages = (reason === 'scrollDistance' || reason === 'scrollIdle') && this.messagesContainer;
+    const shouldPrependOlderMessages = (
+      reason === 'scrollDistance' ||
+      reason === 'scrollIdle' ||
+      reason === 'prewarm'
+    ) && this.messagesContainer;
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
@@ -15414,6 +15420,7 @@ class ChatModal {
         distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
         distanceToRenderedTop: beforeSnapshot ? beforeSnapshot.distanceToRenderedTop : 'n/a',
         loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
+        renderedTopThreshold: Math.round(this.getChatRenderedTopLoadAheadThreshold(beforeSnapshot)),
         remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
         totalMessages: messages.length
       });
@@ -15498,7 +15505,7 @@ class ChatModal {
           0,
           this.messagesContainer.scrollTop - this.getChatHistorySpacerHeight()
         );
-        if (distanceToRenderedTop <= this.getChatLoadAheadThreshold()) {
+        if (distanceToRenderedTop <= this.getChatRenderedTopLoadAheadThreshold()) {
           this.scheduleChatSpacerCatchup('afterPrepend');
         }
       }
@@ -15562,6 +15569,7 @@ class ChatModal {
         clientHeight: scrollSnapshot.clientHeight,
         messageListHeight: scrollSnapshot.messageListHeight,
         loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
+        renderedTopThreshold: Math.round(this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot)),
         topSpacerHeight: scrollSnapshot.topSpacerHeight,
         distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
         renderedOldestIndex,
@@ -15572,6 +15580,7 @@ class ChatModal {
       });
     }
     const loadAheadThreshold = this.getChatLoadAheadThreshold();
+    const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
     if (
       Number.isFinite(this.chatExpansionRearmDistanceFromBottom) &&
       scrollSnapshot.distanceFromBottom < Math.max(0, loadAheadThreshold * 0.5)
@@ -15580,10 +15589,11 @@ class ChatModal {
     }
     const isExpansionRearmed = !Number.isFinite(this.chatExpansionRearmDistanceFromBottom) ||
       scrollSnapshot.distanceFromBottom >= this.chatExpansionRearmDistanceFromBottom;
+    const isNearRenderedTop = remainingOlder > 0 &&
+      scrollSnapshot.distanceToRenderedTop <= renderedTopThreshold;
     if (
-      remainingOlder > 0 &&
-      scrollSnapshot.distanceToRenderedTop <= loadAheadThreshold &&
-      isExpansionRearmed
+      isNearRenderedTop &&
+      (isExpansionRearmed || scrollSnapshot.topSpacerHeight > 0)
     ) {
       if (scrollSnapshot.topSpacerHeight > 0) {
         this.expandChatRenderWindow('scrollDistance');
@@ -15596,6 +15606,21 @@ class ChatModal {
   getChatLoadAheadThreshold() {
     const containerHeight = this.messagesContainer?.clientHeight || 0;
     return Math.max(1200, containerHeight * 3);
+  }
+
+  getChatRenderedTopLoadAheadThreshold(scrollSnapshot = null) {
+    const baseThreshold = this.getChatLoadAheadThreshold();
+    const snapshot = scrollSnapshot || this.getChatScrollSnapshot();
+    if (
+      !snapshot ||
+      !Number.isFinite(snapshot.maxScrollTop) ||
+      !Number.isFinite(snapshot.topSpacerHeight)
+    ) {
+      return baseThreshold;
+    }
+
+    const renderedRunway = Math.max(0, snapshot.maxScrollTop - snapshot.topSpacerHeight);
+    return Math.max(baseThreshold, renderedRunway * 0.5);
   }
 
   getChatOlderRenderBatchSize() {
@@ -15616,6 +15641,55 @@ class ChatModal {
     this.chatSpacerCatchupTimer = null;
   }
 
+  cancelChatSpacerPrewarm() {
+    if (!this.chatSpacerPrewarmTimer) return;
+    clearTimeout(this.chatSpacerPrewarmTimer);
+    this.chatSpacerPrewarmTimer = null;
+  }
+
+  scheduleChatSpacerPrewarm(address, reason = 'afterDeferred') {
+    if (!address || this.chatSpacerPrewarmTimer || this.isExpandingChatRenderWindow) return;
+    this.logChatPerf('window:prewarmScheduled', {
+      contact: this.formatChatPerfAddress(address, myData.contacts[address]),
+      reason,
+      currentOldestIndex: Number.isInteger(this.chatRenderedOldestIndex) ? this.chatRenderedOldestIndex : 'n/a',
+      topSpacerHeight: Math.round(this.getChatHistorySpacerHeight())
+    });
+    this.chatSpacerPrewarmTimer = setTimeout(() => {
+      this.chatSpacerPrewarmTimer = null;
+      if (!this.isActive() || this.address !== address || !this.messagesContainer || !this.messagesList) return;
+      const contact = myData.contacts[address];
+      const messages = contact?.messages;
+      if (!Array.isArray(messages) || messages.length === 0) return;
+      const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+        ? this.chatRenderedOldestIndex
+        : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
+      const remainingOlder = Math.max(0, messages.length - 1 - currentOldestIndex);
+      const topSpacerHeight = this.getChatHistorySpacerHeight();
+      if (remainingOlder <= 0 || topSpacerHeight <= 0 || this.isExpandingChatRenderWindow) {
+        this.logChatPerf('window:prewarmSkipped', {
+          contact: this.formatChatPerfAddress(address, contact),
+          reason,
+          currentOldestIndex,
+          remainingOlder,
+          topSpacerHeight: Math.round(topSpacerHeight),
+          isExpanding: this.isExpandingChatRenderWindow
+        });
+        return;
+      }
+
+      this.logChatPerf('window:prewarm', {
+        contact: this.formatChatPerfAddress(address, contact),
+        reason,
+        currentOldestIndex,
+        batchSize: this.getChatOlderRenderBatchSize(),
+        remainingOlder,
+        topSpacerHeight: Math.round(topSpacerHeight)
+      });
+      this.expandChatRenderWindow('prewarm');
+    }, 80);
+  }
+
   scheduleChatSpacerCatchup(reason) {
     if (this.chatSpacerCatchupTimer || this.isExpandingChatRenderWindow) return;
     this.chatSpacerCatchupTimer = setTimeout(() => {
@@ -15631,7 +15705,7 @@ class ChatModal {
 
       const topSpacerHeight = this.getChatHistorySpacerHeight();
       const distanceToRenderedTop = Math.max(0, this.messagesContainer.scrollTop - topSpacerHeight);
-      const loadAheadThreshold = this.getChatLoadAheadThreshold();
+      const loadAheadThreshold = this.getChatRenderedTopLoadAheadThreshold();
       if (topSpacerHeight <= 0 || distanceToRenderedTop > loadAheadThreshold) return;
 
       this.logChatPerf('window:spacerCatchup', {
@@ -15640,7 +15714,7 @@ class ChatModal {
         scrollTop: Math.round(this.messagesContainer.scrollTop),
         topSpacerHeight: Math.round(topSpacerHeight),
         distanceToRenderedTop: Math.round(distanceToRenderedTop),
-        loadAheadThreshold: Math.round(loadAheadThreshold),
+        renderedTopThreshold: Math.round(loadAheadThreshold),
         remainingOlder: Math.max(0, messages.length - 1 - currentOldestIndex)
       });
       this.expandChatRenderWindow('scrollDistance');
@@ -17458,6 +17532,7 @@ class ChatModal {
                     rendered: renderedMessages.length,
                     remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
                   });
+                  this.scheduleChatSpacerPrewarm(renderedAddress, 'afterDeferred');
                 }
               },
               (error) => {

--- a/app.js
+++ b/app.js
@@ -13943,7 +13943,6 @@ class ChatModal {
     this.dropOverlay = null;
 
     this.chatInitialRenderCount = 50;
-    this.chatFirstOlderRenderBatchSize = 25;
     this.chatOlderRenderBatchSize = 50;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
@@ -15091,7 +15090,7 @@ class ChatModal {
 
     const nextOldestIndex = Math.min(
       messages.length - 1,
-      currentOldestIndex + this.getChatOlderRenderBatchSize()
+      currentOldestIndex + this.chatOlderRenderBatchSize
     );
 
     const beforeSnapshot = this.getChatScrollSnapshot();
@@ -15165,16 +15164,6 @@ class ChatModal {
 
   getChatRenderedBoundaryThreshold(scrollSnapshot) {
     return Math.max(32, Math.min(180, scrollSnapshot.clientHeight * 0.2));
-  }
-
-  getChatOlderRenderBatchSize() {
-    const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-      ? this.chatRenderedOldestIndex
-      : this.chatInitialRenderCount - 1;
-    if (currentOldestIndex <= this.chatInitialRenderCount - 1) {
-      return this.chatFirstOlderRenderBatchSize;
-    }
-    return this.chatOlderRenderBatchSize;
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -13946,7 +13946,7 @@ class ChatModal {
     this.chatPerfLogFlushTimer = null;
 
     this.chatInitialRenderCount = 40;
-    this.chatOlderRenderBatchSize = 40;
+    this.chatOlderRenderBatchSize = 60;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
@@ -15098,6 +15098,8 @@ class ChatModal {
       previousOldestIndex: currentOldestIndex,
       nextOldestIndex,
       batchSize: renderBatchSize,
+      scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
+      loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
       totalMessages: messages.length
     });
 
@@ -15132,7 +15134,7 @@ class ChatModal {
 
   getChatLoadAheadThreshold() {
     const containerHeight = this.messagesContainer?.clientHeight || 0;
-    return Math.max(2400, containerHeight * 4);
+    return Math.max(5200, containerHeight * 8);
   }
 
   getChatOlderRenderBatchSize() {

--- a/app.js
+++ b/app.js
@@ -15477,6 +15477,10 @@ class ChatModal {
 
     if (shouldPrependOlderMessages) {
       const prependPerfStart = this.getChatPerfTime();
+      const cachedClientHeight = Number.isFinite(beforeSnapshot?.clientHeight)
+        ? beforeSnapshot.clientHeight
+        : (this.messagesContainer?.clientHeight || 0);
+      const cachedLoadAheadThreshold = Math.max(1200, cachedClientHeight * 3);
       const readScrollTopPerfStart = this.getChatPerfTime();
       const snapshotScrollTop = Number.isFinite(beforeSnapshot?.scrollTop)
         ? beforeSnapshot.scrollTop
@@ -15550,8 +15554,8 @@ class ChatModal {
           }
         : null;
       const rearmDistance = (beforeSnapshot?.distanceFromBottom || 0) + Math.max(
-        beforeSnapshot?.clientHeight || this.messagesContainer.clientHeight || 0,
-        this.getChatLoadAheadThreshold()
+        cachedClientHeight,
+        cachedLoadAheadThreshold
       );
       this.chatExpansionRearmDistanceFromBottom = rearmDistance;
       if (this.chatPerfLoggingEnabled) {
@@ -15746,8 +15750,10 @@ class ChatModal {
   }
 
   getChatRenderedTopLoadAheadThreshold(scrollSnapshot = null) {
-    const baseThreshold = this.getChatLoadAheadThreshold();
     const snapshot = scrollSnapshot || this.getChatScrollSnapshot();
+    const baseThreshold = Number.isFinite(snapshot?.clientHeight)
+      ? Math.max(1200, snapshot.clientHeight * 3)
+      : this.getChatLoadAheadThreshold();
     if (
       !snapshot ||
       !Number.isFinite(snapshot.maxScrollTop) ||

--- a/app.js
+++ b/app.js
@@ -13881,7 +13881,6 @@ const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
 const CHAT_INITIAL_RENDER_COUNT = 100;
 const CHAT_OLDER_RENDER_BATCH_SIZE = 200;
 const CHAT_SCROLL_EXPAND_DELAY_MS = 220;
-const CHAT_HISTORY_LOADING_TOAST_MIN_MS = 300;
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
@@ -13950,7 +13949,6 @@ class ChatModal {
     this.chatScrollExpandTimer = null;
     this.chatRenderSequence = 0;
     this.chatTouchStartY = null;
-    this.chatHistoryLoadingToast = null;
   }
 
   /**
@@ -14899,7 +14897,6 @@ class ChatModal {
 
   resetChatRenderWindow() {
     this.clearPendingChatScrollExpand();
-    this.clearChatHistoryLoadingToast();
     this.chatRenderedOldestIndex = null;
     this.chatTouchStartY = null;
   }
@@ -14930,59 +14927,6 @@ class ChatModal {
       clientHeight: Math.round(container.clientHeight),
       distanceToRenderedTop: Math.max(0, scrollTop)
     };
-  }
-
-  showChatHistoryLoadingToast() {
-    const toast = this.chatHistoryLoadingToast;
-    if (toast?.hideTimer) {
-      clearTimeout(toast.hideTimer);
-      toast.hideTimer = null;
-    }
-    if (toast) return;
-
-    this.chatHistoryLoadingToast = {
-      id: showToast('Loading messages', 0, 'loading', false, { dedupe: false }),
-      shownAt: Date.now(),
-      hideTimer: null
-    };
-  }
-
-  clearChatHistoryLoadingToast() {
-    const toast = this.chatHistoryLoadingToast;
-    if (!toast) return;
-
-    if (toast.hideTimer) {
-      clearTimeout(toast.hideTimer);
-    }
-    hideToast(toast.id);
-    this.chatHistoryLoadingToast = null;
-  }
-
-  hideChatHistoryLoadingToast() {
-    const toast = this.chatHistoryLoadingToast;
-    if (!toast) return;
-
-    const remainingMs = CHAT_HISTORY_LOADING_TOAST_MIN_MS - (Date.now() - toast.shownAt);
-    if (remainingMs > 0) {
-      if (toast.hideTimer) {
-        clearTimeout(toast.hideTimer);
-      }
-      toast.hideTimer = setTimeout(() => {
-        toast.hideTimer = null;
-        this.hideChatHistoryLoadingToast();
-      }, remainingMs);
-      return;
-    }
-
-    this.clearChatHistoryLoadingToast();
-  }
-
-  startChatTopBoundaryScrollHold() {
-    this.showChatHistoryLoadingToast();
-  }
-
-  stopChatTopBoundaryScrollHold() {
-    this.hideChatHistoryLoadingToast();
   }
 
   handleMessagesTouchStart(event) {
@@ -15030,17 +14974,10 @@ class ChatModal {
 
     const scrollSnapshot = this.getChatScrollSnapshot();
     if (scrollSnapshot.distanceToRenderedTop > this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot)) {
-      this.stopChatTopBoundaryScrollHold();
       return;
     }
 
-    if (scrollSnapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(scrollSnapshot)) {
-      this.startChatTopBoundaryScrollHold();
-    }
-    const expanded = this.expandChatRenderWindow();
-    if (!expanded) {
-      this.stopChatTopBoundaryScrollHold();
-    }
+    this.expandChatRenderWindow();
   }
 
   expandChatRenderWindow() {
@@ -15053,7 +14990,6 @@ class ChatModal {
       ? this.chatRenderedOldestIndex
       : Math.min(messages.length - 1, CHAT_INITIAL_RENDER_COUNT - 1);
     if (currentOldestIndex >= messages.length - 1) {
-      this.stopChatTopBoundaryScrollHold();
       return false;
     }
 
@@ -15085,7 +15021,6 @@ class ChatModal {
     const insertedHeight = container.scrollHeight - oldScrollHeight;
     container.scrollTop = oldScrollTop + insertedHeight;
     this.loadPrependedThumbnails(prependedThumbnailRows);
-    this.stopChatTopBoundaryScrollHold();
     return true;
   }
 
@@ -15101,26 +15036,17 @@ class ChatModal {
     const remainingOlder = Math.max(0, totalMessages - 1 - renderedOldestIndex);
     if (remainingOlder === 0) {
       this.clearPendingChatScrollExpand();
-      this.stopChatTopBoundaryScrollHold();
       return;
     }
 
     const isNearRenderedTop = scrollSnapshot.distanceToRenderedTop <= this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
-    const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(scrollSnapshot);
     if (isNearRenderedTop) {
-      if (scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold) {
-        this.startChatTopBoundaryScrollHold();
-      }
       this.schedulePendingChatScrollExpand();
     }
   }
 
   getChatRenderedTopLoadAheadThreshold(scrollSnapshot) {
     return Math.max(420, Math.min(900, scrollSnapshot.clientHeight * 1.25));
-  }
-
-  getChatRenderedBoundaryThreshold(scrollSnapshot) {
-    return Math.max(32, Math.min(180, scrollSnapshot.clientHeight * 0.2));
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -14892,32 +14892,6 @@ class ChatModal {
     this.chatRenderedOldestIndex = null;
   }
 
-  getChatRenderRange(messages) {
-    const totalMessages = messages.length;
-    if (totalMessages === 0) {
-      return { newestIndex: 0, oldestIndex: -1 };
-    }
-
-    const oldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-      ? Math.min(this.chatRenderedOldestIndex, totalMessages - 1)
-      : Math.min(totalMessages - 1, CHAT_INITIAL_RENDER_COUNT - 1);
-    this.chatRenderedOldestIndex = oldestIndex;
-    return {
-      newestIndex: 0,
-      oldestIndex
-    };
-  }
-
-  getChatScrollSnapshot() {
-    const container = this.messagesContainer;
-    const scrollTop = Math.round(container.scrollTop);
-    return {
-      scrollTop,
-      clientHeight: Math.round(container.clientHeight),
-      distanceToRenderedTop: Math.max(0, scrollTop)
-    };
-  }
-
   expandChatRenderWindow() {
     const contact = myData.contacts[this.address];
     const messages = contact.messages;
@@ -14928,7 +14902,7 @@ class ChatModal {
       ? this.chatRenderedOldestIndex
       : Math.min(messages.length - 1, CHAT_INITIAL_RENDER_COUNT - 1);
     if (currentOldestIndex >= messages.length - 1) {
-      return false;
+      return;
     }
 
     const nextOldestIndex = Math.min(
@@ -14936,7 +14910,7 @@ class ChatModal {
       currentOldestIndex + CHAT_OLDER_RENDER_BATCH_SIZE
     );
 
-    const oldScrollTop = this.getChatScrollSnapshot().scrollTop;
+    const oldScrollTop = Math.round(container.scrollTop);
     const oldScrollHeight = container.scrollHeight;
     const range = this.buildChatMessageRangeHTML(
       messages,
@@ -14958,32 +14932,25 @@ class ChatModal {
 
     const insertedHeight = container.scrollHeight - oldScrollHeight;
     container.scrollTop = oldScrollTop + insertedHeight;
-    this.loadPrependedThumbnails(prependedThumbnailRows);
-    return true;
+    this.loadThumbnailsKeepingScrollAnchored(prependedThumbnailRows);
   }
 
   handleMessagesContainerScroll() {
     this.closeAllContextMenus();
     if (!this.isActive()) return;
-    const scrollSnapshot = this.getChatScrollSnapshot();
+    const container = this.messagesContainer;
     const messages = myData.contacts[this.address].messages;
-    const totalMessages = messages.length;
     const renderedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
       : CHAT_INITIAL_RENDER_COUNT - 1;
-    const remainingOlder = Math.max(0, totalMessages - 1 - renderedOldestIndex);
-    if (remainingOlder === 0) {
+    if (renderedOldestIndex >= messages.length - 1) {
       return;
     }
 
-    const isNearRenderedTop = scrollSnapshot.distanceToRenderedTop <= this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
-    if (isNearRenderedTop) {
+    const loadAheadPx = Math.max(420, Math.min(900, container.clientHeight * 1.25));
+    if (container.scrollTop <= loadAheadPx) {
       this.expandChatRenderWindow();
     }
-  }
-
-  getChatRenderedTopLoadAheadThreshold(scrollSnapshot) {
-    return Math.max(420, Math.min(900, scrollSnapshot.clientHeight * 1.25));
   }
 
   /**
@@ -16049,7 +16016,7 @@ class ChatModal {
     };
   }
 
-  renderChatMessageHTML(item, index, { contact, messagesByTxid, lastReadTs }) {
+  renderChatMessageHTML(item, index, { contact, lastReadTs }) {
     const timeString = formatTime(item.timestamp);
     const timestampAttribute = `data-message-timestamp="${item.timestamp}"`;
     const txidAttribute = item?.txid ? `data-txid="${item.txid}"` : '';
@@ -16090,7 +16057,7 @@ class ChatModal {
     if (item.replyId) {
       const replyText = escapeHtml(item.replyMessage || 'View original message');
       const ownerIsMineHint = item.replyOwnerIsMine;
-      const targetMsg = messagesByTxid.get(item.replyId);
+      const targetMsg = contact.messages.find((message) => message.txid === item.replyId);
       const isOwnerMine = typeof ownerIsMineHint === 'undefined'
         ? !!(targetMsg && targetMsg.my)
         : item.my === (ownerIsMineHint === true || ownerIsMineHint === '1');
@@ -16217,12 +16184,6 @@ class ChatModal {
   }
 
   buildChatMessageRangeHTML(messages, contact, oldestIndex, newestIndex) {
-    const messagesByTxid = new Map();
-    messages.forEach((message) => {
-      if (message?.txid) {
-        messagesByTxid.set(message.txid, message);
-      }
-    });
     const lastReadTs = contact.lastChatOpenTs || 0;
     const renderedMessages = [];
     const renderedTxids = [];
@@ -16230,7 +16191,7 @@ class ChatModal {
     for (let i = oldestIndex; i >= newestIndex; i--) {
       const item = messages[i];
       if (!item) continue;
-      renderedMessages.push(this.renderChatMessageHTML(item, i, { contact, messagesByTxid, lastReadTs }));
+      renderedMessages.push(this.renderChatMessageHTML(item, i, { contact, lastReadTs }));
       if (item.txid) renderedTxids.push(item.txid);
     }
 
@@ -16271,12 +16232,20 @@ class ChatModal {
     this.newestReceivedMessage = newestReceivedItem;
     this.newestSentMessage = messages.find((item) => item.my);
 
-    const renderRange = this.getChatRenderRange(messages);
+    let oldestIndex = -1;
+    if (messages.length > 0) {
+      const requestedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+        ? this.chatRenderedOldestIndex
+        : CHAT_INITIAL_RENDER_COUNT - 1;
+      oldestIndex = Math.min(Math.max(0, requestedOldestIndex), messages.length - 1);
+      this.chatRenderedOldestIndex = oldestIndex;
+    }
+
     const range = this.buildChatMessageRangeHTML(
       messages,
       contact,
-      renderRange.oldestIndex,
-      renderRange.newestIndex
+      oldestIndex,
+      0
     );
 
     // Replace the list once to avoid one DOM mutation per message.
@@ -16285,21 +16254,20 @@ class ChatModal {
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
     if (shouldKeepBottomAnchored) {
-      this.loadThumbnailsForAttachmentsKeepingBottomAnchored();
+      const thumbnailRows = this.messagesList.querySelectorAll(
+        '[data-image-attachment="true"], [data-video-attachment="true"]'
+      );
+      this.loadThumbnailsKeepingScrollAnchored(thumbnailRows);
     } else {
       this.loadThumbnailsForAttachments();
     }
 
     const renderedAddress = currentAddress;
-    const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame
-      : (callback) => setTimeout(callback, 0);
-    scheduleAfterPaint(() => {
-      scheduleAfterPaint(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
         if (
           !this.isActive() ||
           this.address !== renderedAddress ||
-          !this.messagesList ||
           renderSequence !== this.chatRenderSequence
         ) {
           return;
@@ -16318,7 +16286,7 @@ class ChatModal {
       return;
     }
 
-    if (shouldKeepBottomAnchored && !highlightNewMessage) {
+    if (shouldKeepBottomAnchored) {
       return;
     }
 
@@ -16371,10 +16339,7 @@ class ChatModal {
         // No received messages found, not highlighting, or highlightNewMessage is false,
         // just scroll to the bottom if the container exists.
         if (messageContainer) {
-          const isNearBottom = messageContainer.scrollHeight - messageContainer.scrollTop - messageContainer.clientHeight <= 120;
-          if (!shouldKeepBottomAnchored || isNearBottom) {
-            messageContainer.scrollTop = messageContainer.scrollHeight;
-          }
+          messageContainer.scrollTop = messageContainer.scrollHeight;
         }
       }
     }, 300); // <<< Delay of 300 milliseconds for rendering
@@ -17196,30 +17161,11 @@ class ChatModal {
   }
 
   /**
-   * Load visible thumbnails while keeping the newest messages anchored.
+   * Load thumbnails without letting row height changes move the viewport.
+   * @param {Iterable<HTMLElement>} attachmentRows
    * @returns {void}
    */
-  async loadThumbnailsForAttachmentsKeepingBottomAnchored() {
-    const thumbnailRows = this.messagesList.querySelectorAll(
-      '[data-image-attachment="true"], [data-video-attachment="true"]'
-    );
-
-    for (const attachmentRow of thumbnailRows) {
-      const oldScrollHeight = this.messagesContainer.scrollHeight;
-      const didUpdate = await this.loadThumbnailForAttachment(attachmentRow);
-      const heightDelta = this.messagesContainer.scrollHeight - oldScrollHeight;
-      if (didUpdate && heightDelta !== 0) {
-        this.messagesContainer.scrollTop = Math.max(0, this.messagesContainer.scrollTop + heightDelta);
-      }
-    }
-  }
-
-  /**
-   * Load thumbnails for prepended rows without moving the user's viewport.
-   * @param {HTMLElement[]} attachmentRows
-   * @returns {void}
-   */
-  async loadPrependedThumbnails(attachmentRows) {
+  async loadThumbnailsKeepingScrollAnchored(attachmentRows) {
     for (const attachmentRow of attachmentRows) {
       const oldScrollHeight = this.messagesContainer.scrollHeight;
       const didUpdate = await this.loadThumbnailForAttachment(attachmentRow);

--- a/app.js
+++ b/app.js
@@ -13881,7 +13881,7 @@ const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
 const CHAT_INITIAL_RENDER_COUNT = 100;
 const CHAT_OLDER_RENDER_BATCH_SIZE = 200;
 const CHAT_SCROLL_EXPAND_DELAY_MS = 220;
-const CHAT_HISTORY_LOADING_TOAST_MIN_MS = 500;
+const CHAT_HISTORY_LOADING_TOAST_MIN_MS = 300;
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',

--- a/app.js
+++ b/app.js
@@ -15465,6 +15465,11 @@ class ChatModal {
         distanceToRenderedTop: beforeSnapshot ? beforeSnapshot.distanceToRenderedTop : 'n/a',
         loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
         renderedTopThreshold: Math.round(this.getChatRenderedTopLoadAheadThreshold(beforeSnapshot)),
+        renderedBoundaryThreshold: Math.round(this.getChatRenderedBoundaryThreshold(beforeSnapshot)),
+        atRenderedBoundary: beforeSnapshot
+          ? beforeSnapshot.topSpacerHeight > 0 &&
+            beforeSnapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(beforeSnapshot)
+          : 'n/a',
         remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
         totalMessages: messages.length
       });
@@ -15472,22 +15477,40 @@ class ChatModal {
 
     if (shouldPrependOlderMessages) {
       const prependPerfStart = this.getChatPerfTime();
-      const oldScrollTop = this.messagesContainer.scrollTop;
+      const readScrollTopPerfStart = this.getChatPerfTime();
+      const snapshotScrollTop = Number.isFinite(beforeSnapshot?.scrollTop)
+        ? beforeSnapshot.scrollTop
+        : null;
+      const oldScrollTop = snapshotScrollTop ?? this.messagesContainer.scrollTop;
+      const oldScrollTopSource = snapshotScrollTop === null ? 'dom' : 'snapshot';
+      const readScrollTopMs = snapshotScrollTop === null
+        ? this.formatChatPerfMs(readScrollTopPerfStart)
+        : 'skipped';
+      const spacerLookupPerfStart = this.getChatPerfTime();
       const spacer = this.getChatHistorySpacerElement();
       const oldSpacerHeight = this.getChatHistorySpacerHeight();
+      const spacerLookupMs = this.formatChatPerfMs(spacerLookupPerfStart);
       const useEstimatedSpacerPreserve = !!spacer && oldSpacerHeight > 0;
+      const oldScrollHeightPerfStart = this.getChatPerfTime();
       const oldScrollHeight = useEstimatedSpacerPreserve ? null : this.messagesContainer.scrollHeight;
+      const oldScrollHeightMs = useEstimatedSpacerPreserve
+        ? 'skipped'
+        : this.formatChatPerfMs(oldScrollHeightPerfStart);
+      const estimatePerfStart = this.getChatPerfTime();
       const estimatedInsertedHeight = this.estimateChatMessagesHeight(
         messages,
         nextOldestIndex,
         currentOldestIndex + 1
       );
+      const estimateMs = this.formatChatPerfMs(estimatePerfStart);
+      const rangePerfStart = this.getChatPerfTime();
       const range = this.buildChatMessageRangeHTML(
         messages,
         contact,
         nextOldestIndex,
         currentOldestIndex + 1
       );
+      const rangeMs = this.formatChatPerfMs(rangePerfStart);
       const domWritePerfStart = this.getChatPerfTime();
       if (useEstimatedSpacerPreserve) {
         spacer.insertAdjacentHTML('afterend', range.html);
@@ -15552,6 +15575,12 @@ class ChatModal {
           replies: range.summary.replies,
           textChars: range.summary.textChars,
           maxTextChars: range.summary.maxTextChars,
+          scrollTopRead: readScrollTopMs,
+          scrollTopSource: oldScrollTopSource,
+          spacerLookup: spacerLookupMs,
+          oldScrollHeightRead: oldScrollHeightMs,
+          estimate: estimateMs,
+          range: rangeMs,
           build: range.buildMs,
           join: range.joinMs,
           domWrite: domWriteMs,
@@ -15573,8 +15602,12 @@ class ChatModal {
       }
       if (useEstimatedSpacerPreserve && nextOldestIndex < messages.length - 1) {
         const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(afterSnapshotEstimate);
+        const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(afterSnapshotEstimate);
         const shouldCatchUp = afterDistanceToRenderedTop <= renderedTopThreshold &&
-          beforeSnapshot?.distanceFromBottom >= rearmDistance;
+          (
+            beforeSnapshot?.distanceFromBottom >= rearmDistance ||
+            afterDistanceToRenderedTop <= renderedBoundaryThreshold
+          );
         if (shouldCatchUp) {
           this.scheduleChatSpacerCatchup('afterPrepend');
         } else if (
@@ -15587,7 +15620,8 @@ class ChatModal {
             distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
             rearmDistance: Math.round(rearmDistance),
             distanceToRenderedTop: Math.round(afterDistanceToRenderedTop),
-            renderedTopThreshold: Math.round(renderedTopThreshold)
+            renderedTopThreshold: Math.round(renderedTopThreshold),
+            renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold)
           });
         }
       }
@@ -15673,7 +15707,12 @@ class ChatModal {
       scrollSnapshot.distanceFromBottom >= this.chatExpansionRearmDistanceFromBottom;
     const isNearRenderedTop = remainingOlder > 0 &&
       scrollSnapshot.distanceToRenderedTop <= renderedTopThreshold;
-    if (isNearRenderedTop && isExpansionRearmed) {
+    const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(scrollSnapshot);
+    const isAtRenderedBoundary = remainingOlder > 0 &&
+      scrollSnapshot.topSpacerHeight > 0 &&
+      scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
+    const canExpandOlderWindow = isExpansionRearmed || isAtRenderedBoundary;
+    if (isNearRenderedTop && canExpandOlderWindow) {
       if (scrollSnapshot.topSpacerHeight > 0) {
         this.expandChatRenderWindow('scrollDistance');
       } else {
@@ -15695,6 +15734,7 @@ class ChatModal {
           : 'n/a',
         distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
         renderedTopThreshold: Math.round(renderedTopThreshold),
+        renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold),
         remainingOlder
       });
     }
@@ -15718,6 +15758,12 @@ class ChatModal {
 
     const renderedRunway = Math.max(0, snapshot.maxScrollTop - snapshot.topSpacerHeight);
     return Math.max(baseThreshold, renderedRunway * 0.5);
+  }
+
+  getChatRenderedBoundaryThreshold(scrollSnapshot = null) {
+    const snapshot = scrollSnapshot || this.getChatScrollSnapshot();
+    const containerHeight = snapshot?.clientHeight || this.messagesContainer?.clientHeight || 0;
+    return Math.max(32, Math.min(180, containerHeight * 0.2));
   }
 
   getChatOlderRenderBatchSize() {

--- a/app.js
+++ b/app.js
@@ -15039,12 +15039,6 @@ class ChatModal {
     };
   }
 
-  getChatTopSpacerHeight(renderRange) {
-    if (!renderRange?.isWindowed) return 0;
-    const hiddenCount = Math.max(0, renderRange.totalMessages - renderRange.oldestIndex - 1);
-    return Math.min(1600, Math.max(480, hiddenCount * 28));
-  }
-
   getFirstVisibleMessageAnchor() {
     const container = this.messagesContainer;
     if (!container || !this.messagesList) return null;
@@ -15127,10 +15121,7 @@ class ChatModal {
         bodyScrollY: Math.round(window.scrollY || 0)
       });
     }
-    const topSpacerHeight = this.messagesList
-      ? this.messagesList.querySelector('.chat-window-top-spacer')?.offsetHeight || 0
-      : 0;
-    const loadAheadThreshold = topSpacerHeight + (this.messagesContainer.clientHeight * 1.5);
+    const loadAheadThreshold = this.messagesContainer.clientHeight * 1.5;
     if (this.messagesContainer.scrollTop <= loadAheadThreshold) {
       this.expandChatRenderWindow();
     }
@@ -16503,10 +16494,7 @@ class ChatModal {
       // The newest received element will be found after the loop completes
     }
     const renderLoopMs = this.formatChatPerfMs(renderLoopPerfStart);
-    const topSpacerHeight = this.getChatTopSpacerHeight(renderRange);
-    if (topSpacerHeight > 0) {
-      renderedMessages.unshift(`<div class="chat-window-top-spacer" style="height: ${topSpacerHeight}px;"></div>`);
-    }
+    const topSpacerHeight = 0;
 
     // Replace the list once to avoid one DOM mutation per message.
     const joinPerfStart = this.getChatPerfTime();

--- a/app.js
+++ b/app.js
@@ -14905,7 +14905,6 @@ class ChatModal {
   }
 
   getChatRenderRange(messages) {
-    assert(Array.isArray(messages), 'Chat messages are required');
     const totalMessages = messages.length;
     if (totalMessages === 0) {
       return { newestIndex: 0, oldestIndex: -1 };
@@ -14923,7 +14922,6 @@ class ChatModal {
 
   getChatScrollSnapshot() {
     const container = this.messagesContainer;
-    assert(container, 'Messages container is required');
     const maxScrollTop = container.scrollHeight - container.clientHeight;
     const scrollTop = Math.round(container.scrollTop);
     return {
@@ -14957,7 +14955,6 @@ class ChatModal {
   clampChatTopBoundaryScrollHold() {
     if (!this.chatHistoryLoadingToastId) return false;
     const container = this.messagesContainer;
-    assert(container, 'Messages container is required');
     if (container.scrollTop >= 0) return false;
     container.scrollTop = 0;
     return true;
@@ -14965,10 +14962,7 @@ class ChatModal {
 
   shouldBlockChatTopBoundaryTouchMove(event) {
     if (!this.chatHistoryLoadingToastId) return false;
-    assert(this.messagesContainer, 'Messages container is required');
     const touch = event.touches[0];
-    assert(touch, 'Touch point is required');
-    assert(typeof this.chatTouchStartY === 'number', 'Touch start y is required');
     if (Math.round(touch.clientY) <= this.chatTouchStartY) return false;
 
     const snapshot = this.getChatScrollSnapshot();
@@ -14977,7 +14971,6 @@ class ChatModal {
 
   handleMessagesTouchStart(event) {
     const touch = event.touches[0];
-    assert(touch, 'Touch point is required');
     this.chatTouchStartY = Math.round(touch.clientY);
   }
 
@@ -15045,13 +15038,10 @@ class ChatModal {
   }
 
   expandChatRenderWindow() {
-    if (!this.address) return false;
-    assert(this.messagesContainer, 'Messages container is required');
-    assert(this.messagesList, 'Messages list is required');
-
     const contact = myData.contacts[this.address];
-    const messages = contact?.messages;
-    assert(Array.isArray(messages), `Missing messages for chat: ${this.address}`);
+    const messages = contact.messages;
+    const container = this.messagesContainer;
+    const list = this.messagesList;
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
@@ -15067,7 +15057,7 @@ class ChatModal {
     );
 
     const oldScrollTop = this.getChatScrollSnapshot().scrollTop;
-    const oldScrollHeight = this.messagesContainer.scrollHeight;
+    const oldScrollHeight = container.scrollHeight;
     const range = this.buildChatMessageRangeHTML(
       messages,
       contact,
@@ -15076,9 +15066,9 @@ class ChatModal {
     );
 
     this.chatRenderedOldestIndex = nextOldestIndex;
-    this.messagesList.insertAdjacentHTML('afterbegin', range.html);
+    list.insertAdjacentHTML('afterbegin', range.html);
     const prependedThumbnailRows = range.renderedTxids.flatMap((txid) => {
-      const messageEl = this.messagesList.querySelector(`.message[data-txid="${CSS.escape(txid)}"]`);
+      const messageEl = list.querySelector(`.message[data-txid="${CSS.escape(txid)}"]`);
       return messageEl
         ? [...messageEl.querySelectorAll('[data-image-attachment="true"], [data-video-attachment="true"]')]
         : [];
@@ -15086,8 +15076,8 @@ class ChatModal {
 
     this.syncRenderedReactionTargets(range.renderedTxids);
 
-    const insertedHeight = this.messagesContainer.scrollHeight - oldScrollHeight;
-    this.messagesContainer.scrollTop = oldScrollTop + insertedHeight;
+    const insertedHeight = container.scrollHeight - oldScrollHeight;
+    container.scrollTop = oldScrollTop + insertedHeight;
     this.loadPrependedThumbnails(prependedThumbnailRows);
     this.stopChatTopBoundaryScrollHold();
     return true;
@@ -15097,9 +15087,7 @@ class ChatModal {
     this.closeAllContextMenus();
     if (!this.isActive()) return;
     const scrollSnapshot = this.getChatScrollSnapshot();
-    const contact = myData.contacts[this.address];
-    const messages = contact?.messages;
-    assert(Array.isArray(messages), `Missing messages for chat: ${this.address}`);
+    const messages = myData.contacts[this.address].messages;
     const totalMessages = messages.length;
     const renderedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
@@ -16406,7 +16394,6 @@ class ChatModal {
 
     if (!this.modal) return;
     if (!this.messagesList) return;
-    assert(this.messagesContainer, 'Messages container is required');
     const renderSequence = ++this.chatRenderSequence;
 
     // --- 1. Identify the actual newest received message data item ---
@@ -17347,7 +17334,6 @@ class ChatModal {
     const thumbnailRows = this.messagesList.querySelectorAll(
       '[data-image-attachment="true"], [data-video-attachment="true"]'
     );
-    assert(this.messagesContainer, 'Messages container is required');
 
     for (const attachmentRow of thumbnailRows) {
       const oldScrollHeight = this.messagesContainer.scrollHeight;
@@ -17365,8 +17351,6 @@ class ChatModal {
    * @returns {void}
    */
   async loadPrependedThumbnails(attachmentRows) {
-    assert(this.messagesContainer, 'Messages container is required');
-
     for (const attachmentRow of attachmentRows) {
       const oldScrollHeight = this.messagesContainer.scrollHeight;
       const didUpdate = await this.loadThumbnailForAttachment(attachmentRow);

--- a/app.js
+++ b/app.js
@@ -4749,7 +4749,7 @@ class FriendModal {
   updateFriendButton(contact, buttonId) {
     const button = document.getElementById(buttonId);
     // Remove all status classes
-    button.classList.remove('status-0', 'status-1', 'status-2', 'status-3');
+    button.classList.remove('status-0', 'status-1', 'status-2');
     // Add the current status class
     button.classList.add(`status-${contact.friend}`);
   }
@@ -13878,6 +13878,9 @@ const CHAT_REACTION_SHEET_RECENT_ACCOUNT_KEY = 'recentReactionEmojis';
 const CHAT_REACTION_SHEET_RECENT_LIMIT = CHAT_REACTION_SHEET_DEFAULT_COMMON_EMOJIS.length;
 const CHAT_REACTION_SHEET_PROMOTION_RATIO = 0.5;
 const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
+const CHAT_INITIAL_RENDER_COUNT = 100;
+const CHAT_OLDER_RENDER_BATCH_SIZE = 200;
+const CHAT_SCROLL_EXPAND_DELAY_MS = 220;
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
@@ -13942,16 +13945,10 @@ class ChatModal {
     this.dragCounter = 0;
     this.dropOverlay = null;
 
-    this.chatInitialRenderCount = 100;
-    this.chatOlderRenderBatchSize = 200;
     this.chatRenderedOldestIndex = null;
-    this.isExpandingChatRenderWindow = false;
-    this.isChatTouchActive = false;
-    this.chatPendingScrollExpand = false;
-    this.chatScrollEndFallbackTimer = null;
+    this.chatScrollExpandTimer = null;
     this.chatRenderSequence = 0;
     this.chatTouchStartY = null;
-    this.chatExpansionRearmDistanceFromBottom = null;
     this.chatHistoryLoadingToastId = null;
   }
 
@@ -14904,8 +14901,7 @@ class ChatModal {
     this.clearPendingChatScrollExpand();
     this.stopChatTopBoundaryScrollHold();
     this.chatRenderedOldestIndex = null;
-    this.isExpandingChatRenderWindow = false;
-    this.chatExpansionRearmDistanceFromBottom = null;
+    this.chatTouchStartY = null;
   }
 
   getChatRenderRange(messages) {
@@ -14916,7 +14912,7 @@ class ChatModal {
     }
 
     if (!Number.isInteger(this.chatRenderedOldestIndex)) {
-      this.chatRenderedOldestIndex = Math.min(totalMessages - 1, this.chatInitialRenderCount - 1);
+      this.chatRenderedOldestIndex = Math.min(totalMessages - 1, CHAT_INITIAL_RENDER_COUNT - 1);
     }
 
     this.chatRenderedOldestIndex = Math.min(this.chatRenderedOldestIndex, totalMessages - 1);
@@ -14970,21 +14966,19 @@ class ChatModal {
 
   shouldBlockChatTopBoundaryTouchMove(event) {
     if (!this.chatHistoryLoadingToastId || !this.messagesContainer) return false;
-    const touch = event.touches?.[0] || null;
-    const y = touch ? Math.round(touch.clientY) : null;
-    const deltaY = typeof y === 'number' && typeof this.chatTouchStartY === 'number'
-      ? y - this.chatTouchStartY
-      : 0;
-    if (deltaY <= 0) return false;
+    const touch = event.touches[0];
+    assert(touch, 'Touch point is required');
+    assert(typeof this.chatTouchStartY === 'number', 'Touch start y is required');
+    if (Math.round(touch.clientY) <= this.chatTouchStartY) return false;
 
     const snapshot = this.getChatScrollSnapshot();
     return snapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(snapshot);
   }
 
   handleMessagesTouchStart(event) {
-    this.isChatTouchActive = true;
-    const touch = event.touches?.[0] || null;
-    this.chatTouchStartY = touch ? Math.round(touch.clientY) : null;
+    const touch = event.touches[0];
+    assert(touch, 'Touch point is required');
+    this.chatTouchStartY = Math.round(touch.clientY);
   }
 
   handleMessagesTouchMove(event) {
@@ -14998,66 +14992,56 @@ class ChatModal {
   }
 
   handleMessagesTouchEnd() {
-    this.isChatTouchActive = false;
-    this.schedulePendingChatScrollExpand();
+    this.chatTouchStartY = null;
+    if (this.chatScrollExpandTimer) {
+      this.schedulePendingChatScrollExpand();
+    }
   }
 
   clearPendingChatScrollExpand() {
-    this.chatPendingScrollExpand = false;
-    if (this.chatScrollEndFallbackTimer) {
-      clearTimeout(this.chatScrollEndFallbackTimer);
-      this.chatScrollEndFallbackTimer = null;
+    if (this.chatScrollExpandTimer) {
+      clearTimeout(this.chatScrollExpandTimer);
+      this.chatScrollExpandTimer = null;
     }
   }
 
   queueChatScrollExpand() {
-    this.chatPendingScrollExpand = true;
     this.schedulePendingChatScrollExpand();
   }
 
   schedulePendingChatScrollExpand() {
-    if (!this.chatPendingScrollExpand) return;
-    if (this.chatScrollEndFallbackTimer) {
-      clearTimeout(this.chatScrollEndFallbackTimer);
+    if (this.chatScrollExpandTimer) {
+      clearTimeout(this.chatScrollExpandTimer);
     }
-    this.chatScrollEndFallbackTimer = setTimeout(() => {
-      this.chatScrollEndFallbackTimer = null;
+    this.chatScrollExpandTimer = setTimeout(() => {
+      this.chatScrollExpandTimer = null;
       this.flushPendingChatScrollExpand();
-    }, 220);
+    }, CHAT_SCROLL_EXPAND_DELAY_MS);
   }
 
   handleMessagesContainerScrollEnd() {
-    this.flushPendingChatScrollExpand();
+    if (this.chatScrollExpandTimer) {
+      this.flushPendingChatScrollExpand();
+    }
   }
 
   flushPendingChatScrollExpand() {
-    if (!this.chatPendingScrollExpand || this.isExpandingChatRenderWindow || !this.isActive()) return;
-    if (this.isChatTouchActive) {
+    this.clearPendingChatScrollExpand();
+    if (!this.isActive()) return;
+    if (this.chatTouchStartY !== null) {
       this.schedulePendingChatScrollExpand();
       return;
     }
 
     const scrollSnapshot = this.getChatScrollSnapshot();
-    const loadAheadThreshold = this.getChatLoadAheadThreshold();
-    const rearmDistance = this.chatExpansionRearmDistanceFromBottom;
-    const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(scrollSnapshot);
-    const isAtRenderedBoundary = scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
-    const isExpansionRearmed = !Number.isFinite(rearmDistance) ||
-      scrollSnapshot.distanceFromBottom >= rearmDistance;
-
-    if (
-      !isAtRenderedBoundary &&
-      (scrollSnapshot.distanceFromBottom < loadAheadThreshold || !isExpansionRearmed)
-    ) {
-      this.clearPendingChatScrollExpand();
+    if (scrollSnapshot.distanceToRenderedTop > this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot)) {
       this.stopChatTopBoundaryScrollHold();
       return;
     }
 
-    if (isAtRenderedBoundary) {
+    if (scrollSnapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(scrollSnapshot)) {
       this.startChatTopBoundaryScrollHold();
     }
-    this.clearPendingChatScrollExpand();
     const expanded = this.expandChatRenderWindow();
     if (!expanded) {
       this.stopChatTopBoundaryScrollHold();
@@ -15065,7 +15049,7 @@ class ChatModal {
   }
 
   expandChatRenderWindow() {
-    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesContainer || !this.messagesList) return false;
+    if (!this.address || !this.messagesContainer || !this.messagesList) return false;
 
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
@@ -15073,7 +15057,7 @@ class ChatModal {
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
-      : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
+      : Math.min(messages.length - 1, CHAT_INITIAL_RENDER_COUNT - 1);
     if (currentOldestIndex >= messages.length - 1) {
       this.stopChatTopBoundaryScrollHold();
       return false;
@@ -15081,11 +15065,10 @@ class ChatModal {
 
     const nextOldestIndex = Math.min(
       messages.length - 1,
-      currentOldestIndex + this.chatOlderRenderBatchSize
+      currentOldestIndex + CHAT_OLDER_RENDER_BATCH_SIZE
     );
 
-    const beforeSnapshot = this.getChatScrollSnapshot();
-    const oldScrollTop = beforeSnapshot.scrollTop;
+    const oldScrollTop = this.getChatScrollSnapshot().scrollTop;
     const oldScrollHeight = this.messagesContainer.scrollHeight;
     const range = this.buildChatMessageRangeHTML(
       messages,
@@ -15094,7 +15077,6 @@ class ChatModal {
       currentOldestIndex + 1
     );
 
-    this.isExpandingChatRenderWindow = true;
     this.chatRenderedOldestIndex = nextOldestIndex;
     this.messagesList.insertAdjacentHTML('afterbegin', range.html);
     const prependedThumbnailRows = range.renderedTxids.flatMap((txid) => {
@@ -15108,53 +15090,37 @@ class ChatModal {
 
     const insertedHeight = this.messagesContainer.scrollHeight - oldScrollHeight;
     this.messagesContainer.scrollTop = oldScrollTop + insertedHeight;
-    this.loadThumbnailsForAttachments({
-      attachmentRows: prependedThumbnailRows,
-      preserveScrollAnchor: true
-    });
-    this.chatExpansionRearmDistanceFromBottom = beforeSnapshot.distanceFromBottom + this.getChatLoadAheadThreshold();
-    this.isExpandingChatRenderWindow = false;
+    this.loadPrependedThumbnails(prependedThumbnailRows);
     this.stopChatTopBoundaryScrollHold();
     return true;
   }
 
   handleMessagesContainerScroll() {
     this.closeAllContextMenus();
-    if (!this.messagesContainer || !this.isActive()) return;
+    if (!this.isActive()) return;
     const scrollSnapshot = this.getChatScrollSnapshot();
-    const contact = this.address ? myData.contacts[this.address] : null;
-    const totalMessages = Array.isArray(contact?.messages) ? contact.messages.length : 0;
+    const contact = myData.contacts[this.address];
+    const messages = contact?.messages;
+    assert(Array.isArray(messages), `Missing messages for chat: ${this.address}`);
+    const totalMessages = messages.length;
     const renderedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
-      : this.chatInitialRenderCount - 1;
+      : CHAT_INITIAL_RENDER_COUNT - 1;
     const remainingOlder = Math.max(0, totalMessages - 1 - renderedOldestIndex);
-    const loadAheadThreshold = this.getChatLoadAheadThreshold();
-    const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
-    if (
-      Number.isFinite(this.chatExpansionRearmDistanceFromBottom) &&
-      scrollSnapshot.distanceFromBottom < Math.max(0, loadAheadThreshold * 0.5)
-    ) {
-      this.chatExpansionRearmDistanceFromBottom = null;
+    if (remainingOlder === 0) {
+      this.clearPendingChatScrollExpand();
+      this.stopChatTopBoundaryScrollHold();
+      return;
     }
-    const isExpansionRearmed = !Number.isFinite(this.chatExpansionRearmDistanceFromBottom) ||
-      scrollSnapshot.distanceFromBottom >= this.chatExpansionRearmDistanceFromBottom;
-    const isNearRenderedTop = remainingOlder > 0 &&
-      scrollSnapshot.distanceToRenderedTop <= renderedTopThreshold;
+
+    const isNearRenderedTop = scrollSnapshot.distanceToRenderedTop <= this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
     const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(scrollSnapshot);
-    const isAtRenderedBoundary = remainingOlder > 0 &&
-      scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
-    const canExpandOlderWindow = isExpansionRearmed || isAtRenderedBoundary;
-    if (isNearRenderedTop && canExpandOlderWindow) {
-      if (isAtRenderedBoundary) {
+    if (isNearRenderedTop) {
+      if (scrollSnapshot.distanceToRenderedTop <= renderedBoundaryThreshold) {
         this.startChatTopBoundaryScrollHold();
       }
       this.queueChatScrollExpand();
     }
-  }
-
-  getChatLoadAheadThreshold() {
-    assert(this.messagesContainer, 'Messages container is required');
-    return Math.max(1200, this.messagesContainer.clientHeight * 3);
   }
 
   getChatRenderedTopLoadAheadThreshold(scrollSnapshot) {
@@ -16263,6 +16229,12 @@ class ChatModal {
                 `;
     }
 
+    const messageType = item.type || 'message';
+    assert(
+      messageType === 'message' || messageType === 'call' || messageType === 'vm',
+      `Unknown chat message type: ${messageType}`
+    );
+
     let replyHTML = '';
     if (item.replyId) {
       const replyText = escapeHtml(item.replyMessage || 'View original message');
@@ -16322,7 +16294,7 @@ class ChatModal {
 
     let messageTextHTML = '';
     if (item.message && item.message.trim()) {
-      if (item.type === 'call') {
+      if (messageType === 'call') {
         const callTimeMs = Number(item.callTime || 0);
         const callStart = callTimeMs > 0 ? callTimeMs : Number(item.timestamp || item.sent_timestamp || 0);
         const isExpired = this.isCallExpired(callStart);
@@ -16352,7 +16324,7 @@ class ChatModal {
       }
     }
 
-    if (item.type === 'vm') {
+    if (messageType === 'vm') {
       const duration = this.formatDuration(item.duration);
       messageTextHTML = `
               <div class="voice-message" data-url="${item.url || ''}" data-name="voice-message" data-type="audio/webm" data-msg-idx="${index}" data-duration="${item.duration || 0}">
@@ -16374,7 +16346,7 @@ class ChatModal {
               </div>`;
     }
 
-    const callTimeAttribute = item.type === 'call' && item.callTime ? `data-call-time="${item.callTime}"` : '';
+    const callTimeAttribute = messageType === 'call' && item.callTime ? `data-call-time="${item.callTime}"` : '';
     const showEditedDot = !item.my && item.edited && item.edited_timestamp && item.edited_timestamp > lastReadTs && !isDeleted(item);
     return `
             <div class="message ${messageClass}" ${timestampAttribute} ${txidAttribute} ${statusAttribute} ${callTimeAttribute}>
@@ -17329,39 +17301,53 @@ class ChatModal {
   }
 
   /**
-   * Load thumbnails for image and video attachments asynchronously
-   * Only loads from local IndexedDB cache - pUrl downloads happen on user action (Preview)
-   * @param {{ attachmentRows?: Iterable<HTMLElement>, preserveScrollAnchor?: boolean }} options
+   * Load a cached thumbnail into one attachment row.
+   * @param {HTMLElement} attachmentRow
+   * @returns {Promise<boolean>}
+   */
+  async loadThumbnailForAttachment(attachmentRow) {
+    if (!attachmentRow.isConnected) return false;
+    const url = attachmentRow.dataset.url;
+    if (!url || url === '#') return false;
+
+    try {
+      const thumbnailBlob = await thumbnailCache.get(url);
+      if (!thumbnailBlob || !attachmentRow.isConnected) return false;
+      return this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
+    } catch (error) {
+      console.warn('Failed to load thumbnail for', url, error);
+      return false;
+    }
+  }
+
+  /**
+   * Load thumbnails for visible image and video attachments.
    * @returns {void}
    */
-  async loadThumbnailsForAttachments({ attachmentRows = null, preserveScrollAnchor = false } = {}) {
-    const thumbnailAttachments = attachmentRows
-      ? [...attachmentRows]
-      : [...this.messagesList.querySelectorAll(
-          '[data-image-attachment="true"], [data-video-attachment="true"]'
-        )];
-    
-    for (const attachmentRow of thumbnailAttachments) {
-      if (!attachmentRow?.isConnected) continue;
-      const url = attachmentRow.dataset.url;
-      if (!url || url === '#') continue;
+  async loadThumbnailsForAttachments() {
+    const thumbnailRows = this.messagesList.querySelectorAll(
+      '[data-image-attachment="true"], [data-video-attachment="true"]'
+    );
 
-      try {
-        const thumbnailBlob = await thumbnailCache.get(url);
-        if (thumbnailBlob && attachmentRow.isConnected) {
-          const oldScrollHeight = preserveScrollAnchor && this.messagesContainer
-            ? this.messagesContainer.scrollHeight
-            : null;
-          const didUpdate = this.updateThumbnailInPlace(attachmentRow, thumbnailBlob);
-          if (didUpdate && Number.isFinite(oldScrollHeight) && this.messagesContainer) {
-            const heightDelta = this.messagesContainer.scrollHeight - oldScrollHeight;
-            if (heightDelta !== 0) {
-              this.messagesContainer.scrollTop = Math.max(0, this.messagesContainer.scrollTop + heightDelta);
-            }
-          }
-        }
-      } catch (error) {
-        console.warn('Failed to load thumbnail for', url, error);
+    for (const attachmentRow of thumbnailRows) {
+      await this.loadThumbnailForAttachment(attachmentRow);
+    }
+  }
+
+  /**
+   * Load thumbnails for prepended rows without moving the user's viewport.
+   * @param {HTMLElement[]} attachmentRows
+   * @returns {void}
+   */
+  async loadPrependedThumbnails(attachmentRows) {
+    assert(this.messagesContainer, 'Messages container is required');
+
+    for (const attachmentRow of attachmentRows) {
+      const oldScrollHeight = this.messagesContainer.scrollHeight;
+      const didUpdate = await this.loadThumbnailForAttachment(attachmentRow);
+      const heightDelta = this.messagesContainer.scrollHeight - oldScrollHeight;
+      if (didUpdate && heightDelta !== 0) {
+        this.messagesContainer.scrollTop = Math.max(0, this.messagesContainer.scrollTop + heightDelta);
       }
     }
   }

--- a/app.js
+++ b/app.js
@@ -13946,7 +13946,7 @@ class ChatModal {
     this.chatPerfLogFlushTimer = null;
 
     this.chatInitialRenderCount = 50;
-    this.chatOlderRenderBatchSize = 50;
+    this.chatOlderRenderBatchSize = 75;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
@@ -15278,7 +15278,7 @@ class ChatModal {
 
   getChatLoadAheadThreshold() {
     const containerHeight = this.messagesContainer?.clientHeight || 0;
-    return Math.max(700, containerHeight);
+    return Math.max(240, containerHeight * 0.35);
   }
 
   getChatOlderRenderBatchSize() {
@@ -16892,7 +16892,12 @@ class ChatModal {
                   total: this.formatChatPerfMs(deferredStart)
                 });
                 if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-                  this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferred');
+                  this.logChatPerf('window:drainSuppressed', {
+                    contact: this.formatChatPerfAddress(renderedAddress, contact),
+                    reason: 'bottomScrollCost',
+                    rendered: renderedMessages.length,
+                    remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
+                  });
                 }
               },
               (error) => {
@@ -16904,7 +16909,12 @@ class ChatModal {
                   error: error?.message || String(error)
                 });
                 if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-                  this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
+                  this.logChatPerf('window:drainSuppressed', {
+                    contact: this.formatChatPerfAddress(renderedAddress, contact),
+                    reason: 'bottomScrollCostAfterDeferredError',
+                    rendered: renderedMessages.length,
+                    remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
+                  });
                 }
               }
             );
@@ -16917,7 +16927,12 @@ class ChatModal {
               error: error?.message || String(error)
             });
             if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-              this.scheduleChatRenderWindowDrain(renderedAddress, 'afterDeferredError');
+              this.logChatPerf('window:drainSuppressed', {
+                contact: this.formatChatPerfAddress(renderedAddress, contact),
+                reason: 'bottomScrollCostAfterDeferredError',
+                rendered: renderedMessages.length,
+                remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
+              });
             }
           }
         });

--- a/app.js
+++ b/app.js
@@ -13944,6 +13944,13 @@ class ChatModal {
 
     this.chatPerfLogBuffer = [];
     this.chatPerfLogFlushTimer = null;
+
+    this.chatInitialRenderCount = 60;
+    this.chatOlderRenderBatchSize = 60;
+    this.chatRenderedOldestIndex = null;
+    this.chatRenderedWindowAddress = null;
+    this.chatForceFullRenderOnce = false;
+    this.isExpandingChatRenderWindow = false;
   }
 
   /**
@@ -14452,9 +14459,7 @@ class ChatModal {
       return true;
     });
     // Close all context menus when messages container scrolls
-    this.messagesContainer.addEventListener('scroll', () => {
-      this.closeAllContextMenus();
-    }, { passive: true });
+    this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
       const reactionButton = e.target.closest('.message-context-reaction-button');
@@ -14993,6 +14998,111 @@ class ChatModal {
     };
   }
 
+  resetChatRenderWindow(address = null) {
+    this.chatRenderedWindowAddress = address;
+    this.chatRenderedOldestIndex = null;
+    this.chatForceFullRenderOnce = false;
+    this.isExpandingChatRenderWindow = false;
+  }
+
+  getChatRenderRange(messages, currentAddress, forceFullRender = false) {
+    const totalMessages = Array.isArray(messages) ? messages.length : 0;
+    if (totalMessages === 0) {
+      return { newestIndex: 0, oldestIndex: -1, totalMessages, isWindowed: false };
+    }
+
+    if (
+      forceFullRender ||
+      this.chatForceFullRenderOnce ||
+      this.chatRenderedWindowAddress !== currentAddress
+    ) {
+      this.chatRenderedWindowAddress = currentAddress;
+      this.chatRenderedOldestIndex = forceFullRender || this.chatForceFullRenderOnce
+        ? totalMessages - 1
+        : Math.min(totalMessages - 1, this.chatInitialRenderCount - 1);
+      this.chatForceFullRenderOnce = false;
+    }
+
+    if (!Number.isInteger(this.chatRenderedOldestIndex)) {
+      this.chatRenderedOldestIndex = Math.min(totalMessages - 1, this.chatInitialRenderCount - 1);
+    }
+
+    this.chatRenderedOldestIndex = Math.min(this.chatRenderedOldestIndex, totalMessages - 1);
+
+    return {
+      newestIndex: 0,
+      oldestIndex: this.chatRenderedOldestIndex,
+      totalMessages,
+      isWindowed: this.chatRenderedOldestIndex < totalMessages - 1
+    };
+  }
+
+  getFirstVisibleMessageAnchor() {
+    const container = this.messagesContainer;
+    if (!container || !this.messagesList) return null;
+
+    const containerTop = container.getBoundingClientRect().top;
+    const messageEls = [...this.messagesList.querySelectorAll('.message')];
+    for (const messageEl of messageEls) {
+      const rect = messageEl.getBoundingClientRect();
+      if (rect.bottom >= containerTop) {
+        return {
+          element: messageEl,
+          offsetTop: rect.top - containerTop
+        };
+      }
+    }
+
+    return null;
+  }
+
+  restoreVisibleMessageAnchor(anchor) {
+    if (!anchor?.element || !this.messagesContainer) return;
+    const containerTop = this.messagesContainer.getBoundingClientRect().top;
+    const nextTop = anchor.element.getBoundingClientRect().top - containerTop;
+    this.messagesContainer.scrollTop += nextTop - anchor.offsetTop;
+  }
+
+  expandChatRenderWindow() {
+    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) return;
+    const contact = myData.contacts[this.address];
+    const messages = contact?.messages;
+    if (!Array.isArray(messages) || messages.length === 0) return;
+
+    const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+      ? this.chatRenderedOldestIndex
+      : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
+    if (currentOldestIndex >= messages.length - 1) return;
+
+    const nextOldestIndex = Math.min(
+      messages.length - 1,
+      currentOldestIndex + this.chatOlderRenderBatchSize
+    );
+    const anchor = this.getFirstVisibleMessageAnchor();
+    this.isExpandingChatRenderWindow = true;
+    this.chatRenderedOldestIndex = nextOldestIndex;
+    this.logChatPerf('window:expand', {
+      contact: this.formatChatPerfAddress(this.address, contact),
+      previousOldestIndex: currentOldestIndex,
+      nextOldestIndex,
+      totalMessages: messages.length
+    });
+
+    this.appendChatModal(false, true);
+    requestAnimationFrame(() => {
+      this.restoreVisibleMessageAnchor(anchor);
+      this.isExpandingChatRenderWindow = false;
+    });
+  }
+
+  handleMessagesContainerScroll() {
+    this.closeAllContextMenus();
+    if (!this.messagesContainer || !this.isActive()) return;
+    if (this.messagesContainer.scrollTop <= 160) {
+      this.expandChatRenderWindow();
+    }
+  }
+
   /**
    * Clears all staged composer attachments.
    * @param {{ deleteFromServer?: boolean }} options
@@ -15043,6 +15153,7 @@ class ChatModal {
     friendModal.setAddress(address);
     footer.closeNewChatButton();
     const contact = myData.contacts[address];
+    this.resetChatRenderWindow(address);
     const chatPerfSummary = this.summarizeChatPerfContact(contact);
     const visualViewportSize = window.visualViewport
       ? `${Math.round(window.visualViewport.width)}x${Math.round(window.visualViewport.height)}`
@@ -15323,6 +15434,7 @@ class ChatModal {
     }
 
     this.address = null;
+    this.resetChatRenderWindow();
   }
 
   clearNotificationsIfAllRead() {

--- a/app.js
+++ b/app.js
@@ -13944,8 +13944,7 @@ class ChatModal {
     this.dragCounter = 0;
     this.dropOverlay = null;
 
-    this.chatRenderedOldestIndex = null;
-    this.chatRenderSequence = 0;
+    this.chatRenderedOldestIndex = CHAT_INITIAL_RENDER_COUNT - 1;
   }
 
   /**
@@ -14889,7 +14888,7 @@ class ChatModal {
   }
 
   resetChatRenderWindow() {
-    this.chatRenderedOldestIndex = null;
+    this.chatRenderedOldestIndex = CHAT_INITIAL_RENDER_COUNT - 1;
   }
 
   expandChatRenderWindow() {
@@ -14898,9 +14897,7 @@ class ChatModal {
     const container = this.messagesContainer;
     const list = this.messagesList;
 
-    const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-      ? this.chatRenderedOldestIndex
-      : Math.min(messages.length - 1, CHAT_INITIAL_RENDER_COUNT - 1);
+    const currentOldestIndex = Math.min(this.chatRenderedOldestIndex, messages.length - 1);
     if (currentOldestIndex >= messages.length - 1) {
       return;
     }
@@ -14940,9 +14937,7 @@ class ChatModal {
     if (!this.isActive()) return;
     const container = this.messagesContainer;
     const messages = myData.contacts[this.address].messages;
-    const renderedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-      ? this.chatRenderedOldestIndex
-      : CHAT_INITIAL_RENDER_COUNT - 1;
+    const renderedOldestIndex = this.chatRenderedOldestIndex;
     if (renderedOldestIndex >= messages.length - 1) {
       return;
     }
@@ -16016,7 +16011,7 @@ class ChatModal {
     };
   }
 
-  renderChatMessageHTML(item, index, { contact, lastReadTs }) {
+  renderChatMessageHTML(item, { contact, lastReadTs }) {
     const timeString = formatTime(item.timestamp);
     const timestampAttribute = `data-message-timestamp="${item.timestamp}"`;
     const txidAttribute = item?.txid ? `data-txid="${item.txid}"` : '';
@@ -16091,7 +16086,6 @@ class ChatModal {
                   data-p-url="${att.pUrl || ''}"
                   data-name="${encodeURIComponent(fileName)}"
                   data-type="${att.type || ''}"
-                  data-msg-idx="${index}"
                   ${isImage ? 'data-image-attachment="true"' : ''}
                   ${isVideo ? 'data-video-attachment="true"' : ''}
                 >
@@ -16148,7 +16142,7 @@ class ChatModal {
       case 'vm': {
         const duration = this.formatDuration(item.duration);
         messageTextHTML = `
-              <div class="voice-message" data-url="${item.url || ''}" data-name="voice-message" data-type="audio/webm" data-msg-idx="${index}" data-duration="${item.duration || 0}">
+              <div class="voice-message" data-url="${item.url || ''}" data-name="voice-message" data-type="audio/webm" data-duration="${item.duration || 0}">
                 <div class="voice-message-controls">
                   <div class="voice-message-top-row">
                     <button class="voice-message-play-button" aria-label="Play voice message">
@@ -16191,7 +16185,7 @@ class ChatModal {
     for (let i = oldestIndex; i >= newestIndex; i--) {
       const item = messages[i];
       if (!item) continue;
-      renderedMessages.push(this.renderChatMessageHTML(item, i, { contact, lastReadTs }));
+      renderedMessages.push(this.renderChatMessageHTML(item, { contact, lastReadTs }));
       if (item.txid) renderedTxids.push(item.txid);
     }
 
@@ -16204,17 +16198,15 @@ class ChatModal {
   }
 
   getOldestRenderedMessageIndex(messages) {
-    const oldestRendered = this.messagesList?.firstElementChild;
+    const oldestRendered = this.messagesList.firstElementChild;
     if (!oldestRendered) return -1;
 
-    const { txid, messageTimestamp } = oldestRendered.dataset || {};
-    if (!txid && !messageTimestamp) return -1;
+    const { txid, messageTimestamp } = oldestRendered.dataset;
+    assert(txid || messageTimestamp, 'Rendered message must have an identity');
 
     return messages.findIndex((message) =>
-      message && (
-        (txid && message.txid === txid) ||
-        (messageTimestamp && message.timestamp == messageTimestamp)
-      )
+      (txid && message.txid === txid) ||
+      (messageTimestamp && message.timestamp == messageTimestamp)
     );
   }
 
@@ -16239,7 +16231,6 @@ class ChatModal {
 
     if (!this.modal) return;
     if (!this.messagesList) return;
-    const renderSequence = ++this.chatRenderSequence;
 
     // --- 1. Identify the actual newest received message data item ---
     // Since messages are sorted descending (newest first), the first item with my: false is the newest received.
@@ -16249,9 +16240,7 @@ class ChatModal {
 
     let oldestIndex = -1;
     if (messages.length > 0) {
-      const requestedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-        ? this.chatRenderedOldestIndex
-        : CHAT_INITIAL_RENDER_COUNT - 1;
+      const requestedOldestIndex = this.chatRenderedOldestIndex;
       const preservedOldestIndex = this.getOldestRenderedMessageIndex(messages);
       oldestIndex = Math.min(
         Math.max(0, requestedOldestIndex, preservedOldestIndex),
@@ -16284,11 +16273,7 @@ class ChatModal {
     const renderedAddress = currentAddress;
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        if (
-          !this.isActive() ||
-          this.address !== renderedAddress ||
-          renderSequence !== this.chatRenderSequence
-        ) {
+        if (!this.isActive() || this.address !== renderedAddress) {
           return;
         }
         if (shouldKeepBottomAnchored) {
@@ -17954,12 +17939,12 @@ class ChatModal {
   }
 
   getMessageRecordFromRenderedChild(element) {
-    const messageEl = element?.closest?.('.message') || null;
-    const messageRecord = this.getMessageRecordFromElement(messageEl);
-    if (messageRecord) return messageRecord;
+    const messageEl = element.closest('.message');
+    assert(messageEl, 'Rendered child must be inside a message');
 
-    const idx = Number(element?.dataset?.msgIdx);
-    return Number.isInteger(idx) ? myData.contacts[this.address]?.messages?.[idx] || null : null;
+    const messageRecord = this.getMessageRecordFromElement(messageEl);
+    assert(messageRecord, 'Rendered message must have a backing record');
+    return messageRecord;
   }
 
   /**
@@ -18264,17 +18249,23 @@ class ChatModal {
   /**
    * Resolve common attachment context fields from an attachment row.
    * @param {HTMLElement} attachmentRow
-   * @returns {{ attachmentRow: HTMLElement, messageEl: HTMLElement | null, idx: number, item: any, url: string }}
+   * @returns {{ attachmentRow: HTMLElement, messageEl: HTMLElement, item: any, url: string }}
    */
   getAttachmentContextFromRow(attachmentRow) {
-    const idx = Number(attachmentRow?.dataset?.msgIdx);
-    const item = this.getMessageRecordFromRenderedChild(attachmentRow);
+    const messageEl = attachmentRow.closest('.message');
+    assert(messageEl, 'Attachment row must be inside a message');
+
+    const item = this.getMessageRecordFromElement(messageEl);
+    assert(item, 'Attachment message must have a backing record');
+
+    const url = attachmentRow.dataset.url;
+    assert(url, 'Attachment row must include a url');
+
     return {
       attachmentRow,
-      messageEl: attachmentRow?.closest?.('.message') || null,
-      idx,
+      messageEl,
       item,
-      url: attachmentRow?.dataset?.url || ''
+      url
     };
   }
 
@@ -18845,10 +18836,7 @@ class ChatModal {
 
     // Get encryption keys from the message
     const message = this.getMessageRecordFromRenderedChild(attachmentRow);
-    if (!message?.xattach) {
-      showToast('Could not find attachment data', 0, 'error');
-      return;
-    }
+    assert(message.xattach, 'VCF attachment message must include attachment data');
 
     // Find the attachment in xattach array
     const attachment = message.xattach.find(att => att.url === url);
@@ -18877,7 +18865,7 @@ class ChatModal {
     let loadingToastId;
     try {
       const { item, url } = this.getAttachmentContextFromRow(attachmentRow);
-      if (!item || !url || url === '#') return;
+      if (url === '#') return;
       
       // Get pUrl from data attributes
       const pUrl = attachmentRow.dataset.pUrl;
@@ -18910,7 +18898,6 @@ class ChatModal {
   async saveImageAttachment(attachmentRow) {
     // Reuse normal attachment download flow (decrypt + download)
     const { item } = this.getAttachmentContextFromRow(attachmentRow);
-    if (!item) return;
 
     // Concurent download prevention
     if (this.attachmentDownloadInProgress) return;
@@ -19473,7 +19460,7 @@ class ChatModal {
         : -1;
       if (targetIndex !== -1) {
         this.chatRenderedOldestIndex = Math.max(
-          Number.isInteger(this.chatRenderedOldestIndex) ? this.chatRenderedOldestIndex : 0,
+          this.chatRenderedOldestIndex,
           targetIndex
         );
         this.appendChatModal(false, true);
@@ -20453,9 +20440,6 @@ class ChatModal {
     try {
       // Check if it's our own message or received message
       const message = this.getMessageRecordFromRenderedChild(voiceMessageElement);
-      if (!message) {
-        throw new Error('Message not found');
-      }
       const isMyMessage = message.my;
       
       // Get keys from message item (voice messages use audio-specific keys with fallback)
@@ -21358,15 +21342,9 @@ class ShareAttachmentModal {
 
     // Get the actual message data from myData to access encryption keys
     const messageData = chatModal.getMessageRecordFromElement(messageEl);
-    if (!messageData) {
-      console.error('Cannot find message data for attachment');
-      return null;
-    }
+    assert(messageData, 'Shared attachment must have a backing message record');
 
-    if (!messageData || !messageData.xattach || !messageData.xattach[0]) {
-      console.error('Cannot find attachment in message data');
-      return null;
-    }
+    assert(messageData.xattach && messageData.xattach[0], 'Shared attachment message must include attachment data');
 
     const attachmentData = messageData.xattach[0];
 

--- a/app.js
+++ b/app.js
@@ -16187,10 +16187,17 @@ class ChatModal {
     // Replace the list once to avoid one DOM mutation per message.
     this.messagesList.innerHTML = renderedMessages.join('');
 
-    this.syncAllRenderedReactionChips();
-
-    // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
-    this.loadThumbnailsForAttachments();
+    const renderedAddress = currentAddress;
+    const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (callback) => setTimeout(callback, 0);
+    scheduleAfterPaint(() => {
+      scheduleAfterPaint(() => {
+        if (!this.isActive() || this.address !== renderedAddress || !this.messagesList) return;
+        this.syncAllRenderedReactionChips();
+        this.loadThumbnailsForAttachments();
+      });
+    });
 
     // --- 5. Find the corresponding DOM element after rendering ---
     // This happens inside the setTimeout to ensure elements are in the DOM

--- a/app.js
+++ b/app.js
@@ -13944,6 +13944,7 @@ class ChatModal {
 
     this.chatPerfLogBuffer = [];
     this.chatPerfLogFlushTimer = null;
+    this.chatPerfLoggingEnabled = true;
 
     this.chatInitialRenderCount = 50;
     this.chatFirstOlderRenderBatchSize = 25;
@@ -14481,10 +14482,14 @@ class ChatModal {
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
     this.messagesContainer.addEventListener('scrollend', () => this.handleMessagesContainerScrollEnd('scrollend'), { passive: true });
     this.messagesContainer.addEventListener('touchstart', (e) => this.handleMessagesTouchStart(e), { passive: true });
-    this.messagesContainer.addEventListener('touchmove', (e) => this.logChatTouchDiagnostics(e, 'messagesMove'), { passive: true });
+    this.messagesContainer.addEventListener('touchmove', (e) => {
+      if (this.chatPerfLoggingEnabled) this.logChatTouchDiagnostics(e, 'messagesMove');
+    }, { passive: true });
     this.messagesContainer.addEventListener('touchend', (e) => this.handleMessagesTouchEnd(e), { passive: true });
     this.messagesContainer.addEventListener('touchcancel', (e) => this.handleMessagesTouchEnd(e), { passive: true });
-    this.modal.addEventListener('touchmove', (e) => this.logChatTouchDiagnostics(e, 'modalMove'), { passive: true });
+    this.modal.addEventListener('touchmove', (e) => {
+      if (this.chatPerfLoggingEnabled) this.logChatTouchDiagnostics(e, 'modalMove');
+    }, { passive: true });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
       const reactionButton = e.target.closest('.message-context-reaction-button');
@@ -14980,6 +14985,7 @@ class ChatModal {
   }
 
   logChatPerf(event, fields = {}) {
+    if (!this.chatPerfLoggingEnabled) return;
     try {
       const details = Object.entries(fields)
         .filter(([, value]) => value !== undefined && value !== null && value !== '')
@@ -15266,12 +15272,16 @@ class ChatModal {
 
   handleMessagesTouchStart(event) {
     this.isChatTouchActive = true;
-    this.logChatTouchDiagnostics(event, 'messagesStart');
+    if (this.chatPerfLoggingEnabled) {
+      this.logChatTouchDiagnostics(event, 'messagesStart');
+    }
   }
 
   handleMessagesTouchEnd(event) {
     this.isChatTouchActive = false;
-    this.logChatTouchDiagnostics(event, 'messagesEnd');
+    if (this.chatPerfLoggingEnabled) {
+      this.logChatTouchDiagnostics(event, 'messagesEnd');
+    }
     this.schedulePendingChatScrollExpand('touchEnd');
   }
 
@@ -15288,7 +15298,7 @@ class ChatModal {
     const wasPending = this.chatPendingScrollExpand;
     this.chatPendingScrollExpand = true;
     this.chatPendingScrollExpandReason = reason;
-    if (!wasPending) {
+    if (!wasPending && this.chatPerfLoggingEnabled) {
       this.logChatPerf('window:expandQueued', {
         reason,
         scrollTop: scrollSnapshot ? scrollSnapshot.scrollTop : 'n/a',
@@ -15331,30 +15341,34 @@ class ChatModal {
       (scrollSnapshot && scrollSnapshot.distanceFromBottom >= rearmDistance);
 
     if (!scrollSnapshot || scrollSnapshot.distanceFromBottom < loadAheadThreshold || !isExpansionRearmed) {
-      this.logChatPerf('window:expandAborted', {
-        trigger,
-        reason: !scrollSnapshot
-          ? 'missingSnapshot'
-          : scrollSnapshot.distanceFromBottom < loadAheadThreshold
-            ? 'belowThreshold'
-            : 'notRearmed',
-        distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
-        loadAheadThreshold: Math.round(loadAheadThreshold),
-        rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
-      });
+      if (this.chatPerfLoggingEnabled) {
+        this.logChatPerf('window:expandAborted', {
+          trigger,
+          reason: !scrollSnapshot
+            ? 'missingSnapshot'
+            : scrollSnapshot.distanceFromBottom < loadAheadThreshold
+              ? 'belowThreshold'
+              : 'notRearmed',
+          distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
+          loadAheadThreshold: Math.round(loadAheadThreshold),
+          rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
+        });
+      }
       this.clearPendingChatScrollExpand();
       return;
     }
 
     const queuedReason = this.chatPendingScrollExpandReason || 'scrollDistance';
     this.clearPendingChatScrollExpand();
-    this.logChatPerf('window:expandFlushed', {
-      trigger,
-      queuedReason,
-      distanceFromBottom: scrollSnapshot.distanceFromBottom,
-      loadAheadThreshold: Math.round(loadAheadThreshold),
-      rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
-    });
+    if (this.chatPerfLoggingEnabled) {
+      this.logChatPerf('window:expandFlushed', {
+        trigger,
+        queuedReason,
+        distanceFromBottom: scrollSnapshot.distanceFromBottom,
+        loadAheadThreshold: Math.round(loadAheadThreshold),
+        rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
+      });
+    }
     this.expandChatRenderWindow('scrollIdle');
   }
 
@@ -15388,19 +15402,22 @@ class ChatModal {
       : this.getChatScrollSnapshot();
     this.isExpandingChatRenderWindow = true;
     this.chatRenderedOldestIndex = nextOldestIndex;
-    this.logChatPerf('window:expand', {
-      contact: this.formatChatPerfAddress(this.address, contact),
-      reason,
-      previousOldestIndex: currentOldestIndex,
-      nextOldestIndex,
-      batchSize: renderBatchSize,
-      scrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
-      maxScrollTop: beforeSnapshot ? beforeSnapshot.maxScrollTop : 'n/a',
-      distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
-      loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
-      remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
-      totalMessages: messages.length
-    });
+    if (this.chatPerfLoggingEnabled) {
+      this.logChatPerf('window:expand', {
+        contact: this.formatChatPerfAddress(this.address, contact),
+        reason,
+        previousOldestIndex: currentOldestIndex,
+        nextOldestIndex,
+        batchSize: renderBatchSize,
+        scrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
+        maxScrollTop: beforeSnapshot ? beforeSnapshot.maxScrollTop : 'n/a',
+        distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
+        distanceToRenderedTop: beforeSnapshot ? beforeSnapshot.distanceToRenderedTop : 'n/a',
+        loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
+        remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
+        totalMessages: messages.length
+      });
+    }
 
     if (shouldPrependOlderMessages) {
       const prependPerfStart = this.getChatPerfTime();
@@ -15452,28 +15469,30 @@ class ChatModal {
         this.getChatLoadAheadThreshold() * 2
       );
       this.chatExpansionRearmDistanceFromBottom = rearmDistance;
-      this.logChatPerf('window:prepend', {
-        contact: this.formatChatPerfAddress(this.address, contact),
-        previousOldestIndex: currentOldestIndex,
-        nextOldestIndex,
-        rendered: range.renderedCount,
-        build: range.buildMs,
-        join: range.joinMs,
-        domWrite: domWriteMs,
-        reactions: reactionsMs,
-        preserveStrategy: useEstimatedSpacerPreserve ? 'estimatedSpacer' : 'scrollHeightDelta',
-        preserve: preserveMs,
-        oldScrollTop: Math.round(oldScrollTop),
-        oldScrollHeight: useEstimatedSpacerPreserve ? 'skipped' : Math.round(oldScrollHeight),
-        oldSpacerHeight: Math.round(oldSpacerHeight),
-        estimatedHeight: Math.round(estimatedInsertedHeight),
-        nextSpacerHeight: Math.round(nextSpacerHeight),
-        scrollDelta: Math.round(scrollDelta),
-        nextScrollTop: Math.round(this.messagesContainer.scrollTop),
-        rearmDistance: Math.round(rearmDistance),
-        children: this.messagesList.children.length,
-        total: this.formatChatPerfMs(prependPerfStart)
-      });
+      if (this.chatPerfLoggingEnabled) {
+        this.logChatPerf('window:prepend', {
+          contact: this.formatChatPerfAddress(this.address, contact),
+          previousOldestIndex: currentOldestIndex,
+          nextOldestIndex,
+          rendered: range.renderedCount,
+          build: range.buildMs,
+          join: range.joinMs,
+          domWrite: domWriteMs,
+          reactions: reactionsMs,
+          preserveStrategy: useEstimatedSpacerPreserve ? 'estimatedSpacer' : 'scrollHeightDelta',
+          preserve: preserveMs,
+          oldScrollTop: Math.round(oldScrollTop),
+          oldScrollHeight: useEstimatedSpacerPreserve ? 'skipped' : Math.round(oldScrollHeight),
+          oldSpacerHeight: Math.round(oldSpacerHeight),
+          estimatedHeight: Math.round(estimatedInsertedHeight),
+          nextSpacerHeight: Math.round(nextSpacerHeight),
+          scrollDelta: Math.round(scrollDelta),
+          nextScrollTop: Math.round(this.messagesContainer.scrollTop),
+          rearmDistance: Math.round(rearmDistance),
+          children: this.messagesList.children.length,
+          total: this.formatChatPerfMs(prependPerfStart)
+        });
+      }
       if (useEstimatedSpacerPreserve && nextOldestIndex < messages.length - 1) {
         const distanceToRenderedTop = Math.max(
           0,
@@ -15532,8 +15551,8 @@ class ChatModal {
     const remainingOlder = Number.isInteger(renderedOldestIndex)
       ? Math.max(0, totalMessages - 1 - renderedOldestIndex)
       : 0;
-    const now = this.getChatPerfTime();
-    if (now - this.lastChatScrollLogAt > 750) {
+    const now = this.chatPerfLoggingEnabled ? this.getChatPerfTime() : 0;
+    if (this.chatPerfLoggingEnabled && now - this.lastChatScrollLogAt > 750) {
       this.lastChatScrollLogAt = now;
       this.logChatPerf('scroll:metrics', {
         scrollTop: scrollSnapshot.scrollTop,
@@ -17484,23 +17503,27 @@ class ChatModal {
     // This happens inside the setTimeout to ensure elements are in the DOM
 
     if (skipAutoScroll) {
-      this.logChatPerf('append:scrollSkipped', {
-        contact: this.formatChatPerfAddress(currentAddress, contact),
-        delay: '0.0ms',
-        reason: 'skipAutoScroll'
-      });
+      if (this.chatPerfLoggingEnabled) {
+        this.logChatPerf('append:scrollSkipped', {
+          contact: this.formatChatPerfAddress(currentAddress, contact),
+          delay: '0.0ms',
+          reason: 'skipAutoScroll'
+        });
+      }
       return;
     }
 
     if (shouldKeepBottomAnchored && !highlightNewMessage) {
-      this.logChatPerf('append:scrollSkipped', {
-        contact: this.formatChatPerfAddress(currentAddress, contact),
-        delay: '0.0ms',
-        reason: 'immediateBottom',
-        scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
-        scrollHeight: this.messagesContainer ? Math.round(this.messagesContainer.scrollHeight) : 'n/a',
-        clientHeight: this.messagesContainer ? Math.round(this.messagesContainer.clientHeight) : 'n/a'
-      });
+      if (this.chatPerfLoggingEnabled) {
+        this.logChatPerf('append:scrollSkipped', {
+          contact: this.formatChatPerfAddress(currentAddress, contact),
+          delay: '0.0ms',
+          reason: 'immediateBottom',
+          scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
+          scrollHeight: this.messagesContainer ? Math.round(this.messagesContainer.scrollHeight) : 'n/a',
+          clientHeight: this.messagesContainer ? Math.round(this.messagesContainer.clientHeight) : 'n/a'
+        });
+      }
       return;
     }
 
@@ -17568,15 +17591,17 @@ class ChatModal {
           }
         }
       }
-      this.logChatPerf('append:scroll', {
-        contact: this.formatChatPerfAddress(currentAddress, contact),
-        delay: this.formatChatPerfMs(scrollScheduledAt, scrollPerfStart),
-        ms: this.formatChatPerfMs(scrollPerfStart),
-        target: scrollTarget,
-        scrollTop: messageContainer ? Math.round(messageContainer.scrollTop) : 'n/a',
-        scrollHeight: messageContainer ? Math.round(messageContainer.scrollHeight) : 'n/a',
-        clientHeight: messageContainer ? Math.round(messageContainer.clientHeight) : 'n/a'
-      });
+      if (this.chatPerfLoggingEnabled) {
+        this.logChatPerf('append:scroll', {
+          contact: this.formatChatPerfAddress(currentAddress, contact),
+          delay: this.formatChatPerfMs(scrollScheduledAt, scrollPerfStart),
+          ms: this.formatChatPerfMs(scrollPerfStart),
+          target: scrollTarget,
+          scrollTop: messageContainer ? Math.round(messageContainer.scrollTop) : 'n/a',
+          scrollHeight: messageContainer ? Math.round(messageContainer.scrollHeight) : 'n/a',
+          clientHeight: messageContainer ? Math.round(messageContainer.clientHeight) : 'n/a'
+        });
+      }
     }, 300); // <<< Delay of 300 milliseconds for rendering
   }
 

--- a/app.js
+++ b/app.js
@@ -17286,9 +17286,9 @@ class ChatModal {
         const isVideo = att.type && att.type.startsWith('video/');
         const hasThumbnail = isImage || isVideo;
         const fileTypeIcon = this.getFileTypeForIcon(att.type || '', fileName);
-        const attachmentClass = hasThumbnail ? 'attachment-row attachment-row-media' : 'attachment-row attachment-row-file';
+        const paddingStyle = hasThumbnail ? 'padding: 5px 5px;' : 'padding: 10px 12px;';
         return `
-                <div class="${attachmentClass}"
+                <div class="attachment-row" style="display: flex; ${hasThumbnail ? 'flex-direction: column;' : 'align-items: center;'} background: #f5f5f7; border-radius: 12px; ${paddingStyle} margin-bottom: 6px;"
                   data-url="${fileUrl}"
                   data-p-url="${att.pUrl || ''}"
                   data-name="${encodeURIComponent(fileName)}"
@@ -17297,14 +17297,15 @@ class ChatModal {
                   ${isImage ? 'data-image-attachment="true"' : ''}
                   ${isVideo ? 'data-video-attachment="true"' : ''}
                 >
-                  <div class="attachment-icon-container">
+                  <div class="attachment-icon-container" style="${hasThumbnail ? 'margin-bottom: 10px; flex-direction: column;' : 'margin-right: 14px; flex-shrink: 0;'}">
                     <div class="attachment-icon" data-file-type="${fileTypeIcon}"></div>
+                    ${hasThumbnail ? '<div class="attachment-preview-hint">Click for options</div>' : ''}
                   </div>
-                  <div class="attachment-details">
-                    <span class="attachment-label">
+                  <div style="min-width:0;">
+                    <span class="attachment-label" style="font-weight:500;color:#222;font-size:0.7em;display:block;word-wrap:break-word;">
                       ${fileName}
-                    </span>
-                    <span class="attachment-meta">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
+                    </span><br>
+                    <span style="font-size: 0.93em; color: #888;">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
                   </div>
                 </div>
               `;
@@ -17585,9 +17586,9 @@ class ChatModal {
               const isVideo = att.type && att.type.startsWith('video/');
               const hasThumbnail = isImage || isVideo;
               const fileTypeIcon = this.getFileTypeForIcon(att.type || '', fileName);
-              const attachmentClass = hasThumbnail ? 'attachment-row attachment-row-media' : 'attachment-row attachment-row-file';
+              const paddingStyle = hasThumbnail ? 'padding: 5px 5px;' : 'padding: 10px 12px;';
               return `
-                <div class="${attachmentClass}"
+                <div class="attachment-row" style="display: flex; ${hasThumbnail ? 'flex-direction: column;' : 'align-items: center;'} background: #f5f5f7; border-radius: 12px; ${paddingStyle} margin-bottom: 6px;"
                   data-url="${fileUrl}"
                   data-p-url="${att.pUrl || ''}"
                   data-name="${encodeURIComponent(fileName)}"
@@ -17596,14 +17597,15 @@ class ChatModal {
                   ${isImage ? 'data-image-attachment="true"' : ''}
                   ${isVideo ? 'data-video-attachment="true"' : ''}
                 >
-                  <div class="attachment-icon-container">
+                  <div class="attachment-icon-container" style="${hasThumbnail ? 'margin-bottom: 10px; flex-direction: column;' : 'margin-right: 14px; flex-shrink: 0;'}">
                     <div class="attachment-icon" data-file-type="${fileTypeIcon}"></div>
+                    ${hasThumbnail ? '<div class="attachment-preview-hint">Click for options</div>' : ''}
                   </div>
-                  <div class="attachment-details">
-                    <span class="attachment-label">
+                  <div style="min-width:0;">
+                    <span class="attachment-label" style="font-weight:500;color:#222;font-size:0.7em;display:block;word-wrap:break-word;">
                       ${fileName}
-                    </span>
-                    <span class="attachment-meta">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
+                    </span><br>
+                    <span style="font-size: 0.93em; color: #888;">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
                   </div>
                 </div>
               `;
@@ -17728,6 +17730,9 @@ class ChatModal {
       total: this.formatChatPerfMs(appendPerfStart)
     });
 
+    // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
+    this.loadThumbnailsForAttachments();
+
     const renderedAddress = currentAddress;
     if (skipDeferredWork) {
       this.logChatPerf('append:deferredSkipped', {
@@ -17763,75 +17768,19 @@ class ChatModal {
           const reactionPerfStart = this.getChatPerfTime();
           this.syncAllRenderedReactionChips();
           const reactionsMs = this.formatChatPerfMs(reactionPerfStart);
-          const wasNearBottomBeforeThumbnails = shouldKeepBottomAnchored
-            ? this.isMessagesContainerNearBottom(80)
-            : false;
-          const thumbnailPerfStart = this.getChatPerfTime();
-          try {
-            const thumbnailResult = this.loadThumbnailsForAttachments();
-            Promise.resolve(thumbnailResult).then(
-              () => {
-                let thumbnailScrollMetrics = null;
-                let thumbnailScrollMs = 'skipped';
-                if (shouldKeepBottomAnchored && wasNearBottomBeforeThumbnails) {
-                  const thumbnailScrollPerfStart = this.getChatPerfTime();
-                  thumbnailScrollMetrics = this.scrollMessagesToBottom();
-                  thumbnailScrollMs = this.formatChatPerfMs(thumbnailScrollPerfStart);
-                }
-                this.logChatPerf('append:deferred', {
-                  contact: this.formatChatPerfAddress(renderedAddress, contact),
-                  delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-                  reactions: reactionsMs,
-                  thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
-                  thumbnailScroll: thumbnailScrollMs,
-                  wasNearBottomBeforeThumbnails,
-                  scrollTop: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollTop : 'n/a',
-                  scrollHeight: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollHeight : 'n/a',
-                  total: this.formatChatPerfMs(deferredStart)
-                });
-                if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-                  this.logChatPerf('window:drainSuppressed', {
-                    contact: this.formatChatPerfAddress(renderedAddress, contact),
-                    reason: 'bottomScrollCost',
-                    rendered: renderedMessages.length,
-                    remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
-                  });
-                }
-              },
-              (error) => {
-                this.logChatPerf('append:deferredError', {
-                  contact: this.formatChatPerfAddress(renderedAddress, contact),
-                  delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-                  reactions: reactionsMs,
-                  thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
-                  error: error?.message || String(error)
-                });
-                if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-                  this.logChatPerf('window:drainSuppressed', {
-                    contact: this.formatChatPerfAddress(renderedAddress, contact),
-                    reason: 'bottomScrollCostAfterDeferredError',
-                    rendered: renderedMessages.length,
-                    remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
-                  });
-                }
-              }
-            );
-          } catch (error) {
-            this.logChatPerf('append:deferredError', {
+          this.logChatPerf('append:deferred', {
+            contact: this.formatChatPerfAddress(renderedAddress, contact),
+            delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+            reactions: reactionsMs,
+            total: this.formatChatPerfMs(deferredStart)
+          });
+          if (shouldKeepBottomAnchored && renderRange.isWindowed) {
+            this.logChatPerf('window:drainSuppressed', {
               contact: this.formatChatPerfAddress(renderedAddress, contact),
-              delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-              reactions: reactionsMs,
-              thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
-              error: error?.message || String(error)
+              reason: 'bottomScrollCost',
+              rendered: renderedMessages.length,
+              remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
             });
-            if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-              this.logChatPerf('window:drainSuppressed', {
-                contact: this.formatChatPerfAddress(renderedAddress, contact),
-                reason: 'bottomScrollCostAfterDeferredError',
-                rendered: renderedMessages.length,
-                remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
-              });
-            }
           }
         });
       });

--- a/app.js
+++ b/app.js
@@ -16444,9 +16444,6 @@ class ChatModal {
     // Replace the list once to avoid one DOM mutation per message.
     this.messagesList.innerHTML = range.html;
     const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
-    if (shouldKeepBottomAnchored) {
-      this.messagesContainer.scrollTop = 1000000000;
-    }
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
     this.loadThumbnailsForAttachments();
@@ -16464,6 +16461,9 @@ class ChatModal {
           renderSequence !== this.chatRenderSequence
         ) {
           return;
+        }
+        if (shouldKeepBottomAnchored) {
+          this.messagesContainer.scrollTop = this.messagesContainer.scrollHeight;
         }
         this.syncAllRenderedReactionChips();
       });

--- a/app.js
+++ b/app.js
@@ -13880,6 +13880,7 @@ const CHAT_REACTION_SHEET_PROMOTION_RATIO = 0.5;
 const CHAT_REACTION_SHEET_CLOSE_DRAG_PX = 120;
 const CHAT_INITIAL_RENDER_COUNT = 100;
 const CHAT_OLDER_RENDER_BATCH_SIZE = 200;
+const CHAT_THUMBNAIL_ATTACHMENT_SELECTOR = '[data-image-attachment="true"], [data-video-attachment="true"]';
 const CHAT_REACTION_SHEET_TAB_ICONS = {
   recent: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/><path d="M12 7v5l3 2"/></svg>',
   smileys: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg>',
@@ -14925,7 +14926,7 @@ class ChatModal {
     const prependedThumbnailRows = [];
     for (let messageEl = list.firstElementChild; messageEl && messageEl !== oldFirstMessage; messageEl = messageEl.nextElementSibling) {
       prependedThumbnailRows.push(
-        ...messageEl.querySelectorAll('[data-image-attachment="true"], [data-video-attachment="true"]')
+        ...messageEl.querySelectorAll(CHAT_THUMBNAIL_ATTACHMENT_SELECTOR)
       );
     }
 
@@ -14957,8 +14958,7 @@ class ChatModal {
     if (!this.isActive()) return;
     const container = this.messagesContainer;
     const messages = myData.contacts[this.address].messages;
-    const renderedOldestIndex = this.chatRenderedOldestIndex;
-    if (renderedOldestIndex >= messages.length - 1) {
+    if (this.chatRenderedOldestIndex >= messages.length - 1) {
       return;
     }
 
@@ -16260,10 +16260,8 @@ class ChatModal {
       if (item.txid) renderedTxids.push(item.txid);
     }
 
-    const html = renderedMessages.join('');
-
     return {
-      html,
+      html: renderedMessages.join(''),
       renderedTxids
     };
   }
@@ -16336,9 +16334,7 @@ class ChatModal {
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
     if (shouldKeepBottomAnchored) {
-      const thumbnailRows = this.messagesList.querySelectorAll(
-        '[data-image-attachment="true"], [data-video-attachment="true"]'
-      );
+      const thumbnailRows = this.messagesList.querySelectorAll(CHAT_THUMBNAIL_ATTACHMENT_SELECTOR);
       this.loadThumbnailsKeepingScrollAnchored(thumbnailRows);
     } else {
       this.loadThumbnailsForAttachments();
@@ -16363,11 +16359,7 @@ class ChatModal {
     // --- 5. Find the corresponding DOM element after rendering ---
     // This happens inside the setTimeout to ensure elements are in the DOM
 
-    if (skipAutoScroll) {
-      return;
-    }
-
-    if (shouldKeepBottomAnchored) {
+    if (skipAutoScroll || shouldKeepBottomAnchored) {
       return;
     }
 
@@ -17256,9 +17248,7 @@ class ChatModal {
    * @returns {void}
    */
   async loadThumbnailsForAttachments() {
-    const thumbnailRows = this.messagesList.querySelectorAll(
-      '[data-image-attachment="true"], [data-video-attachment="true"]'
-    );
+    const thumbnailRows = this.messagesList.querySelectorAll(CHAT_THUMBNAIL_ATTACHMENT_SELECTOR);
 
     for (const attachmentRow of thumbnailRows) {
       await this.loadThumbnailForAttachment(attachmentRow);
@@ -17463,9 +17453,7 @@ class ChatModal {
       // Generate and cache thumbnail for images and videos, then update in place
       if (blob.type.startsWith('image/') || blob.type.startsWith('video/')) {
         const attachmentUrl = linkEl.dataset.url;
-        const attachmentRow = linkEl.closest('.attachment-row') || 
-          linkEl.closest('[data-image-attachment="true"]') ||
-          linkEl.closest('[data-video-attachment="true"]');
+        const attachmentRow = linkEl.closest('.attachment-row') || linkEl.closest(CHAT_THUMBNAIL_ATTACHMENT_SELECTOR);
         
         const thumbnailPromise = blob.type.startsWith('image/')
           ? thumbnailCache.generateThumbnail(blob)
@@ -18013,10 +18001,9 @@ class ChatModal {
       return contact.messages.find((msg) => msg?.txid === txid) || null;
     }
 
-    const messageIndex = contact.messages.findIndex((msg) =>
+    return contact.messages.find((msg) =>
       timestamp && msg?.timestamp == timestamp
-    );
-    return messageIndex === -1 ? null : contact.messages[messageIndex];
+    ) || null;
   }
 
   getMessageRecordFromRenderedChild(element) {

--- a/app.js
+++ b/app.js
@@ -16250,9 +16250,9 @@ class ChatModal {
               const isVideo = att.type && att.type.startsWith('video/');
               const hasThumbnail = isImage || isVideo;
               const fileTypeIcon = this.getFileTypeForIcon(att.type || '', fileName);
-              const paddingStyle = hasThumbnail ? 'padding: 5px 5px;' : 'padding: 10px 12px;';
+              const attachmentClass = hasThumbnail ? 'attachment-row attachment-row-media' : 'attachment-row attachment-row-file';
               return `
-                <div class="attachment-row" style="display: flex; ${hasThumbnail ? 'flex-direction: column;' : 'align-items: center;'} background: #f5f5f7; border-radius: 12px; ${paddingStyle} margin-bottom: 6px;"
+                <div class="${attachmentClass}"
                   data-url="${fileUrl}"
                   data-p-url="${att.pUrl || ''}"
                   data-name="${encodeURIComponent(fileName)}"
@@ -16261,15 +16261,14 @@ class ChatModal {
                   ${isImage ? 'data-image-attachment="true"' : ''}
                   ${isVideo ? 'data-video-attachment="true"' : ''}
                 >
-                  <div class="attachment-icon-container" style="${hasThumbnail ? 'margin-bottom: 10px; flex-direction: column;' : 'margin-right: 14px; flex-shrink: 0;'}">
+                  <div class="attachment-icon-container">
                     <div class="attachment-icon" data-file-type="${fileTypeIcon}"></div>
-                    ${hasThumbnail ? '<div class="attachment-preview-hint">Click for options</div>' : ''}
                   </div>
-                  <div style="min-width:0;">
-                    <span class="attachment-label" style="font-weight:500;color:#222;font-size:0.7em;display:block;word-wrap:break-word;">
+                  <div class="attachment-details">
+                    <span class="attachment-label">
                       ${fileName}
-                    </span><br>
-                    <span style="font-size: 0.93em; color: #888;">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
+                    </span>
+                    <span class="attachment-meta">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
                   </div>
                 </div>
               `;

--- a/app.js
+++ b/app.js
@@ -15977,6 +15977,12 @@ class ChatModal {
     this.newestSentMessage = messages.find((item) => item.my);
 
     const renderedMessages = [];
+    const messagesByTxid = new Map();
+    messages.forEach((message) => {
+      if (message?.txid) {
+        messagesByTxid.set(message.txid, message);
+      }
+    });
 
     // 3. Iterate backwards through messages (oldest to newest for rendering order)
     // messages are already sorted descending (newest first) in myData
@@ -16051,7 +16057,7 @@ class ChatModal {
                 const isSelfReply = ownerIsMineHint === true || ownerIsMineHint === '1';
                 isOwnerMine = item.my === isSelfReply;
               } else {
-                const targetMsg = contact.messages?.find((m) => m.txid === item.replyId);
+                const targetMsg = messagesByTxid.get(item.replyId);
                 isOwnerMine = !!(targetMsg && targetMsg.my);
               }
               const ownerText = isOwnerMine ? 'You' : (getContactDisplayName(contact) || 'Contact');

--- a/app.js
+++ b/app.js
@@ -16229,9 +16229,12 @@ class ChatModal {
     const { txid, messageTimestamp } = oldestRendered.dataset;
     assert(txid || messageTimestamp, 'Rendered message must have an identity');
 
+    if (txid) {
+      return messages.findIndex((message) => message?.txid === txid);
+    }
+
     return messages.findIndex((message) =>
-      (txid && message.txid === txid) ||
-      (messageTimestamp && message.timestamp == messageTimestamp)
+      messageTimestamp && message?.timestamp == messageTimestamp
     );
   }
 
@@ -17957,8 +17960,12 @@ class ChatModal {
     const contact = myData.contacts[this.address];
     if (!contact?.messages?.length) return null;
 
+    if (txid) {
+      return contact.messages.find((msg) => msg?.txid === txid) || null;
+    }
+
     const messageIndex = contact.messages.findIndex((msg) =>
-      msg && (msg.txid === txid || msg.timestamp == timestamp)
+      timestamp && msg?.timestamp == timestamp
     );
     return messageIndex === -1 ? null : contact.messages[messageIndex];
   }

--- a/app.js
+++ b/app.js
@@ -16427,7 +16427,7 @@ class ChatModal {
     const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
-    this.loadThumbnailsForAttachments();
+    this.loadThumbnailsForAttachments({ keepBottomAnchored: shouldKeepBottomAnchored });
 
     const renderedAddress = currentAddress;
     const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
@@ -17322,15 +17322,21 @@ class ChatModal {
 
   /**
    * Load thumbnails for visible image and video attachments.
+   * @param {{ keepBottomAnchored?: boolean }} options
    * @returns {void}
    */
-  async loadThumbnailsForAttachments() {
+  async loadThumbnailsForAttachments({ keepBottomAnchored = false } = {}) {
     const thumbnailRows = this.messagesList.querySelectorAll(
       '[data-image-attachment="true"], [data-video-attachment="true"]'
     );
 
     for (const attachmentRow of thumbnailRows) {
-      await this.loadThumbnailForAttachment(attachmentRow);
+      const oldScrollHeight = this.messagesContainer?.scrollHeight ?? 0;
+      const didUpdate = await this.loadThumbnailForAttachment(attachmentRow);
+      const heightDelta = (this.messagesContainer?.scrollHeight ?? 0) - oldScrollHeight;
+      if (keepBottomAnchored && didUpdate && heightDelta !== 0 && this.messagesContainer) {
+        this.messagesContainer.scrollTop = Math.max(0, this.messagesContainer.scrollTop + heightDelta);
+      }
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -14918,14 +14918,16 @@ class ChatModal {
       nextOldestIndex,
       currentOldestIndex + 1
     );
+    const oldFirstMessage = list.firstElementChild;
 
     this.chatRenderedOldestIndex = nextOldestIndex;
     list.insertAdjacentHTML('afterbegin', range.html);
-    const prependedThumbnailRows = range.renderedTxids.flatMap((txid) => {
-      const messageEl = list.querySelector(`.message[data-txid="${CSS.escape(txid)}"]`);
-      assert(messageEl, `Rendered message missing for ${txid}`);
-      return [...messageEl.querySelectorAll('[data-image-attachment="true"], [data-video-attachment="true"]')];
-    });
+    const prependedThumbnailRows = [];
+    for (let messageEl = list.firstElementChild; messageEl && messageEl !== oldFirstMessage; messageEl = messageEl.nextElementSibling) {
+      prependedThumbnailRows.push(
+        ...messageEl.querySelectorAll('[data-image-attachment="true"], [data-video-attachment="true"]')
+      );
+    }
 
     this.syncRenderedReactionTargets(range.renderedTxids);
 

--- a/app.js
+++ b/app.js
@@ -15085,9 +15085,10 @@ class ChatModal {
       : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
     if (currentOldestIndex >= messages.length - 1) return;
 
+    const renderBatchSize = this.getChatOlderRenderBatchSize();
     const nextOldestIndex = Math.min(
       messages.length - 1,
-      currentOldestIndex + this.chatOlderRenderBatchSize
+      currentOldestIndex + renderBatchSize
     );
     const anchor = this.getFirstVisibleMessageAnchor();
     this.isExpandingChatRenderWindow = true;
@@ -15096,6 +15097,7 @@ class ChatModal {
       contact: this.formatChatPerfAddress(this.address, contact),
       previousOldestIndex: currentOldestIndex,
       nextOldestIndex,
+      batchSize: renderBatchSize,
       totalMessages: messages.length
     });
 
@@ -15117,14 +15119,28 @@ class ChatModal {
         scrollHeight: Math.round(this.messagesContainer.scrollHeight),
         clientHeight: Math.round(this.messagesContainer.clientHeight),
         messageListHeight: this.messagesList ? Math.round(this.messagesList.scrollHeight) : 'n/a',
+        loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
         modalScrollTop: this.modal ? Math.round(this.modal.scrollTop || 0) : 'n/a',
         bodyScrollY: Math.round(window.scrollY || 0)
       });
     }
-    const loadAheadThreshold = this.messagesContainer.clientHeight * 1.5;
+    const loadAheadThreshold = this.getChatLoadAheadThreshold();
     if (this.messagesContainer.scrollTop <= loadAheadThreshold) {
       this.expandChatRenderWindow();
     }
+  }
+
+  getChatLoadAheadThreshold() {
+    const containerHeight = this.messagesContainer?.clientHeight || 0;
+    return Math.max(2400, containerHeight * 4);
+  }
+
+  getChatOlderRenderBatchSize() {
+    const scrollTop = this.messagesContainer?.scrollTop ?? Infinity;
+    const urgentThreshold = (this.messagesContainer?.clientHeight || 0) * 1.5;
+    return scrollTop <= urgentThreshold
+      ? this.chatOlderRenderBatchSize * 2
+      : this.chatOlderRenderBatchSize;
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -19704,7 +19704,22 @@ class ChatModal {
    */
   scrollToMessage(txid) {
     if (!txid || !this.messagesList) return;
-    const target = this.messagesList.querySelector(`[data-txid="${txid}"]`);
+    let target = this.messagesList.querySelector(`[data-txid="${CSS.escape(txid)}"]`);
+    if (!target && this.address) {
+      const contact = myData.contacts[this.address];
+      const messages = contact?.messages;
+      const targetIndex = Array.isArray(messages)
+        ? messages.findIndex((message) => message?.txid === txid)
+        : -1;
+      if (targetIndex !== -1) {
+        this.chatRenderedOldestIndex = Math.max(
+          Number.isInteger(this.chatRenderedOldestIndex) ? this.chatRenderedOldestIndex : 0,
+          targetIndex
+        );
+        this.appendChatModal(false, true);
+        target = this.messagesList.querySelector(`[data-txid="${CSS.escape(txid)}"]`);
+      }
+    }
     if (!target) {
       showToast('Message not found', 2000, 'info');
       return;

--- a/app.js
+++ b/app.js
@@ -13947,7 +13947,7 @@ class ChatModal {
     this.chatPerfLoggingEnabled = true;
 
     this.chatInitialRenderCount = 50;
-    this.chatFirstOlderRenderBatchSize = 25;
+    this.chatFirstOlderRenderBatchSize = 10;
     this.chatOlderRenderBatchSize = 25;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;

--- a/app.js
+++ b/app.js
@@ -13941,6 +13941,9 @@ class ChatModal {
     // Drag and drop state
     this.dragCounter = 0;
     this.dropOverlay = null;
+
+    this.chatPerfLogBuffer = [];
+    this.chatPerfLogFlushTimer = null;
   }
 
   /**
@@ -14885,6 +14888,94 @@ class ChatModal {
     return !!(editInput?.value?.trim?.());
   }
 
+  getChatPerfTime() {
+    return typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+  }
+
+  formatChatPerfMs(start, end = this.getChatPerfTime()) {
+    return `${Math.max(0, end - start).toFixed(1)}ms`;
+  }
+
+  formatChatPerfAddress(address, contact) {
+    const compactAddress = address
+      ? `${address.slice(0, 8)}...${address.slice(-6)}`
+      : 'unknown';
+    const displayName = contact ? getContactDisplayName(contact) : '';
+    return displayName && displayName !== address
+      ? `${displayName}(${compactAddress})`
+      : compactAddress;
+  }
+
+  summarizeChatPerfContact(contact) {
+    const messages = Array.isArray(contact?.messages) ? contact.messages : [];
+    const summary = {
+      messages: messages.length,
+      replies: 0,
+      attachments: 0,
+      mediaAttachments: 0,
+      voice: 0,
+      payments: 0,
+      calls: 0,
+      edited: 0,
+      deleted: 0,
+      textChars: 0,
+      reactions: Array.isArray(contact?.reactions) ? contact.reactions.length : 0
+    };
+
+    messages.forEach((message) => {
+      if (message?.replyId) summary.replies++;
+      if (typeof message?.amount === 'bigint') summary.payments++;
+      if (message?.type === 'vm') summary.voice++;
+      if (message?.type === 'call') summary.calls++;
+      if (message?.edited) summary.edited++;
+      if (isDeleted(message)) summary.deleted++;
+      if (typeof message?.message === 'string') summary.textChars += message.message.length;
+      if (Array.isArray(message?.xattach)) {
+        summary.attachments += message.xattach.length;
+        summary.mediaAttachments += message.xattach.filter((attachment) => {
+          const type = attachment?.type || '';
+          return type.startsWith('image/') || type.startsWith('video/');
+        }).length;
+      }
+    });
+
+    return summary;
+  }
+
+  logChatPerf(event, fields = {}) {
+    try {
+      const details = Object.entries(fields)
+        .filter(([, value]) => value !== undefined && value !== null && value !== '')
+        .map(([key, value]) => `${key}=${value}`)
+        .join(' ');
+      this.chatPerfLogBuffer.push(`[ChatPerf] ${event}${details ? ` ${details}` : ''}`);
+      this.scheduleChatPerfLogFlush();
+    } catch (error) {
+      console.warn('Failed to write chat performance log:', error);
+    }
+  }
+
+  scheduleChatPerfLogFlush() {
+    if (this.chatPerfLogFlushTimer) return;
+    this.chatPerfLogFlushTimer = setTimeout(() => {
+      this.chatPerfLogFlushTimer = null;
+      this.flushChatPerfLogs();
+    }, 500);
+  }
+
+  flushChatPerfLogs() {
+    if (!this.chatPerfLogBuffer.length) return;
+    try {
+      if (typeof logsModal === 'undefined' || typeof logsModal.log !== 'function') return;
+      const logBlock = this.chatPerfLogBuffer.splice(0, this.chatPerfLogBuffer.length).join('\n');
+      logsModal.log(logBlock);
+    } catch (error) {
+      console.warn('Failed to flush chat performance logs:', error);
+    }
+  }
+
   /**
    * Clears all staged composer attachments.
    * @param {{ deleteFromServer?: boolean }} options
@@ -14914,6 +15005,7 @@ class ChatModal {
    * @returns {Promise<void>}
    */
   async open(address, skipAutoScroll = false) {
+    const openPerfStart = this.getChatPerfTime();
     this.closeReactionSheet();
 
     // Set active chat address early so async refreshes target the correct chat.
@@ -14934,6 +15026,30 @@ class ChatModal {
     friendModal.setAddress(address);
     footer.closeNewChatButton();
     const contact = myData.contacts[address];
+    const chatPerfSummary = this.summarizeChatPerfContact(contact);
+    const visualViewportSize = window.visualViewport
+      ? `${Math.round(window.visualViewport.width)}x${Math.round(window.visualViewport.height)}`
+      : 'n/a';
+    this.logChatPerf('open:start', {
+      contact: this.formatChatPerfAddress(address, contact),
+      messages: chatPerfSummary.messages,
+      replies: chatPerfSummary.replies,
+      attachments: chatPerfSummary.attachments,
+      mediaAttachments: chatPerfSummary.mediaAttachments,
+      voice: chatPerfSummary.voice,
+      payments: chatPerfSummary.payments,
+      calls: chatPerfSummary.calls,
+      edited: chatPerfSummary.edited,
+      deleted: chatPerfSummary.deleted,
+      reactions: chatPerfSummary.reactions,
+      textChars: chatPerfSummary.textChars,
+      skipAutoScroll,
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+      visualViewport: visualViewportSize,
+      contentVisibility: typeof CSS !== 'undefined' && typeof CSS.supports === 'function'
+        ? CSS.supports('content-visibility', 'auto')
+        : 'unknown'
+    });
     // Cache whether the contact has me blocked, and disable attachments accordingly
     this.blockedByRecipient = Number(contact?.tollRequiredToSend) === 2;
     this.addAttachmentButton.disabled = this.blockedByRecipient;
@@ -14942,7 +15058,12 @@ class ChatModal {
     // Set user info
     this.modalTitle.textContent = getContactDisplayName(contact);
 
+    const walletPerfStart = this.getChatPerfTime();
     walletScreen.updateWalletBalances();
+    this.logChatPerf('open:wallet', {
+      ms: this.formatChatPerfMs(walletPerfStart),
+      total: this.formatChatPerfMs(openPerfStart)
+    });
 
     // update the toll value. Will not await this and it'll update the toll value while the modal is open.
     this.updateTollValue(address);
@@ -14963,13 +15084,32 @@ class ChatModal {
       }
     }
 
+    const avatarPerfStart = this.getChatPerfTime();
     this.modalAvatar.innerHTML = await getContactAvatarHtml(contact, 40);
+    this.logChatPerf('open:avatar', {
+      ms: this.formatChatPerfMs(avatarPerfStart),
+      total: this.formatChatPerfMs(openPerfStart)
+    });
 
     // Stop and cleanup all voice messages from previous conversation
-    this.messagesList?.querySelectorAll('.voice-message').forEach(vm => this.stopVoiceMessage(vm));
+    const cleanupPerfStart = this.getChatPerfTime();
+    const previousVoiceMessages = this.messagesList
+      ? this.messagesList.querySelectorAll('.voice-message')
+      : [];
+    previousVoiceMessages.forEach(vm => this.stopVoiceMessage(vm));
+    this.logChatPerf('open:cleanupPreviousVoice', {
+      ms: this.formatChatPerfMs(cleanupPerfStart),
+      previousVoice: previousVoiceMessages.length,
+      total: this.formatChatPerfMs(openPerfStart)
+    });
 
     // Clear previous messages from the UI
+    const clearPerfStart = this.getChatPerfTime();
     this.messagesList.innerHTML = '';
+    this.logChatPerf('open:clearPreviousDom', {
+      ms: this.formatChatPerfMs(clearPerfStart),
+      total: this.formatChatPerfMs(openPerfStart)
+    });
 
     // Scroll to bottom (initial scroll for empty list, appendChatModal will scroll later)
     // Skip if we're going to scroll to a specific message
@@ -14996,6 +15136,9 @@ class ChatModal {
 
     // Show modal
     this.modal.classList.add('active');
+    this.logChatPerf('open:modalActive', {
+      total: this.formatChatPerfMs(openPerfStart)
+    });
 
     // Clear unread count
     const totalUnread = contact.unread;
@@ -15011,7 +15154,12 @@ class ChatModal {
     // One-time tolled deposit toast (only if explicitly enabled on the contact)
     this.maybeShowTolledDepositToast(address);
 
+    const appendPerfStart = this.getChatPerfTime();
     this.appendChatModal(false, skipAutoScroll); // Call appendChatModal to render messages, ensure highlight=false
+    this.logChatPerf('open:appendSyncReturned', {
+      ms: this.formatChatPerfMs(appendPerfStart),
+      total: this.formatChatPerfMs(openPerfStart)
+    });
     void this.maybePromptReclaimToll(address);
   }
 
@@ -15953,6 +16101,7 @@ class ChatModal {
    * @returns {void}
    */
   appendChatModal(highlightNewMessage = false, skipAutoScroll = false) {
+    const appendPerfStart = this.getChatPerfTime();
     const currentAddress = this.address; // Use a local constant
     if (!currentAddress) {
       return;
@@ -15977,15 +16126,18 @@ class ChatModal {
     this.newestSentMessage = messages.find((item) => item.my);
 
     const renderedMessages = [];
+    const txidMapPerfStart = this.getChatPerfTime();
     const messagesByTxid = new Map();
     messages.forEach((message) => {
       if (message?.txid) {
         messagesByTxid.set(message.txid, message);
       }
     });
+    const txidMapMs = this.formatChatPerfMs(txidMapPerfStart);
 
     // 3. Iterate backwards through messages (oldest to newest for rendering order)
     // messages are already sorted descending (newest first) in myData
+    const renderLoopPerfStart = this.getChatPerfTime();
     for (let i = messages.length - 1; i >= 0; i--) {
       const item = messages[i];
       let messageHTML = '';
@@ -16189,19 +16341,78 @@ class ChatModal {
       renderedMessages.push(messageHTML);
       // The newest received element will be found after the loop completes
     }
+    const renderLoopMs = this.formatChatPerfMs(renderLoopPerfStart);
 
     // Replace the list once to avoid one DOM mutation per message.
-    this.messagesList.innerHTML = renderedMessages.join('');
+    const joinPerfStart = this.getChatPerfTime();
+    const renderedHTML = renderedMessages.join('');
+    const joinMs = this.formatChatPerfMs(joinPerfStart);
+    const domWritePerfStart = this.getChatPerfTime();
+    this.messagesList.innerHTML = renderedHTML;
+    const domWriteMs = this.formatChatPerfMs(domWritePerfStart);
+    this.logChatPerf('append:sync', {
+      contact: this.formatChatPerfAddress(currentAddress, contact),
+      messages: messages.length,
+      txidMap: txidMapMs,
+      build: renderLoopMs,
+      join: joinMs,
+      domWrite: domWriteMs,
+      htmlChars: renderedHTML.length,
+      children: this.messagesList.children.length,
+      total: this.formatChatPerfMs(appendPerfStart)
+    });
 
     const renderedAddress = currentAddress;
+    const deferredScheduledAt = this.getChatPerfTime();
     const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
       ? requestAnimationFrame
       : (callback) => setTimeout(callback, 0);
     scheduleAfterPaint(() => {
       scheduleAfterPaint(() => {
-        if (!this.isActive() || this.address !== renderedAddress || !this.messagesList) return;
+        const deferredStart = this.getChatPerfTime();
+        if (!this.isActive() || this.address !== renderedAddress || !this.messagesList) {
+          this.logChatPerf('append:deferredSkipped', {
+            contact: this.formatChatPerfAddress(renderedAddress, contact),
+            delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+            currentAddress: this.address || 'none'
+          });
+          return;
+        }
+        const reactionPerfStart = this.getChatPerfTime();
         this.syncAllRenderedReactionChips();
-        this.loadThumbnailsForAttachments();
+        const reactionsMs = this.formatChatPerfMs(reactionPerfStart);
+        const thumbnailPerfStart = this.getChatPerfTime();
+        try {
+          const thumbnailResult = this.loadThumbnailsForAttachments();
+          Promise.resolve(thumbnailResult).then(
+            () => {
+              this.logChatPerf('append:deferred', {
+                contact: this.formatChatPerfAddress(renderedAddress, contact),
+                delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+                reactions: reactionsMs,
+                thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
+                total: this.formatChatPerfMs(deferredStart)
+              });
+            },
+            (error) => {
+              this.logChatPerf('append:deferredError', {
+                contact: this.formatChatPerfAddress(renderedAddress, contact),
+                delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+                reactions: reactionsMs,
+                thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
+                error: error?.message || String(error)
+              });
+            }
+          );
+        } catch (error) {
+          this.logChatPerf('append:deferredError', {
+            contact: this.formatChatPerfAddress(renderedAddress, contact),
+            delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
+            reactions: reactionsMs,
+            thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
+            error: error?.message || String(error)
+          });
+        }
       });
     });
 
@@ -16209,11 +16420,20 @@ class ChatModal {
     // This happens inside the setTimeout to ensure elements are in the DOM
 
     // 6. Delayed Scrolling & Highlighting Logic (after loop)
+    const scrollScheduledAt = this.getChatPerfTime();
     setTimeout(() => {
+      const scrollPerfStart = this.getChatPerfTime();
       // Skip auto-scrolling if we're going to scroll to a specific message
-      if (skipAutoScroll) return;
+      if (skipAutoScroll) {
+        this.logChatPerf('append:scrollSkipped', {
+          contact: this.formatChatPerfAddress(currentAddress, contact),
+          delay: this.formatChatPerfMs(scrollScheduledAt, scrollPerfStart)
+        });
+        return;
+      }
 
       const messageContainer = this.messagesList.parentElement;
+      let scrollTarget = 'bottom';
 
       // Find the DOM element for the actual newest received item using its timestamp
       // Only proceed if newestReceivedItem was found and highlightNewMessage is true
@@ -16234,6 +16454,7 @@ class ChatModal {
             
             // Scroll to the calculated position
             messageContainer.scrollTop = scrollTop;
+            scrollTarget = 'highlight';
           }
           
           // Apply highlight immediately
@@ -16254,6 +16475,7 @@ class ChatModal {
           // If element not found, just scroll to bottom
           if (messageContainer) {
             messageContainer.scrollTop = messageContainer.scrollHeight;
+            scrollTarget = 'fallbackBottom';
           }
         }
       } else {
@@ -16263,6 +16485,15 @@ class ChatModal {
           messageContainer.scrollTop = messageContainer.scrollHeight;
         }
       }
+      this.logChatPerf('append:scroll', {
+        contact: this.formatChatPerfAddress(currentAddress, contact),
+        delay: this.formatChatPerfMs(scrollScheduledAt, scrollPerfStart),
+        ms: this.formatChatPerfMs(scrollPerfStart),
+        target: scrollTarget,
+        scrollTop: messageContainer ? Math.round(messageContainer.scrollTop) : 'n/a',
+        scrollHeight: messageContainer ? Math.round(messageContainer.scrollHeight) : 'n/a',
+        clientHeight: messageContainer ? Math.round(messageContainer.clientHeight) : 'n/a'
+      });
     }, 300); // <<< Delay of 300 milliseconds for rendering
   }
 

--- a/app.js
+++ b/app.js
@@ -13965,6 +13965,7 @@ class ChatModal {
     this.chatSpacerCatchupTimer = null;
     this.chatRenderSequence = 0;
     this.lastChatTouchLogAt = 0;
+    this.lastChatExpandBlockedLogAt = 0;
     this.chatTouchStartY = null;
     this.chatExpansionRearmDistanceFromBottom = null;
     this.chatHistorySpacerHeight = 0;
@@ -14984,6 +14985,51 @@ class ChatModal {
     return summary;
   }
 
+  updateChatPerfBatchSummary(summary, message) {
+    if (!summary || !message) return;
+    if (message.replyId) summary.replies++;
+    if (typeof message.amount === 'bigint') {
+      summary.payments++;
+      summary.types.add('payment');
+    } else if (message.type) {
+      summary.types.add(message.type);
+    } else {
+      summary.types.add('text');
+    }
+    if (message.type === 'vm') summary.voice++;
+    if (message.type === 'call') summary.calls++;
+    if (message.edited) summary.edited++;
+    if (isDeleted(message)) summary.deleted++;
+    if (typeof message.message === 'string') {
+      summary.textChars += message.message.length;
+      summary.maxTextChars = Math.max(summary.maxTextChars, message.message.length);
+    }
+    if (Array.isArray(message.xattach)) {
+      summary.attachments += message.xattach.length;
+      message.xattach.forEach((attachment) => {
+        const type = attachment?.type || 'unknown';
+        summary.attachmentTypes.add(type);
+        if (type.startsWith('image/')) {
+          summary.mediaAttachments++;
+          summary.imageAttachments++;
+        } else if (type.startsWith('video/')) {
+          summary.mediaAttachments++;
+          summary.videoAttachments++;
+        } else {
+          summary.fileAttachments++;
+        }
+      });
+    }
+  }
+
+  formatChatPerfSet(set, maxItems = 4) {
+    if (!set || typeof set[Symbol.iterator] !== 'function') return 'none';
+    const values = [...set].filter(Boolean);
+    if (values.length === 0) return 'none';
+    const visible = values.slice(0, maxItems).join('|');
+    return values.length > maxItems ? `${visible}|+${values.length - maxItems}` : visible;
+  }
+
   logChatPerf(event, fields = {}) {
     if (!this.chatPerfLoggingEnabled) return;
     try {
@@ -15123,6 +15169,7 @@ class ChatModal {
     this.isExpandingChatRenderWindow = false;
     this.chatExpansionRearmDistanceFromBottom = null;
     this.chatHistorySpacerHeight = 0;
+    this.lastChatExpandBlockedLogAt = 0;
   }
 
   getChatRenderRange(messages, currentAddress, forceFullRender = false) {
@@ -15468,17 +15515,43 @@ class ChatModal {
       this.chatRenderedOldestIndex = nextOldestIndex;
       this.isExpandingChatRenderWindow = false;
 
+      const expectedScrollTop = useEstimatedSpacerPreserve
+        ? oldScrollTop
+        : this.messagesContainer.scrollTop;
+      const afterDistanceToRenderedTop = Math.max(0, expectedScrollTop - nextSpacerHeight);
+      const afterSnapshotEstimate = beforeSnapshot && useEstimatedSpacerPreserve
+        ? {
+            ...beforeSnapshot,
+            topSpacerHeight: Math.round(nextSpacerHeight),
+            distanceToRenderedTop: Math.round(afterDistanceToRenderedTop)
+          }
+        : null;
       const rearmDistance = (beforeSnapshot?.distanceFromBottom || 0) + Math.max(
         beforeSnapshot?.clientHeight || this.messagesContainer.clientHeight || 0,
-        this.getChatLoadAheadThreshold() * 2
+        this.getChatLoadAheadThreshold()
       );
       this.chatExpansionRearmDistanceFromBottom = rearmDistance;
       if (this.chatPerfLoggingEnabled) {
+        const totalMs = this.formatChatPerfMs(prependPerfStart);
         this.logChatPerf('window:prepend', {
           contact: this.formatChatPerfAddress(this.address, contact),
           previousOldestIndex: currentOldestIndex,
           nextOldestIndex,
           rendered: range.renderedCount,
+          batchTypes: range.summary.types,
+          attachments: range.summary.attachments,
+          media: range.summary.mediaAttachments,
+          images: range.summary.imageAttachments,
+          videos: range.summary.videoAttachments,
+          files: range.summary.fileAttachments,
+          attachmentTypes: range.summary.attachmentTypes,
+          voice: range.summary.voice,
+          payments: range.summary.payments,
+          calls: range.summary.calls,
+          deleted: range.summary.deleted,
+          replies: range.summary.replies,
+          textChars: range.summary.textChars,
+          maxTextChars: range.summary.maxTextChars,
           build: range.buildMs,
           join: range.joinMs,
           domWrite: domWriteMs,
@@ -15491,19 +15564,31 @@ class ChatModal {
           estimatedHeight: Math.round(estimatedInsertedHeight),
           nextSpacerHeight: Math.round(nextSpacerHeight),
           scrollDelta: Math.round(scrollDelta),
-          nextScrollTop: Math.round(this.messagesContainer.scrollTop),
+          nextScrollTop: Math.round(expectedScrollTop),
+          afterDistanceToRenderedTop: Math.round(afterDistanceToRenderedTop),
           rearmDistance: Math.round(rearmDistance),
           children: this.messagesList.children.length,
-          total: this.formatChatPerfMs(prependPerfStart)
+          total: totalMs
         });
       }
       if (useEstimatedSpacerPreserve && nextOldestIndex < messages.length - 1) {
-        const distanceToRenderedTop = Math.max(
-          0,
-          this.messagesContainer.scrollTop - this.getChatHistorySpacerHeight()
-        );
-        if (distanceToRenderedTop <= this.getChatRenderedTopLoadAheadThreshold()) {
+        const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(afterSnapshotEstimate);
+        const shouldCatchUp = afterDistanceToRenderedTop <= renderedTopThreshold &&
+          beforeSnapshot?.distanceFromBottom >= rearmDistance;
+        if (shouldCatchUp) {
           this.scheduleChatSpacerCatchup('afterPrepend');
+        } else if (
+          this.chatPerfLoggingEnabled &&
+          afterDistanceToRenderedTop <= renderedTopThreshold
+        ) {
+          this.logChatPerf('window:catchupDeferred', {
+            contact: this.formatChatPerfAddress(this.address, contact),
+            reason: 'notRearmed',
+            distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
+            rearmDistance: Math.round(rearmDistance),
+            distanceToRenderedTop: Math.round(afterDistanceToRenderedTop),
+            renderedTopThreshold: Math.round(renderedTopThreshold)
+          });
         }
       }
       return true;
@@ -15588,15 +15673,30 @@ class ChatModal {
       scrollSnapshot.distanceFromBottom >= this.chatExpansionRearmDistanceFromBottom;
     const isNearRenderedTop = remainingOlder > 0 &&
       scrollSnapshot.distanceToRenderedTop <= renderedTopThreshold;
-    if (
-      isNearRenderedTop &&
-      (isExpansionRearmed || scrollSnapshot.topSpacerHeight > 0)
-    ) {
+    if (isNearRenderedTop && isExpansionRearmed) {
       if (scrollSnapshot.topSpacerHeight > 0) {
         this.expandChatRenderWindow('scrollDistance');
       } else {
         this.queueChatScrollExpand('scrollDistance', scrollSnapshot);
       }
+    } else if (
+      this.chatPerfLoggingEnabled &&
+      isNearRenderedTop &&
+      !isExpansionRearmed &&
+      now - this.lastChatExpandBlockedLogAt > 750
+    ) {
+      this.lastChatExpandBlockedLogAt = now;
+      this.logChatPerf('window:expandBlocked', {
+        reason: 'notRearmed',
+        scrollTop: scrollSnapshot.scrollTop,
+        distanceFromBottom: scrollSnapshot.distanceFromBottom,
+        rearmDistance: Number.isFinite(this.chatExpansionRearmDistanceFromBottom)
+          ? Math.round(this.chatExpansionRearmDistanceFromBottom)
+          : 'n/a',
+        distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
+        renderedTopThreshold: Math.round(renderedTopThreshold),
+        remainingOlder
+      });
     }
   }
 
@@ -17098,10 +17198,28 @@ class ChatModal {
     const lastReadTs = contact.lastChatOpenTs || 0;
     const renderedMessages = [];
     const renderedTxids = [];
+    const summary = {
+      replies: 0,
+      attachments: 0,
+      mediaAttachments: 0,
+      imageAttachments: 0,
+      videoAttachments: 0,
+      fileAttachments: 0,
+      voice: 0,
+      payments: 0,
+      calls: 0,
+      edited: 0,
+      deleted: 0,
+      textChars: 0,
+      maxTextChars: 0,
+      types: new Set(),
+      attachmentTypes: new Set()
+    };
 
     for (let i = oldestIndex; i >= newestIndex; i--) {
       const item = messages[i];
       if (!item) continue;
+      this.updateChatPerfBatchSummary(summary, item);
       renderedMessages.push(this.renderChatMessageHTML(item, i, { contact, messagesByTxid, lastReadTs }));
       if (item.txid) renderedTxids.push(item.txid);
     }
@@ -17115,6 +17233,23 @@ class ChatModal {
       html,
       renderedCount: renderedMessages.length,
       renderedTxids,
+      summary: {
+        replies: summary.replies,
+        attachments: summary.attachments,
+        mediaAttachments: summary.mediaAttachments,
+        imageAttachments: summary.imageAttachments,
+        videoAttachments: summary.videoAttachments,
+        fileAttachments: summary.fileAttachments,
+        voice: summary.voice,
+        payments: summary.payments,
+        calls: summary.calls,
+        edited: summary.edited,
+        deleted: summary.deleted,
+        textChars: summary.textChars,
+        maxTextChars: summary.maxTextChars,
+        types: this.formatChatPerfSet(summary.types),
+        attachmentTypes: this.formatChatPerfSet(summary.attachmentTypes)
+      },
       buildMs,
       joinMs
     };

--- a/app.js
+++ b/app.js
@@ -13945,7 +13945,6 @@ class ChatModal {
     this.chatInitialRenderCount = 50;
     this.chatOlderRenderBatchSize = 50;
     this.chatRenderedOldestIndex = null;
-    this.chatRenderedWindowAddress = null;
     this.isExpandingChatRenderWindow = false;
     this.isChatTouchActive = false;
     this.chatPendingScrollExpand = false;
@@ -14901,27 +14900,19 @@ class ChatModal {
     return !!(editInput?.value?.trim?.());
   }
 
-  resetChatRenderWindow(address) {
+  resetChatRenderWindow() {
     this.clearPendingChatScrollExpand();
     this.stopChatTopBoundaryScrollHold();
-    this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
     this.isExpandingChatRenderWindow = false;
     this.chatExpansionRearmDistanceFromBottom = null;
   }
 
-  getChatRenderRange(messages, currentAddress, renderAll) {
+  getChatRenderRange(messages) {
     assert(Array.isArray(messages), 'Chat messages are required');
     const totalMessages = messages.length;
     if (totalMessages === 0) {
       return { newestIndex: 0, oldestIndex: -1 };
-    }
-
-    if (renderAll || this.chatRenderedWindowAddress !== currentAddress) {
-      this.chatRenderedWindowAddress = currentAddress;
-      this.chatRenderedOldestIndex = renderAll
-        ? totalMessages - 1
-        : Math.min(totalMessages - 1, this.chatInitialRenderCount - 1);
     }
 
     if (!Number.isInteger(this.chatRenderedOldestIndex)) {
@@ -15107,9 +15098,7 @@ class ChatModal {
     this.chatRenderedOldestIndex = nextOldestIndex;
     this.messagesList.insertAdjacentHTML('afterbegin', range.html);
 
-    if (range.renderedTxids.length > 0) {
-      this.syncRenderedReactionTargets(range.renderedTxids);
-    }
+    this.syncRenderedReactionTargets(range.renderedTxids);
 
     const insertedHeight = this.messagesContainer.scrollHeight - oldScrollHeight;
     this.messagesContainer.scrollTop = oldScrollTop + insertedHeight;
@@ -15215,7 +15204,7 @@ class ChatModal {
     friendModal.setAddress(address);
     footer.closeNewChatButton();
     const contact = myData.contacts[address];
-    this.resetChatRenderWindow(address);
+    this.resetChatRenderWindow();
     // Cache whether the contact has me blocked, and disable attachments accordingly
     this.blockedByRecipient = Number(contact?.tollRequiredToSend) === 2;
     this.addAttachmentButton.disabled = this.blockedByRecipient;
@@ -15442,7 +15431,7 @@ class ChatModal {
     }
 
     this.address = null;
-    this.resetChatRenderWindow(null);
+    this.resetChatRenderWindow();
   }
 
   clearNotificationsIfAllRead() {
@@ -16229,16 +16218,6 @@ class ChatModal {
     };
   }
 
-  buildChatMessagesByTxid(messages) {
-    const messagesByTxid = new Map();
-    messages.forEach((message) => {
-      if (message?.txid) {
-        messagesByTxid.set(message.txid, message);
-      }
-    });
-    return messagesByTxid;
-  }
-
   renderChatMessageHTML(item, index, { contact, messagesByTxid, lastReadTs }) {
     const timeString = formatTime(item.timestamp);
     const timestampAttribute = `data-message-timestamp="${item.timestamp}"`;
@@ -16278,15 +16257,10 @@ class ChatModal {
     if (item.replyId) {
       const replyText = escapeHtml(item.replyMessage || 'View original message');
       const ownerIsMineHint = item.replyOwnerIsMine;
-      const hasHint = typeof ownerIsMineHint !== 'undefined';
-      let isOwnerMine = false;
-      if (hasHint) {
-        const isSelfReply = ownerIsMineHint === true || ownerIsMineHint === '1';
-        isOwnerMine = item.my === isSelfReply;
-      } else {
-        const targetMsg = messagesByTxid.get(item.replyId);
-        isOwnerMine = !!(targetMsg && targetMsg.my);
-      }
+      const targetMsg = messagesByTxid.get(item.replyId);
+      const isOwnerMine = typeof ownerIsMineHint === 'undefined'
+        ? !!(targetMsg && targetMsg.my)
+        : item.my === (ownerIsMineHint === true || ownerIsMineHint === '1');
       const ownerText = isOwnerMine ? 'You' : (getContactDisplayName(contact) || 'Contact');
       const ownerClass = isOwnerMine ? 'reply-owner-me' : 'reply-owner-contact';
       const replyOwnerLabel = `<span class="reply-quote-label ${ownerClass}">${escapeHtml(ownerText)}</span>`;
@@ -16403,7 +16377,12 @@ class ChatModal {
   }
 
   buildChatMessageRangeHTML(messages, contact, oldestIndex, newestIndex) {
-    const messagesByTxid = this.buildChatMessagesByTxid(messages);
+    const messagesByTxid = new Map();
+    messages.forEach((message) => {
+      if (message?.txid) {
+        messagesByTxid.set(message.txid, message);
+      }
+    });
     const lastReadTs = contact.lastChatOpenTs || 0;
     const renderedMessages = [];
     const renderedTxids = [];
@@ -16453,8 +16432,7 @@ class ChatModal {
     this.newestReceivedMessage = newestReceivedItem;
     this.newestSentMessage = messages.find((item) => item.my);
 
-    const forceFullRender = highlightNewMessage && skipAutoScroll;
-    const renderRange = this.getChatRenderRange(messages, currentAddress, forceFullRender);
+    const renderRange = this.getChatRenderRange(messages);
     const range = this.buildChatMessageRangeHTML(
       messages,
       contact,

--- a/app.js
+++ b/app.js
@@ -16203,6 +16203,21 @@ class ChatModal {
     };
   }
 
+  getOldestRenderedMessageIndex(messages) {
+    const oldestRendered = this.messagesList?.firstElementChild;
+    if (!oldestRendered) return -1;
+
+    const { txid, messageTimestamp } = oldestRendered.dataset || {};
+    if (!txid && !messageTimestamp) return -1;
+
+    return messages.findIndex((message) =>
+      message && (
+        (txid && message.txid === txid) ||
+        (messageTimestamp && message.timestamp == messageTimestamp)
+      )
+    );
+  }
+
   /**
    * Appends the chat modal to the DOM
    * @param {boolean} highlightNewMessage - Whether to highlight the newest message
@@ -16237,7 +16252,11 @@ class ChatModal {
       const requestedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
         ? this.chatRenderedOldestIndex
         : CHAT_INITIAL_RENDER_COUNT - 1;
-      oldestIndex = Math.min(Math.max(0, requestedOldestIndex), messages.length - 1);
+      const preservedOldestIndex = this.getOldestRenderedMessageIndex(messages);
+      oldestIndex = Math.min(
+        Math.max(0, requestedOldestIndex, preservedOldestIndex),
+        messages.length - 1
+      );
       this.chatRenderedOldestIndex = oldestIndex;
     }
 
@@ -17934,6 +17953,15 @@ class ChatModal {
     return messageIndex === -1 ? null : contact.messages[messageIndex];
   }
 
+  getMessageRecordFromRenderedChild(element) {
+    const messageEl = element?.closest?.('.message') || null;
+    const messageRecord = this.getMessageRecordFromElement(messageEl);
+    if (messageRecord) return messageRecord;
+
+    const idx = Number(element?.dataset?.msgIdx);
+    return Number.isInteger(idx) ? myData.contacts[this.address]?.messages?.[idx] || null : null;
+  }
+
   /**
    * Returns the current user's stored reaction emoji for a rendered message.
    * @param {HTMLElement | null} messageEl
@@ -18240,7 +18268,7 @@ class ChatModal {
    */
   getAttachmentContextFromRow(attachmentRow) {
     const idx = Number(attachmentRow?.dataset?.msgIdx);
-    const item = Number.isFinite(idx) ? myData.contacts[this.address]?.messages?.[idx] : null;
+    const item = this.getMessageRecordFromRenderedChild(attachmentRow);
     return {
       attachmentRow,
       messageEl: attachmentRow?.closest?.('.message') || null,
@@ -18814,11 +18842,9 @@ class ChatModal {
     const url = attachmentRow.dataset.url;
     const name = attachmentRow.dataset.name ? decodeURIComponent(attachmentRow.dataset.name) : 'contacts.vcf';
     const type = attachmentRow.dataset.type || 'text/vcard';
-    const msgIdx = attachmentRow.dataset.msgIdx;
 
     // Get encryption keys from the message
-    const contact = myData.contacts[this.address];
-    const message = contact?.messages?.[msgIdx];
+    const message = this.getMessageRecordFromRenderedChild(attachmentRow);
     if (!message?.xattach) {
       showToast('Could not find attachment data', 0, 'error');
       return;
@@ -20418,7 +20444,6 @@ class ChatModal {
     }
 
     const voiceUrl = voiceMessageElement.dataset.url;
-    const msgIdx = voiceMessageElement.dataset.msgIdx;
 
     if (!voiceUrl) {
       showToast('Voice message URL not found', 0, 'error');
@@ -20427,7 +20452,7 @@ class ChatModal {
 
     try {
       // Check if it's our own message or received message
-      const message = myData.contacts[this.address].messages[msgIdx];
+      const message = this.getMessageRecordFromRenderedChild(voiceMessageElement);
       if (!message) {
         throw new Error('Message not found');
       }
@@ -21328,20 +21353,16 @@ class ShareAttachmentModal {
     const url = attachmentRow.dataset.url;
     const name = attachmentRow.dataset.name;
     const type = attachmentRow.dataset.type;
-    const msgIdx = attachmentRow.dataset.msgIdx;
 
     if (!url) return null;
 
     // Get the actual message data from myData to access encryption keys
-    const contactAddress = chatModal.address;
-    const contact = myData.contacts[contactAddress];
-    
-    if (!contact || !contact.messages || !msgIdx) {
+    const messageData = chatModal.getMessageRecordFromElement(messageEl);
+    if (!messageData) {
       console.error('Cannot find message data for attachment');
       return null;
     }
 
-    const messageData = contact.messages[parseInt(msgIdx)];
     if (!messageData || !messageData.xattach || !messageData.xattach[0]) {
       console.error('Cannot find attachment in message data');
       return null;

--- a/app.js
+++ b/app.js
@@ -13924,6 +13924,7 @@ class ChatModal {
     // Track whether we've locked background/modal scroll
     this.scrollLocked = false;
     this._touchMoveBlocker = null; // blocks touch outside messages container
+    this.messagesContainerTouchY = null;
 
     // Track which voice message element is playing
     this.playingVoiceMessageElement = null;
@@ -14454,6 +14455,8 @@ class ChatModal {
     });
     // Close all context menus when messages container scrolls
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
+    this.messagesContainer.addEventListener('touchstart', (e) => this.handleMessagesContainerTouchStart(e), { passive: true });
+    this.messagesContainer.addEventListener('touchmove', (e) => this.handleMessagesContainerTouchMove(e), { passive: false });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
       const reactionButton = e.target.closest('.message-context-reaction-button');
@@ -14944,6 +14947,28 @@ class ChatModal {
     const loadAheadPx = Math.max(420, Math.min(900, container.clientHeight * 1.25));
     if (container.scrollTop <= loadAheadPx) {
       this.expandChatRenderWindow();
+    }
+  }
+
+  handleMessagesContainerTouchStart(e) {
+    this.messagesContainerTouchY = e.touches?.[0]?.clientY ?? null;
+  }
+
+  handleMessagesContainerTouchMove(e) {
+    const container = this.messagesContainer;
+    const nextY = e.touches?.[0]?.clientY;
+    if (!container || !Number.isFinite(nextY) || !Number.isFinite(this.messagesContainerTouchY)) return;
+
+    const deltaY = nextY - this.messagesContainerTouchY;
+    this.messagesContainerTouchY = nextY;
+    if (deltaY === 0) return;
+
+    const isScrollable = container.scrollHeight > container.clientHeight + 1;
+    const atTop = container.scrollTop <= 0;
+    const atBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - 1;
+
+    if (!isScrollable || (deltaY > 0 && atTop) || (deltaY < 0 && atBottom)) {
+      e.preventDefault();
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -13969,6 +13969,10 @@ class ChatModal {
     this.chatTouchStartY = null;
     this.chatExpansionRearmDistanceFromBottom = null;
     this.chatHistorySpacerHeight = 0;
+    this.chatHistoryLoadingToastId = null;
+    this.chatTopBoundaryScrollHoldActive = false;
+    this.chatTopBoundaryScrollHoldTop = 0;
+    this.lastChatTopBoundaryBlockLogAt = 0;
   }
 
   /**
@@ -14483,9 +14487,7 @@ class ChatModal {
     this.messagesContainer.addEventListener('scroll', () => this.handleMessagesContainerScroll(), { passive: true });
     this.messagesContainer.addEventListener('scrollend', () => this.handleMessagesContainerScrollEnd('scrollend'), { passive: true });
     this.messagesContainer.addEventListener('touchstart', (e) => this.handleMessagesTouchStart(e), { passive: true });
-    this.messagesContainer.addEventListener('touchmove', (e) => {
-      if (this.chatPerfLoggingEnabled) this.logChatTouchDiagnostics(e, 'messagesMove');
-    }, { passive: true });
+    this.messagesContainer.addEventListener('touchmove', (e) => this.handleMessagesTouchMove(e), { passive: false });
     this.messagesContainer.addEventListener('touchend', (e) => this.handleMessagesTouchEnd(e), { passive: true });
     this.messagesContainer.addEventListener('touchcancel', (e) => this.handleMessagesTouchEnd(e), { passive: true });
     this.modal.addEventListener('touchmove', (e) => {
@@ -15163,6 +15165,7 @@ class ChatModal {
     this.cancelChatRenderWindowDrain();
     this.cancelChatSpacerCatchup();
     this.clearPendingChatScrollExpand();
+    this.stopChatTopBoundaryScrollHold('reset');
     this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
     this.chatForceFullRenderOnce = false;
@@ -15170,6 +15173,7 @@ class ChatModal {
     this.chatExpansionRearmDistanceFromBottom = null;
     this.chatHistorySpacerHeight = 0;
     this.lastChatExpandBlockedLogAt = 0;
+    this.lastChatTopBoundaryBlockLogAt = 0;
   }
 
   getChatRenderRange(messages, currentAddress, forceFullRender = false) {
@@ -15257,6 +15261,70 @@ class ChatModal {
     };
   }
 
+  showChatHistoryLoadingToast() {
+    if (this.chatHistoryLoadingToastId && document.getElementById(this.chatHistoryLoadingToastId)) {
+      return;
+    }
+    this.chatHistoryLoadingToastId = showToast('Loading messages', 0, 'loading', false, { dedupe: false });
+  }
+
+  hideChatHistoryLoadingToast() {
+    if (!this.chatHistoryLoadingToastId) return;
+    hideToast(this.chatHistoryLoadingToastId);
+    this.chatHistoryLoadingToastId = null;
+  }
+
+  startChatTopBoundaryScrollHold(scrollSnapshot, reason = 'topBoundary') {
+    const wasActive = this.chatTopBoundaryScrollHoldActive;
+    this.chatTopBoundaryScrollHoldActive = true;
+    this.chatTopBoundaryScrollHoldTop = Math.max(0, Math.round(scrollSnapshot?.topSpacerHeight || 0));
+    this.showChatHistoryLoadingToast();
+    this.clampChatTopBoundaryScrollHold();
+
+    if (!wasActive && this.chatPerfLoggingEnabled) {
+      this.logChatPerf('window:topBoundaryHold', {
+        reason,
+        scrollTop: scrollSnapshot ? scrollSnapshot.scrollTop : 'n/a',
+        distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
+        distanceToRenderedTop: scrollSnapshot ? scrollSnapshot.distanceToRenderedTop : 'n/a',
+        holdTop: Math.round(this.chatTopBoundaryScrollHoldTop)
+      });
+    }
+  }
+
+  stopChatTopBoundaryScrollHold(reason = 'rendered') {
+    if (!this.chatTopBoundaryScrollHoldActive && !this.chatHistoryLoadingToastId) return;
+    this.chatTopBoundaryScrollHoldActive = false;
+    this.chatTopBoundaryScrollHoldTop = 0;
+    this.hideChatHistoryLoadingToast();
+
+    if (this.chatPerfLoggingEnabled) {
+      this.logChatPerf('window:topBoundaryRelease', { reason });
+    }
+  }
+
+  clampChatTopBoundaryScrollHold() {
+    if (!this.chatTopBoundaryScrollHoldActive || !this.messagesContainer) return false;
+    const holdTop = Math.max(0, Math.round(this.chatTopBoundaryScrollHoldTop || 0));
+    if (this.messagesContainer.scrollTop >= holdTop) return false;
+    this.messagesContainer.scrollTop = holdTop;
+    return true;
+  }
+
+  shouldBlockChatTopBoundaryTouchMove(event) {
+    if (!this.chatTopBoundaryScrollHoldActive || !this.messagesContainer) return false;
+    const touch = event.touches?.[0] || null;
+    const y = touch ? Math.round(touch.clientY) : null;
+    const deltaY = typeof y === 'number' && typeof this.chatTouchStartY === 'number'
+      ? y - this.chatTouchStartY
+      : 0;
+    if (deltaY <= 0) return false;
+
+    const snapshot = this.getChatScrollSnapshot();
+    const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(snapshot);
+    return !snapshot || snapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
+  }
+
   describeChatTouchTarget(target) {
     if (!target || typeof target.closest !== 'function') return 'unknown';
     if (target.closest('.message-input-container')) return 'composer';
@@ -15321,6 +15389,34 @@ class ChatModal {
     this.isChatTouchActive = true;
     if (this.chatPerfLoggingEnabled) {
       this.logChatTouchDiagnostics(event, 'messagesStart');
+    }
+  }
+
+  handleMessagesTouchMove(event) {
+    if (this.chatPerfLoggingEnabled) {
+      this.logChatTouchDiagnostics(event, 'messagesMove');
+    }
+
+    if (!this.shouldBlockChatTopBoundaryTouchMove(event)) return;
+
+    const clamped = this.clampChatTopBoundaryScrollHold();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    event.stopPropagation();
+
+    const now = this.chatPerfLoggingEnabled ? this.getChatPerfTime() : 0;
+    if (this.chatPerfLoggingEnabled && now - this.lastChatTopBoundaryBlockLogAt > 350) {
+      this.lastChatTopBoundaryBlockLogAt = now;
+      const snapshot = this.getChatScrollSnapshot();
+      this.logChatPerf('window:topBoundaryScrollBlocked', {
+        scrollTop: snapshot ? snapshot.scrollTop : 'n/a',
+        distanceFromBottom: snapshot ? snapshot.distanceFromBottom : 'n/a',
+        distanceToRenderedTop: snapshot ? snapshot.distanceToRenderedTop : 'n/a',
+        holdTop: Math.round(this.chatTopBoundaryScrollHoldTop || 0),
+        clamped,
+        cancelable: event.cancelable
+      });
     }
   }
 
@@ -15411,10 +15507,14 @@ class ChatModal {
         });
       }
       this.clearPendingChatScrollExpand();
+      this.stopChatTopBoundaryScrollHold('expandAborted');
       return;
     }
 
     const queuedReason = this.chatPendingScrollExpandReason || 'scrollDistance';
+    if (isAtRenderedBoundary) {
+      this.startChatTopBoundaryScrollHold(scrollSnapshot, 'expandFlush');
+    }
     this.clearPendingChatScrollExpand();
     if (this.chatPerfLoggingEnabled) {
       this.logChatPerf('window:expandFlushed', {
@@ -15427,14 +15527,23 @@ class ChatModal {
         rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
       });
     }
-    this.expandChatRenderWindow('scrollIdle');
+    const expanded = this.expandChatRenderWindow('scrollIdle');
+    if (!expanded) {
+      this.stopChatTopBoundaryScrollHold('expandSkipped');
+    }
   }
 
   expandChatRenderWindow(reason = 'scroll') {
-    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) return false;
+    if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) {
+      this.stopChatTopBoundaryScrollHold('expandUnavailable');
+      return false;
+    }
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
-    if (!Array.isArray(messages) || messages.length === 0) return false;
+    if (!Array.isArray(messages) || messages.length === 0) {
+      this.stopChatTopBoundaryScrollHold('expandNoMessages');
+      return false;
+    }
     const isOpenDrain = reason === 'openDrain';
     const shouldPrependOlderMessages = (
       reason === 'scrollDistance' ||
@@ -15444,7 +15553,10 @@ class ChatModal {
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
       ? this.chatRenderedOldestIndex
       : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
-    if (currentOldestIndex >= messages.length - 1) return false;
+    if (currentOldestIndex >= messages.length - 1) {
+      this.stopChatTopBoundaryScrollHold('expandComplete');
+      return false;
+    }
 
     const renderBatchSize = isOpenDrain
       ? this.chatOlderRenderBatchSize
@@ -15643,6 +15755,7 @@ class ChatModal {
           });
         }
       }
+      this.stopChatTopBoundaryScrollHold('rendered');
       return true;
     }
 
@@ -15733,6 +15846,9 @@ class ChatModal {
       if (scrollSnapshot.topSpacerHeight > 0) {
         this.expandChatRenderWindow('scrollDistance');
       } else {
+        if (isAtRenderedBoundary) {
+          this.startChatTopBoundaryScrollHold(scrollSnapshot, 'scrollBoundary');
+        }
         this.queueChatScrollExpand('scrollDistance', scrollSnapshot);
       }
     } else if (

--- a/app.js
+++ b/app.js
@@ -14902,7 +14902,7 @@ class ChatModal {
 
     const currentOldestIndex = Math.min(this.chatRenderedOldestIndex, messages.length - 1);
     if (currentOldestIndex >= messages.length - 1) {
-      return;
+      return false;
     }
 
     const nextOldestIndex = Math.min(
@@ -14932,6 +14932,22 @@ class ChatModal {
     const insertedHeight = container.scrollHeight - oldScrollHeight;
     container.scrollTop = oldScrollTop + insertedHeight;
     this.loadThumbnailsKeepingScrollAnchored(prependedThumbnailRows);
+    return true;
+  }
+
+  ensureScrollableChatRenderWindow() {
+    if (!this.messagesContainer || !this.messagesList || !this.address) return;
+
+    const contact = myData.contacts[this.address];
+    const messages = contact?.messages;
+    if (!messages?.length) return;
+
+    while (
+      this.chatRenderedOldestIndex < messages.length - 1 &&
+      this.messagesContainer.scrollHeight <= this.messagesContainer.clientHeight + 1
+    ) {
+      if (!this.expandChatRenderWindow()) break;
+    }
   }
 
   handleMessagesContainerScroll() {
@@ -16334,6 +16350,9 @@ class ChatModal {
         }
         if (shouldKeepBottomAnchored) {
           this.messagesContainer.scrollTop = this.messagesContainer.scrollHeight;
+        }
+        if (!skipAutoScroll) {
+          this.ensureScrollableChatRenderWindow();
         }
         this.syncAllRenderedReactionChips();
       });

--- a/app.js
+++ b/app.js
@@ -14976,6 +14976,23 @@ class ChatModal {
     }
   }
 
+  isMessagesContainerNearBottom(thresholdPx = 50) {
+    const container = this.messagesContainer || this.messagesList?.parentElement;
+    if (!container) return false;
+    return container.scrollHeight - container.scrollTop - container.clientHeight <= thresholdPx;
+  }
+
+  scrollMessagesToBottom() {
+    const container = this.messagesContainer || this.messagesList?.parentElement;
+    if (!container) return null;
+    container.scrollTop = container.scrollHeight;
+    return {
+      scrollTop: Math.round(container.scrollTop),
+      scrollHeight: Math.round(container.scrollHeight),
+      clientHeight: Math.round(container.clientHeight)
+    };
+  }
+
   /**
    * Clears all staged composer attachments.
    * @param {{ deleteFromServer?: boolean }} options
@@ -15046,9 +15063,7 @@ class ChatModal {
       skipAutoScroll,
       viewport: `${window.innerWidth}x${window.innerHeight}`,
       visualViewport: visualViewportSize,
-      contentVisibility: typeof CSS !== 'undefined' && typeof CSS.supports === 'function'
-        ? CSS.supports('content-visibility', 'auto')
-        : 'unknown'
+      contentVisibilityApplied: false
     });
     // Cache whether the contact has me blocked, and disable attachments accordingly
     this.blockedByRecipient = Number(contact?.tollRequiredToSend) === 2;
@@ -16350,6 +16365,14 @@ class ChatModal {
     const domWritePerfStart = this.getChatPerfTime();
     this.messagesList.innerHTML = renderedHTML;
     const domWriteMs = this.formatChatPerfMs(domWritePerfStart);
+    let immediateScrollMetrics = null;
+    let immediateScrollMs = 'skipped';
+    const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
+    if (shouldKeepBottomAnchored) {
+      const immediateScrollPerfStart = this.getChatPerfTime();
+      immediateScrollMetrics = this.scrollMessagesToBottom();
+      immediateScrollMs = this.formatChatPerfMs(immediateScrollPerfStart);
+    }
     this.logChatPerf('append:sync', {
       contact: this.formatChatPerfAddress(currentAddress, contact),
       messages: messages.length,
@@ -16357,6 +16380,9 @@ class ChatModal {
       build: renderLoopMs,
       join: joinMs,
       domWrite: domWriteMs,
+      immediateScroll: immediateScrollMs,
+      immediateScrollTop: immediateScrollMetrics ? immediateScrollMetrics.scrollTop : 'n/a',
+      immediateScrollHeight: immediateScrollMetrics ? immediateScrollMetrics.scrollHeight : 'n/a',
       htmlChars: renderedHTML.length,
       children: this.messagesList.children.length,
       total: this.formatChatPerfMs(appendPerfStart)
@@ -16381,16 +16407,30 @@ class ChatModal {
         const reactionPerfStart = this.getChatPerfTime();
         this.syncAllRenderedReactionChips();
         const reactionsMs = this.formatChatPerfMs(reactionPerfStart);
+        const wasNearBottomBeforeThumbnails = shouldKeepBottomAnchored
+          ? this.isMessagesContainerNearBottom(80)
+          : false;
         const thumbnailPerfStart = this.getChatPerfTime();
         try {
           const thumbnailResult = this.loadThumbnailsForAttachments();
           Promise.resolve(thumbnailResult).then(
             () => {
+              let thumbnailScrollMetrics = null;
+              let thumbnailScrollMs = 'skipped';
+              if (shouldKeepBottomAnchored && wasNearBottomBeforeThumbnails) {
+                const thumbnailScrollPerfStart = this.getChatPerfTime();
+                thumbnailScrollMetrics = this.scrollMessagesToBottom();
+                thumbnailScrollMs = this.formatChatPerfMs(thumbnailScrollPerfStart);
+              }
               this.logChatPerf('append:deferred', {
                 contact: this.formatChatPerfAddress(renderedAddress, contact),
                 delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
                 reactions: reactionsMs,
                 thumbnails: this.formatChatPerfMs(thumbnailPerfStart),
+                thumbnailScroll: thumbnailScrollMs,
+                wasNearBottomBeforeThumbnails,
+                scrollTop: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollTop : 'n/a',
+                scrollHeight: thumbnailScrollMetrics ? thumbnailScrollMetrics.scrollHeight : 'n/a',
                 total: this.formatChatPerfMs(deferredStart)
               });
             },
@@ -16482,7 +16522,14 @@ class ChatModal {
         // No received messages found, not highlighting, or highlightNewMessage is false,
         // just scroll to the bottom if the container exists.
         if (messageContainer) {
-          messageContainer.scrollTop = messageContainer.scrollHeight;
+          const userStayedAtInitialBottom = immediateScrollMetrics
+            ? Math.abs(messageContainer.scrollTop - immediateScrollMetrics.scrollTop) <= 2
+            : true;
+          if (!shouldKeepBottomAnchored || userStayedAtInitialBottom || this.isMessagesContainerNearBottom(120)) {
+            messageContainer.scrollTop = messageContainer.scrollHeight;
+          } else {
+            scrollTarget = 'bottomSkippedUserScrolled';
+          }
         }
       }
       this.logChatPerf('append:scroll', {

--- a/app.js
+++ b/app.js
@@ -13945,8 +13945,8 @@ class ChatModal {
     this.chatPerfLogBuffer = [];
     this.chatPerfLogFlushTimer = null;
 
-    this.chatInitialRenderCount = 40;
-    this.chatOlderRenderBatchSize = 60;
+    this.chatInitialRenderCount = 80;
+    this.chatOlderRenderBatchSize = 80;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
@@ -15074,7 +15074,21 @@ class ChatModal {
     this.messagesContainer.scrollTop += nextTop - anchor.offsetTop;
   }
 
-  expandChatRenderWindow() {
+  getChatScrollSnapshot() {
+    const container = this.messagesContainer || this.messagesList?.parentElement;
+    if (!container) return null;
+    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    return {
+      scrollTop: Math.round(container.scrollTop),
+      maxScrollTop: Math.round(maxScrollTop),
+      distanceFromBottom: Math.round(Math.max(0, maxScrollTop - container.scrollTop)),
+      scrollHeight: Math.round(container.scrollHeight),
+      clientHeight: Math.round(container.clientHeight),
+      messageListHeight: this.messagesList ? Math.round(this.messagesList.scrollHeight) : 'n/a'
+    };
+  }
+
+  expandChatRenderWindow(reason = 'scroll') {
     if (this.isExpandingChatRenderWindow || !this.address || !this.messagesList) return;
     const contact = myData.contacts[this.address];
     const messages = contact?.messages;
@@ -15091,58 +15105,116 @@ class ChatModal {
       currentOldestIndex + renderBatchSize
     );
     const anchor = this.getFirstVisibleMessageAnchor();
+    const beforeSnapshot = this.getChatScrollSnapshot();
     this.isExpandingChatRenderWindow = true;
     this.chatRenderedOldestIndex = nextOldestIndex;
     this.logChatPerf('window:expand', {
       contact: this.formatChatPerfAddress(this.address, contact),
+      reason,
       previousOldestIndex: currentOldestIndex,
       nextOldestIndex,
       batchSize: renderBatchSize,
-      scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
+      scrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
+      maxScrollTop: beforeSnapshot ? beforeSnapshot.maxScrollTop : 'n/a',
+      distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
       loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
+      remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
       totalMessages: messages.length
     });
 
     this.appendChatModal(false, true);
-    requestAnimationFrame(() => {
-      this.restoreVisibleMessageAnchor(anchor);
-      this.isExpandingChatRenderWindow = false;
+    const afterWriteSnapshot = this.getChatScrollSnapshot();
+    this.restoreVisibleMessageAnchor(anchor);
+    const afterRestoreSnapshot = this.getChatScrollSnapshot();
+    this.isExpandingChatRenderWindow = false;
+    this.logChatPerf('window:anchorRestored', {
+      contact: this.formatChatPerfAddress(this.address, contact),
+      reason,
+      anchor: anchor?.selector ? 'found' : 'none',
+      beforeScrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
+      afterWriteScrollTop: afterWriteSnapshot ? afterWriteSnapshot.scrollTop : 'n/a',
+      afterRestoreScrollTop: afterRestoreSnapshot ? afterRestoreSnapshot.scrollTop : 'n/a',
+      afterRestoreDistanceFromBottom: afterRestoreSnapshot ? afterRestoreSnapshot.distanceFromBottom : 'n/a',
+      afterRestoreScrollHeight: afterRestoreSnapshot ? afterRestoreSnapshot.scrollHeight : 'n/a'
     });
   }
 
   handleMessagesContainerScroll() {
     this.closeAllContextMenus();
     if (!this.messagesContainer || !this.isActive()) return;
+    const scrollSnapshot = this.getChatScrollSnapshot();
+    if (!scrollSnapshot) return;
+    const contact = this.address ? myData.contacts[this.address] : null;
+    const totalMessages = Array.isArray(contact?.messages) ? contact.messages.length : 0;
+    const renderedOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+      ? this.chatRenderedOldestIndex
+      : 'n/a';
     const now = this.getChatPerfTime();
     if (now - this.lastChatScrollLogAt > 750) {
       this.lastChatScrollLogAt = now;
       this.logChatPerf('scroll:metrics', {
-        scrollTop: Math.round(this.messagesContainer.scrollTop),
-        scrollHeight: Math.round(this.messagesContainer.scrollHeight),
-        clientHeight: Math.round(this.messagesContainer.clientHeight),
-        messageListHeight: this.messagesList ? Math.round(this.messagesList.scrollHeight) : 'n/a',
+        scrollTop: scrollSnapshot.scrollTop,
+        maxScrollTop: scrollSnapshot.maxScrollTop,
+        distanceFromBottom: scrollSnapshot.distanceFromBottom,
+        scrollHeight: scrollSnapshot.scrollHeight,
+        clientHeight: scrollSnapshot.clientHeight,
+        messageListHeight: scrollSnapshot.messageListHeight,
         loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
+        renderedOldestIndex,
+        remainingOlder: Number.isInteger(renderedOldestIndex)
+          ? Math.max(0, totalMessages - 1 - renderedOldestIndex)
+          : 'n/a',
+        isExpanding: this.isExpandingChatRenderWindow,
         modalScrollTop: this.modal ? Math.round(this.modal.scrollTop || 0) : 'n/a',
         bodyScrollY: Math.round(window.scrollY || 0)
       });
     }
     const loadAheadThreshold = this.getChatLoadAheadThreshold();
-    if (this.messagesContainer.scrollTop <= loadAheadThreshold) {
-      this.expandChatRenderWindow();
+    if (scrollSnapshot.distanceFromBottom >= loadAheadThreshold) {
+      this.expandChatRenderWindow('scrollDistance');
     }
   }
 
   getChatLoadAheadThreshold() {
     const containerHeight = this.messagesContainer?.clientHeight || 0;
-    return Math.max(5200, containerHeight * 8);
+    return Math.max(700, containerHeight);
   }
 
   getChatOlderRenderBatchSize() {
-    const scrollTop = this.messagesContainer?.scrollTop ?? Infinity;
-    const urgentThreshold = (this.messagesContainer?.clientHeight || 0) * 1.5;
-    return scrollTop <= urgentThreshold
+    const container = this.messagesContainer;
+    if (!container) return this.chatOlderRenderBatchSize;
+    const scrollSnapshot = this.getChatScrollSnapshot();
+    const distanceFromBottom = scrollSnapshot ? scrollSnapshot.distanceFromBottom : 0;
+    const urgentThreshold = (container.clientHeight || 0) * 3;
+    return distanceFromBottom >= urgentThreshold
       ? this.chatOlderRenderBatchSize * 2
       : this.chatOlderRenderBatchSize;
+  }
+
+  scheduleChatRenderWindowWarmup(address) {
+    const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (callback) => setTimeout(callback, 0);
+
+    scheduleAfterPaint(() => {
+      scheduleAfterPaint(() => {
+        if (!this.isActive() || this.address !== address || this.isExpandingChatRenderWindow) return;
+        const contact = myData.contacts[address];
+        const messages = contact?.messages;
+        if (!Array.isArray(messages) || messages.length === 0) return;
+        const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
+          ? this.chatRenderedOldestIndex
+          : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
+        if (currentOldestIndex >= messages.length - 1) return;
+        this.logChatPerf('window:warmup', {
+          contact: this.formatChatPerfAddress(address, contact),
+          currentOldestIndex,
+          batchSize: this.chatOlderRenderBatchSize,
+          totalMessages: messages.length
+        });
+        this.expandChatRenderWindow('openWarmup');
+      });
+    });
   }
 
   /**
@@ -15328,6 +15400,9 @@ class ChatModal {
       ms: this.formatChatPerfMs(appendPerfStart),
       total: this.formatChatPerfMs(openPerfStart)
     });
+    if (!skipAutoScroll) {
+      this.scheduleChatRenderWindowWarmup(address);
+    }
     void this.maybePromptReclaimToll(address);
   }
 
@@ -16619,19 +16694,19 @@ class ChatModal {
     // --- 5. Find the corresponding DOM element after rendering ---
     // This happens inside the setTimeout to ensure elements are in the DOM
 
+    if (skipAutoScroll) {
+      this.logChatPerf('append:scrollSkipped', {
+        contact: this.formatChatPerfAddress(currentAddress, contact),
+        delay: '0.0ms',
+        reason: 'skipAutoScroll'
+      });
+      return;
+    }
+
     // 6. Delayed Scrolling & Highlighting Logic (after loop)
     const scrollScheduledAt = this.getChatPerfTime();
     setTimeout(() => {
       const scrollPerfStart = this.getChatPerfTime();
-      // Skip auto-scrolling if we're going to scroll to a specific message
-      if (skipAutoScroll) {
-        this.logChatPerf('append:scrollSkipped', {
-          contact: this.formatChatPerfAddress(currentAddress, contact),
-          delay: this.formatChatPerfMs(scrollScheduledAt, scrollPerfStart)
-        });
-        return;
-      }
-
       const messageContainer = this.messagesList.parentElement;
       let scrollTarget = 'bottom';
 

--- a/app.js
+++ b/app.js
@@ -16012,17 +16012,23 @@ class ChatModal {
 
   renderChatMessageHTML(item, { contact, lastReadTs }) {
     const timeString = formatTime(item.timestamp);
+    // Use a consistent timestamp attribute for potential future use (e.g., message jumping)
     const timestampAttribute = `data-message-timestamp="${item.timestamp}"`;
+    // Add txid attribute if available
     const txidAttribute = item.txid ? `data-txid="${item.txid}"` : '';
     const statusAttribute = item.status ? `data-status="${item.status}"` : '';
 
+    // Check if it's a payment based on the presence of the amount property (BigInt)
     if (typeof item.amount === 'bigint') {
+      // Assuming LIB (18 decimals) for now. TODO: Handle different asset decimals if needed.
+      // Format amount correctly using big2str
       const amountStr = big2str(item.amount, 18);
       const amountNum = parseFloat(amountStr);
       const amountDisplay = `${amountNum.toFixed(6)} ${item.symbol || 'LIB'}`;
       const directionText = item.my ? '-' : '+';
       const messageClass = item.my ? 'sent' : 'received';
       const showEditedDot = !item.my && item.edited && item.edited_timestamp && item.edited_timestamp > lastReadTs && !isDeleted(item);
+      // --- Render Payment Transaction ---
       return `
           <div class="message ${messageClass} payment-info" ${timestampAttribute} ${txidAttribute} ${statusAttribute}>
             <div class="payment-header">
@@ -16035,8 +16041,11 @@ class ChatModal {
         `;
     }
 
+    // --- Render Chat Message ---
     const messageClass = item.my ? 'sent' : 'received';
+    // Check if message was deleted
     if (isDeleted(item)) {
+      // Render deleted message with special styling
       return `
                     <div class="message ${messageClass} deleted-message" ${timestampAttribute} ${txidAttribute} ${statusAttribute}>
                         <div class="message-content deleted-content">${item.message}</div>
@@ -16048,10 +16057,16 @@ class ChatModal {
     const messageType = item.type || 'message';
 
     let replyHTML = '';
+    // --- Render Reply Quote if present ---
     if (item.replyId) {
       const replyText = escapeHtml(item.replyMessage || 'View original message');
+      // Determine owner label: "You" if the referenced message is ours, else contact name
       const ownerIsMineHint = item.replyOwnerIsMine;
       const targetMsg = contact.messages.find((message) => message.txid === item.replyId);
+      // Use both item.my and replyOwnerIsMine to determine from current viewer's perspective
+      // item.my: true if reply is from current user (viewer's perspective)
+      // replyOwnerIsMine: true if original message was from sender's perspective
+      // If they match (both true or both false), original message is from current user's perspective
       const isOwnerMine = typeof ownerIsMineHint === 'undefined'
         ? !!(targetMsg && targetMsg.my)
         : item.my === (ownerIsMineHint === true || ownerIsMineHint === '1');
@@ -16067,6 +16082,7 @@ class ChatModal {
               `;
     }
 
+    // --- Render Attachments if present ---
     let attachmentsHTML = '';
     if (item.xattach && Array.isArray(item.xattach) && item.xattach.length > 0) {
       attachmentsHTML = item.xattach.map(att => {
@@ -16103,6 +16119,7 @@ class ChatModal {
       }).join('');
     }
 
+    // --- Render message text (if any) ---
     let messageTextHTML = '';
     switch (messageType) {
       case 'message':
@@ -16112,11 +16129,13 @@ class ChatModal {
         break;
       case 'call': {
         if (!item.message || !item.message.trim()) break;
+        // Determine call timing and whether join should be allowed
         const callTimeMs = Number(item.callTime || 0);
         const callStart = callTimeMs > 0 ? callTimeMs : Number(item.timestamp || item.sent_timestamp || 0);
         const isExpired = this.isCallExpired(callStart);
 
         if (isExpired) {
+          // Over 2 hours since call time: show as plain text without join button
           const theirName = getContactDisplayName(contact);
           const label = item.my ? `You called ${escapeHtml(theirName)}` : `${escapeHtml(theirName)} called you`;
           messageTextHTML = `
@@ -16124,7 +16143,10 @@ class ChatModal {
                     <div class="call-message-text"><i>${label}</i></div>
                   </div>`;
         } else {
+          // Build scheduled label if in the future
           const scheduleHTML = this.buildCallScheduleHTML(callTimeMs);
+          // Render call message with a left circular phone icon (clickable) and plain text to the right
+          // TODO - remove the href and instead have it call a function which will open the URL and at the time of opening it adds the callUrlParam and username
           messageTextHTML = `
                   <div class="call-message">
                     <a href='${item.message}${callUrlParams}"${myAccount.username}"' target="_blank" rel="noopener noreferrer" class="call-message-phone-button" aria-label="Join Video Call">
@@ -16139,7 +16161,9 @@ class ChatModal {
         break;
       }
       case 'vm': {
+        // Check for voice message
         const duration = this.formatDuration(item.duration);
+        // Use audio encryption keys for playback, fall back to message encryption keys if not available
         messageTextHTML = `
               <div class="voice-message" data-url="${item.url || ''}" data-name="voice-message" data-type="audio/webm" data-duration="${item.duration || 0}">
                 <div class="voice-message-controls">
@@ -16177,10 +16201,13 @@ class ChatModal {
   }
 
   buildChatMessageRangeHTML(messages, contact, oldestIndex, newestIndex) {
+    // Last time user previously had this chat open (used to mark newly edited messages)
     const lastReadTs = contact.lastChatOpenTs || 0;
     const renderedMessages = [];
     const renderedTxids = [];
 
+    // Iterate backwards through messages (oldest to newest for rendering order)
+    // messages are already sorted descending (newest first) in myData
     for (let i = oldestIndex; i >= newestIndex; i--) {
       const item = messages[i];
       renderedMessages.push(this.renderChatMessageHTML(item, { contact, lastReadTs }));

--- a/app.js
+++ b/app.js
@@ -13963,7 +13963,6 @@ class ChatModal {
     this.chatRenderWindowDrainAddress = null;
     this.chatRenderWindowDrainStartedAt = 0;
     this.chatSpacerCatchupTimer = null;
-    this.chatSpacerPrewarmTimer = null;
     this.chatRenderSequence = 0;
     this.lastChatTouchLogAt = 0;
     this.chatTouchStartY = null;
@@ -15117,7 +15116,6 @@ class ChatModal {
   resetChatRenderWindow(address = null) {
     this.cancelChatRenderWindowDrain();
     this.cancelChatSpacerCatchup();
-    this.cancelChatSpacerPrewarm();
     this.clearPendingChatScrollExpand();
     this.chatRenderedWindowAddress = address;
     this.chatRenderedOldestIndex = null;
@@ -15382,8 +15380,7 @@ class ChatModal {
     const isOpenDrain = reason === 'openDrain';
     const shouldPrependOlderMessages = (
       reason === 'scrollDistance' ||
-      reason === 'scrollIdle' ||
-      reason === 'prewarm'
+      reason === 'scrollIdle'
     ) && this.messagesContainer;
 
     const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
@@ -15639,55 +15636,6 @@ class ChatModal {
     if (!this.chatSpacerCatchupTimer) return;
     clearTimeout(this.chatSpacerCatchupTimer);
     this.chatSpacerCatchupTimer = null;
-  }
-
-  cancelChatSpacerPrewarm() {
-    if (!this.chatSpacerPrewarmTimer) return;
-    clearTimeout(this.chatSpacerPrewarmTimer);
-    this.chatSpacerPrewarmTimer = null;
-  }
-
-  scheduleChatSpacerPrewarm(address, reason = 'afterDeferred') {
-    if (!address || this.chatSpacerPrewarmTimer || this.isExpandingChatRenderWindow) return;
-    this.logChatPerf('window:prewarmScheduled', {
-      contact: this.formatChatPerfAddress(address, myData.contacts[address]),
-      reason,
-      currentOldestIndex: Number.isInteger(this.chatRenderedOldestIndex) ? this.chatRenderedOldestIndex : 'n/a',
-      topSpacerHeight: Math.round(this.getChatHistorySpacerHeight())
-    });
-    this.chatSpacerPrewarmTimer = setTimeout(() => {
-      this.chatSpacerPrewarmTimer = null;
-      if (!this.isActive() || this.address !== address || !this.messagesContainer || !this.messagesList) return;
-      const contact = myData.contacts[address];
-      const messages = contact?.messages;
-      if (!Array.isArray(messages) || messages.length === 0) return;
-      const currentOldestIndex = Number.isInteger(this.chatRenderedOldestIndex)
-        ? this.chatRenderedOldestIndex
-        : Math.min(messages.length - 1, this.chatInitialRenderCount - 1);
-      const remainingOlder = Math.max(0, messages.length - 1 - currentOldestIndex);
-      const topSpacerHeight = this.getChatHistorySpacerHeight();
-      if (remainingOlder <= 0 || topSpacerHeight <= 0 || this.isExpandingChatRenderWindow) {
-        this.logChatPerf('window:prewarmSkipped', {
-          contact: this.formatChatPerfAddress(address, contact),
-          reason,
-          currentOldestIndex,
-          remainingOlder,
-          topSpacerHeight: Math.round(topSpacerHeight),
-          isExpanding: this.isExpandingChatRenderWindow
-        });
-        return;
-      }
-
-      this.logChatPerf('window:prewarm', {
-        contact: this.formatChatPerfAddress(address, contact),
-        reason,
-        currentOldestIndex,
-        batchSize: this.getChatOlderRenderBatchSize(),
-        remainingOlder,
-        topSpacerHeight: Math.round(topSpacerHeight)
-      });
-      this.expandChatRenderWindow('prewarm');
-    }, 80);
   }
 
   scheduleChatSpacerCatchup(reason) {
@@ -17532,7 +17480,6 @@ class ChatModal {
                     rendered: renderedMessages.length,
                     remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
                   });
-                  this.scheduleChatSpacerPrewarm(renderedAddress, 'afterDeferred');
                 }
               },
               (error) => {

--- a/app.js
+++ b/app.js
@@ -13942,13 +13942,9 @@ class ChatModal {
     this.dragCounter = 0;
     this.dropOverlay = null;
 
-    this.chatPerfLogBuffer = [];
-    this.chatPerfLogFlushTimer = null;
-    this.chatPerfLoggingEnabled = true;
-
     this.chatInitialRenderCount = 50;
-    this.chatFirstOlderRenderBatchSize = 10;
-    this.chatOlderRenderBatchSize = 10;
+    this.chatFirstOlderRenderBatchSize = 25;
+    this.chatOlderRenderBatchSize = 50;
     this.chatRenderedOldestIndex = null;
     this.chatRenderedWindowAddress = null;
     this.chatForceFullRenderOnce = false;
@@ -13957,22 +13953,17 @@ class ChatModal {
     this.chatPendingScrollExpand = false;
     this.chatPendingScrollExpandReason = null;
     this.chatScrollEndFallbackTimer = null;
-    this.lastChatScrollLogAt = 0;
     this.chatRenderWindowDrainTimer = null;
     this.chatRenderWindowDrainFrame = null;
     this.chatRenderWindowDrainAddress = null;
-    this.chatRenderWindowDrainStartedAt = 0;
     this.chatSpacerCatchupTimer = null;
     this.chatRenderSequence = 0;
-    this.lastChatTouchLogAt = 0;
-    this.lastChatExpandBlockedLogAt = 0;
     this.chatTouchStartY = null;
     this.chatExpansionRearmDistanceFromBottom = null;
     this.chatHistorySpacerHeight = 0;
     this.chatHistoryLoadingToastId = null;
     this.chatTopBoundaryScrollHoldActive = false;
     this.chatTopBoundaryScrollHoldTop = 0;
-    this.lastChatTopBoundaryBlockLogAt = 0;
   }
 
   /**
@@ -14396,7 +14387,6 @@ class ChatModal {
    * @returns {void}
    */
   load() {
-    const loadPerfStart = this.getChatPerfTime();
     this.modal = document.getElementById('chatModal');
     assert(this.modal, 'chatModal element is required');
     this.closeButton = document.getElementById('closeChatModal');
@@ -14465,8 +14455,6 @@ class ChatModal {
     this.contactsOpt = this.attachmentOptionsContextMenu?.querySelector('.context-menu-option[data-action="contacts"]');
     
     this.currentImageAttachmentRow = null;
-    const refsMs = this.formatChatPerfMs(loadPerfStart);
-    const listenerPerfStart = this.getChatPerfTime();
     
     // Add event delegation for message clicks (since messages are created dynamically)
     this.messagesList.addEventListener('click', this.handleMessageClick.bind(this));
@@ -14490,9 +14478,6 @@ class ChatModal {
     this.messagesContainer.addEventListener('touchmove', (e) => this.handleMessagesTouchMove(e), { passive: false });
     this.messagesContainer.addEventListener('touchend', (e) => this.handleMessagesTouchEnd(e), { passive: true });
     this.messagesContainer.addEventListener('touchcancel', (e) => this.handleMessagesTouchEnd(e), { passive: true });
-    this.modal.addEventListener('touchmove', (e) => {
-      if (this.chatPerfLoggingEnabled) this.logChatTouchDiagnostics(e, 'modalMove');
-    }, { passive: true });
     // Add context menu option listeners
     this.contextMenu.addEventListener('click', (e) => {
       const reactionButton = e.target.closest('.message-context-reaction-button');
@@ -14796,11 +14781,6 @@ class ChatModal {
     }
 
     this.toggleSendButtonVisibility();
-    this.logChatPerf('load:listeners', {
-      refs: refsMs,
-      listeners: this.formatChatPerfMs(listenerPerfStart),
-      total: this.formatChatPerfMs(loadPerfStart)
-    });
   }
 
     // Voice message seek slider live time display (works even before playback)
@@ -14931,140 +14911,6 @@ class ChatModal {
     return !!(editInput?.value?.trim?.());
   }
 
-  getChatPerfTime() {
-    return typeof performance !== 'undefined' && typeof performance.now === 'function'
-      ? performance.now()
-      : Date.now();
-  }
-
-  formatChatPerfMs(start, end = this.getChatPerfTime()) {
-    return `${Math.max(0, end - start).toFixed(1)}ms`;
-  }
-
-  formatChatPerfAddress(address, contact) {
-    const compactAddress = address
-      ? `${address.slice(0, 8)}...${address.slice(-6)}`
-      : 'unknown';
-    const displayName = contact ? getContactDisplayName(contact) : '';
-    return displayName && displayName !== address
-      ? `${displayName}(${compactAddress})`
-      : compactAddress;
-  }
-
-  summarizeChatPerfContact(contact) {
-    const messages = Array.isArray(contact?.messages) ? contact.messages : [];
-    const summary = {
-      messages: messages.length,
-      replies: 0,
-      attachments: 0,
-      mediaAttachments: 0,
-      voice: 0,
-      payments: 0,
-      calls: 0,
-      edited: 0,
-      deleted: 0,
-      textChars: 0,
-      reactions: Array.isArray(contact?.reactions) ? contact.reactions.length : 0
-    };
-
-    messages.forEach((message) => {
-      if (message?.replyId) summary.replies++;
-      if (typeof message?.amount === 'bigint') summary.payments++;
-      if (message?.type === 'vm') summary.voice++;
-      if (message?.type === 'call') summary.calls++;
-      if (message?.edited) summary.edited++;
-      if (isDeleted(message)) summary.deleted++;
-      if (typeof message?.message === 'string') summary.textChars += message.message.length;
-      if (Array.isArray(message?.xattach)) {
-        summary.attachments += message.xattach.length;
-        summary.mediaAttachments += message.xattach.filter((attachment) => {
-          const type = attachment?.type || '';
-          return type.startsWith('image/') || type.startsWith('video/');
-        }).length;
-      }
-    });
-
-    return summary;
-  }
-
-  updateChatPerfBatchSummary(summary, message) {
-    if (!summary || !message) return;
-    if (message.replyId) summary.replies++;
-    if (typeof message.amount === 'bigint') {
-      summary.payments++;
-      summary.types.add('payment');
-    } else if (message.type) {
-      summary.types.add(message.type);
-    } else {
-      summary.types.add('text');
-    }
-    if (message.type === 'vm') summary.voice++;
-    if (message.type === 'call') summary.calls++;
-    if (message.edited) summary.edited++;
-    if (isDeleted(message)) summary.deleted++;
-    if (typeof message.message === 'string') {
-      summary.textChars += message.message.length;
-      summary.maxTextChars = Math.max(summary.maxTextChars, message.message.length);
-    }
-    if (Array.isArray(message.xattach)) {
-      summary.attachments += message.xattach.length;
-      message.xattach.forEach((attachment) => {
-        const type = attachment?.type || 'unknown';
-        summary.attachmentTypes.add(type);
-        if (type.startsWith('image/')) {
-          summary.mediaAttachments++;
-          summary.imageAttachments++;
-        } else if (type.startsWith('video/')) {
-          summary.mediaAttachments++;
-          summary.videoAttachments++;
-        } else {
-          summary.fileAttachments++;
-        }
-      });
-    }
-  }
-
-  formatChatPerfSet(set, maxItems = 4) {
-    if (!set || typeof set[Symbol.iterator] !== 'function') return 'none';
-    const values = [...set].filter(Boolean);
-    if (values.length === 0) return 'none';
-    const visible = values.slice(0, maxItems).join('|');
-    return values.length > maxItems ? `${visible}|+${values.length - maxItems}` : visible;
-  }
-
-  logChatPerf(event, fields = {}) {
-    if (!this.chatPerfLoggingEnabled) return;
-    try {
-      const details = Object.entries(fields)
-        .filter(([, value]) => value !== undefined && value !== null && value !== '')
-        .map(([key, value]) => `${key}=${value}`)
-        .join(' ');
-      this.chatPerfLogBuffer.push(`[ChatPerf] ${event}${details ? ` ${details}` : ''}`);
-      this.scheduleChatPerfLogFlush();
-    } catch (error) {
-      console.warn('Failed to write chat performance log:', error);
-    }
-  }
-
-  scheduleChatPerfLogFlush() {
-    if (this.chatPerfLogFlushTimer) return;
-    this.chatPerfLogFlushTimer = setTimeout(() => {
-      this.chatPerfLogFlushTimer = null;
-      this.flushChatPerfLogs();
-    }, 500);
-  }
-
-  flushChatPerfLogs() {
-    if (!this.chatPerfLogBuffer.length) return;
-    try {
-      if (typeof logsModal === 'undefined' || typeof logsModal.log !== 'function') return;
-      const logBlock = this.chatPerfLogBuffer.splice(0, this.chatPerfLogBuffer.length).join('\n');
-      logsModal.log(logBlock);
-    } catch (error) {
-      console.warn('Failed to flush chat performance logs:', error);
-    }
-  }
-
   isMessagesContainerNearBottom(thresholdPx = 50) {
     const container = this.messagesContainer || this.messagesList?.parentElement;
     if (!container) return false;
@@ -15172,8 +15018,6 @@ class ChatModal {
     this.isExpandingChatRenderWindow = false;
     this.chatExpansionRearmDistanceFromBottom = null;
     this.chatHistorySpacerHeight = 0;
-    this.lastChatExpandBlockedLogAt = 0;
-    this.lastChatTopBoundaryBlockLogAt = 0;
   }
 
   getChatRenderRange(messages, currentAddress, forceFullRender = false) {
@@ -15274,22 +15118,11 @@ class ChatModal {
     this.chatHistoryLoadingToastId = null;
   }
 
-  startChatTopBoundaryScrollHold(scrollSnapshot, reason = 'topBoundary') {
-    const wasActive = this.chatTopBoundaryScrollHoldActive;
+  startChatTopBoundaryScrollHold(scrollSnapshot) {
     this.chatTopBoundaryScrollHoldActive = true;
     this.chatTopBoundaryScrollHoldTop = Math.max(0, Math.round(scrollSnapshot?.topSpacerHeight || 0));
     this.showChatHistoryLoadingToast();
     this.clampChatTopBoundaryScrollHold();
-
-    if (!wasActive && this.chatPerfLoggingEnabled) {
-      this.logChatPerf('window:topBoundaryHold', {
-        reason,
-        scrollTop: scrollSnapshot ? scrollSnapshot.scrollTop : 'n/a',
-        distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
-        distanceToRenderedTop: scrollSnapshot ? scrollSnapshot.distanceToRenderedTop : 'n/a',
-        holdTop: Math.round(this.chatTopBoundaryScrollHoldTop)
-      });
-    }
   }
 
   stopChatTopBoundaryScrollHold(reason = 'rendered') {
@@ -15297,10 +15130,6 @@ class ChatModal {
     this.chatTopBoundaryScrollHoldActive = false;
     this.chatTopBoundaryScrollHoldTop = 0;
     this.hideChatHistoryLoadingToast();
-
-    if (this.chatPerfLoggingEnabled) {
-      this.logChatPerf('window:topBoundaryRelease', { reason });
-    }
   }
 
   clampChatTopBoundaryScrollHold() {
@@ -15325,106 +15154,24 @@ class ChatModal {
     return !snapshot || snapshot.distanceToRenderedTop <= renderedBoundaryThreshold;
   }
 
-  describeChatTouchTarget(target) {
-    if (!target || typeof target.closest !== 'function') return 'unknown';
-    if (target.closest('.message-input-container')) return 'composer';
-    if (target.closest('.modal-header')) return 'header';
-    if (target.closest('.attachment-row')) return 'attachment';
-    if (target.closest('.message')) return 'message';
-    if (target.closest('.messages-list')) return 'messages-list';
-    if (target.closest('.messages-container')) return 'messages-container';
-    if (target.closest('#chatModal')) return 'chat-modal';
-    return target.id || target.className || target.tagName || 'unknown';
-  }
-
-  logChatTouchDiagnostics(event, phase) {
-    if (!this.isActive() || !this.messagesContainer) return;
-    const now = this.getChatPerfTime();
-    if (phase !== 'messagesStart' && now - this.lastChatTouchLogAt < 350) return;
-    this.lastChatTouchLogAt = now;
-
-    const touch = event.touches?.[0] || event.changedTouches?.[0] || null;
-    const y = touch ? Math.round(touch.clientY) : 'n/a';
-    if (phase === 'messagesStart' && typeof y === 'number') {
-      this.chatTouchStartY = y;
-    }
-    const deltaY = typeof y === 'number' && typeof this.chatTouchStartY === 'number'
-      ? y - this.chatTouchStartY
-      : 'n/a';
-    const snapshot = this.getChatScrollSnapshot();
-    const containerStyle = getComputedStyle(this.messagesContainer);
-    const modalStyle = this.modal ? getComputedStyle(this.modal) : null;
-    const activeElement = document.activeElement;
-
-    this.logChatPerf(`touch:${phase}`, {
-      target: this.describeChatTouchTarget(event.target),
-      inMessagesContainer: !!event.target.closest?.('.messages-container'),
-      inMessagesList: !!event.target.closest?.('.messages-list'),
-      y,
-      deltaY,
-      cancelable: event.cancelable,
-      defaultPrevented: event.defaultPrevented,
-      canScroll: snapshot ? snapshot.scrollHeight > snapshot.clientHeight : 'n/a',
-      atTop: snapshot ? snapshot.scrollTop <= 0 : 'n/a',
-      atBottom: snapshot ? snapshot.distanceFromBottom <= 1 : 'n/a',
-      scrollTop: snapshot ? snapshot.scrollTop : 'n/a',
-      maxScrollTop: snapshot ? snapshot.maxScrollTop : 'n/a',
-      distanceFromBottom: snapshot ? snapshot.distanceFromBottom : 'n/a',
-      distanceToRenderedTop: snapshot ? snapshot.distanceToRenderedTop : 'n/a',
-      topSpacerHeight: snapshot ? snapshot.topSpacerHeight : 'n/a',
-      containerOverflowY: containerStyle.overflowY,
-      containerTouchAction: containerStyle.touchAction,
-      containerWebkitOverflow: containerStyle.webkitOverflowScrolling || 'n/a',
-      modalTouchAction: modalStyle ? modalStyle.touchAction : 'n/a',
-      modalScrollTop: this.modal ? Math.round(this.modal.scrollTop || 0) : 'n/a',
-      bodyScrollY: Math.round(window.scrollY || 0),
-      htmlOverflow: getComputedStyle(document.documentElement).overflow,
-      bodyOverflow: getComputedStyle(document.body).overflow,
-      activeElement: activeElement?.id || activeElement?.className || activeElement?.tagName || 'none',
-      scrollLocked: this.scrollLocked
-    });
-  }
-
   handleMessagesTouchStart(event) {
     this.isChatTouchActive = true;
-    if (this.chatPerfLoggingEnabled) {
-      this.logChatTouchDiagnostics(event, 'messagesStart');
-    }
+    const touch = event.touches?.[0] || null;
+    this.chatTouchStartY = touch ? Math.round(touch.clientY) : null;
   }
 
   handleMessagesTouchMove(event) {
-    if (this.chatPerfLoggingEnabled) {
-      this.logChatTouchDiagnostics(event, 'messagesMove');
-    }
-
     if (!this.shouldBlockChatTopBoundaryTouchMove(event)) return;
 
-    const clamped = this.clampChatTopBoundaryScrollHold();
+    this.clampChatTopBoundaryScrollHold();
     if (event.cancelable) {
       event.preventDefault();
     }
     event.stopPropagation();
-
-    const now = this.chatPerfLoggingEnabled ? this.getChatPerfTime() : 0;
-    if (this.chatPerfLoggingEnabled && now - this.lastChatTopBoundaryBlockLogAt > 350) {
-      this.lastChatTopBoundaryBlockLogAt = now;
-      const snapshot = this.getChatScrollSnapshot();
-      this.logChatPerf('window:topBoundaryScrollBlocked', {
-        scrollTop: snapshot ? snapshot.scrollTop : 'n/a',
-        distanceFromBottom: snapshot ? snapshot.distanceFromBottom : 'n/a',
-        distanceToRenderedTop: snapshot ? snapshot.distanceToRenderedTop : 'n/a',
-        holdTop: Math.round(this.chatTopBoundaryScrollHoldTop || 0),
-        clamped,
-        cancelable: event.cancelable
-      });
-    }
   }
 
   handleMessagesTouchEnd(event) {
     this.isChatTouchActive = false;
-    if (this.chatPerfLoggingEnabled) {
-      this.logChatTouchDiagnostics(event, 'messagesEnd');
-    }
     this.schedulePendingChatScrollExpand('touchEnd');
   }
 
@@ -15438,20 +15185,8 @@ class ChatModal {
   }
 
   queueChatScrollExpand(reason, scrollSnapshot) {
-    const wasPending = this.chatPendingScrollExpand;
     this.chatPendingScrollExpand = true;
     this.chatPendingScrollExpandReason = reason;
-    if (!wasPending && this.chatPerfLoggingEnabled) {
-      this.logChatPerf('window:expandQueued', {
-        reason,
-        scrollTop: scrollSnapshot ? scrollSnapshot.scrollTop : 'n/a',
-        distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
-        distanceToRenderedTop: scrollSnapshot ? scrollSnapshot.distanceToRenderedTop : 'n/a',
-        topSpacerHeight: scrollSnapshot ? scrollSnapshot.topSpacerHeight : 'n/a',
-        loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
-        touchActive: this.isChatTouchActive
-      });
-    }
     this.schedulePendingChatScrollExpand('scrollIdleFallback');
   }
 
@@ -15491,42 +15226,15 @@ class ChatModal {
       scrollSnapshot.distanceFromBottom < loadAheadThreshold ||
       (!isExpansionRearmed && !isAtRenderedBoundary)
     ) {
-      if (this.chatPerfLoggingEnabled) {
-        this.logChatPerf('window:expandAborted', {
-          trigger,
-          reason: !scrollSnapshot
-            ? 'missingSnapshot'
-            : scrollSnapshot.distanceFromBottom < loadAheadThreshold
-              ? 'belowThreshold'
-              : 'notRearmed',
-          distanceFromBottom: scrollSnapshot ? scrollSnapshot.distanceFromBottom : 'n/a',
-          loadAheadThreshold: Math.round(loadAheadThreshold),
-          distanceToRenderedTop: scrollSnapshot ? scrollSnapshot.distanceToRenderedTop : 'n/a',
-          renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold),
-          rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
-        });
-      }
       this.clearPendingChatScrollExpand();
       this.stopChatTopBoundaryScrollHold('expandAborted');
       return;
     }
 
-    const queuedReason = this.chatPendingScrollExpandReason || 'scrollDistance';
     if (isAtRenderedBoundary) {
       this.startChatTopBoundaryScrollHold(scrollSnapshot, 'expandFlush');
     }
     this.clearPendingChatScrollExpand();
-    if (this.chatPerfLoggingEnabled) {
-      this.logChatPerf('window:expandFlushed', {
-        trigger,
-        queuedReason,
-        distanceFromBottom: scrollSnapshot.distanceFromBottom,
-        loadAheadThreshold: Math.round(loadAheadThreshold),
-        distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
-        renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold),
-        rearmDistance: Number.isFinite(rearmDistance) ? Math.round(rearmDistance) : 'n/a'
-      });
-    }
     const expanded = this.expandChatRenderWindow('scrollIdle');
     if (!expanded) {
       this.stopChatTopBoundaryScrollHold('expandSkipped');
@@ -15575,95 +15283,49 @@ class ChatModal {
       : this.getChatScrollSnapshot();
     this.isExpandingChatRenderWindow = true;
     this.chatRenderedOldestIndex = nextOldestIndex;
-    if (this.chatPerfLoggingEnabled) {
-      this.logChatPerf('window:expand', {
-        contact: this.formatChatPerfAddress(this.address, contact),
-        reason,
-        previousOldestIndex: currentOldestIndex,
-        nextOldestIndex,
-        batchSize: renderBatchSize,
-        scrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
-        maxScrollTop: beforeSnapshot ? beforeSnapshot.maxScrollTop : 'n/a',
-        distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
-        distanceToRenderedTop: beforeSnapshot ? beforeSnapshot.distanceToRenderedTop : 'n/a',
-        loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
-        renderedTopThreshold: Math.round(this.getChatRenderedTopLoadAheadThreshold(beforeSnapshot)),
-        renderedBoundaryThreshold: Math.round(this.getChatRenderedBoundaryThreshold(beforeSnapshot)),
-        atRenderedBoundary: beforeSnapshot
-          ? beforeSnapshot.distanceToRenderedTop <= this.getChatRenderedBoundaryThreshold(beforeSnapshot)
-          : 'n/a',
-        remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
-        totalMessages: messages.length
-      });
-    }
 
     if (shouldPrependOlderMessages) {
-      const prependPerfStart = this.getChatPerfTime();
       const cachedClientHeight = Number.isFinite(beforeSnapshot?.clientHeight)
         ? beforeSnapshot.clientHeight
         : (this.messagesContainer?.clientHeight || 0);
       const cachedLoadAheadThreshold = Math.max(1200, cachedClientHeight * 3);
-      const readScrollTopPerfStart = this.getChatPerfTime();
       const snapshotScrollTop = Number.isFinite(beforeSnapshot?.scrollTop)
         ? beforeSnapshot.scrollTop
         : null;
       const oldScrollTop = snapshotScrollTop ?? this.messagesContainer.scrollTop;
-      const oldScrollTopSource = snapshotScrollTop === null ? 'dom' : 'snapshot';
-      const readScrollTopMs = snapshotScrollTop === null
-        ? this.formatChatPerfMs(readScrollTopPerfStart)
-        : 'skipped';
-      const spacerLookupPerfStart = this.getChatPerfTime();
       const spacer = this.getChatHistorySpacerElement();
       const oldSpacerHeight = this.getChatHistorySpacerHeight();
-      const spacerLookupMs = this.formatChatPerfMs(spacerLookupPerfStart);
       const useEstimatedSpacerPreserve = !!spacer && oldSpacerHeight > 0;
-      const oldScrollHeightPerfStart = this.getChatPerfTime();
       const oldScrollHeight = useEstimatedSpacerPreserve ? null : this.messagesContainer.scrollHeight;
-      const oldScrollHeightMs = useEstimatedSpacerPreserve
-        ? 'skipped'
-        : this.formatChatPerfMs(oldScrollHeightPerfStart);
-      const estimatePerfStart = this.getChatPerfTime();
       const estimatedInsertedHeight = this.estimateChatMessagesHeight(
         messages,
         nextOldestIndex,
         currentOldestIndex + 1
       );
-      const estimateMs = this.formatChatPerfMs(estimatePerfStart);
-      const rangePerfStart = this.getChatPerfTime();
       const range = this.buildChatMessageRangeHTML(
         messages,
         contact,
         nextOldestIndex,
         currentOldestIndex + 1
       );
-      const rangeMs = this.formatChatPerfMs(rangePerfStart);
-      const domWritePerfStart = this.getChatPerfTime();
       if (useEstimatedSpacerPreserve) {
         spacer.insertAdjacentHTML('afterend', range.html);
       } else {
         this.messagesList.insertAdjacentHTML('afterbegin', range.html);
       }
-      const domWriteMs = this.formatChatPerfMs(domWritePerfStart);
-      const reactionsPerfStart = this.getChatPerfTime();
       if (range.renderedTxids.length > 0) {
         this.syncRenderedReactionTargets(range.renderedTxids);
       }
-      const reactionsMs = this.formatChatPerfMs(reactionsPerfStart);
-      const preservePerfStart = this.getChatPerfTime();
       let scrollDelta = estimatedInsertedHeight;
       let nextSpacerHeight = oldSpacerHeight;
-      let newScrollHeightMs = 'skipped';
       if (useEstimatedSpacerPreserve) {
         nextSpacerHeight = Math.max(0, oldSpacerHeight - estimatedInsertedHeight);
         this.setChatHistorySpacerHeight(nextSpacerHeight);
       } else {
-        const newScrollHeightPerfStart = this.getChatPerfTime();
         const newScrollHeight = this.messagesContainer.scrollHeight;
-        newScrollHeightMs = this.formatChatPerfMs(newScrollHeightPerfStart);
         scrollDelta = newScrollHeight - oldScrollHeight;
         this.messagesContainer.scrollTop = oldScrollTop + scrollDelta;
       }
-      const preserveMs = this.formatChatPerfMs(preservePerfStart);
       this.chatRenderedOldestIndex = nextOldestIndex;
       this.isExpandingChatRenderWindow = false;
 
@@ -15683,53 +15345,6 @@ class ChatModal {
         cachedLoadAheadThreshold
       );
       this.chatExpansionRearmDistanceFromBottom = rearmDistance;
-      if (this.chatPerfLoggingEnabled) {
-        const totalMs = this.formatChatPerfMs(prependPerfStart);
-        this.logChatPerf('window:prepend', {
-          contact: this.formatChatPerfAddress(this.address, contact),
-          previousOldestIndex: currentOldestIndex,
-          nextOldestIndex,
-          rendered: range.renderedCount,
-          batchTypes: range.summary.types,
-          attachments: range.summary.attachments,
-          media: range.summary.mediaAttachments,
-          images: range.summary.imageAttachments,
-          videos: range.summary.videoAttachments,
-          files: range.summary.fileAttachments,
-          attachmentTypes: range.summary.attachmentTypes,
-          voice: range.summary.voice,
-          payments: range.summary.payments,
-          calls: range.summary.calls,
-          deleted: range.summary.deleted,
-          replies: range.summary.replies,
-          textChars: range.summary.textChars,
-          maxTextChars: range.summary.maxTextChars,
-          scrollTopRead: readScrollTopMs,
-          scrollTopSource: oldScrollTopSource,
-          spacerLookup: spacerLookupMs,
-          oldScrollHeightRead: oldScrollHeightMs,
-          newScrollHeightRead: newScrollHeightMs,
-          estimate: estimateMs,
-          range: rangeMs,
-          build: range.buildMs,
-          join: range.joinMs,
-          domWrite: domWriteMs,
-          reactions: reactionsMs,
-          preserveStrategy: useEstimatedSpacerPreserve ? 'estimatedSpacer' : 'scrollHeightDelta',
-          preserve: preserveMs,
-          oldScrollTop: Math.round(oldScrollTop),
-          oldScrollHeight: useEstimatedSpacerPreserve ? 'skipped' : Math.round(oldScrollHeight),
-          oldSpacerHeight: Math.round(oldSpacerHeight),
-          estimatedHeight: Math.round(estimatedInsertedHeight),
-          nextSpacerHeight: Math.round(nextSpacerHeight),
-          scrollDelta: Math.round(scrollDelta),
-          nextScrollTop: Math.round(expectedScrollTop),
-          afterDistanceToRenderedTop: Math.round(afterDistanceToRenderedTop),
-          rearmDistance: Math.round(rearmDistance),
-          children: this.messagesList.children.length,
-          total: totalMs
-        });
-      }
       if (useEstimatedSpacerPreserve && nextOldestIndex < messages.length - 1) {
         const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(afterSnapshotEstimate);
         const renderedBoundaryThreshold = this.getChatRenderedBoundaryThreshold(afterSnapshotEstimate);
@@ -15737,22 +15352,9 @@ class ChatModal {
           (
             beforeSnapshot?.distanceFromBottom >= rearmDistance ||
             afterDistanceToRenderedTop <= renderedBoundaryThreshold
-          );
+        );
         if (shouldCatchUp) {
           this.scheduleChatSpacerCatchup('afterPrepend');
-        } else if (
-          this.chatPerfLoggingEnabled &&
-          afterDistanceToRenderedTop <= renderedTopThreshold
-        ) {
-          this.logChatPerf('window:catchupDeferred', {
-            contact: this.formatChatPerfAddress(this.address, contact),
-            reason: 'notRearmed',
-            distanceFromBottom: beforeSnapshot ? beforeSnapshot.distanceFromBottom : 'n/a',
-            rearmDistance: Math.round(rearmDistance),
-            distanceToRenderedTop: Math.round(afterDistanceToRenderedTop),
-            renderedTopThreshold: Math.round(renderedTopThreshold),
-            renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold)
-          });
         }
       }
       this.stopChatTopBoundaryScrollHold('rendered');
@@ -15762,33 +15364,13 @@ class ChatModal {
     this.chatRenderedOldestIndex = nextOldestIndex;
     this.appendChatModal(false, true, { skipDeferredWork: isOpenDrain });
     if (isOpenDrain) {
-      const bottomScrollPerfStart = this.getChatPerfTime();
       this.scrollMessagesToBottom({ readMetrics: false });
       this.isExpandingChatRenderWindow = false;
-      this.logChatPerf('window:bottomRestored', {
-        contact: this.formatChatPerfAddress(this.address, contact),
-        reason,
-        beforeScrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
-        bottomScroll: this.formatChatPerfMs(bottomScrollPerfStart),
-        remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex)
-      });
       return true;
     }
 
-    const afterWriteSnapshot = this.getChatScrollSnapshot();
     this.restoreVisibleMessageAnchor(anchor);
-    const afterRestoreSnapshot = this.getChatScrollSnapshot();
     this.isExpandingChatRenderWindow = false;
-    this.logChatPerf('window:anchorRestored', {
-      contact: this.formatChatPerfAddress(this.address, contact),
-      reason,
-      anchor: anchor?.selector ? 'found' : 'none',
-      beforeScrollTop: beforeSnapshot ? beforeSnapshot.scrollTop : 'n/a',
-      afterWriteScrollTop: afterWriteSnapshot ? afterWriteSnapshot.scrollTop : 'n/a',
-      afterRestoreScrollTop: afterRestoreSnapshot ? afterRestoreSnapshot.scrollTop : 'n/a',
-      afterRestoreDistanceFromBottom: afterRestoreSnapshot ? afterRestoreSnapshot.distanceFromBottom : 'n/a',
-      afterRestoreScrollHeight: afterRestoreSnapshot ? afterRestoreSnapshot.scrollHeight : 'n/a'
-    });
     return true;
   }
 
@@ -15805,27 +15387,6 @@ class ChatModal {
     const remainingOlder = Number.isInteger(renderedOldestIndex)
       ? Math.max(0, totalMessages - 1 - renderedOldestIndex)
       : 0;
-    const now = this.chatPerfLoggingEnabled ? this.getChatPerfTime() : 0;
-    if (this.chatPerfLoggingEnabled && now - this.lastChatScrollLogAt > 750) {
-      this.lastChatScrollLogAt = now;
-      this.logChatPerf('scroll:metrics', {
-        scrollTop: scrollSnapshot.scrollTop,
-        maxScrollTop: scrollSnapshot.maxScrollTop,
-        distanceFromBottom: scrollSnapshot.distanceFromBottom,
-        scrollHeight: scrollSnapshot.scrollHeight,
-        clientHeight: scrollSnapshot.clientHeight,
-        messageListHeight: scrollSnapshot.messageListHeight,
-        loadAheadThreshold: Math.round(this.getChatLoadAheadThreshold()),
-        renderedTopThreshold: Math.round(this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot)),
-        topSpacerHeight: scrollSnapshot.topSpacerHeight,
-        distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
-        renderedOldestIndex,
-        remainingOlder: Number.isInteger(renderedOldestIndex) ? remainingOlder : 'n/a',
-        isExpanding: this.isExpandingChatRenderWindow,
-        modalScrollTop: this.modal ? Math.round(this.modal.scrollTop || 0) : 'n/a',
-        bodyScrollY: Math.round(window.scrollY || 0)
-      });
-    }
     const loadAheadThreshold = this.getChatLoadAheadThreshold();
     const renderedTopThreshold = this.getChatRenderedTopLoadAheadThreshold(scrollSnapshot);
     if (
@@ -15851,25 +15412,6 @@ class ChatModal {
         }
         this.queueChatScrollExpand('scrollDistance', scrollSnapshot);
       }
-    } else if (
-      this.chatPerfLoggingEnabled &&
-      isNearRenderedTop &&
-      !isExpansionRearmed &&
-      now - this.lastChatExpandBlockedLogAt > 750
-    ) {
-      this.lastChatExpandBlockedLogAt = now;
-      this.logChatPerf('window:expandBlocked', {
-        reason: 'notRearmed',
-        scrollTop: scrollSnapshot.scrollTop,
-        distanceFromBottom: scrollSnapshot.distanceFromBottom,
-        rearmDistance: Number.isFinite(this.chatExpansionRearmDistanceFromBottom)
-          ? Math.round(this.chatExpansionRearmDistanceFromBottom)
-          : 'n/a',
-        distanceToRenderedTop: scrollSnapshot.distanceToRenderedTop,
-        renderedTopThreshold: Math.round(renderedTopThreshold),
-        renderedBoundaryThreshold: Math.round(renderedBoundaryThreshold),
-        remainingOlder
-      });
     }
   }
 
@@ -15941,15 +15483,6 @@ class ChatModal {
       const loadAheadThreshold = this.getChatRenderedTopLoadAheadThreshold();
       if (topSpacerHeight <= 0 || distanceToRenderedTop > loadAheadThreshold) return;
 
-      this.logChatPerf('window:spacerCatchup', {
-        contact: this.formatChatPerfAddress(this.address, contact),
-        reason,
-        scrollTop: Math.round(this.messagesContainer.scrollTop),
-        topSpacerHeight: Math.round(topSpacerHeight),
-        distanceToRenderedTop: Math.round(distanceToRenderedTop),
-        renderedTopThreshold: Math.round(loadAheadThreshold),
-        remainingOlder: Math.max(0, messages.length - 1 - currentOldestIndex)
-      });
       this.expandChatRenderWindow('scrollDistance');
     }, 16);
   }
@@ -15966,10 +15499,9 @@ class ChatModal {
       this.chatRenderWindowDrainFrame = null;
     }
     this.chatRenderWindowDrainAddress = null;
-    this.chatRenderWindowDrainStartedAt = 0;
   }
 
-  scheduleChatRenderWindowDrain(address, reason = 'afterDeferred') {
+  scheduleChatRenderWindowDrain(address) {
     if (!address || this.chatRenderWindowDrainAddress === address) return;
     const contact = myData.contacts[address];
     const messages = contact?.messages;
@@ -15982,15 +15514,6 @@ class ChatModal {
     if (getCurrentOldestIndex() >= messages.length - 1) return;
 
     this.chatRenderWindowDrainAddress = address;
-    this.chatRenderWindowDrainStartedAt = this.getChatPerfTime();
-    this.logChatPerf('window:drainScheduled', {
-      contact: this.formatChatPerfAddress(address, contact),
-      reason,
-      currentOldestIndex: getCurrentOldestIndex(),
-      batchSize: this.chatOlderRenderBatchSize,
-      remainingOlder: Math.max(0, messages.length - 1 - getCurrentOldestIndex()),
-      totalMessages: messages.length
-    });
 
     const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
       ? requestAnimationFrame
@@ -16015,11 +15538,6 @@ class ChatModal {
       scheduleDrainFrame(() => {
         scheduleAfterPaint(() => {
           if (!this.isActive() || this.address !== address) {
-            this.logChatPerf('window:drainAbort', {
-              contact: this.formatChatPerfAddress(address, contact),
-              reason: this.address !== address ? 'addressChanged' : 'inactive',
-              elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
-            });
             this.cancelChatRenderWindowDrain();
             return;
           }
@@ -16031,39 +15549,16 @@ class ChatModal {
 
           const currentOldestIndex = getCurrentOldestIndex();
           if (currentOldestIndex >= messages.length - 1) {
-            this.logChatPerf('window:drainDone', {
-              contact: this.formatChatPerfAddress(address, contact),
-              currentOldestIndex,
-              totalMessages: messages.length,
-              elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
-            });
             this.cancelChatRenderWindowDrain();
             return;
           }
 
-          const stepStart = this.getChatPerfTime();
-          const expanded = this.expandChatRenderWindow('openDrain');
-          const stepMs = this.formatChatPerfMs(stepStart);
+          this.expandChatRenderWindow('openDrain');
           const nextOldestIndex = getCurrentOldestIndex();
-          this.logChatPerf('window:drainStep', {
-            contact: this.formatChatPerfAddress(address, contact),
-            expanded,
-            previousOldestIndex: currentOldestIndex,
-            currentOldestIndex: nextOldestIndex,
-            remainingOlder: Math.max(0, messages.length - 1 - nextOldestIndex),
-            step: stepMs,
-            elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
-          });
 
           if (nextOldestIndex < messages.length - 1) {
             scheduleNextDrainStep();
           } else {
-            this.logChatPerf('window:drainDone', {
-              contact: this.formatChatPerfAddress(address, contact),
-              currentOldestIndex: nextOldestIndex,
-              totalMessages: messages.length,
-              elapsed: this.formatChatPerfMs(this.chatRenderWindowDrainStartedAt)
-            });
             this.cancelChatRenderWindowDrain();
           }
         });
@@ -16106,7 +15601,6 @@ class ChatModal {
    * @returns {Promise<void>}
    */
   async open(address, skipAutoScroll = false) {
-    const openPerfStart = this.getChatPerfTime();
     this.closeReactionSheet();
 
     // Set active chat address early so async refreshes target the correct chat.
@@ -16128,52 +15622,15 @@ class ChatModal {
     footer.closeNewChatButton();
     const contact = myData.contacts[address];
     this.resetChatRenderWindow(address);
-    const chatPerfSummary = this.summarizeChatPerfContact(contact);
-    const visualViewportSize = window.visualViewport
-      ? `${Math.round(window.visualViewport.width)}x${Math.round(window.visualViewport.height)}`
-      : 'n/a';
-    this.logChatPerf('open:start', {
-      contact: this.formatChatPerfAddress(address, contact),
-      messages: chatPerfSummary.messages,
-      replies: chatPerfSummary.replies,
-      attachments: chatPerfSummary.attachments,
-      mediaAttachments: chatPerfSummary.mediaAttachments,
-      voice: chatPerfSummary.voice,
-      payments: chatPerfSummary.payments,
-      calls: chatPerfSummary.calls,
-      edited: chatPerfSummary.edited,
-      deleted: chatPerfSummary.deleted,
-      reactions: chatPerfSummary.reactions,
-      textChars: chatPerfSummary.textChars,
-      skipAutoScroll,
-      viewport: `${window.innerWidth}x${window.innerHeight}`,
-      visualViewport: visualViewportSize,
-      contentVisibilityApplied: false
-    });
     // Cache whether the contact has me blocked, and disable attachments accordingly
     this.blockedByRecipient = Number(contact?.tollRequiredToSend) === 2;
     this.addAttachmentButton.disabled = this.blockedByRecipient;
     if (this.voiceRecordButton) this.voiceRecordButton.disabled = this.blockedByRecipient || !isOnline;
-    const friendButtonPerfStart = this.getChatPerfTime();
     friendModal.updateFriendButton(contact, 'addFriendButtonChat');
-    const friendButtonClass = this.addFriendButtonChat
-      ? [...this.addFriendButtonChat.classList].filter((className) => className.startsWith('status-')).join(',')
-      : 'missing';
-    this.logChatPerf('open:friendButton', {
-      ms: this.formatChatPerfMs(friendButtonPerfStart),
-      friend: contact?.friend,
-      class: friendButtonClass,
-      total: this.formatChatPerfMs(openPerfStart)
-    });
     // Set user info
     this.modalTitle.textContent = getContactDisplayName(contact);
 
-    const walletPerfStart = this.getChatPerfTime();
     walletScreen.updateWalletBalances();
-    this.logChatPerf('open:wallet', {
-      ms: this.formatChatPerfMs(walletPerfStart),
-      total: this.formatChatPerfMs(openPerfStart)
-    });
 
     // update the toll value. Will not await this and it'll update the toll value while the modal is open.
     this.updateTollValue(address);
@@ -16194,32 +15651,16 @@ class ChatModal {
       }
     }
 
-    const avatarPerfStart = this.getChatPerfTime();
     this.modalAvatar.innerHTML = await getContactAvatarHtml(contact, 40);
-    this.logChatPerf('open:avatar', {
-      ms: this.formatChatPerfMs(avatarPerfStart),
-      total: this.formatChatPerfMs(openPerfStart)
-    });
 
     // Stop and cleanup all voice messages from previous conversation
-    const cleanupPerfStart = this.getChatPerfTime();
     const previousVoiceMessages = this.messagesList
       ? this.messagesList.querySelectorAll('.voice-message')
       : [];
     previousVoiceMessages.forEach(vm => this.stopVoiceMessage(vm));
-    this.logChatPerf('open:cleanupPreviousVoice', {
-      ms: this.formatChatPerfMs(cleanupPerfStart),
-      previousVoice: previousVoiceMessages.length,
-      total: this.formatChatPerfMs(openPerfStart)
-    });
 
     // Clear previous messages from the UI
-    const clearPerfStart = this.getChatPerfTime();
     this.messagesList.innerHTML = '';
-    this.logChatPerf('open:clearPreviousDom', {
-      ms: this.formatChatPerfMs(clearPerfStart),
-      total: this.formatChatPerfMs(openPerfStart)
-    });
 
     // Scroll to bottom (initial scroll for empty list, appendChatModal will scroll later)
     // Skip if we're going to scroll to a specific message
@@ -16246,9 +15687,6 @@ class ChatModal {
 
     // Show modal
     this.modal.classList.add('active');
-    this.logChatPerf('open:modalActive', {
-      total: this.formatChatPerfMs(openPerfStart)
-    });
 
     // Clear unread count
     const totalUnread = contact.unread;
@@ -16264,12 +15702,7 @@ class ChatModal {
     // One-time tolled deposit toast (only if explicitly enabled on the contact)
     this.maybeShowTolledDepositToast(address);
 
-    const appendPerfStart = this.getChatPerfTime();
     this.appendChatModal(false, skipAutoScroll); // Call appendChatModal to render messages, ensure highlight=false
-    this.logChatPerf('open:appendSyncReturned', {
-      ms: this.formatChatPerfMs(appendPerfStart),
-      total: this.formatChatPerfMs(openPerfStart)
-    });
     void this.maybePromptReclaimToll(address);
   }
 
@@ -17379,65 +16812,24 @@ class ChatModal {
   }
 
   buildChatMessageRangeHTML(messages, contact, oldestIndex, newestIndex) {
-    const buildPerfStart = this.getChatPerfTime();
     const messagesByTxid = this.buildChatMessagesByTxid(messages);
     const lastReadTs = contact.lastChatOpenTs || 0;
     const renderedMessages = [];
     const renderedTxids = [];
-    const summary = {
-      replies: 0,
-      attachments: 0,
-      mediaAttachments: 0,
-      imageAttachments: 0,
-      videoAttachments: 0,
-      fileAttachments: 0,
-      voice: 0,
-      payments: 0,
-      calls: 0,
-      edited: 0,
-      deleted: 0,
-      textChars: 0,
-      maxTextChars: 0,
-      types: new Set(),
-      attachmentTypes: new Set()
-    };
 
     for (let i = oldestIndex; i >= newestIndex; i--) {
       const item = messages[i];
       if (!item) continue;
-      this.updateChatPerfBatchSummary(summary, item);
       renderedMessages.push(this.renderChatMessageHTML(item, i, { contact, messagesByTxid, lastReadTs }));
       if (item.txid) renderedTxids.push(item.txid);
     }
 
-    const buildMs = this.formatChatPerfMs(buildPerfStart);
-    const joinPerfStart = this.getChatPerfTime();
     const html = renderedMessages.join('');
-    const joinMs = this.formatChatPerfMs(joinPerfStart);
 
     return {
       html,
       renderedCount: renderedMessages.length,
-      renderedTxids,
-      summary: {
-        replies: summary.replies,
-        attachments: summary.attachments,
-        mediaAttachments: summary.mediaAttachments,
-        imageAttachments: summary.imageAttachments,
-        videoAttachments: summary.videoAttachments,
-        fileAttachments: summary.fileAttachments,
-        voice: summary.voice,
-        payments: summary.payments,
-        calls: summary.calls,
-        edited: summary.edited,
-        deleted: summary.deleted,
-        textChars: summary.textChars,
-        maxTextChars: summary.maxTextChars,
-        types: this.formatChatPerfSet(summary.types),
-        attachmentTypes: this.formatChatPerfSet(summary.attachmentTypes)
-      },
-      buildMs,
-      joinMs
+      renderedTxids
     };
   }
 
@@ -17449,7 +16841,6 @@ class ChatModal {
    * @returns {void}
    */
   appendChatModal(highlightNewMessage = false, skipAutoScroll = false, { skipDeferredWork = false } = {}) {
-    const appendPerfStart = this.getChatPerfTime();
     const currentAddress = this.address; // Use a local constant
     if (!currentAddress) {
       return;
@@ -17475,20 +16866,17 @@ class ChatModal {
     this.newestSentMessage = messages.find((item) => item.my);
 
     const renderedMessages = [];
-    const txidMapPerfStart = this.getChatPerfTime();
     const messagesByTxid = new Map();
     messages.forEach((message) => {
       if (message?.txid) {
         messagesByTxid.set(message.txid, message);
       }
     });
-    const txidMapMs = this.formatChatPerfMs(txidMapPerfStart);
     const forceFullRender = highlightNewMessage && skipAutoScroll;
     const renderRange = this.getChatRenderRange(messages, currentAddress, forceFullRender);
 
     // 3. Iterate backwards through messages (oldest to newest for rendering order)
     // messages are already sorted descending (newest first) in myData
-    const renderLoopPerfStart = this.getChatPerfTime();
     for (let i = renderRange.oldestIndex; i >= renderRange.newestIndex; i--) {
       const item = messages[i];
       let messageHTML = '';
@@ -17692,96 +17080,35 @@ class ChatModal {
       renderedMessages.push(messageHTML);
       // The newest received element will be found after the loop completes
     }
-    const renderLoopMs = this.formatChatPerfMs(renderLoopPerfStart);
-    const topSpacerHeight = 0;
     this.chatHistorySpacerHeight = 0;
 
     // Replace the list once to avoid one DOM mutation per message.
-    const joinPerfStart = this.getChatPerfTime();
     const renderedHTML = renderedMessages.join('');
-    const joinMs = this.formatChatPerfMs(joinPerfStart);
-    const domWritePerfStart = this.getChatPerfTime();
     this.messagesList.innerHTML = renderedHTML;
-    const domWriteMs = this.formatChatPerfMs(domWritePerfStart);
-    let immediateScrollMetrics = null;
-    let immediateScrollMs = 'skipped';
     const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
     if (shouldKeepBottomAnchored) {
-      const immediateScrollPerfStart = this.getChatPerfTime();
-      immediateScrollMetrics = this.scrollMessagesToBottom({ readMetrics: false });
-      immediateScrollMs = this.formatChatPerfMs(immediateScrollPerfStart);
+      this.scrollMessagesToBottom({ readMetrics: false });
     }
-    this.logChatPerf('append:sync', {
-      contact: this.formatChatPerfAddress(currentAddress, contact),
-      messages: messages.length,
-      rendered: renderedMessages.length,
-      oldestIndex: renderRange.oldestIndex,
-      isWindowed: renderRange.isWindowed,
-      topSpacer: topSpacerHeight,
-      txidMap: txidMapMs,
-      build: renderLoopMs,
-      join: joinMs,
-      domWrite: domWriteMs,
-      immediateScroll: immediateScrollMs,
-      immediateScrollTop: immediateScrollMetrics ? immediateScrollMetrics.scrollTop : 'n/a',
-      immediateScrollHeight: immediateScrollMetrics ? immediateScrollMetrics.scrollHeight : 'n/a',
-      htmlChars: renderedHTML.length,
-      children: this.messagesList.children.length,
-      total: this.formatChatPerfMs(appendPerfStart)
-    });
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
     this.loadThumbnailsForAttachments();
 
     const renderedAddress = currentAddress;
-    if (skipDeferredWork) {
-      this.logChatPerf('append:deferredSkipped', {
-        contact: this.formatChatPerfAddress(renderedAddress, contact),
-        delay: '0.0ms',
-        reason: 'skipDeferredWork',
-        renderSequence
-      });
-    } else {
-      const deferredScheduledAt = this.getChatPerfTime();
+    if (!skipDeferredWork) {
       const scheduleAfterPaint = typeof requestAnimationFrame === 'function'
         ? requestAnimationFrame
         : (callback) => setTimeout(callback, 0);
       scheduleAfterPaint(() => {
         scheduleAfterPaint(() => {
-          const deferredStart = this.getChatPerfTime();
           if (
             !this.isActive() ||
             this.address !== renderedAddress ||
             !this.messagesList ||
             renderSequence !== this.chatRenderSequence
           ) {
-            this.logChatPerf('append:deferredSkipped', {
-              contact: this.formatChatPerfAddress(renderedAddress, contact),
-              delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-              reason: renderSequence !== this.chatRenderSequence ? 'staleRender' : 'inactive',
-              renderSequence,
-              currentRenderSequence: this.chatRenderSequence,
-              currentAddress: this.address || 'none'
-            });
             return;
           }
-          const reactionPerfStart = this.getChatPerfTime();
           this.syncAllRenderedReactionChips();
-          const reactionsMs = this.formatChatPerfMs(reactionPerfStart);
-          this.logChatPerf('append:deferred', {
-            contact: this.formatChatPerfAddress(renderedAddress, contact),
-            delay: this.formatChatPerfMs(deferredScheduledAt, deferredStart),
-            reactions: reactionsMs,
-            total: this.formatChatPerfMs(deferredStart)
-          });
-          if (shouldKeepBottomAnchored && renderRange.isWindowed) {
-            this.logChatPerf('window:drainSuppressed', {
-              contact: this.formatChatPerfAddress(renderedAddress, contact),
-              reason: 'bottomScrollCost',
-              rendered: renderedMessages.length,
-              remainingOlder: Math.max(0, messages.length - 1 - renderRange.oldestIndex)
-            });
-          }
         });
       });
     }
@@ -17790,36 +17117,16 @@ class ChatModal {
     // This happens inside the setTimeout to ensure elements are in the DOM
 
     if (skipAutoScroll) {
-      if (this.chatPerfLoggingEnabled) {
-        this.logChatPerf('append:scrollSkipped', {
-          contact: this.formatChatPerfAddress(currentAddress, contact),
-          delay: '0.0ms',
-          reason: 'skipAutoScroll'
-        });
-      }
       return;
     }
 
     if (shouldKeepBottomAnchored && !highlightNewMessage) {
-      if (this.chatPerfLoggingEnabled) {
-        this.logChatPerf('append:scrollSkipped', {
-          contact: this.formatChatPerfAddress(currentAddress, contact),
-          delay: '0.0ms',
-          reason: 'immediateBottom',
-          scrollTop: this.messagesContainer ? Math.round(this.messagesContainer.scrollTop) : 'n/a',
-          scrollHeight: this.messagesContainer ? Math.round(this.messagesContainer.scrollHeight) : 'n/a',
-          clientHeight: this.messagesContainer ? Math.round(this.messagesContainer.clientHeight) : 'n/a'
-        });
-      }
       return;
     }
 
     // 6. Delayed Scrolling & Highlighting Logic (after loop)
-    const scrollScheduledAt = this.getChatPerfTime();
     setTimeout(() => {
-      const scrollPerfStart = this.getChatPerfTime();
       const messageContainer = this.messagesList.parentElement;
-      let scrollTarget = 'bottom';
 
       // Find the DOM element for the actual newest received item using its timestamp
       // Only proceed if newestReceivedItem was found and highlightNewMessage is true
@@ -17840,7 +17147,6 @@ class ChatModal {
             
             // Scroll to the calculated position
             messageContainer.scrollTop = scrollTop;
-            scrollTarget = 'highlight';
           }
           
           // Apply highlight immediately
@@ -17861,33 +17167,16 @@ class ChatModal {
           // If element not found, just scroll to bottom
           if (messageContainer) {
             messageContainer.scrollTop = messageContainer.scrollHeight;
-            scrollTarget = 'fallbackBottom';
           }
         }
       } else {
         // No received messages found, not highlighting, or highlightNewMessage is false,
         // just scroll to the bottom if the container exists.
         if (messageContainer) {
-          const userStayedAtInitialBottom = immediateScrollMetrics
-            ? Math.abs(messageContainer.scrollTop - immediateScrollMetrics.scrollTop) <= 2
-            : false;
-          if (!shouldKeepBottomAnchored || userStayedAtInitialBottom || this.isMessagesContainerNearBottom(120)) {
+          if (!shouldKeepBottomAnchored || this.isMessagesContainerNearBottom(120)) {
             messageContainer.scrollTop = messageContainer.scrollHeight;
-          } else {
-            scrollTarget = 'bottomSkippedUserScrolled';
           }
         }
-      }
-      if (this.chatPerfLoggingEnabled) {
-        this.logChatPerf('append:scroll', {
-          contact: this.formatChatPerfAddress(currentAddress, contact),
-          delay: this.formatChatPerfMs(scrollScheduledAt, scrollPerfStart),
-          ms: this.formatChatPerfMs(scrollPerfStart),
-          target: scrollTarget,
-          scrollTop: messageContainer ? Math.round(messageContainer.scrollTop) : 'n/a',
-          scrollHeight: messageContainer ? Math.round(messageContainer.scrollHeight) : 'n/a',
-          clientHeight: messageContainer ? Math.round(messageContainer.clientHeight) : 'n/a'
-        });
       }
     }, 300); // <<< Delay of 300 milliseconds for rendering
   }

--- a/styles.css
+++ b/styles.css
@@ -6170,6 +6170,39 @@ small {
   margin-bottom: 8px;
 }
 
+/* Thumbnail image in attachment rows */
+.attachment-thumbnail {
+  width: 100%;
+  max-width: 300px;
+  height: auto;
+  object-fit: contain;
+  border-radius: 8px;
+  background: #f0f0f0;
+  display: block;
+  margin: 0 auto;
+  /* Disable long press context menus on iOS and Android */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.attachment-icon-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  max-height: 400px;
+}
+
+.attachment-preview-hint {
+  font-size: 0.75em;
+  color: #000000;
+  text-align: center;
+  font-style: italic;
+  font-weight: 600;
+  opacity: 0.8;
+}
+
 .attachment-icon {
   width: 36px;
   height: 36px;
@@ -6180,73 +6213,6 @@ small {
   cursor: pointer;
   transition: opacity 0.2s ease;
   flex-shrink: 0;
-}
-
-.attachment-row {
-  display: grid;
-  grid-template-columns: 96px minmax(0, 1fr);
-  align-items: center;
-  gap: 12px;
-  width: min(100%, 320px);
-  min-height: 120px;
-  padding: 10px;
-  margin-bottom: 6px;
-  border-radius: 12px;
-  background: #f5f5f7;
-  color: #222;
-  overflow: hidden;
-}
-
-.attachment-icon-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-  width: 96px;
-  height: 96px;
-  border-radius: 8px;
-  background: rgba(0, 0, 0, 0.03);
-}
-
-/* Thumbnail image in attachment rows */
-.attachment-thumbnail {
-  width: 96px;
-  height: 96px;
-  object-fit: cover;
-  border-radius: 8px;
-  background: #f0f0f0;
-  display: block;
-  /* Disable long press context menus on iOS and Android */
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  user-select: none;
-}
-
-.attachment-details {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.attachment-label {
-  display: -webkit-box;
-  max-height: 3.6em;
-  overflow: hidden;
-  color: #222;
-  font-size: 0.78rem;
-  font-weight: 500;
-  line-height: 1.2;
-  overflow-wrap: anywhere;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-}
-
-.attachment-meta {
-  color: #888;
-  font-size: 0.95rem;
-  line-height: 1.25;
-  overflow-wrap: anywhere;
 }
 
 .attachment-icon:hover {
@@ -6261,9 +6227,9 @@ small {
 /* Image and video icons in message display (not preview) */
 .attachment-row .attachment-icon[data-file-type="image"],
 .attachment-row .attachment-icon[data-file-type="video"] {
-  width: 72px;
-  height: 72px;
-  background-size: 72px;
+  width: 144px;
+  height: 144px;
+  background-size: 144px;
 }
 
 .attachment-icon[data-file-type="audio"] {

--- a/styles.css
+++ b/styles.css
@@ -2190,6 +2190,13 @@ input[type='file'].form-control::file-selector-button {
   transition: filter 0.2s ease;
 }
 
+@supports (content-visibility: auto) {
+  .messages-list .message {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 72px;
+  }
+}
+
 .message:hover {
   filter: brightness(95%);
 }

--- a/styles.css
+++ b/styles.css
@@ -2178,9 +2178,13 @@ input[type='file'].form-control::file-selector-button {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 0 0 auto;
   min-height: 100%;
-  justify-content: flex-end;
   padding-top: 1rem;
+}
+
+.messages-list > .message:first-child {
+  margin-top: auto;
 }
 
 .message {

--- a/styles.css
+++ b/styles.css
@@ -1873,6 +1873,8 @@ input[type='file'].form-control::file-selector-button {
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
+  -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain; /* stop scroll chaining to modal/body */
   touch-action: pan-y; /* allow vertical panning only */
   transition: padding-bottom 0.2s ease-out;

--- a/styles.css
+++ b/styles.css
@@ -2179,6 +2179,7 @@ input[type='file'].form-control::file-selector-button {
   flex-direction: column;
   gap: 1rem;
   min-height: 100%;
+  justify-content: flex-end;
   padding-top: 1rem;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -6160,40 +6160,6 @@ small {
   margin-bottom: 8px;
 }
 
-/* Thumbnail image in attachment rows */
-.attachment-thumbnail {
-  width: 144px;
-  height: 144px;
-  object-fit: cover;
-  border-radius: 8px;
-  background: #f0f0f0;
-  display: block;
-  margin: 0 auto;
-  /* Disable long press context menus on iOS and Android */
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  user-select: none;
-}
-
-.attachment-icon-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-  width: 144px;
-  height: 144px;
-  flex: 0 0 144px;
-}
-
-.attachment-preview-hint {
-  font-size: 0.75em;
-  color: #000000;
-  text-align: center;
-  font-style: italic;
-  font-weight: 600;
-  opacity: 0.8;
-}
-
 .attachment-icon {
   width: 36px;
   height: 36px;
@@ -6204,6 +6170,73 @@ small {
   cursor: pointer;
   transition: opacity 0.2s ease;
   flex-shrink: 0;
+}
+
+.attachment-row {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  width: min(100%, 320px);
+  min-height: 120px;
+  padding: 10px;
+  margin-bottom: 6px;
+  border-radius: 12px;
+  background: #f5f5f7;
+  color: #222;
+  overflow: hidden;
+}
+
+.attachment-icon-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  width: 96px;
+  height: 96px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+/* Thumbnail image in attachment rows */
+.attachment-thumbnail {
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 8px;
+  background: #f0f0f0;
+  display: block;
+  /* Disable long press context menus on iOS and Android */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.attachment-details {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.attachment-label {
+  display: -webkit-box;
+  max-height: 3.6em;
+  overflow: hidden;
+  color: #222;
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.attachment-meta {
+  color: #888;
+  font-size: 0.95rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .attachment-icon:hover {
@@ -6218,9 +6251,9 @@ small {
 /* Image and video icons in message display (not preview) */
 .attachment-row .attachment-icon[data-file-type="image"],
 .attachment-row .attachment-icon[data-file-type="video"] {
-  width: 144px;
-  height: 144px;
-  background-size: 144px;
+  width: 72px;
+  height: 72px;
+  background-size: 72px;
 }
 
 .attachment-icon[data-file-type="audio"] {

--- a/styles.css
+++ b/styles.css
@@ -2180,10 +2180,6 @@ input[type='file'].form-control::file-selector-button {
   padding-top: 1rem;
 }
 
-.chat-window-top-spacer {
-  flex: 0 0 auto;
-}
-
 .message {
   max-width: 80%;
   padding: 0.75rem 1rem;

--- a/styles.css
+++ b/styles.css
@@ -2190,13 +2190,6 @@ input[type='file'].form-control::file-selector-button {
   transition: filter 0.2s ease;
 }
 
-@supports (content-visibility: auto) {
-  .messages-list .message {
-    content-visibility: auto;
-    contain-intrinsic-size: auto 72px;
-  }
-}
-
 .message:hover {
   filter: brightness(95%);
 }

--- a/styles.css
+++ b/styles.css
@@ -2176,7 +2176,9 @@ input[type='file'].form-control::file-selector-button {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-top:1000px; /* keeps message list scrollable */
+  justify-content: flex-end;
+  min-height: 100%;
+  padding-top: 1rem;
 }
 
 .message {

--- a/styles.css
+++ b/styles.css
@@ -6162,10 +6162,9 @@ small {
 
 /* Thumbnail image in attachment rows */
 .attachment-thumbnail {
-  width: 100%;
-  max-width: 300px;
-  height: auto;
-  object-fit: contain;
+  width: 144px;
+  height: 144px;
+  object-fit: cover;
   border-radius: 8px;
   background: #f0f0f0;
   display: block;
@@ -6181,7 +6180,9 @@ small {
   justify-content: center;
   align-items: center;
   overflow: hidden;
-  max-height: 400px;
+  width: 144px;
+  height: 144px;
+  flex: 0 0 144px;
 }
 
 .attachment-preview-hint {

--- a/styles.css
+++ b/styles.css
@@ -2182,13 +2182,6 @@ input[type='file'].form-control::file-selector-button {
   padding-top: 1rem;
 }
 
-.chat-history-spacer {
-  flex: 0 0 auto;
-  min-height: 0;
-  pointer-events: none;
-  overflow: hidden;
-}
-
 .message {
   max-width: 80%;
   padding: 0.75rem 1rem;

--- a/styles.css
+++ b/styles.css
@@ -2182,6 +2182,13 @@ input[type='file'].form-control::file-selector-button {
   padding-top: 1rem;
 }
 
+.chat-history-spacer {
+  flex: 0 0 auto;
+  min-height: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
 .message {
   max-width: 80%;
   padding: 0.75rem 1rem;

--- a/styles.css
+++ b/styles.css
@@ -2301,13 +2301,21 @@ input[type='file'].form-control::file-selector-button {
 }
 
 .message-content {
-  overflow-wrap: break-word;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   word-wrap: break-word;
-  word-break: normal; /* Use normal word breaking to allow hyphens to work */
+  word-break: break-word;
   white-space: normal; /* Ensure text can wrap */
   -webkit-hyphens: auto; /* Add hyphens at line breaks (Chrome/Safari) */
   -moz-hyphens: auto; /* Add hyphens at line breaks (Firefox) */
   hyphens: auto; /* Add hyphens at line breaks */
+}
+
+.message-content a,
+.payment-memo,
+.payment-memo a {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Wrapper for the send button and the toll information */

--- a/styles.css
+++ b/styles.css
@@ -2176,9 +2176,12 @@ input[type='file'].form-control::file-selector-button {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  justify-content: flex-end;
   min-height: 100%;
   padding-top: 1rem;
+}
+
+.chat-window-top-spacer {
+  flex: 0 0 auto;
 }
 
 .message {


### PR DESCRIPTION
## What Changed

This PR improves ChatModal open performance on iPhone WebView by rendering a bounded message window first and lazily prepending older history.

- `appendChatModal` now mounts the newest `100` messages in one DOM replacement, preserves the expanded render window across rerenders, and syncs reactions against rendered records.
- `expandChatRenderWindow` prepends older messages in `200`-message batches near the scroll top and preserves the viewport with the actual `scrollHeight` delta.
- `renderChatMessageHTML()` and `buildChatMessageRangeHTML()` share the rendering path for initial loads and prepends, keeping replies, attachments, payments, calls, voice messages, deleted/edited states, and text rows consistent.
- Attachment, voice, sharing, VCF import, and image reaction actions now resolve backing records from the closest rendered `.message` instead of relying on stale `data-msg-idx` values.
- Cached thumbnail loading decodes images before replacing attachment icons and adjusts `scrollTop` for thumbnail-induced height changes.
- Chat CSS bottom-aligns short conversations without large padding, enables momentum scrolling, contains overscroll, and wraps long unbroken text, links, and payment memos.

## Fixed Flow

1. A user opens a chat with a large message history in iPhone WebView.
2. ChatModal renders only the newest message window, anchors it to the bottom, and loads cached thumbnails without moving the viewport.
3. As the user scrolls near the top, older messages are prepended from in-memory `contact.messages`.
4. The viewport is restored by the actual inserted height, and message actions still target the correct backing record after pagination or rerendering.

## Why

Previously, opening a chat rendered the full history and used large top padding, forcing WebView to lay out many variable-height rows before the modal was usable. Long unbroken text and links amplified that cost because `scrollHeight` measurements after insertion could stall.

Windowed rendering removes the full-history initial layout cost, exact height-delta anchoring keeps variable-height rows stable, and DOM-to-record lookup keeps actions correct once rendered rows no longer map to fixed array indices. Touch boundary handling and overscroll containment stop modal/body scroll bleed while preserving vertical panning inside the message list.

## Validation

- `node --check app.js`
