### PR TITLE
Delete reactions when messages are deleted

### DIFF
--- a/app.js
+++ b/app.js
@@ -6290,7 +6290,7 @@ function purgePendingReactionsForTarget(contactAddress, targetTxid) {
       pendingTx.to === normalizedContactAddress &&
       pendingTx.reactionPending &&
       pendingTx.reactionPending.targetTxid === targetTxid;
-    const isAwaitingInject = isTargetReaction && pendingTx.checkedts === 0;
+    const isAwaitingInject = isTargetReaction && pendingTx.reactionInjectPending === true;
     return !(isTargetReaction && !isAwaitingInject);
   });
 }
@@ -6668,6 +6668,7 @@ function trackPendingReactionBeforeInject(txid, contactAddress, reactionPending)
     submittedts: getCorrectedTimestamp(),
     checkedts: 0,
     to: normalizeAddress(contactAddress),
+    reactionInjectPending: true,
     reactionPending,
   });
 }
@@ -19108,10 +19109,14 @@ class ChatModal {
       console.error('reaction message failed to send', response);
       const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
       assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
+      pendingTxInfo.reactionInjectPending = false;
 
       const outcome = settlePendingReaction(pendingTxInfo, 'failure');
       if (!outcome.hasPending) {
         cleanupResolvedReactionChain(currentAddress, outcome.targetTxid);
+      }
+      if (isDeleted(targetMessage)) {
+        purgePendingReactionsForTarget(currentAddress, reaction.reactId);
       }
       const reason = response?.result?.reason || '';
       if (outcome.didChange) {
@@ -19129,10 +19134,12 @@ class ChatModal {
       return false;
     }
 
-    assert(
-      myData.pending.some((pendingTx) => pendingTx.txid === txid),
-      `Pending reaction metadata missing for ${txid}`
-    );
+    const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+    assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
+    pendingTxInfo.reactionInjectPending = false;
+    if (isDeleted(targetMessage)) {
+      purgePendingReactionsForTarget(currentAddress, reaction.reactId);
+    }
     saveState();
 
     return true;

--- a/app.js
+++ b/app.js
@@ -6274,6 +6274,27 @@ function purgeContactReactionsForTarget(contact, targetTxid) {
 }
 
 /**
+ * Removes pending reaction transactions that would rematerialize chips for a deleted message.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ */
+function purgePendingReactionsForTarget(contactAddress, targetTxid) {
+  if (!Array.isArray(myData?.pending) || !contactAddress || !targetTxid) {
+    return;
+  }
+
+  const normalizedContactAddress = normalizeAddress(contactAddress);
+  myData.pending = myData.pending.filter((pendingTx) => {
+    return !(
+      pendingTx.type === 'message' &&
+      pendingTx.to === normalizedContactAddress &&
+      pendingTx.reactionPending &&
+      pendingTx.reactionPending.targetTxid === targetTxid
+    );
+  });
+}
+
+/**
  * Applies a reaction control message to the contact-level active reaction state.
  * @param {Object} contact
  * @param {ReactionUpdate} reaction
@@ -6886,6 +6907,7 @@ async function processChats(chats, keys) {
                   }
                   if (didDeleteMessage) {
                     purgeContactReactionsForTarget(contact, messageToDelete.txid);
+                    purgePendingReactionsForTarget(from, messageToDelete.txid);
                     syncChatLatestActivityTimestamp(from, contact);
                     didChangeReactionPreview = true;
                     if (wasUnreadIncomingMessage) {
@@ -17898,6 +17920,11 @@ class ChatModal {
       existingContainer.remove();
     }
 
+    const messageRecord = this.getMessageRecordFromElement(messageEl);
+    if (messageRecord && isDeleted(messageRecord)) {
+      return;
+    }
+
     const reactionHtml = this.buildReactionChipsHTML(reactionsForTarget);
     if (!reactionHtml) return;
 
@@ -19466,6 +19493,7 @@ class ChatModal {
       this.purgeThumbnail(message.xattach);
       delete message.xattach;
       purgeContactReactionsForTarget(contact, message.txid);
+      purgePendingReactionsForTarget(this.address, message.txid);
       syncChatLatestActivityTimestamp(this.address, contact);
       
       this.appendChatModal();

--- a/app.js
+++ b/app.js
@@ -6290,8 +6290,10 @@ function purgePendingReactionsForTarget(contactAddress, targetTxid) {
       pendingTx.to === normalizedContactAddress &&
       pendingTx.reactionPending &&
       pendingTx.reactionPending.targetTxid === targetTxid;
-    const isAwaitingInject = isTargetReaction && pendingTx.reactionInjectPending === true;
-    return !(isTargetReaction && !isAwaitingInject);
+    if (!isTargetReaction) {
+      return true;
+    }
+    return pendingTx.reactionInjectPending === true;
   });
 }
 
@@ -6671,6 +6673,18 @@ function trackPendingReactionBeforeInject(txid, contactAddress, reactionPending)
     reactionInjectPending: true,
     reactionPending,
   });
+}
+
+/**
+ * Marks pending reaction metadata as safe for deletion after `/inject` returns.
+ * @param {string} txid
+ * @returns {Object}
+ */
+function finishPendingReactionInject(txid) {
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+  assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
+  pendingTxInfo.reactionInjectPending = false;
+  return pendingTxInfo;
 }
 
 /**
@@ -19107,9 +19121,7 @@ class ChatModal {
     const response = await injectTx(chatMessageObj, txid);
     if (!response?.result?.success) {
       console.error('reaction message failed to send', response);
-      const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-      assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
-      pendingTxInfo.reactionInjectPending = false;
+      const pendingTxInfo = finishPendingReactionInject(txid);
 
       const outcome = settlePendingReaction(pendingTxInfo, 'failure');
       if (!outcome.hasPending) {
@@ -19134,9 +19146,7 @@ class ChatModal {
       return false;
     }
 
-    const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-    assert(pendingTxInfo, `Pending reaction metadata missing for ${txid}`);
-    pendingTxInfo.reactionInjectPending = false;
+    finishPendingReactionInject(txid);
     if (isDeleted(targetMessage)) {
       purgePendingReactionsForTarget(currentAddress, reaction.reactId);
     }

--- a/app.js
+++ b/app.js
@@ -6285,12 +6285,13 @@ function purgePendingReactionsForTarget(contactAddress, targetTxid) {
 
   const normalizedContactAddress = normalizeAddress(contactAddress);
   myData.pending = myData.pending.filter((pendingTx) => {
-    return !(
+    const isTargetReaction =
       pendingTx.type === 'message' &&
       pendingTx.to === normalizedContactAddress &&
       pendingTx.reactionPending &&
-      pendingTx.reactionPending.targetTxid === targetTxid
-    );
+      pendingTx.reactionPending.targetTxid === targetTxid;
+    const isAwaitingInject = isTargetReaction && pendingTx.checkedts === 0;
+    return !(isTargetReaction && !isAwaitingInject);
   });
 }
 


### PR DESCRIPTION
## What Changed

This PR makes message deletion clean up reactions at both layers where reactions can exist.

- `purgeContactReactionsForTarget(contact, txid)` is now used when a message is deleted. This removes active reaction objects from `contact.reactions` for that message.
- `purgePendingReactionsForTarget(contactAddress, txid)` was added. This removes pending reaction mutations from `myData.pending` so they cannot later replay and recreate reaction state for a deleted message.
- A `reactionInjectPending` marker was added for reaction sends. This protects the short window where a reaction has been optimistically added locally but `/inject` has not returned yet, because `sendReactionMessage()` still needs that pending metadata to finish cleanly.
- A UI guard was added in reaction chip rendering. If the message record is deleted, the modal does not render reaction chips for it.

## Fixed Flow

1. A message has one or more reactions.
2. The message is deleted locally, or a delete-for-all control message is processed.
3. The message is marked deleted.
4. Active reactions targeting that message are removed from `contact.reactions`.
5. Accepted pending reaction entries targeting that message are removed from `myData.pending`.
6. If a reaction send is currently mid-`/inject`, its provisional metadata is kept only until `/inject` returns.
7. Once `/inject` finishes, the marker is cleared, and if the message was deleted during the wait, the pending reaction is purged too.

## Why

Previously, deleted messages could still have reaction state hanging around. In some cases, pending reaction reconciliation could replay stale reaction data and make chips reappear for a message that was already deleted. This fixes the source-of-truth data, while the render guard acts as a final UI safety net.

## Validation

- `node --check app.js`

Closes #1313