### PR TITLE
Move chat toll amount above composer input

### DIFF
--- a/index.html
+++ b/index.html
@@ -1192,17 +1192,17 @@
             </div>
             <button class="reply-preview-close" id="replyPreviewClose" aria-label="Cancel reply" type="button"></button>
           </div>
+          <div class="toll-container chat-toll-container">
+            <span class="toll-label" id="tollLabel">Toll:</span>
+            <span class="toll-value" id="tollValue"></span>
+            <span class="toll-info-icon" data-icon="info"></span>
+          </div>
           <div class="message-input-row">
             <button class="icon-button add-attachment-button" id="addAttachmentButton" aria-label="Add attachment"></button>
             <!-- Cancel Edit button (shown only when editing a message) -->
             <button class="icon-button cancel-edit-button" id="cancelEditButton" aria-label="Cancel edit" style="display: none;"></button>
             <div class="message-input-wrapper">
               <textarea class="message-input" placeholder="Type a message..."></textarea>
-              <div class="toll-container">
-                <span class="toll-label" id="tollLabel">Toll:</span>
-                <span class="toll-value" id="tollValue"></span>
-                <span class="toll-info-icon" data-icon="info"></span>
-              </div>
               <button class="icon-button voice-record-button" id="voiceRecordButton" aria-label="Record voice message"></button>
               <button class="send-button" id="handleSendMessage">
                 <svg viewBox="0 0 24 24">

--- a/styles.css
+++ b/styles.css
@@ -1883,7 +1883,7 @@ input[type='file'].form-control::file-selector-button {
 .message-input-container {
   min-height: 80px;
   padding: 8px 14px;
-  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 18px);
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 8px);
   background: white;
   display: flex;
   flex-direction: column; /* Change to column layout */
@@ -2323,7 +2323,7 @@ input[type='file'].form-control::file-selector-button {
   word-break: break-word;
 }
 
-/* Wrapper for the send button and the toll information */
+/* Wrapper for the message input and inline action buttons */
 .message-input-wrapper {
   position: relative;
   flex: 1;
@@ -2332,18 +2332,17 @@ input[type='file'].form-control::file-selector-button {
   pointer-events: auto;
 }
 
-.toll-container {
-  position: absolute;
-  top: 100%;
-  left: 17px; /* This aligns the container's right edge with the parent's right edge */
-  margin-top: 1px; /* Keeping your existing margin */
-  font-size: 0.8rem; /* Keeping your existing font size */
-  line-height: 1.3; /* Keeping your existing line height */
-  color: var(--secondary-text-color); /* Keeping your existing color */
-  font-weight: 500; /* Keeping your existing font weight */
-  white-space: nowrap; /* Essential to keep it on one line and allow overflow to the left */
-  text-align: left; /* Aligns the text content itself to the right within the container */
-  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1); /* Keeping your existing text shadow */
+#chatModal .chat-toll-container {
+  align-self: flex-end;
+  margin: 0 16px 4px 0;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  color: var(--secondary-text-color);
+  font-weight: 500;
+  white-space: nowrap;
+  text-align: right;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
+  pointer-events: auto;
 }
 
 /* .toll-label {
@@ -2357,7 +2356,7 @@ input[type='file'].form-control::file-selector-button {
 
 .toll-value {
   /* Specific styles for the value part (e.g., "0 LIB").
-     It will inherit from .toll-container.
+     It will inherit from the surrounding toll display.
      If you want the value to be even bolder than the label (which is now 500 weight): */
   /* font-weight: bold;  */ /* or  */
   font-weight: 500;


### PR DESCRIPTION
## What Changed

This PR moves the chat toll amount above the message input so the input remains the bottom-most composer control on mobile keyboards.

- `chatModal` renders the toll amount as its own composer row above `.message-input-row` instead of inside the input wrapper.
- `chat-toll-container` uses normal flex layout instead of absolute positioning, and aligns the toll text to the right side of the composer.
- `.message-input-container` no longer keeps the extra bottom padding that compensated for the old under-input toll line, while still preserving safe-area padding.

## Fixed Flow

1. A user opens `chatModal` on desktop, mobile browser, iOS WebView, or Android WebView.
2. The composer renders attachment/reply previews, then the toll row, then the message input row.
3. The toll amount stays visible above the input without relying on `position: absolute`.
4. Focusing the message input keeps the input as the bottom-most composer control above the keyboard.

## Why

The previous toll layout positioned the toll amount below the textarea wrapper with `top: 100%`. That made the toll line part of the lower composer area and required extra bottom padding, which could crowd the composer when mobile keyboards opened. Rendering the toll row in normal flow above the input removes that bottom-position assumption and keeps keyboard focus behavior centered on the message input.

## Validation

- `git diff --check origin/main...HEAD`
- `google-chrome --headless --disable-gpu --no-sandbox --dump-dom --virtual-time-budget=1000 --window-size=390,844 file:///tmp/issue-1316-chat-layout-check.html`

Closes #1316

<img width="516" height="1045" alt="image" src="https://github.com/user-attachments/assets/cf7fedcd-8c40-4cf6-91e8-029cc777eaab" />
