### PR TITLE
ci: run smoke e2e on pull requests

### DIFF
--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -53,7 +53,8 @@ jobs:
       WEB_CLIENT_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.web_client_ref || github.sha }}
       CLIENT_TESTING_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.client_testing_ref || 'main' }}
       BROWSER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.browser || 'chromium' }}
-      TEST_PATH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_path || '' }}
+      TEST_PATH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_path || 'tests/smoke.e2e.test.js' }}
+      TEST_GREP: ${{ github.event_name != 'workflow_dispatch' && '@smoke' || '' }}
       WORKERS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.workers || '4' }}
       PORT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.port || '4173' }}
 
@@ -148,6 +149,10 @@ jobs:
             echo "Running full test suite"
           fi
           "${CMD[@]}"
+          if [ -n "${TEST_GREP}" ]; then
+            echo "Running tests matching grep: ${TEST_GREP}"
+            "${CMD[@]}" --grep "${TEST_GREP}" --pass-with-no-tests
+          fi
 
       - name: Upload Playwright HTML report
         if: always()
@@ -190,6 +195,9 @@ jobs:
             TEST_SCOPE="${TEST_PATH}"
           else
             TEST_SCOPE="(full suite)"
+          fi
+          if [ -n "${TEST_GREP}" ]; then
+            TEST_SCOPE="${TEST_SCOPE} plus grep ${TEST_GREP}"
           fi
           if [ "${{ job.status }}" = "success" ]; then
             RESULT="PASS"


### PR DESCRIPTION
## Summary
- Change PR-triggered Client E2E runs to target the existing `tests/smoke.e2e.test.js` Playwright spec from `Liberdus/client-testing`.
- Also run any Playwright tests whose title/description matches `@smoke` on PR events.
- Preserve `workflow_dispatch` behavior, including the existing optional `test_path` input and full-suite default when it is left blank.
- Do not add local-network wiring; PRs continue to use the current dev-network e2e workflow path.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/client-e2e.yml`
- `git diff --check`

## Notes
- The `@smoke` grep pass uses `--pass-with-no-tests`, so the workflow remains green if the selected `client-testing` ref has no `@smoke` tests yet.
- Did not run the Playwright suite locally to avoid a long network-dependent e2e run; this PR only changes the workflow test selection for PR events.