### PR TITLE
Fix long memo confirmation modal scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4710,6 +4710,11 @@ small {
   padding: 16px;
 }
 
+#sendAssetConfirmModal .form-container {
+  overflow-y: visible;
+  overscroll-behavior: auto;
+}
+
 #sendAssetConfirmModal label {
   display: block;
   font-size: var(--font-size-sm);

--- a/styles.css
+++ b/styles.css
@@ -1372,6 +1372,7 @@ button:disabled {
 .modal.fixed-header .form-container {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior: auto;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -4708,11 +4709,6 @@ small {
   background-color: var(--hover-background-purple);
   border-radius: 12px;
   padding: 16px;
-}
-
-#sendAssetConfirmModal .form-container {
-  overflow-y: visible;
-  overscroll-behavior: auto;
 }
 
 #sendAssetConfirmModal label {


### PR DESCRIPTION
## What Changed

This PR keeps fixed-header modal form containers scrollable from their content area when a long memo is shown on the Confirm Transaction screen.

- `.modal.fixed-header .form-container` now allows normal overscroll chaining while preserving the existing scroll container and momentum scrolling behavior.
- Long valid memo content no longer traps wheel/touch gestures before the user can reach the confirmation controls.

## Fixed Flow

1. User enters a valid long memo and opens the Confirm Transaction screen.
2. The memo content makes the fixed-header modal taller than the viewport.
3. Wheel/touch scrolling from the modal content can continue through the form container.
4. The user can reach Confirm Send and Cancel without needing to drag the scrollbar directly.

## Why

The form container inherited contained overscroll behavior, which could trap scrolling when a long memo expanded the confirmation details. Allowing normal overscroll behavior on fixed-header modal form containers keeps the existing layout intact while letting the modal remain usable for long valid memo content.

## Validation

- Manual browser check: confirmed the long memo Confirm Transaction screen can scroll from the page content area.

Closes #1320
