### PR TITLE
Change attachment server domain to att.liberdus.com

### DIFF
--- a/network.js
+++ b/network.js
@@ -34,7 +34,7 @@ const network = {
   ],
   "farmUrl": "https://liberdus.com/farm",
   "validatorUrl": "https://liberdus.com/validator",
-  "attachmentServerUrl": "https://inv.liberdus.com:2083",
+  "attachmentServerUrl": "https://att.liberdus.com:2083",
   "bridgeUrl": "./bridge",
   // App version requirements for native apps (format: YYYY.MMDD.HHmm)
   "app_version": {

--- a/network.js_dev
+++ b/network.js_dev
@@ -34,7 +34,7 @@ const network = {
   ],
   "farmUrl": "https://liberdus.com/farm",
   "validatorUrl": "https://liberdus.com/validator",
-  "attachmentServerUrl": "https://inv.liberdus.com:2083",
+  "attachmentServerUrl": "https://att.liberdus.com:2083",
   "bridgeUrl": "./bridge",
   // App version requirements for native apps (format: YYYY.MMDD.HHmm)
   "app_version": {

--- a/network.js_test
+++ b/network.js_test
@@ -31,7 +31,7 @@ const network = {
   ],
   "farmUrl": "https://liberdus.com/farm",
   "validatorUrl": "https://liberdus.com/validator",
-  "attachmentServerUrl": "https://inv.liberdus.com:2083",
+  "attachmentServerUrl": "https://att.liberdus.com:2083",
   "bridgeUrl": "./bridge",
   // App version requirements for native apps (format: YYYY.MMDD.HHmm)
   "app_version": {


### PR DESCRIPTION
## What Changed

This PR updates the attachment server domain from `inv.liberdus.com` to `att.liberdus.com`.

- `attachmentServerUrl` now points to `https://att.liberdus.com:2083` in `network.js`, `network.js_dev`, and `network.js_test`.
- Uploads, downloads, avatar fetches, and deletes continue to use `network.attachmentServerUrl`, so no app logic changes were required.

## Why

The attachment server is moving to the new `att.liberdus.com` domain. Updating the network configs keeps attachment and avatar flows pointed at the correct server.

## Test plan

- [x] Upload an attachment in chat
- [x] Download/view an existing attachment
- [x] Upload and display an avatar

Closes #1326