### PR TITLE
Sign In modal: show accounts as clickable cards

### DIFF
--- a/app.js
+++ b/app.js
@@ -3576,6 +3576,7 @@ function showCloseFeeFailureWarningOnce(reason, action, alreadyShown = false) {
 }
 
 // Sign In Modal Management
+/** Action sheet copy and button visibility by sign-in error reason. */
 const SIGN_IN_ACTION_SHEETS = {
   'not-found': {
     message: 'This account is not on the network. You can recreate it from local data or remove it from this device.',
@@ -3653,11 +3654,17 @@ class SignInModal {
     });
   }
 
+  /** Hide the account error action sheet. */
   closeActionSheet() {
     this.actionSheetOverlay.classList.remove('active');
     this.actionSheetOverlay.setAttribute('aria-hidden', 'true');
   }
 
+  /**
+   * Show the bottom action sheet for a sign-in edge case.
+   * @param {string} username
+   * @param {'not-found'|'taken'|'network-error'} reason
+   */
   openActionSheet(username, reason) {
     const sheet = SIGN_IN_ACTION_SHEETS[reason];
     assert(sheet, `Unknown sign-in action sheet: ${reason}`);
@@ -3675,6 +3682,10 @@ class SignInModal {
     }
   }
 
+  /**
+   * Open Create Account with the selected username and stored private key prefilled.
+   * @param {string} username
+   */
   openRecreateFlow(username) {
     const { netid } = network;
     const accountData = loadState(`${username}_${netid}`);
@@ -3688,6 +3699,10 @@ class SignInModal {
     createAccountModal.usernameInput.dispatchEvent(new Event('input'));
   }
 
+  /**
+   * Get the available usernames for the current network.
+   * @returns {{ usernames: string[], netidAccounts: Object }}
+   */
   getSignInUsernames() {
     const { netid } = network;
     const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
@@ -3696,6 +3711,11 @@ class SignInModal {
     return { usernames, netidAccounts: netidAccounts || { usernames: {} } };
   }
 
+  /**
+   * Render the account list with notification indicators and sort by notification status.
+   * @param {string} [preserveUsername] - Optionally preserve a selected username
+   * @returns {string[]} Usernames for the current network
+   */
   renderAccountList(preserveUsername) {
     const { usernames, netidAccounts } = this.getSignInUsernames();
     const { netid } = network;
@@ -3911,6 +3931,11 @@ class SignInModal {
     callsModal.startPeriodicCallsRefresh();
   }
 
+  /**
+   * Check username availability and sign in, or show the action sheet for edge cases.
+   * @param {string} username
+   * @returns {Promise<string|null>} Availability result from checkUsernameAvailability
+   */
   async handleAccountClick(username) {
     const clickSeq = ++this.accountClickSeq;
     this.closeActionSheet();
@@ -3972,7 +3997,8 @@ class SignInModal {
   }
 
   /**
-   * Update the display when new notifications arrive while the modal is open.
+   * Update the display to reflect new notifications while the modal is open.
+   * This is called when new notifications arrive while the modal is open.
    */
   updateNotificationDisplay() {
     if (!this.isActive()) return;

--- a/app.js
+++ b/app.js
@@ -3764,14 +3764,17 @@ class SignInModal {
 
     const renderListItem = (username) => {
       const isNotifiedAccount = notifiedUsernameSet.has(username);
-      const notificationIndicator = isNotifiedAccount ? ' 🔔' : '';
       const isPrivateAccount = isPrivateMap[username];
       const displayName = isPrivateAccount ? `- ${username}` : username;
       const privateClass = isPrivateAccount ? ' is-private' : '';
+      const notificationBadge = isNotifiedAccount
+        ? '<span class="sign-in-account-badge" aria-label="Has notifications">🔔</span>'
+        : '';
       return `
-        <li class="chat-item sign-in-account-item${privateClass}" role="option" data-username="${username}">
-          <div class="chat-content">
-            <div class="chat-name">${escapeHtml(displayName)}${notificationIndicator}</div>
+        <li class="sign-in-account-item${privateClass}" role="option" data-username="${username}">
+          <div class="sign-in-account-card">
+            <span class="sign-in-account-name">${escapeHtml(displayName)}</span>
+            ${notificationBadge}
           </div>
         </li>
       `;

--- a/app.js
+++ b/app.js
@@ -3821,6 +3821,7 @@ class SignInModal {
   }
 
   close() {
+    this.accountClickSeq++;
     this.selectedUsername = null;
     this.isSigningIn = false;
     this.preselectedUsername = null;
@@ -3951,8 +3952,8 @@ class SignInModal {
         logsModal.log(`[SignInModal] After 3 attempts username '${username}' still reported as available.`);
       }
     }
-    // Ignore stale results if the user tapped a different account while we were waiting.
-    if (clickSeq !== this.accountClickSeq) return null;
+    // Ignore stale results if the user tapped a different account or closed the modal while we were waiting.
+    if (clickSeq !== this.accountClickSeq || !this.isActive()) return null;
 
     switch (availability) {
       case 'mine':

--- a/app.js
+++ b/app.js
@@ -3761,7 +3761,7 @@ class SignInModal {
         ? '<span class="sign-in-account-badge" aria-label="Has notifications">🔔</span>'
         : '';
       return `
-        <li class="sign-in-account-item${privateClass}" role="option" data-username="${username}">
+        <li class="sign-in-account-item${privateClass}" data-username="${username}">
           <div class="sign-in-account-card">
             <span class="sign-in-account-name">${escapeHtml(displayName)}</span>
             ${notificationBadge}

--- a/app.js
+++ b/app.js
@@ -3579,11 +3579,14 @@ function showCloseFeeFailureWarningOnce(reason, action, alreadyShown = false) {
 class SignInModal {
   constructor() {
     this.preselectedUsername = null;
+    this.selectedUsername = null;
+    this.isSigningIn = false;
   }
 
   load () {
     this.modal = document.getElementById('signInModal');
-    this.usernameSelect = document.getElementById('username');
+    this.accountList = document.getElementById('signInAccountList');
+    this.accountActions = document.getElementById('signInAccountActions');
     this.submitButton = document.querySelector('#signInForm button[type="submit"]');
     this.removeButton = document.getElementById('removeAccountButton');
     this.notFoundMessage = document.getElementById('usernameNotFound');
@@ -3593,7 +3596,7 @@ class SignInModal {
     // Sign in form submission (2s cooldown; both buttons disabled; revalidate restores state)
     const signInRevalidate = () => {
       this.removeButton.disabled = false;
-      if (this.isActive()) this.handleUsernameChange();
+      if (this.isActive() && this.selectedUsername) this.handleAccountClick(this.selectedUsername);
     };
     document.getElementById('signInForm').addEventListener('submit', withButtonCooldown(
       [this.submitButton, this.removeButton],
@@ -3602,8 +3605,13 @@ class SignInModal {
       (event) => this.handleSignIn(event)
     ));
 
-    // Username selection change
-    this.usernameSelect.addEventListener('change', () => this.handleUsernameChange());
+    this.accountList.addEventListener('click', (event) => {
+      const item = event.target.closest('.sign-in-account-item');
+      if (!item || this.isSigningIn) return;
+      const username = item.dataset.username;
+      if (!username) return;
+      this.handleAccountClick(username);
+    });
 
     // Remove account button (2s cooldown; both buttons disabled)
     this.removeButton.addEventListener('click', withButtonCooldown(
@@ -3618,45 +3626,60 @@ class SignInModal {
   }
 
   // Centralized UI state helpers for availability results
+  showAccountActions() {
+    this.accountActions.style.display = 'block';
+  }
+
+  hideAccountActions() {
+    this.accountActions.style.display = 'none';
+  }
+
   setUiForMine() {
+    this.showAccountActions();
     this.submitButton.disabled = false;
     this.submitButton.textContent = 'Sign In';
     this.submitButton.style.display = 'inline';
     this.removeButton.style.display = 'none';
+    this.notFoundMessage.textContent = '';
     this.notFoundMessage.style.display = 'none';
   }
 
   setUiDisabledSignIn() {
+    this.hideAccountActions();
     this.submitButton.disabled = true;
     this.submitButton.textContent = 'Sign In';
     this.submitButton.style.display = 'inline';
     this.removeButton.style.display = 'none';
+    this.notFoundMessage.textContent = '';
     this.notFoundMessage.style.display = 'none';
   }
 
   setUiForTaken() {
+    this.showAccountActions();
     this.submitButton.style.display = 'none';
     this.removeButton.style.display = 'inline';
     this.notFoundMessage.textContent = 'taken';
-    this.notFoundMessage.style.display = 'inline';
+    this.notFoundMessage.style.display = 'block';
   }
 
   setUiForAvailableNotFound() {
+    this.showAccountActions();
     this.submitButton.disabled = false;
     this.submitButton.textContent = 'Recreate';
     this.submitButton.style.display = 'inline';
     this.removeButton.style.display = 'inline';
     this.notFoundMessage.textContent = 'not found';
-    this.notFoundMessage.style.display = 'inline';
+    this.notFoundMessage.style.display = 'block';
   }
 
   setUiForNetworkError() {
+    this.showAccountActions();
     this.submitButton.disabled = true;
     this.submitButton.textContent = 'Sign In';
     this.submitButton.style.display = 'none';
     this.removeButton.style.display = 'none';
     this.notFoundMessage.textContent = 'network error';
-    this.notFoundMessage.style.display = 'inline';
+    this.notFoundMessage.style.display = 'block';
     showToast('The gateway server is down, please try again later.', 5000, 'warning');
   }
 
@@ -3685,11 +3708,11 @@ class SignInModal {
   }
 
   /**
-   * Update the username select dropdown with notification indicators and sort by notification status
+   * Render the account list with notification indicators and sort by notification status
    * @param {string} [selectedUsername] - Optionally preserve a selected username
    * @returns {Object} Object containing usernames array and account information
    */
-  updateUsernameSelect(selectedUsername = null) {
+  renderAccountList(selectedUsername = null) {
     const signInData = signInModal.getSignInUsernames() || {};
     const usernames = Array.isArray(signInData.usernames) ? signInData.usernames : [];
     const netidAccounts = signInData.netidAccounts || { usernames: {} };
@@ -3718,9 +3741,7 @@ class SignInModal {
       sortedUsernames = [...notifiedUsernames, ...otherUsernames];
     }
 
-    // Populate select with sorted usernames.
-    // Build a map of privacy flags to avoid multiple loadState calls and
-    // render options via a small helper to reduce duplication.
+    // Build a map of privacy flags to avoid multiple loadState calls.
     const isPrivateMap = Object.create(null);
     for (const username of sortedUsernames) {
       let isPrivateAccount = false;
@@ -3735,71 +3756,69 @@ class SignInModal {
 
     // Keep notified accounts (any privacy) at the very top, in the order
     // they appear in sortedUsernames. Then render remaining public accounts,
-    // and finally remaining private accounts grouped under a disabled label.
+    // and finally remaining private accounts grouped under a section label.
     const notifiedTop = sortedUsernames.filter(u => notifiedUsernameSet.has(u));
     const remaining = sortedUsernames.filter(u => !notifiedUsernameSet.has(u));
     const publicRemaining = remaining.filter(u => !isPrivateMap[u]);
     const privateRemaining = remaining.filter(u => isPrivateMap[u]);
 
-    const renderOption = (username) => {
+    const renderListItem = (username) => {
       const isNotifiedAccount = notifiedUsernameSet.has(username);
-      const dotIndicator = isNotifiedAccount ? ' 🔔' : '';
-      const optionColor = isPrivateMap[username] ? 'var(--danger-color)' : 'var(--text-color)';
-      const displayName = isPrivateMap[username] ? `- ${username}` : username;
-      return `<option value="${username}" style="color: ${optionColor};">${displayName}${dotIndicator}</option>`;
+      const notificationIndicator = isNotifiedAccount ? ' 🔔' : '';
+      const isPrivateAccount = isPrivateMap[username];
+      const displayName = isPrivateAccount ? `- ${username}` : username;
+      const privateClass = isPrivateAccount ? ' is-private' : '';
+      return `
+        <li class="chat-item sign-in-account-item${privateClass}" role="option" data-username="${username}">
+          <div class="chat-content">
+            <div class="chat-name">${escapeHtml(displayName)}${notificationIndicator}</div>
+          </div>
+        </li>
+      `;
     };
 
-    let html = `<option value="" disabled selected hidden>Select an account</option>`;
+    let html = '';
 
     if (notifiedTop.length > 0) {
-      html += notifiedTop.map(renderOption).join('');
+      html += notifiedTop.map(renderListItem).join('');
     }
 
     if (publicRemaining.length > 0) {
-      html += publicRemaining.map(renderOption).join('');
+      html += publicRemaining.map(renderListItem).join('');
     }
 
-    // Private accounts grouped with a disabled label (avoids optgroup indentation)
     if (privateRemaining.length > 0) {
-      html += `<option value="" disabled style="font-weight:600; color:var(--danger-color);">Private accounts</option>`;
-      html += privateRemaining.map(renderOption).join('');
+      html += '<li class="sign-in-account-section" role="presentation">Private accounts</li>';
+      html += privateRemaining.map(renderListItem).join('');
     }
 
-    this.usernameSelect.innerHTML = html;
+    this.accountList.innerHTML = html;
 
-    // Restore the previously selected username if it exists
     if (selectedUsername && usernames.includes(selectedUsername)) {
-      this.usernameSelect.value = selectedUsername;
+      this.selectedUsername = selectedUsername;
     }
 
-    // Update selected styling (so chosen private account shows red when the dropdown is closed)
-    this.updateSelectedAccountPrivateIndicator(netid);
+    this.updateSelectedAccountStyling(netid);
 
     return { usernames, netidAccounts, sortedUsernames };
   }
 
-  updateSelectedAccountPrivateIndicator(netid) {
-    const username = this.usernameSelect.value;
-    if (!username) {
-      this.usernameSelect.classList.remove('is-private');
-      return;
-    }
-
-    let isPrivateAccount = false;
-    try {
-      const localState = loadState(`${username}_${netid}`);
-      isPrivateAccount = localState?.account?.private === true;
-    } catch (e) {
-      isPrivateAccount = false;
-    }
-    this.usernameSelect.classList.toggle('is-private', isPrivateAccount);
+  updateSelectedAccountStyling(netid) {
+    const items = this.accountList.querySelectorAll('.sign-in-account-item');
+    items.forEach((item) => {
+      const isSelected = item.dataset.username === this.selectedUsername;
+      item.classList.toggle('is-selected', isSelected);
+      item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+    });
   }
 
   async open(preselectedUsername_) {
     this.preselectedUsername = preselectedUsername_;
+    this.selectedUsername = null;
+    this.isSigningIn = false;
 
-    // Update username select and get usernames BEFORE opening modal
-    const { usernames } = this.updateUsernameSelect();
+    // Render account list and get usernames BEFORE opening modal
+    const { usernames } = this.renderAccountList();
 
     // Wait for browser to process DOM changes before starting modal transition
     requestAnimationFrame(async () => {
@@ -3812,11 +3831,10 @@ class SignInModal {
         return;
       }
 
-      // If a username should be auto-selected (either preselect or only one account), do it
-      if ((preselectedUsername_ && usernames.includes(preselectedUsername_))) {
-        this.usernameSelect.value = this.preselectedUsername;
-        await this.handleUsernameChange();
-        // happens when autoselect parameter is given since new account was just created and network may not have propagated account
+      // If a username should be auto-selected after account creation, sign in directly
+      if (preselectedUsername_ && usernames.includes(preselectedUsername_)) {
+        await this.handleAccountClick(preselectedUsername_);
+        // Network may not have propagated the new account yet
         if (this.notFoundMessage.textContent === 'not found') {
           this.applyAutoSelectNotFoundOverride();
           this.handleSignIn();
@@ -3824,14 +3842,12 @@ class SignInModal {
         return;
       }
 
-      // If only one account exists, select it and trigger change event
+      // If only one account exists, sign in directly when available
       if (usernames.length === 1) {
-        this.usernameSelect.value = usernames[0];
-        this.usernameSelect.dispatchEvent(new Event('change'));
+        await this.handleAccountClick(usernames[0]);
         return;
       }
 
-      // Multiple accounts exist, show modal with select dropdown
       this.setUiDisabledSignIn();
 
       // set timeout to focus on the last item so shift+tab and tab prevention works
@@ -3842,9 +3858,10 @@ class SignInModal {
   }
 
   close() {
-    // clear signInModal input fields
-    this.usernameSelect.value = '';
+    this.selectedUsername = null;
+    this.isSigningIn = false;
     this.setUiDisabledSignIn();
+    this.accountList.innerHTML = '';
     
     this.modal.classList.remove('active');
     this.preselectedUsername = null;
@@ -3860,7 +3877,8 @@ class SignInModal {
     
     enterFullscreen();
     
-    const username = this.usernameSelect.value;
+    const username = this.selectedUsername;
+    if (!username) return;
 
     // Get network ID from network.js
     const { netid } = network;
@@ -3972,23 +3990,21 @@ class SignInModal {
     callsModal.startPeriodicCallsRefresh();
   }
 
-  async handleUsernameChange() {
-    // Get existing accounts
+  async handleAccountClick(username) {
     const { netid } = network;
     const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
     const netidAccounts = existingAccounts.netids[netid];
     const usernames = netidAccounts?.usernames ? Object.keys(netidAccounts.usernames) : [];
-    // Enable submit button when an account is selected
-    const username = this.usernameSelect.value;
-    if (!username) {
-      this.submitButton.disabled = true;
-      this.notFoundMessage.style.display = 'none';
+
+    if (!username || !netidAccounts?.usernames?.[username]) {
+      this.selectedUsername = null;
+      this.setUiDisabledSignIn();
       return;
     }
 
-    // Update selected styling
-    this.updateSelectedAccountPrivateIndicator(netid);
-    //        const address = netidAccounts.usernames[username].keys.address;
+    this.selectedUsername = username;
+    this.updateSelectedAccountStyling(netid);
+
     const address = netidAccounts.usernames[username].address;
     let availability = await checkUsernameAvailability(username, address);
     // Retry logic: if availability reported as 'available' but we have local account data
@@ -4017,21 +4033,16 @@ class SignInModal {
         }
       }
     }
-    //console.log('usernames.length', usernames.length);
-    //console.log('availability', availability);
 
-    // If this username was pre-selected and is available, auto-sign-in
-    if (this.preselectedUsername && username === this.preselectedUsername && availability === 'mine') {
-      this.handleSignIn();
+    if (availability === 'mine') {
+      this.isSigningIn = true;
+      await this.handleSignIn();
+      this.isSigningIn = false;
       this.preselectedUsername = null;
       return;
     }
-    if (usernames.length === 1 && availability === 'mine') {
-      this.handleSignIn();
-      return;
-    } else if (availability === 'mine') {
-      this.setUiForMine();
-    } else if (availability === 'taken') {
+
+    if (availability === 'taken') {
       this.setUiForTaken();
     } else if (availability === 'available') {
       this.setUiForAvailableNotFound();
@@ -4041,7 +4052,7 @@ class SignInModal {
   }
 
   async handleRemoveAccount() {
-    const username = this.usernameSelect.value;
+    const username = this.selectedUsername;
     if (!username) {
       showToast('Please select an account to remove', 2000, 'warning');
       return;
@@ -4061,12 +4072,8 @@ class SignInModal {
     // Only update if the modal is actually active
     if (!this.isActive()) return;
     
-    // Get the currently selected username so we can keep it selected after the update
-    const selectedUsername = this.usernameSelect.value;
-    
-    // Update the dropdown with sorted usernames and notification indicators
-    // This will also preserve the selected username if it still exists
-    this.updateUsernameSelect(selectedUsername);
+    // Preserve the currently selected username after re-rendering the list
+    this.renderAccountList(this.selectedUsername);
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -3596,7 +3596,6 @@ class SignInModal {
     this.actionSheetMessage = document.getElementById('signInActionSheetMessage');
     this.actionRecreateButton = document.getElementById('signInActionRecreate');
     this.actionRemoveButton = document.getElementById('signInActionRemove');
-    this.actionRetryButton = document.getElementById('signInActionRetry');
     this.closeActionSheetButton = document.getElementById('closeSignInActionSheet');
 
     this.accountList.addEventListener('click', (event) => {
@@ -3617,10 +3616,9 @@ class SignInModal {
     const actionSheetRevalidate = () => {
       this.actionRecreateButton.disabled = false;
       this.actionRemoveButton.disabled = false;
-      this.actionRetryButton.disabled = false;
     };
     this.actionRecreateButton.addEventListener('click', withButtonCooldown(
-      [this.actionRecreateButton, this.actionRemoveButton, this.actionRetryButton],
+      [this.actionRecreateButton, this.actionRemoveButton],
       BUTTON_COOLDOWN_MS,
       actionSheetRevalidate,
       () => {
@@ -3630,24 +3628,13 @@ class SignInModal {
       }
     ));
     this.actionRemoveButton.addEventListener('click', withButtonCooldown(
-      [this.actionRecreateButton, this.actionRemoveButton, this.actionRetryButton],
+      [this.actionRecreateButton, this.actionRemoveButton],
       BUTTON_COOLDOWN_MS,
       actionSheetRevalidate,
       () => {
         const username = this.actionSheetUsername;
         if (!username) return;
         this.handleRemoveAccount(username);
-      }
-    ));
-    this.actionRetryButton.addEventListener('click', withButtonCooldown(
-      [this.actionRecreateButton, this.actionRemoveButton, this.actionRetryButton],
-      BUTTON_COOLDOWN_MS,
-      actionSheetRevalidate,
-      () => {
-        const username = this.actionSheetUsername;
-        if (!username) return;
-        this.closeActionSheet();
-        this.handleAccountClick(username);
       }
     ));
 
@@ -3677,19 +3664,16 @@ class SignInModal {
         message: 'This account is not on the network. You can recreate it from local data or remove it from this device.',
         showRecreate: true,
         showRemove: true,
-        showRetry: false,
       },
       taken: {
         message: 'This username is taken on the network by a different address.',
         showRecreate: false,
         showRemove: true,
-        showRetry: false,
       },
       'network-error': {
         message: 'Could not reach the network. Check your connection and try again.',
         showRecreate: false,
         showRemove: false,
-        showRetry: true,
       },
     }[reason];
 
@@ -3700,7 +3684,6 @@ class SignInModal {
     this.actionSheetMessage.textContent = copy.message;
     this.actionRecreateButton.hidden = !copy.showRecreate;
     this.actionRemoveButton.hidden = !copy.showRemove;
-    this.actionRetryButton.hidden = !copy.showRetry;
     this.actionSheetOverlay.classList.add('active');
     this.actionSheetOverlay.setAttribute('aria-hidden', 'false');
 

--- a/app.js
+++ b/app.js
@@ -3581,29 +3581,23 @@ class SignInModal {
     this.preselectedUsername = null;
     this.selectedUsername = null;
     this.isSigningIn = false;
+    this.accountClickSeq = 0;
+    this.actionSheetUsername = null;
   }
 
   load () {
     this.modal = document.getElementById('signInModal');
     this.accountList = document.getElementById('signInAccountList');
-    this.accountActions = document.getElementById('signInAccountActions');
-    this.submitButton = document.querySelector('#signInForm button[type="submit"]');
-    this.removeButton = document.getElementById('removeAccountButton');
-    this.notFoundMessage = document.getElementById('usernameNotFound');
     this.signInModalLastItem = document.getElementById('signInModalLastItem');
     this.backButton = document.getElementById('closeSignInModal');
-
-    // Sign in form submission (2s cooldown; both buttons disabled; revalidate restores state)
-    const signInRevalidate = () => {
-      this.removeButton.disabled = false;
-      if (this.isActive() && this.selectedUsername) this.handleAccountClick(this.selectedUsername);
-    };
-    document.getElementById('signInForm').addEventListener('submit', withButtonCooldown(
-      [this.submitButton, this.removeButton],
-      BUTTON_COOLDOWN_MS,
-      signInRevalidate,
-      (event) => this.handleSignIn(event)
-    ));
+    this.actionSheetOverlay = document.getElementById('signInActionSheetOverlay');
+    this.actionSheet = document.getElementById('signInActionSheet');
+    this.actionSheetTitle = document.getElementById('signInActionSheetTitle');
+    this.actionSheetMessage = document.getElementById('signInActionSheetMessage');
+    this.actionRecreateButton = document.getElementById('signInActionRecreate');
+    this.actionRemoveButton = document.getElementById('signInActionRemove');
+    this.actionRetryButton = document.getElementById('signInActionRetry');
+    this.closeActionSheetButton = document.getElementById('closeSignInActionSheet');
 
     this.accountList.addEventListener('click', (event) => {
       const item = event.target.closest('.sign-in-account-item');
@@ -3613,86 +3607,122 @@ class SignInModal {
       this.handleAccountClick(username);
     });
 
-    // Remove account button (2s cooldown; both buttons disabled)
-    this.removeButton.addEventListener('click', withButtonCooldown(
-      [this.removeButton, this.submitButton],
+    this.actionSheetOverlay.addEventListener('click', (event) => {
+      if (event.target === this.actionSheetOverlay) {
+        this.closeActionSheet();
+      }
+    });
+    this.closeActionSheetButton.addEventListener('click', () => this.closeActionSheet());
+
+    const actionSheetRevalidate = () => {
+      this.actionRecreateButton.disabled = false;
+      this.actionRemoveButton.disabled = false;
+      this.actionRetryButton.disabled = false;
+    };
+    this.actionRecreateButton.addEventListener('click', withButtonCooldown(
+      [this.actionRecreateButton, this.actionRemoveButton, this.actionRetryButton],
       BUTTON_COOLDOWN_MS,
-      signInRevalidate,
-      () => this.handleRemoveAccount()
+      actionSheetRevalidate,
+      () => {
+        const username = this.actionSheetUsername;
+        if (!username) return;
+        this.openRecreateFlow(username);
+      }
+    ));
+    this.actionRemoveButton.addEventListener('click', withButtonCooldown(
+      [this.actionRecreateButton, this.actionRemoveButton, this.actionRetryButton],
+      BUTTON_COOLDOWN_MS,
+      actionSheetRevalidate,
+      () => {
+        const username = this.actionSheetUsername;
+        if (!username) return;
+        this.handleRemoveAccount(username);
+      }
+    ));
+    this.actionRetryButton.addEventListener('click', withButtonCooldown(
+      [this.actionRecreateButton, this.actionRemoveButton, this.actionRetryButton],
+      BUTTON_COOLDOWN_MS,
+      actionSheetRevalidate,
+      () => {
+        const username = this.actionSheetUsername;
+        if (!username) return;
+        this.closeActionSheet();
+        this.handleAccountClick(username);
+      }
     ));
 
-    // Back button
-    this.backButton.addEventListener('click', () => this.close());
+    this.backButton.addEventListener('click', () => {
+      if (this.isActionSheetOpen()) {
+        this.closeActionSheet();
+        return;
+      }
+      this.close();
+    });
   }
 
-  // Centralized UI state helpers for availability results
-  showAccountActions() {
-    this.accountActions.style.display = 'block';
+  isActionSheetOpen() {
+    return this.actionSheetOverlay?.classList.contains('active');
   }
 
-  hideAccountActions() {
-    this.accountActions.style.display = 'none';
+  closeActionSheet() {
+    if (!this.actionSheetOverlay) return;
+    this.actionSheetOverlay.classList.remove('active');
+    this.actionSheetOverlay.setAttribute('aria-hidden', 'true');
+    this.actionSheetUsername = null;
   }
 
-  setUiForMine() {
-    this.showAccountActions();
-    this.submitButton.disabled = false;
-    this.submitButton.textContent = 'Sign In';
-    this.submitButton.style.display = 'inline';
-    this.removeButton.style.display = 'none';
-    this.notFoundMessage.textContent = '';
-    this.notFoundMessage.style.display = 'none';
+  openActionSheet(username, reason) {
+    const copy = {
+      'not-found': {
+        message: 'This account is not on the network. You can recreate it from local data or remove it from this device.',
+        showRecreate: true,
+        showRemove: true,
+        showRetry: false,
+      },
+      taken: {
+        message: 'This username is taken on the network by a different address.',
+        showRecreate: false,
+        showRemove: true,
+        showRetry: false,
+      },
+      'network-error': {
+        message: 'Could not reach the network. Check your connection and try again.',
+        showRecreate: false,
+        showRemove: false,
+        showRetry: true,
+      },
+    }[reason];
+
+    if (!copy) return;
+
+    this.actionSheetUsername = username;
+    this.actionSheetTitle.textContent = username;
+    this.actionSheetMessage.textContent = copy.message;
+    this.actionRecreateButton.hidden = !copy.showRecreate;
+    this.actionRemoveButton.hidden = !copy.showRemove;
+    this.actionRetryButton.hidden = !copy.showRetry;
+    this.actionSheetOverlay.classList.add('active');
+    this.actionSheetOverlay.setAttribute('aria-hidden', 'false');
+
+    if (reason === 'network-error') {
+      showToast('The gateway server is down, please try again later.', 5000, 'warning');
+    }
   }
 
-  setUiDisabledSignIn() {
-    this.hideAccountActions();
-    this.submitButton.disabled = true;
-    this.submitButton.textContent = 'Sign In';
-    this.submitButton.style.display = 'inline';
-    this.removeButton.style.display = 'none';
-    this.notFoundMessage.textContent = '';
-    this.notFoundMessage.style.display = 'none';
-  }
+  openRecreateFlow(username) {
+    const { netid } = network;
+    const accountData = loadState(`${username}_${netid}`);
+    const privateKey = accountData?.account?.keys?.secret;
+    if (!privateKey) {
+      showToast('Account data not found', 0, 'error');
+      return;
+    }
 
-  setUiForTaken() {
-    this.showAccountActions();
-    this.submitButton.style.display = 'none';
-    this.removeButton.style.display = 'inline';
-    this.notFoundMessage.textContent = 'taken';
-    this.notFoundMessage.style.display = 'block';
-  }
-
-  setUiForAvailableNotFound() {
-    this.showAccountActions();
-    this.submitButton.disabled = false;
-    this.submitButton.textContent = 'Recreate';
-    this.submitButton.style.display = 'inline';
-    this.removeButton.style.display = 'inline';
-    this.notFoundMessage.textContent = 'not found';
-    this.notFoundMessage.style.display = 'block';
-  }
-
-  setUiForNetworkError() {
-    this.showAccountActions();
-    this.submitButton.disabled = true;
-    this.submitButton.textContent = 'Sign In';
-    this.submitButton.style.display = 'none';
-    this.removeButton.style.display = 'none';
-    this.notFoundMessage.textContent = 'network error';
-    this.notFoundMessage.style.display = 'block';
-    showToast('The gateway server is down, please try again later.', 5000, 'warning');
-  }
-
-  // When auto-selecting after account creation, the network may not have propagated
-  // the alias yet. In that case we suppress the
-  // transient "not found" and allow local sign-in using stored state.
-  applyAutoSelectNotFoundOverride() {
-    this.notFoundMessage.textContent = '';
-    this.notFoundMessage.style.display = 'none';
-    this.submitButton.style.display = 'inline';
-    this.submitButton.disabled = false;
-    this.submitButton.textContent = 'Sign In';
-    this.removeButton.style.display = 'none';
+    createAccountModal.usernameInput.value = username;
+    createAccountModal.privateKeyInput.value = privateKey;
+    this.close();
+    createAccountModal.open();
+    createAccountModal.usernameInput.dispatchEvent(new Event('input'));
   }
 
   /**
@@ -3819,6 +3849,7 @@ class SignInModal {
     this.preselectedUsername = preselectedUsername_;
     this.selectedUsername = null;
     this.isSigningIn = false;
+    this.closeActionSheet();
 
     // Render account list and get usernames BEFORE opening modal
     const { usernames } = this.renderAccountList();
@@ -3836,11 +3867,10 @@ class SignInModal {
 
       // If a username should be auto-selected after account creation, sign in directly
       if (preselectedUsername_ && usernames.includes(preselectedUsername_)) {
-        await this.handleAccountClick(preselectedUsername_);
+        const availability = await this.handleAccountClick(preselectedUsername_);
         // Network may not have propagated the new account yet
-        if (this.notFoundMessage.textContent === 'not found') {
-          this.applyAutoSelectNotFoundOverride();
-          this.handleSignIn();
+        if (availability === 'available') {
+          await this.handleSignIn();
         }
         return;
       }
@@ -3850,8 +3880,6 @@ class SignInModal {
         await this.handleAccountClick(usernames[0]);
         return;
       }
-
-      this.setUiDisabledSignIn();
 
       // set timeout to focus on the last item so shift+tab and tab prevention works
       setTimeout(() => {
@@ -3863,18 +3891,14 @@ class SignInModal {
   close() {
     this.selectedUsername = null;
     this.isSigningIn = false;
-    this.setUiDisabledSignIn();
+    this.closeActionSheet();
     this.accountList.innerHTML = '';
     
     this.modal.classList.remove('active');
     this.preselectedUsername = null;
   }
 
-  async handleSignIn(event) {
-    if (event) {
-      event.preventDefault();
-    }
-
+  async handleSignIn() {
     history.pushState({state:1}, "", ".")
     window.addEventListener('popstate', handleBrowserBackButton);
     
@@ -3892,21 +3916,6 @@ class SignInModal {
     // Check if username exists
     if (!existingAccounts.netids[netid]?.usernames?.[username]) {
       console.error('Account not found');
-      return;
-    }
-
-    // Check if the button text is 'Recreate'
-    if (this.submitButton.textContent === 'Recreate') {
-//      const myData = parse(localStorage.getItem(`${username}_${netid}`));
-      const myData = loadState(`${username}_${netid}`);
-      const privateKey = myData.account.keys.secret;
-      createAccountModal.usernameInput.value = username;
-
-      createAccountModal.privateKeyInput.value = privateKey;
-      this.close();
-      createAccountModal.open();
-      // Dispatch a change event to trigger the availability check
-      createAccountModal.usernameInput.dispatchEvent(new Event('input'));
       return;
     }
 
@@ -3994,15 +4003,16 @@ class SignInModal {
   }
 
   async handleAccountClick(username) {
+    const clickSeq = ++this.accountClickSeq;
+    this.closeActionSheet();
+
     const { netid } = network;
     const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
     const netidAccounts = existingAccounts.netids[netid];
-    const usernames = netidAccounts?.usernames ? Object.keys(netidAccounts.usernames) : [];
 
     if (!username || !netidAccounts?.usernames?.[username]) {
       this.selectedUsername = null;
-      this.setUiDisabledSignIn();
-      return;
+      return null;
     }
 
     this.selectedUsername = username;
@@ -4037,25 +4047,36 @@ class SignInModal {
       }
     }
 
+    if (clickSeq !== this.accountClickSeq) {
+      return null;
+    }
+
     if (availability === 'mine') {
       this.isSigningIn = true;
-      await this.handleSignIn();
-      this.isSigningIn = false;
+      try {
+        await this.handleSignIn();
+      } finally {
+        this.isSigningIn = false;
+      }
       this.preselectedUsername = null;
-      return;
+      return availability;
     }
 
     if (availability === 'taken') {
-      this.setUiForTaken();
+      this.openActionSheet(username, 'taken');
     } else if (availability === 'available') {
-      this.setUiForAvailableNotFound();
+      // Post-creation preselect may sign in locally without showing the sheet.
+      if (!(this.preselectedUsername && username === this.preselectedUsername)) {
+        this.openActionSheet(username, 'not-found');
+      }
     } else {
-      this.setUiForNetworkError();
+      this.openActionSheet(username, 'network-error');
     }
+
+    return availability;
   }
 
-  async handleRemoveAccount() {
-    const username = this.selectedUsername;
+  handleRemoveAccount(username = this.actionSheetUsername || this.selectedUsername) {
     if (!username) {
       showToast('Please select an account to remove', 2000, 'warning');
       return;

--- a/app.js
+++ b/app.js
@@ -3713,10 +3713,9 @@ class SignInModal {
 
   /**
    * Render the account list with notification indicators and sort by notification status.
-   * @param {string} [preserveUsername] - Optionally preserve a selected username
-   * @returns {string[]} Usernames for the current network
+   * @returns {string[]} Usernames for the current network (registry order, not display order)
    */
-  renderAccountList(preserveUsername) {
+  renderAccountList() {
     const { usernames, netidAccounts } = this.getSignInUsernames();
     const { netid } = network;
     const notifiedAddresses = reactNativeApp.isReactNativeWebView ? reactNativeApp.getNotificationAddresses() : [];
@@ -3780,15 +3779,6 @@ class SignInModal {
       sections.push(...privateRemaining.map(renderListItem));
     }
     this.accountList.innerHTML = sections.join('');
-
-    if (preserveUsername && usernames.includes(preserveUsername)) {
-      this.selectedUsername = preserveUsername;
-    }
-    for (const item of this.accountList.querySelectorAll('.sign-in-account-item')) {
-      const isSelected = item.dataset.username === this.selectedUsername;
-      item.classList.toggle('is-selected', isSelected);
-      item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
-    }
 
     return usernames;
   }
@@ -4002,8 +3992,7 @@ class SignInModal {
    */
   updateNotificationDisplay() {
     if (!this.isActive()) return;
-    // Preserve the currently selected username after re-rendering the list.
-    this.renderAccountList(this.selectedUsername);
+    this.renderAccountList();
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -3576,13 +3576,30 @@ function showCloseFeeFailureWarningOnce(reason, action, alreadyShown = false) {
 }
 
 // Sign In Modal Management
+const SIGN_IN_ACTION_SHEETS = {
+  'not-found': {
+    message: 'This account is not on the network. You can recreate it from local data or remove it from this device.',
+    showRecreate: true,
+    showRemove: true,
+  },
+  taken: {
+    message: 'This username is taken on the network by a different address.',
+    showRecreate: false,
+    showRemove: true,
+  },
+  'network-error': {
+    message: 'Could not reach the network. Check your connection and try again.',
+    showRecreate: false,
+    showRemove: false,
+  },
+};
+
 class SignInModal {
   constructor() {
     this.preselectedUsername = null;
     this.selectedUsername = null;
     this.isSigningIn = false;
     this.accountClickSeq = 0;
-    this.actionSheetUsername = null;
   }
 
   load () {
@@ -3591,55 +3608,44 @@ class SignInModal {
     this.signInModalLastItem = document.getElementById('signInModalLastItem');
     this.backButton = document.getElementById('closeSignInModal');
     this.actionSheetOverlay = document.getElementById('signInActionSheetOverlay');
-    this.actionSheet = document.getElementById('signInActionSheet');
     this.actionSheetTitle = document.getElementById('signInActionSheetTitle');
     this.actionSheetMessage = document.getElementById('signInActionSheetMessage');
     this.actionRecreateButton = document.getElementById('signInActionRecreate');
     this.actionRemoveButton = document.getElementById('signInActionRemove');
     this.closeActionSheetButton = document.getElementById('closeSignInActionSheet');
+    assert(this.modal && this.accountList && this.actionSheetOverlay, 'SignInModal DOM is incomplete');
 
     this.accountList.addEventListener('click', (event) => {
       const item = event.target.closest('.sign-in-account-item');
       if (!item || this.isSigningIn) return;
       const username = item.dataset.username;
-      if (!username) return;
+      assert(username, 'Sign-in account item is missing username');
       this.handleAccountClick(username);
     });
 
     this.actionSheetOverlay.addEventListener('click', (event) => {
-      if (event.target === this.actionSheetOverlay) {
-        this.closeActionSheet();
-      }
+      if (event.target === this.actionSheetOverlay) this.closeActionSheet();
     });
     this.closeActionSheetButton.addEventListener('click', () => this.closeActionSheet());
 
-    const actionSheetRevalidate = () => {
+    const enableActionButtons = () => {
       this.actionRecreateButton.disabled = false;
       this.actionRemoveButton.disabled = false;
     };
-    this.actionRecreateButton.addEventListener('click', withButtonCooldown(
+    const runSheetAction = (action) => withButtonCooldown(
       [this.actionRecreateButton, this.actionRemoveButton],
       BUTTON_COOLDOWN_MS,
-      actionSheetRevalidate,
+      enableActionButtons,
       () => {
-        const username = this.actionSheetUsername;
-        if (!username) return;
-        this.openRecreateFlow(username);
+        assert(this.selectedUsername, 'Sign-in action sheet requires selected account');
+        action(this.selectedUsername);
       }
-    ));
-    this.actionRemoveButton.addEventListener('click', withButtonCooldown(
-      [this.actionRecreateButton, this.actionRemoveButton],
-      BUTTON_COOLDOWN_MS,
-      actionSheetRevalidate,
-      () => {
-        const username = this.actionSheetUsername;
-        if (!username) return;
-        this.handleRemoveAccount(username);
-      }
-    ));
+    );
+    this.actionRecreateButton.addEventListener('click', runSheetAction((username) => this.openRecreateFlow(username)));
+    this.actionRemoveButton.addEventListener('click', runSheetAction((username) => removeAccountModal.removeAccount(username)));
 
     this.backButton.addEventListener('click', () => {
-      if (this.isActionSheetOpen()) {
+      if (this.actionSheetOverlay.classList.contains('active')) {
         this.closeActionSheet();
         return;
       }
@@ -3647,43 +3653,20 @@ class SignInModal {
     });
   }
 
-  isActionSheetOpen() {
-    return this.actionSheetOverlay?.classList.contains('active');
-  }
-
   closeActionSheet() {
-    if (!this.actionSheetOverlay) return;
     this.actionSheetOverlay.classList.remove('active');
     this.actionSheetOverlay.setAttribute('aria-hidden', 'true');
-    this.actionSheetUsername = null;
   }
 
   openActionSheet(username, reason) {
-    const copy = {
-      'not-found': {
-        message: 'This account is not on the network. You can recreate it from local data or remove it from this device.',
-        showRecreate: true,
-        showRemove: true,
-      },
-      taken: {
-        message: 'This username is taken on the network by a different address.',
-        showRecreate: false,
-        showRemove: true,
-      },
-      'network-error': {
-        message: 'Could not reach the network. Check your connection and try again.',
-        showRecreate: false,
-        showRemove: false,
-      },
-    }[reason];
+    const sheet = SIGN_IN_ACTION_SHEETS[reason];
+    assert(sheet, `Unknown sign-in action sheet: ${reason}`);
 
-    if (!copy) return;
-
-    this.actionSheetUsername = username;
+    this.selectedUsername = username;
     this.actionSheetTitle.textContent = username;
-    this.actionSheetMessage.textContent = copy.message;
-    this.actionRecreateButton.hidden = !copy.showRecreate;
-    this.actionRemoveButton.hidden = !copy.showRemove;
+    this.actionSheetMessage.textContent = sheet.message;
+    this.actionRecreateButton.hidden = !sheet.showRecreate;
+    this.actionRemoveButton.hidden = !sheet.showRemove;
     this.actionSheetOverlay.classList.add('active');
     this.actionSheetOverlay.setAttribute('aria-hidden', 'false');
 
@@ -3695,11 +3678,8 @@ class SignInModal {
   openRecreateFlow(username) {
     const { netid } = network;
     const accountData = loadState(`${username}_${netid}`);
-    const privateKey = accountData?.account?.keys?.secret;
-    if (!privateKey) {
-      showToast('Account data not found', 0, 'error');
-      return;
-    }
+    assert(accountData?.account?.keys?.secret, `Missing private key for ${username}`);
+    const privateKey = accountData.account.keys.secret;
 
     createAccountModal.usernameInput.value = username;
     createAccountModal.privateKeyInput.value = privateKey;
@@ -3708,43 +3688,29 @@ class SignInModal {
     createAccountModal.usernameInput.dispatchEvent(new Event('input'));
   }
 
-  /**
-   * Get the available usernames for the current network
-   * @returns {string[]} - An array of available usernames
-   */
   getSignInUsernames() {
     const { netid } = network;
     const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
     const netidAccounts = accounts.netids[netid];
-    if (!netidAccounts || !netidAccounts.usernames) return [];
-    return { usernames: Object.keys(netidAccounts.usernames), netidAccounts };
+    const usernames = netidAccounts?.usernames ? Object.keys(netidAccounts.usernames) : [];
+    return { usernames, netidAccounts: netidAccounts || { usernames: {} } };
   }
 
-  /**
-   * Render the account list with notification indicators and sort by notification status
-   * @param {string} [selectedUsername] - Optionally preserve a selected username
-   * @returns {Object} Object containing usernames array and account information
-   */
-  renderAccountList(selectedUsername = null) {
-    const signInData = signInModal.getSignInUsernames() || {};
-    const usernames = Array.isArray(signInData.usernames) ? signInData.usernames : [];
-    const netidAccounts = signInData.netidAccounts || { usernames: {} };
+  renderAccountList(preserveUsername) {
+    const { usernames, netidAccounts } = this.getSignInUsernames();
     const { netid } = network;
-
-    // Get the notified addresses and sort usernames to prioritize them
     const notifiedAddresses = reactNativeApp.isReactNativeWebView ? reactNativeApp.getNotificationAddresses() : [];
-    let sortedUsernames = [...usernames];
     const notifiedUsernameSet = new Set();
-    
-    // if there are notified addresses, partition the usernames (stable) so notified come first
+    let sortedUsernames = usernames;
+
+    // If there are notified addresses, partition usernames (stable) so notified come first.
     if (notifiedAddresses.length > 0) {
-      const normalizedNotifiedSet = new Set(notifiedAddresses.map(addr => normalizeAddress(addr)));
+      const normalizedNotifiedSet = new Set(notifiedAddresses.map((addr) => normalizeAddress(addr)));
       const notifiedUsernames = [];
       const otherUsernames = [];
-      for (const username of sortedUsernames) {
-        const address = netidAccounts?.usernames?.[username]?.address;
-        const isNotified = address && normalizedNotifiedSet.has(normalizeAddress(address));
-        if (isNotified) {
+      for (const username of usernames) {
+        const address = netidAccounts.usernames[username].address;
+        if (normalizedNotifiedSet.has(normalizeAddress(address))) {
           notifiedUsernames.push(username);
           notifiedUsernameSet.add(username);
         } else {
@@ -3757,30 +3723,22 @@ class SignInModal {
     // Build a map of privacy flags to avoid multiple loadState calls.
     const isPrivateMap = Object.create(null);
     for (const username of sortedUsernames) {
-      let isPrivateAccount = false;
-      try {
-        const localState = loadState(`${username}_${netid}`);
-        isPrivateAccount = localState?.account?.private === true;
-      } catch (e) {
-        isPrivateAccount = false;
-      }
-      isPrivateMap[username] = isPrivateAccount;
+      const localState = loadState(`${username}_${netid}`);
+      isPrivateMap[username] = localState?.account?.private === true;
     }
 
-    // Keep notified accounts (any privacy) at the very top, in the order
-    // they appear in sortedUsernames. Then render remaining public accounts,
-    // and finally remaining private accounts grouped under a section label.
-    const notifiedTop = sortedUsernames.filter(u => notifiedUsernameSet.has(u));
-    const remaining = sortedUsernames.filter(u => !notifiedUsernameSet.has(u));
-    const publicRemaining = remaining.filter(u => !isPrivateMap[u]);
-    const privateRemaining = remaining.filter(u => isPrivateMap[u]);
+    // Keep notified accounts (any privacy) at the top, then public accounts,
+    // then remaining private accounts grouped under a section label.
+    const notifiedTop = sortedUsernames.filter((username) => notifiedUsernameSet.has(username));
+    const remaining = sortedUsernames.filter((username) => !notifiedUsernameSet.has(username));
+    const publicRemaining = remaining.filter((username) => !isPrivateMap[username]);
+    const privateRemaining = remaining.filter((username) => isPrivateMap[username]);
 
     const renderListItem = (username) => {
-      const isNotifiedAccount = notifiedUsernameSet.has(username);
       const isPrivateAccount = isPrivateMap[username];
       const displayName = isPrivateAccount ? `- ${username}` : username;
       const privateClass = isPrivateAccount ? ' is-private' : '';
-      const notificationBadge = isNotifiedAccount
+      const notificationBadge = notifiedUsernameSet.has(username)
         ? '<span class="sign-in-account-badge" aria-label="Has notifications">🔔</span>'
         : '';
       return `
@@ -3793,120 +3751,88 @@ class SignInModal {
       `;
     };
 
-    let html = '';
-
-    if (notifiedTop.length > 0) {
-      html += notifiedTop.map(renderListItem).join('');
-    }
-
-    if (publicRemaining.length > 0) {
-      html += publicRemaining.map(renderListItem).join('');
-    }
-
+    const sections = [
+      ...notifiedTop.map(renderListItem),
+      ...publicRemaining.map(renderListItem),
+    ];
     if (privateRemaining.length > 0) {
-      html += '<li class="sign-in-account-section" role="presentation">Private accounts</li>';
-      html += privateRemaining.map(renderListItem).join('');
+      sections.push('<li class="sign-in-account-section" role="presentation">Private accounts</li>');
+      sections.push(...privateRemaining.map(renderListItem));
     }
+    this.accountList.innerHTML = sections.join('');
 
-    this.accountList.innerHTML = html;
-
-    if (selectedUsername && usernames.includes(selectedUsername)) {
-      this.selectedUsername = selectedUsername;
+    if (preserveUsername && usernames.includes(preserveUsername)) {
+      this.selectedUsername = preserveUsername;
     }
-
-    this.updateSelectedAccountStyling(netid);
-
-    return { usernames, netidAccounts, sortedUsernames };
-  }
-
-  updateSelectedAccountStyling(netid) {
-    const items = this.accountList.querySelectorAll('.sign-in-account-item');
-    items.forEach((item) => {
+    for (const item of this.accountList.querySelectorAll('.sign-in-account-item')) {
       const isSelected = item.dataset.username === this.selectedUsername;
       item.classList.toggle('is-selected', isSelected);
       item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
-    });
+    }
+
+    return usernames;
   }
 
-  async open(preselectedUsername_) {
-    this.preselectedUsername = preselectedUsername_;
+  async open(preselectedUsername) {
+    this.preselectedUsername = preselectedUsername;
     this.selectedUsername = null;
     this.isSigningIn = false;
     this.closeActionSheet();
 
-    // Render account list and get usernames BEFORE opening modal
-    const { usernames } = this.renderAccountList();
+    // Render account list before opening modal.
+    const usernames = this.renderAccountList();
 
-    // Wait for browser to process DOM changes before starting modal transition
+    // Wait for browser to process DOM changes before starting modal transition.
     requestAnimationFrame(async () => {
       this.modal.classList.add('active');
 
-      // If no accounts exist, close modal and open Create Account modal
+      // No accounts on this device — open Create Account instead.
       if (usernames.length === 0) {
         this.close();
         createAccountModal.open();
         return;
       }
 
-      // If a username should be auto-selected after account creation, sign in directly
-      if (preselectedUsername_ && usernames.includes(preselectedUsername_)) {
-        const availability = await this.handleAccountClick(preselectedUsername_);
-        // Network may not have propagated the new account yet
-        if (availability === 'available') {
-          await this.handleSignIn();
-        }
+      // Auto-select after account creation; network may not have propagated yet.
+      if (preselectedUsername && usernames.includes(preselectedUsername)) {
+        const availability = await this.handleAccountClick(preselectedUsername);
+        if (availability === 'available') await this.handleSignIn();
         return;
       }
 
-      // If only one account exists, sign in directly when available
       if (usernames.length === 1) {
         await this.handleAccountClick(usernames[0]);
         return;
       }
 
-      // set timeout to focus on the last item so shift+tab and tab prevention works
-      setTimeout(() => {
-        this.signInModalLastItem.focus();
-      }, 325);
+      // Focus last item so shift+tab and tab prevention works.
+      setTimeout(() => this.signInModalLastItem.focus(), 325);
     });
   }
 
   close() {
     this.selectedUsername = null;
     this.isSigningIn = false;
+    this.preselectedUsername = null;
     this.closeActionSheet();
     this.accountList.innerHTML = '';
-    
     this.modal.classList.remove('active');
-    this.preselectedUsername = null;
   }
 
   async handleSignIn() {
+    const username = this.selectedUsername;
+    assert(username, 'Sign-in requires selected account');
+
     history.pushState({state:1}, "", ".")
     window.addEventListener('popstate', handleBrowserBackButton);
-    
     enterFullscreen();
-    
-    const username = this.selectedUsername;
-    if (!username) return;
 
-    // Get network ID from network.js
     const { netid } = network;
-
-    // Get existing accounts
     const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+    assert(existingAccounts.netids[netid]?.usernames?.[username], `Account registry missing ${username}`);
 
-    // Check if username exists
-    if (!existingAccounts.netids[netid]?.usernames?.[username]) {
-      console.error('Account not found');
-      return;
-    }
-
-    myData = loadState(`${username}_${netid}`)
-    if (!myData) {
-      console.warn('Account data not found');
-      return;
-    }
+    myData = loadState(`${username}_${netid}`);
+    assert(myData, `Account data missing for ${username}`);
     myAccount = myData.account;
     logsModal.log(`SignIn as ${username}_${netid}`)
 
@@ -3990,81 +3916,55 @@ class SignInModal {
     this.closeActionSheet();
 
     const { netid } = network;
-    const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
-    const netidAccounts = existingAccounts.netids[netid];
-
-    if (!username || !netidAccounts?.usernames?.[username]) {
+    const netidAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}').netids[netid];
+    if (!netidAccounts?.usernames?.[username]) {
       this.selectedUsername = null;
       return null;
     }
 
     this.selectedUsername = username;
-    this.updateSelectedAccountStyling(netid);
-
     const address = netidAccounts.usernames[username].address;
     let availability = await checkUsernameAvailability(username, address);
-    // Retry logic: if availability reported as 'available' but we have local account data
-    // (meaning the account previously existed locally), we suspect propagation delay.
-    if (availability === 'available' && netidAccounts?.usernames?.[username]) {
-      const localStateKey = `${username}_${netid}`;
-      const hasLocalState = !!localStorage.getItem(localStateKey);
-      if (hasLocalState) {
-        const maxAttempts = 3; // total attempts including initial (so 2 more re-tries)
-        const delayMs = 200;
-        let attempt = 1;
-        while (attempt < maxAttempts && availability === 'available') {
-          attempt++;
-          logsModal.log(`[SignInModal] Retry ${attempt}/${maxAttempts} username availability for '${username}' because local data exists but network returned 'available'.`);
-          try {
-            await new Promise(res => setTimeout(res, delayMs));
-            availability = await checkUsernameAvailability(username, address);
-          } catch (err) {
-            break; // break on explicit error; will treat as network error below if availability not set
-          }
+    // Retry when network says 'available' but local account data still exists (propagation delay).
+    if (availability === 'available' && localStorage.getItem(`${username}_${netid}`)) {
+      for (let attempt = 2; attempt <= 3 && availability === 'available'; attempt++) {
+        logsModal.log(`[SignInModal] Retry ${attempt}/3 username availability for '${username}' because local data exists but network returned 'available'.`);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        availability = await checkUsernameAvailability(username, address);
+      }
+      if (availability === 'available') {
+        logsModal.log(`[SignInModal] After 3 attempts username '${username}' still reported as available.`);
+      }
+    }
+    // Ignore stale results if the user tapped a different account while we were waiting.
+    if (clickSeq !== this.accountClickSeq) return null;
+
+    switch (availability) {
+      case 'mine':
+        this.isSigningIn = true;
+        try {
+          await this.handleSignIn();
+        } finally {
+          this.isSigningIn = false;
         }
-        if (availability === 'available') {
-          logsModal.log(`[SignInModal] After ${maxAttempts} attempts username '${username}' still reported as available. Assuming account deleted on network; offering recreate/delete options.`);
-        } else {
-          logsModal.log(`[SignInModal] Availability resolved to '${availability}' after retries for '${username}'.`);
-        }
-      }
-    }
-
-    if (clickSeq !== this.accountClickSeq) {
-      return null;
-    }
-
-    if (availability === 'mine') {
-      this.isSigningIn = true;
-      try {
-        await this.handleSignIn();
-      } finally {
-        this.isSigningIn = false;
-      }
-      this.preselectedUsername = null;
-      return availability;
-    }
-
-    if (availability === 'taken') {
-      this.openActionSheet(username, 'taken');
-    } else if (availability === 'available') {
-      // Post-creation preselect may sign in locally without showing the sheet.
-      if (!(this.preselectedUsername && username === this.preselectedUsername)) {
-        this.openActionSheet(username, 'not-found');
-      }
-    } else {
-      this.openActionSheet(username, 'network-error');
+        this.preselectedUsername = null;
+        break;
+      case 'taken':
+        this.openActionSheet(username, 'taken');
+        break;
+      case 'available':
+        // Post-creation preselect may sign in locally without showing the sheet.
+        if (this.preselectedUsername !== username) this.openActionSheet(username, 'not-found');
+        break;
+      case 'error':
+      case 'error2':
+        this.openActionSheet(username, 'network-error');
+        break;
+      default:
+        assert(false, `Unknown username availability: ${availability}`);
     }
 
     return availability;
-  }
-
-  handleRemoveAccount(username = this.actionSheetUsername || this.selectedUsername) {
-    if (!username) {
-      showToast('Please select an account to remove', 2000, 'warning');
-      return;
-    }
-    removeAccountModal.removeAccount(username);
   }
 
   isActive() {
@@ -4072,14 +3972,11 @@ class SignInModal {
   }
 
   /**
-   * Update the display to reflect new notifications while the modal is open
-   * This is called when new notifications arrive while the modal is open
+   * Update the display when new notifications arrive while the modal is open.
    */
   updateNotificationDisplay() {
-    // Only update if the modal is actually active
     if (!this.isActive()) return;
-    
-    // Preserve the currently selected username after re-rendering the list
+    // Preserve the currently selected username after re-rendering the list.
     this.renderAccountList(this.selectedUsername);
   }
 }

--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@
         </div>
         <div class="modal-content">
           <div class="form-container">
-            <ul class="sign-in-account-list" id="signInAccountList" role="listbox" aria-label="Accounts"></ul>
+            <ul class="sign-in-account-list" id="signInAccountList" aria-label="Accounts"></ul>
             <a class="last-item" href="#" id="signInModalLastItem"> </a>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -698,7 +698,6 @@
             <div class="sign-in-action-sheet-buttons">
               <button type="button" id="signInActionRecreate" class="btn btn--primary btn--pill btn--full" hidden>Recreate</button>
               <button type="button" id="signInActionRemove" class="btn btn--danger btn--pill btn--full" hidden>Remove</button>
-              <button type="button" id="signInActionRetry" class="btn btn--secondary btn--pill btn--full" hidden>Retry</button>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -684,14 +684,9 @@
         <div class="modal-content">
           <div class="form-container">
             <form id="signInForm" class="form--narrow">
-              <div class="form-group">
-                <label for="username"
-                  >Select Account
-                  <span id="usernameNotFound" style="color: #dc3545; display: none; display: inline"></span
-                ></label>
-                <select id="username" class="form-control" required></select>
-              </div>
-              <div class="form-actions">
+              <ul class="chat-list" id="signInAccountList" role="listbox" aria-label="Accounts"></ul>
+              <div class="form-actions sign-in-account-actions" id="signInAccountActions" style="display: none">
+                <p class="sign-in-account-status" id="usernameNotFound"></p>
                 <button type="submit" class="btn btn--primary btn--pill btn--full" disabled>Sign In</button>
                 <button type="button" id="removeAccountButton" class="btn btn--secondary btn--pill btn--full" style="display: none">
                   Remove

--- a/index.html
+++ b/index.html
@@ -683,17 +683,23 @@
         </div>
         <div class="modal-content">
           <div class="form-container">
-            <form id="signInForm" class="form--narrow">
-              <ul class="sign-in-account-list" id="signInAccountList" role="listbox" aria-label="Accounts"></ul>
-              <div class="form-actions sign-in-account-actions" id="signInAccountActions" style="display: none">
-                <p class="sign-in-account-status" id="usernameNotFound"></p>
-                <button type="submit" class="btn btn--primary btn--pill btn--full" disabled>Sign In</button>
-                <button type="button" id="removeAccountButton" class="btn btn--secondary btn--pill btn--full" style="display: none">
-                  Remove
-                </button>
-              </div>
-            </form>
+            <ul class="sign-in-account-list" id="signInAccountList" role="listbox" aria-label="Accounts"></ul>
             <a class="last-item" href="#" id="signInModalLastItem"> </a>
+          </div>
+        </div>
+        <div class="sign-in-action-sheet-overlay" id="signInActionSheetOverlay" aria-hidden="true">
+          <div class="sign-in-action-sheet" id="signInActionSheet" role="dialog" aria-labelledby="signInActionSheetTitle">
+            <div class="sign-in-action-sheet-handle" aria-hidden="true"></div>
+            <div class="sign-in-action-sheet-header">
+              <div class="sign-in-action-sheet-title" id="signInActionSheetTitle"></div>
+              <button class="sign-in-action-sheet-close" id="closeSignInActionSheet" type="button" aria-label="Close">Close</button>
+            </div>
+            <p class="sign-in-action-sheet-message" id="signInActionSheetMessage"></p>
+            <div class="sign-in-action-sheet-buttons">
+              <button type="button" id="signInActionRecreate" class="btn btn--primary btn--pill btn--full" hidden>Recreate</button>
+              <button type="button" id="signInActionRemove" class="btn btn--danger btn--pill btn--full" hidden>Remove</button>
+              <button type="button" id="signInActionRetry" class="btn btn--secondary btn--pill btn--full" hidden>Retry</button>
+            </div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -684,7 +684,7 @@
         <div class="modal-content">
           <div class="form-container">
             <form id="signInForm" class="form--narrow">
-              <ul class="chat-list" id="signInAccountList" role="listbox" aria-label="Accounts"></ul>
+              <ul class="sign-in-account-list" id="signInAccountList" role="listbox" aria-label="Accounts"></ul>
               <div class="form-actions sign-in-account-actions" id="signInAccountActions" style="display: none">
                 <p class="sign-in-account-status" id="usernameNotFound"></p>
                 <button type="submit" class="btn btn--primary btn--pill btn--full" disabled>Sign In</button>

--- a/styles.css
+++ b/styles.css
@@ -3174,6 +3174,43 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   accent-color: var(--primary-color, #007bff);
 }
 
+/* Sign In Modal account list */
+#signInModal #signInAccountList {
+  margin-bottom: 0.5rem;
+}
+
+#signInModal .sign-in-account-item {
+  border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.06));
+}
+
+#signInModal .sign-in-account-item.is-private .chat-name {
+  color: var(--danger-color);
+}
+
+#signInModal .sign-in-account-item.is-selected {
+  background: var(--hover-background);
+}
+
+#signInModal .sign-in-account-section {
+  padding: 10px 16px 4px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--danger-color);
+  list-style: none;
+  cursor: default;
+}
+
+#signInModal .sign-in-account-actions {
+  margin-top: 0.75rem;
+}
+
+#signInModal .sign-in-account-status {
+  margin: 0 0 0.75rem;
+  color: var(--danger-color);
+  font-size: var(--font-size-base);
+  text-align: center;
+}
+
 #removeAccountsModal .remove-account-username {
   font-weight: 600;
   flex: 0 0 auto;

--- a/styles.css
+++ b/styles.css
@@ -3258,15 +3258,82 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   cursor: default;
 }
 
-#signInModal .sign-in-account-actions {
-  margin-top: 0.75rem;
+/* Sign In account action sheet (reaction-sheet cousin) */
+.sign-in-action-sheet-overlay {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: flex-end;
+  justify-content: stretch;
+  background: rgba(15, 23, 42, 0.22);
+  z-index: var(--overlay-z-index-high);
 }
 
-#signInModal .sign-in-account-status {
-  margin: 0 0 0.75rem;
-  color: var(--danger-color);
+.sign-in-action-sheet-overlay.active {
+  display: flex;
+}
+
+.sign-in-action-sheet {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 10px 16px calc(env(safe-area-inset-bottom, 0px) + 16px);
+  border-radius: 22px 22px 0 0;
+  background: var(--background-color);
+  box-shadow: 0 -12px 36px rgba(15, 23, 42, 0.2);
+}
+
+.sign-in-action-sheet-handle {
+  flex: 0 0 auto;
+  width: 42px;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.16);
+  margin: 0 auto 12px;
+}
+
+.sign-in-action-sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.sign-in-action-sheet-title {
   font-size: var(--font-size-base);
-  text-align: center;
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-color);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sign-in-action-sheet-close {
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text-color);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.sign-in-action-sheet-message {
+  margin: 0 0 16px;
+  font-size: var(--font-size-sm);
+  color: var(--neutral-600);
+  text-align: left;
+  line-height: 1.45;
+}
+
+.sign-in-action-sheet-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 #removeAccountsModal .remove-account-username {

--- a/styles.css
+++ b/styles.css
@@ -3175,26 +3175,84 @@ input[type='number'].form-control::-webkit-inner-spin-button {
 }
 
 /* Sign In Modal account list */
-#signInModal #signInAccountList {
-  margin-bottom: 0.5rem;
+#signInModal .sign-in-account-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 #signInModal .sign-in-account-item {
-  border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.06));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
 }
 
-#signInModal .sign-in-account-item.is-private .chat-name {
+#signInModal .sign-in-account-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--background-color);
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
+  border-radius: 12px;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+#signInModal .sign-in-account-item:hover .sign-in-account-card {
+  background: var(--hover-background);
+  border-color: var(--primary-tint-20);
+}
+
+#signInModal .sign-in-account-item:active .sign-in-account-card {
+  transform: scale(0.99);
+}
+
+#signInModal .sign-in-account-item.is-selected .sign-in-account-card {
+  background: var(--primary-tint-04);
+  border-color: var(--primary-color);
+}
+
+#signInModal .sign-in-account-name {
+  font-family: var(--font-primary);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--text-color);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#signInModal .sign-in-account-item.is-private .sign-in-account-card {
+  border-color: rgba(220, 53, 69, 0.35);
+}
+
+#signInModal .sign-in-account-item.is-private .sign-in-account-name {
   color: var(--danger-color);
 }
 
-#signInModal .sign-in-account-item.is-selected {
-  background: var(--hover-background);
+#signInModal .sign-in-account-item.is-private:hover .sign-in-account-card,
+#signInModal .sign-in-account-item.is-private.is-selected .sign-in-account-card {
+  border-color: var(--danger-color);
+}
+
+#signInModal .sign-in-account-badge {
+  flex: 0 0 auto;
+  font-size: 1rem;
+  line-height: 1;
 }
 
 #signInModal .sign-in-account-section {
-  padding: 10px 16px 4px;
-  font-size: 0.85rem;
+  padding: 4px 2px 0;
+  font-size: 0.8rem;
   font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--danger-color);
   list-style: none;
   cursor: default;

--- a/styles.css
+++ b/styles.css
@@ -3212,11 +3212,6 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   transform: scale(0.99);
 }
 
-#signInModal .sign-in-account-item.is-selected .sign-in-account-card {
-  background: var(--primary-tint-04);
-  border-color: var(--primary-color);
-}
-
 #signInModal .sign-in-account-name {
   font-family: var(--font-primary);
   font-size: var(--font-size-base);
@@ -3236,8 +3231,7 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   color: var(--danger-color);
 }
 
-#signInModal .sign-in-account-item.is-private:hover .sign-in-account-card,
-#signInModal .sign-in-account-item.is-private.is-selected .sign-in-account-card {
+#signInModal .sign-in-account-item.is-private:hover .sign-in-account-card {
   border-color: var(--danger-color);
 }
 
@@ -3364,26 +3358,6 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   font-size: var(--font-size-base);
   color: var(--text-color);
 } /* Specific style for search icon to ensure consistent size */
-
-/* Sign In Modal specific styles */
-#removeAccountButton {
-  width: calc(100% - 32px);
-  height: 48px;
-  margin: 8px 16px;
-  background-color: var(--hover-background);
-  color: var(--danger-color);
-  border: none;
-  border-radius: 24px;
-  font-family: var(--font-primary);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-bold);
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-#removeAccountButton:hover {
-  background-color: var(--hover-background);
-}
 
 /* About Modal Content Styles */
 #aboutModal #netIdAbout {


### PR DESCRIPTION
## Summary

- Replaces the Sign In modal account dropdown with a clickable card list; tapping an account signs in immediately when it is available on the network.
- Preserves existing account ordering (notifications first), private account grouping, and edge-case handling for recreate/remove when an account is taken, not found, or unreachable.
- Guards pending account availability checks so stale results cannot sign in or open the action sheet after the modal closes.
- Styles each account as a flat bordered card with hover/selected states and a notification badge.

Closes #1330

## Test plan

- [x] Run node --check app.js
- [x] Open Sign In with multiple saved accounts and confirm each account appears as a card in the list
- [x] Click an available account and confirm it signs in without needing a separate Sign In button
- [x] Verify notified accounts appear first with a notification badge
- [x] Verify private accounts appear under the "Private accounts" section with red styling
- [x] Open Sign In with only one account and confirm it still auto-signs in
- [x] Create a new account and confirm preselected auto-sign-in still works after account creation
- [x] Test edge cases: taken account, not-found account (Recreate/Remove actions appear), and network error toast
- [x] Confirm card hover/selected states look correct and have no shadows
