### PR TITLE
Sign In modal: avoid focus jump on open

### DIFF
--- a/app.js
+++ b/app.js
@@ -3606,7 +3606,6 @@ class SignInModal {
   load () {
     this.modal = document.getElementById('signInModal');
     this.accountList = document.getElementById('signInAccountList');
-    this.signInModalLastItem = document.getElementById('signInModalLastItem');
     this.backButton = document.getElementById('closeSignInModal');
     this.actionSheetOverlay = document.getElementById('signInActionSheetOverlay');
     this.actionSheetTitle = document.getElementById('signInActionSheetTitle');
@@ -3814,9 +3813,6 @@ class SignInModal {
         await this.handleAccountClick(usernames[0]);
         return;
       }
-
-      // Focus last item so shift+tab and tab prevention works.
-      setTimeout(() => this.signInModalLastItem.focus(), 325);
     });
   }
 


### PR DESCRIPTION
## Summary
- Remove the delayed programmatic focus on the sign-in modal sentinel at the end of the list.
- Keep existing sign-in flow behavior intact (preselected one-account auto-sign in path unchanged).
- Prevents focus-induced scroll positioning when the account list overflows.

## Validation
- [x] Manual: open sign-in modal with many accounts and confirm list starts at top without scrolling jump.
