### PR TITLE
Favor recent sign-in profiles

### DIFF
--- a/app.js
+++ b/app.js
@@ -3594,6 +3594,8 @@ const SIGN_IN_ACTION_SHEETS = {
     showRemove: false,
   },
 };
+const SIGN_IN_RECENT_USERNAME_KEY = 'recentSignInUsernames';
+const SIGN_IN_USERNAME_PROMOTION_RATIO = 0.5;
 
 class SignInModal {
   constructor() {
@@ -3710,6 +3712,90 @@ class SignInModal {
     return { usernames, netidAccounts: netidAccounts || { usernames: {} } };
   }
 
+  normalizeRecentSignInUsernameList(usernames, availableUsernameSet = null) {
+    if (!Array.isArray(usernames)) {
+      return [];
+    }
+
+    const normalizedUsernames = [];
+    const seen = new Set();
+    for (const entry of usernames) {
+      const username = typeof entry === 'string' ? entry.trim() : '';
+      if (!username || seen.has(username)) {
+        continue;
+      }
+      if (availableUsernameSet && !availableUsernameSet.has(username)) {
+        continue;
+      }
+      seen.add(username);
+      normalizedUsernames.push(username);
+    }
+
+    return normalizedUsernames;
+  }
+
+  getRecentSignInUsernames(usernames, netidAccounts) {
+    const rankedUsernames = [];
+    const seen = new Set();
+    const availableUsernameSet = new Set(usernames);
+    const addUsername = (username) => {
+      if (!username || seen.has(username) || !availableUsernameSet.has(username)) {
+        return;
+      }
+      seen.add(username);
+      rankedUsernames.push(username);
+    };
+
+    this.normalizeRecentSignInUsernameList(
+      netidAccounts?.[SIGN_IN_RECENT_USERNAME_KEY],
+      availableUsernameSet
+    ).forEach(addUsername);
+    usernames.forEach(addUsername);
+
+    return rankedUsernames;
+  }
+
+  promoteRecentSignInUsername(recentUsernames, selectedUsername) {
+    const username = typeof selectedUsername === 'string' ? selectedUsername.trim() : '';
+    if (!username) {
+      return this.normalizeRecentSignInUsernameList(recentUsernames);
+    }
+
+    const currentUsernames = this.normalizeRecentSignInUsernameList(recentUsernames);
+    const currentIndex = currentUsernames.indexOf(username);
+    const remainingUsernames = currentUsernames.filter((entry) => entry !== username);
+    const targetIndex = currentIndex === -1
+      ? currentUsernames.length
+      : Math.max(
+          0,
+          currentIndex - Math.max(1, Math.ceil((currentIndex + 1) * SIGN_IN_USERNAME_PROMOTION_RATIO))
+        );
+
+    remainingUsernames.splice(targetIndex, 0, username);
+    return remainingUsernames;
+  }
+
+  recordRecentSignInUsername(username) {
+    const selectedUsername = typeof username === 'string' ? username.trim() : '';
+    if (!selectedUsername) {
+      return;
+    }
+
+    const { netid } = network;
+    const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+    const netidAccounts = accounts.netids[netid];
+    if (!netidAccounts?.usernames?.[selectedUsername]) {
+      return;
+    }
+
+    const usernames = Object.keys(netidAccounts.usernames);
+    netidAccounts[SIGN_IN_RECENT_USERNAME_KEY] = this.promoteRecentSignInUsername(
+      this.getRecentSignInUsernames(usernames, netidAccounts),
+      selectedUsername
+    );
+    localStorage.setItem('accounts', stringify(accounts));
+  }
+
   /**
    * Render the account list with notification indicators and sort by notification status.
    * @returns {string[]} Usernames for the current network (registry order, not display order)
@@ -3719,14 +3805,14 @@ class SignInModal {
     const { netid } = network;
     const notifiedAddresses = reactNativeApp.isReactNativeWebView ? reactNativeApp.getNotificationAddresses() : [];
     const notifiedUsernameSet = new Set();
-    let sortedUsernames = usernames;
+    let sortedUsernames = this.getRecentSignInUsernames(usernames, netidAccounts);
 
     // If there are notified addresses, partition usernames (stable) so notified come first.
     if (notifiedAddresses.length > 0) {
       const normalizedNotifiedSet = new Set(notifiedAddresses.map((addr) => normalizeAddress(addr)));
       const notifiedUsernames = [];
       const otherUsernames = [];
-      for (const username of usernames) {
+      for (const username of sortedUsernames) {
         const address = netidAccounts.usernames[username].address;
         if (normalizedNotifiedSet.has(normalizeAddress(address))) {
           notifiedUsernames.push(username);
@@ -3842,6 +3928,7 @@ class SignInModal {
     assert(myData, `Account data missing for ${username}`);
     myAccount = myData.account;
     logsModal.log(`SignIn as ${username}_${netid}`)
+    this.recordRecentSignInUsername(username);
 
     // One-time migration: convert legacy friend status to connection
     if (migrateFriendStatusToConnection(myData)) {

--- a/app.js
+++ b/app.js
@@ -10223,6 +10223,18 @@ class RemoveAccountModal {
     this.modal.classList.remove('active');
   }
 
+  removeSignInUsernameOrder(netidAccounts, username) {
+    const usernameOrder = netidAccounts[SIGN_IN_USERNAME_ORDER_KEY];
+    if (!usernameOrder) return;
+
+    usernameOrder.public = usernameOrder.public.filter((storedUsername) => storedUsername !== username);
+    usernameOrder.private = usernameOrder.private.filter((storedUsername) => storedUsername !== username);
+
+    if (usernameOrder.public.length === 0 && usernameOrder.private.length === 0) {
+      delete netidAccounts[SIGN_IN_USERNAME_ORDER_KEY];
+    }
+  }
+
   submit(username = myAccount.username) {
     // called when the form is submitted
     // Get network ID from network.js
@@ -10232,8 +10244,10 @@ class RemoveAccountModal {
     const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
 
     // Remove the account from the accounts object
-    if (existingAccounts.netids[netid] && existingAccounts.netids[netid].usernames) {
-      delete existingAccounts.netids[netid].usernames[username];
+    const netidAccounts = existingAccounts.netids[netid];
+    if (netidAccounts && netidAccounts.usernames) {
+      delete netidAccounts.usernames[username];
+      this.removeSignInUsernameOrder(netidAccounts, username);
       localStorage.setItem('accounts', stringify(existingAccounts));
     }
     // Remove the account data from localStorage
@@ -10264,8 +10278,10 @@ class RemoveAccountModal {
     const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
 
     // Remove the account from the accounts object
-    if (existingAccounts.netids[netid] && existingAccounts.netids[netid].usernames) {
-      delete existingAccounts.netids[netid].usernames[username];
+    const netidAccounts = existingAccounts.netids[netid];
+    if (netidAccounts && netidAccounts.usernames) {
+      delete netidAccounts.usernames[username];
+      this.removeSignInUsernameOrder(netidAccounts, username);
       localStorage.setItem('accounts', stringify(existingAccounts));
     }
     // Remove the account data from localStorage

--- a/app.js
+++ b/app.js
@@ -10521,6 +10521,7 @@ class RemoveAccountsModal {
       // remove from registry if present
       if (accountsObj.netids[netid] && accountsObj.netids[netid].usernames && accountsObj.netids[netid].usernames[username]) {
         delete accountsObj.netids[netid].usernames[username];
+        removeAccountModal.removeSignInUsernameOrder(accountsObj.netids[netid], username);
       }
     });
     localStorage.setItem('accounts', stringify(accountsObj));

--- a/app.js
+++ b/app.js
@@ -3718,9 +3718,9 @@ class SignInModal {
   }
 
   /**
-   * Normalize stored recent sign-in usernames against accounts on the active network.
+   * Normalize stored recent sign-in usernames against the supplied valid username set.
    * @param {string[]} storedUsernames Stored recent username values.
-   * @param {Set<string>} availableUsernameSet Usernames still available for the active network.
+   * @param {Set<string>} availableUsernameSet Usernames that should remain in the recent order.
    * @returns {string[]} Clean recent username list.
    */
   normalizeRecentSignInUsernameList(storedUsernames, availableUsernameSet) {

--- a/app.js
+++ b/app.js
@@ -3893,18 +3893,31 @@ class SignInModal {
     const { usernameGroups, isPrivateMap } = this.getSignInUsernameGroups(usernames, netid);
     const usernameOrder = this.getSignInUsernameOrder(usernameGroups, netidAccounts);
     const notifiedAddresses = reactNativeApp.isReactNativeWebView ? reactNativeApp.getNotificationAddresses() : [];
-    const normalizedNotifiedSet = new Set(notifiedAddresses.map((addr) => normalizeAddress(addr)));
+    const normalizedNotifiedSet = new Set();
+    for (const address of notifiedAddresses) {
+      try {
+        normalizedNotifiedSet.add(normalizeAddress(address));
+      } catch (error) {
+        console.warn('Skipping invalid notification address:', error);
+      }
+    }
     const notifiedUsernameSet = new Set();
     const notifiedTop = [];
     const publicRemaining = [];
     const privateRemaining = [];
 
     const placeUsername = (username, remainingUsernames) => {
-      const address = netidAccounts.usernames[username].address;
-      if (normalizedNotifiedSet.has(normalizeAddress(address))) {
-        notifiedTop.push(username);
-        notifiedUsernameSet.add(username);
-        return;
+      if (normalizedNotifiedSet.size > 0) {
+        const address = netidAccounts.usernames[username]?.address;
+        try {
+          if (address && normalizedNotifiedSet.has(normalizeAddress(address))) {
+            notifiedTop.push(username);
+            notifiedUsernameSet.add(username);
+            return;
+          }
+        } catch (error) {
+          console.warn(`Skipping invalid sign-in account address for ${username}:`, error);
+        }
       }
       remainingUsernames.push(username);
     };

--- a/app.js
+++ b/app.js
@@ -3594,7 +3594,8 @@ const SIGN_IN_ACTION_SHEETS = {
     showRemove: false,
   },
 };
-const SIGN_IN_RECENT_USERNAME_KEY = 'recentSignInUsernames';
+const SIGN_IN_LEGACY_RECENT_USERNAME_KEY = 'recentSignInUsernames';
+const SIGN_IN_USERNAME_ORDER_KEY = 'signInUsernameOrder';
 const SIGN_IN_USERNAME_PROMOTION_RATIO = 0.5;
 
 class SignInModal {
@@ -3718,12 +3719,33 @@ class SignInModal {
   }
 
   /**
-   * Normalize stored recent sign-in usernames against the supplied valid username set.
-   * @param {string[]} storedUsernames Stored recent username values.
-   * @param {Set<string>} availableUsernameSet Usernames that should remain in the recent order.
-   * @returns {string[]} Clean recent username list.
+   * Split current usernames into the same account groups shown in the sign-in list.
+   * @param {string[]} usernames Current network usernames in registry order.
+   * @param {string} netid Active network id.
+   * @returns {{ usernameGroups: { public: string[], private: string[] }, isPrivateMap: Object }}
    */
-  normalizeRecentSignInUsernameList(storedUsernames, availableUsernameSet) {
+  getSignInUsernameGroups(usernames, netid) {
+    const usernameGroups = { public: [], private: [] };
+    const isPrivateMap = Object.create(null);
+
+    for (const username of usernames) {
+      const localState = loadState(`${username}_${netid}`);
+      const isPrivate = localState?.account?.private === true;
+      const usernameType = isPrivate ? 'private' : 'public';
+      isPrivateMap[username] = isPrivate;
+      usernameGroups[usernameType].push(username);
+    }
+
+    return { usernameGroups, isPrivateMap };
+  }
+
+  /**
+   * Normalize stored sign-in usernames against the supplied valid username set.
+   * @param {string[]} storedUsernames Stored username values.
+   * @param {Set<string>} availableUsernameSet Usernames that should remain in the order.
+   * @returns {string[]} Clean username list.
+   */
+  normalizeSignInUsernameList(storedUsernames, availableUsernameSet) {
     if (!Array.isArray(storedUsernames)) {
       return [];
     }
@@ -3744,50 +3766,73 @@ class SignInModal {
   }
 
   /**
-   * Build the ranked sign-in username list from saved recent order plus current registry order.
-   * @param {string[]} usernames Current network usernames in registry order.
-   * @param {Object} netidAccounts Current network account registry.
-   * @returns {string[]} Usernames ordered by recent sign-in preference.
+   * Build one visible sign-in group from saved order plus current registry order.
+   * @param {string[]} usernames Current group usernames in registry order.
+   * @param {string[]} storedUsernames Stored order for the same group.
+   * @returns {string[]} Usernames ordered by sign-in preference.
    */
-  getRecentSignInUsernames(usernames, netidAccounts) {
-    const hasStoredUsernames = Object.prototype.hasOwnProperty.call(
-      netidAccounts,
-      SIGN_IN_RECENT_USERNAME_KEY
-    );
-    const storedUsernames = hasStoredUsernames ? netidAccounts[SIGN_IN_RECENT_USERNAME_KEY] : [];
+  getOrderedSignInUsernames(usernames, storedUsernames) {
     const availableUsernameSet = new Set(usernames);
-    const recentUsernames = this.normalizeRecentSignInUsernameList(storedUsernames, availableUsernameSet);
-    const recentUsernameSet = new Set(recentUsernames);
+    const orderedUsernames = this.normalizeSignInUsernameList(storedUsernames, availableUsernameSet);
+    const orderedUsernameSet = new Set(orderedUsernames);
 
     return [
-      ...recentUsernames,
-      ...usernames.filter((username) => !recentUsernameSet.has(username)),
+      ...orderedUsernames,
+      ...usernames.filter((username) => !orderedUsernameSet.has(username)),
     ];
   }
 
   /**
-   * Move the selected username halfway closer to the front, matching emoji picker promotion.
-   * @param {string[]} recentUsernames Current recent sign-in username order.
-   * @param {string} selectedUsername Username selected for sign-in.
-   * @returns {string[]} Updated recent sign-in username order.
+   * Get public and private sign-in ordering for the active network.
+   * @param {{ public: string[], private: string[] }} usernameGroups Current usernames split by type.
+   * @param {Object} netidAccounts Current network account registry.
+   * @returns {{ public: string[], private: string[] }} Ordered usernames split by type.
    */
-  promoteRecentSignInUsername(recentUsernames, selectedUsername) {
-    const currentIndex = recentUsernames.indexOf(selectedUsername);
-    assert(currentIndex !== -1, `Recent sign-in list missing ${selectedUsername}`);
+  getSignInUsernameOrder(usernameGroups, netidAccounts) {
+    const hasStoredOrder = Object.prototype.hasOwnProperty.call(
+      netidAccounts,
+      SIGN_IN_USERNAME_ORDER_KEY
+    );
+    const storedOrder = hasStoredOrder ? netidAccounts[SIGN_IN_USERNAME_ORDER_KEY] || {} : {};
+    const legacyUsernames = !hasStoredOrder && Array.isArray(netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY])
+      ? netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY]
+      : [];
+
+    return {
+      public: this.getOrderedSignInUsernames(
+        usernameGroups.public,
+        hasStoredOrder ? storedOrder.public : legacyUsernames
+      ),
+      private: this.getOrderedSignInUsernames(
+        usernameGroups.private,
+        hasStoredOrder ? storedOrder.private : legacyUsernames
+      ),
+    };
+  }
+
+  /**
+   * Move the selected username halfway closer to the front, matching emoji picker promotion.
+   * @param {string[]} signInUsernames Current sign-in username order.
+   * @param {string} selectedUsername Username selected for sign-in.
+   * @returns {string[]} Updated sign-in username order.
+   */
+  promoteSignInUsername(signInUsernames, selectedUsername) {
+    const currentIndex = signInUsernames.indexOf(selectedUsername);
+    assert(currentIndex !== -1, `Sign-in order missing ${selectedUsername}`);
 
     const promotionDistance = Math.max(
       1,
       Math.ceil((currentIndex + 1) * SIGN_IN_USERNAME_PROMOTION_RATIO)
     );
     const targetIndex = Math.max(0, currentIndex - promotionDistance);
-    const promotedUsernames = recentUsernames.filter((username) => username !== selectedUsername);
+    const promotedUsernames = signInUsernames.filter((username) => username !== selectedUsername);
 
     promotedUsernames.splice(targetIndex, 0, selectedUsername);
     return promotedUsernames;
   }
 
   /**
-   * Persist a valid sign-in selection to the active network's recent username order.
+   * Persist a valid sign-in selection to the active network's username order.
    * @param {string} username Username selected for sign-in.
    * @returns {void}
    */
@@ -3801,24 +3846,29 @@ class SignInModal {
       }
 
       const usernames = Object.keys(netidAccounts.usernames);
-      const rankedUsernames = this.getRecentSignInUsernames(usernames, netidAccounts);
-      netidAccounts[SIGN_IN_RECENT_USERNAME_KEY] = this.promoteRecentSignInUsername(
-        rankedUsernames,
-        username
-      );
+      const { usernameGroups } = this.getSignInUsernameGroups(usernames, netid);
+      const usernameOrder = this.getSignInUsernameOrder(usernameGroups, netidAccounts);
+      const usernameType = usernameGroups.private.includes(username) ? 'private' : 'public';
+      usernameOrder[usernameType] = this.promoteSignInUsername(usernameOrder[usernameType], username);
+
+      netidAccounts[SIGN_IN_USERNAME_ORDER_KEY] = usernameOrder;
+      delete netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY];
       localStorage.setItem('accounts', stringify(accounts));
     } catch (error) {
-      console.warn('Failed to update recent sign-in order:', error);
+      console.warn('Failed to update sign-in order:', error);
     }
   }
 
   /**
    * Check whether the active network has a custom sign-in username order.
-   * @returns {boolean} True when recent sign-in order is stored.
+   * @returns {boolean} True when sign-in order is stored.
    */
   hasRecentSignInUsernameOverrides() {
     const { netidAccounts } = this.getSignInUsernames();
-    return Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_RECENT_USERNAME_KEY);
+    return (
+      Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_USERNAME_ORDER_KEY) ||
+      Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_LEGACY_RECENT_USERNAME_KEY)
+    );
   }
 
   /**
@@ -3839,7 +3889,7 @@ class SignInModal {
     const netidAccounts = accounts.netids[netid];
     assert(netidAccounts, 'Active network account registry is missing');
 
-    if (!Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_RECENT_USERNAME_KEY)) {
+    if (!this.hasRecentSignInUsernameOverrides()) {
       return;
     }
 
@@ -3848,7 +3898,8 @@ class SignInModal {
       return;
     }
 
-    delete netidAccounts[SIGN_IN_RECENT_USERNAME_KEY];
+    delete netidAccounts[SIGN_IN_USERNAME_ORDER_KEY];
+    delete netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY];
     localStorage.setItem('accounts', stringify(accounts));
     this.renderAccountList();
     showToast('Sign-in order reset', 2000, 'success');
@@ -3861,40 +3912,27 @@ class SignInModal {
   renderAccountList() {
     const { usernames, netidAccounts } = this.getSignInUsernames();
     const { netid } = network;
+    const { usernameGroups, isPrivateMap } = this.getSignInUsernameGroups(usernames, netid);
+    const usernameOrder = this.getSignInUsernameOrder(usernameGroups, netidAccounts);
     const notifiedAddresses = reactNativeApp.isReactNativeWebView ? reactNativeApp.getNotificationAddresses() : [];
+    const normalizedNotifiedSet = new Set(notifiedAddresses.map((addr) => normalizeAddress(addr)));
     const notifiedUsernameSet = new Set();
-    let sortedUsernames = this.getRecentSignInUsernames(usernames, netidAccounts);
+    const notifiedTop = [];
+    const publicRemaining = [];
+    const privateRemaining = [];
 
-    // If there are notified addresses, partition usernames (stable) so notified come first.
-    if (notifiedAddresses.length > 0) {
-      const normalizedNotifiedSet = new Set(notifiedAddresses.map((addr) => normalizeAddress(addr)));
-      const notifiedUsernames = [];
-      const otherUsernames = [];
-      for (const username of sortedUsernames) {
-        const address = netidAccounts.usernames[username].address;
-        if (normalizedNotifiedSet.has(normalizeAddress(address))) {
-          notifiedUsernames.push(username);
-          notifiedUsernameSet.add(username);
-        } else {
-          otherUsernames.push(username);
-        }
+    const placeUsername = (username, remainingUsernames) => {
+      const address = netidAccounts.usernames[username].address;
+      if (normalizedNotifiedSet.has(normalizeAddress(address))) {
+        notifiedTop.push(username);
+        notifiedUsernameSet.add(username);
+        return;
       }
-      sortedUsernames = [...notifiedUsernames, ...otherUsernames];
-    }
+      remainingUsernames.push(username);
+    };
 
-    // Build a map of privacy flags to avoid multiple loadState calls.
-    const isPrivateMap = Object.create(null);
-    for (const username of sortedUsernames) {
-      const localState = loadState(`${username}_${netid}`);
-      isPrivateMap[username] = localState?.account?.private === true;
-    }
-
-    // Keep notified accounts (any privacy) at the top, then public accounts,
-    // then remaining private accounts grouped under a section label.
-    const notifiedTop = sortedUsernames.filter((username) => notifiedUsernameSet.has(username));
-    const remaining = sortedUsernames.filter((username) => !notifiedUsernameSet.has(username));
-    const publicRemaining = remaining.filter((username) => !isPrivateMap[username]);
-    const privateRemaining = remaining.filter((username) => isPrivateMap[username]);
+    usernameOrder.public.forEach((username) => placeUsername(username, publicRemaining));
+    usernameOrder.private.forEach((username) => placeUsername(username, privateRemaining));
 
     const renderListItem = (username) => {
       const isPrivateAccount = isPrivateMap[username];

--- a/app.js
+++ b/app.js
@@ -3724,12 +3724,16 @@ class SignInModal {
    * @returns {string[]} Clean recent username list.
    */
   normalizeRecentSignInUsernameList(storedUsernames, availableUsernameSet) {
-    assert(Array.isArray(storedUsernames), 'Recent sign-in usernames must be an array');
+    if (!Array.isArray(storedUsernames)) {
+      return [];
+    }
 
     const normalizedUsernames = [];
     const seen = new Set();
     for (const username of storedUsernames) {
-      assert(typeof username === 'string' && username, 'Recent sign-in username must be a string');
+      if (typeof username !== 'string' || !username) {
+        continue;
+      }
       if (!seen.has(username) && availableUsernameSet.has(username)) {
         seen.add(username);
         normalizedUsernames.push(username);
@@ -3788,18 +3792,24 @@ class SignInModal {
    * @returns {void}
    */
   recordRecentSignInUsername(username) {
-    const { netid } = network;
-    const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
-    const netidAccounts = accounts.netids[netid];
-    assert(netidAccounts?.usernames?.[username], `Account registry missing ${username}`);
+    try {
+      const { netid } = network;
+      const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+      const netidAccounts = accounts.netids[netid];
+      if (!netidAccounts?.usernames?.[username]) {
+        return;
+      }
 
-    const usernames = Object.keys(netidAccounts.usernames);
-    const rankedUsernames = this.getRecentSignInUsernames(usernames, netidAccounts);
-    netidAccounts[SIGN_IN_RECENT_USERNAME_KEY] = this.promoteRecentSignInUsername(
-      rankedUsernames,
-      username
-    );
-    localStorage.setItem('accounts', stringify(accounts));
+      const usernames = Object.keys(netidAccounts.usernames);
+      const rankedUsernames = this.getRecentSignInUsernames(usernames, netidAccounts);
+      netidAccounts[SIGN_IN_RECENT_USERNAME_KEY] = this.promoteRecentSignInUsername(
+        rankedUsernames,
+        username
+      );
+      localStorage.setItem('accounts', stringify(accounts));
+    } catch (error) {
+      console.warn('Failed to update recent sign-in order:', error);
+    }
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -3594,7 +3594,6 @@ const SIGN_IN_ACTION_SHEETS = {
     showRemove: false,
   },
 };
-const SIGN_IN_LEGACY_RECENT_USERNAME_KEY = 'recentSignInUsernames';
 const SIGN_IN_USERNAME_ORDER_KEY = 'signInUsernameOrder';
 const SIGN_IN_USERNAME_PROMOTION_RATIO = 0.5;
 
@@ -3789,24 +3788,11 @@ class SignInModal {
    * @returns {{ public: string[], private: string[] }} Ordered usernames split by type.
    */
   getSignInUsernameOrder(usernameGroups, netidAccounts) {
-    const hasStoredOrder = Object.prototype.hasOwnProperty.call(
-      netidAccounts,
-      SIGN_IN_USERNAME_ORDER_KEY
-    );
-    const storedOrder = hasStoredOrder ? netidAccounts[SIGN_IN_USERNAME_ORDER_KEY] || {} : {};
-    const legacyUsernames = !hasStoredOrder && Array.isArray(netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY])
-      ? netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY]
-      : [];
+    const storedOrder = netidAccounts[SIGN_IN_USERNAME_ORDER_KEY] || {};
 
     return {
-      public: this.getOrderedSignInUsernames(
-        usernameGroups.public,
-        hasStoredOrder ? storedOrder.public : legacyUsernames
-      ),
-      private: this.getOrderedSignInUsernames(
-        usernameGroups.private,
-        hasStoredOrder ? storedOrder.private : legacyUsernames
-      ),
+      public: this.getOrderedSignInUsernames(usernameGroups.public, storedOrder.public),
+      private: this.getOrderedSignInUsernames(usernameGroups.private, storedOrder.private),
     };
   }
 
@@ -3852,7 +3838,6 @@ class SignInModal {
       usernameOrder[usernameType] = this.promoteSignInUsername(usernameOrder[usernameType], username);
 
       netidAccounts[SIGN_IN_USERNAME_ORDER_KEY] = usernameOrder;
-      delete netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY];
       localStorage.setItem('accounts', stringify(accounts));
     } catch (error) {
       console.warn('Failed to update sign-in order:', error);
@@ -3865,10 +3850,7 @@ class SignInModal {
    */
   hasRecentSignInUsernameOverrides() {
     const { netidAccounts } = this.getSignInUsernames();
-    return (
-      Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_USERNAME_ORDER_KEY) ||
-      Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_LEGACY_RECENT_USERNAME_KEY)
-    );
+    return Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_USERNAME_ORDER_KEY);
   }
 
   /**
@@ -3899,7 +3881,6 @@ class SignInModal {
     }
 
     delete netidAccounts[SIGN_IN_USERNAME_ORDER_KEY];
-    delete netidAccounts[SIGN_IN_LEGACY_RECENT_USERNAME_KEY];
     localStorage.setItem('accounts', stringify(accounts));
     this.renderAccountList();
     showToast('Sign-in order reset', 2000, 'success');

--- a/app.js
+++ b/app.js
@@ -3718,28 +3718,22 @@ class SignInModal {
   }
 
   /**
-   * Normalize recent sign-in usernames, de-duping entries and optionally dropping stale accounts.
-   * @param {Array} usernames Stored recent username values.
-   * @param {Set<string>|null} [availableUsernameSet=null] Usernames still available for the active network.
+   * Normalize stored recent sign-in usernames against accounts on the active network.
+   * @param {string[]} storedUsernames Stored recent username values.
+   * @param {Set<string>} availableUsernameSet Usernames still available for the active network.
    * @returns {string[]} Clean recent username list.
    */
-  normalizeRecentSignInUsernameList(usernames, availableUsernameSet = null) {
-    if (!Array.isArray(usernames)) {
-      return [];
-    }
+  normalizeRecentSignInUsernameList(storedUsernames, availableUsernameSet) {
+    assert(Array.isArray(storedUsernames), 'Recent sign-in usernames must be an array');
 
     const normalizedUsernames = [];
     const seen = new Set();
-    for (const entry of usernames) {
-      const username = typeof entry === 'string' ? entry.trim() : '';
-      if (!username || seen.has(username)) {
-        continue;
+    for (const username of storedUsernames) {
+      assert(typeof username === 'string' && username, 'Recent sign-in username must be a string');
+      if (!seen.has(username) && availableUsernameSet.has(username)) {
+        seen.add(username);
+        normalizedUsernames.push(username);
       }
-      if (availableUsernameSet && !availableUsernameSet.has(username)) {
-        continue;
-      }
-      seen.add(username);
-      normalizedUsernames.push(username);
     }
 
     return normalizedUsernames;
@@ -3752,24 +3746,19 @@ class SignInModal {
    * @returns {string[]} Usernames ordered by recent sign-in preference.
    */
   getRecentSignInUsernames(usernames, netidAccounts) {
-    const rankedUsernames = [];
-    const seen = new Set();
+    const hasStoredUsernames = Object.prototype.hasOwnProperty.call(
+      netidAccounts,
+      SIGN_IN_RECENT_USERNAME_KEY
+    );
+    const storedUsernames = hasStoredUsernames ? netidAccounts[SIGN_IN_RECENT_USERNAME_KEY] : [];
     const availableUsernameSet = new Set(usernames);
-    const addUsername = (username) => {
-      if (!username || seen.has(username) || !availableUsernameSet.has(username)) {
-        return;
-      }
-      seen.add(username);
-      rankedUsernames.push(username);
-    };
+    const recentUsernames = this.normalizeRecentSignInUsernameList(storedUsernames, availableUsernameSet);
+    const recentUsernameSet = new Set(recentUsernames);
 
-    this.normalizeRecentSignInUsernameList(
-      netidAccounts?.[SIGN_IN_RECENT_USERNAME_KEY],
-      availableUsernameSet
-    ).forEach(addUsername);
-    usernames.forEach(addUsername);
-
-    return rankedUsernames;
+    return [
+      ...recentUsernames,
+      ...usernames.filter((username) => !recentUsernameSet.has(username)),
+    ];
   }
 
   /**
@@ -3779,23 +3768,18 @@ class SignInModal {
    * @returns {string[]} Updated recent sign-in username order.
    */
   promoteRecentSignInUsername(recentUsernames, selectedUsername) {
-    const username = typeof selectedUsername === 'string' ? selectedUsername.trim() : '';
-    if (!username) {
-      return this.normalizeRecentSignInUsernameList(recentUsernames);
-    }
+    const currentIndex = recentUsernames.indexOf(selectedUsername);
+    assert(currentIndex !== -1, `Recent sign-in list missing ${selectedUsername}`);
 
-    const currentUsernames = this.normalizeRecentSignInUsernameList(recentUsernames);
-    const currentIndex = currentUsernames.indexOf(username);
-    const remainingUsernames = currentUsernames.filter((entry) => entry !== username);
-    const targetIndex = currentIndex === -1
-      ? currentUsernames.length
-      : Math.max(
-          0,
-          currentIndex - Math.max(1, Math.ceil((currentIndex + 1) * SIGN_IN_USERNAME_PROMOTION_RATIO))
-        );
+    const promotionDistance = Math.max(
+      1,
+      Math.ceil((currentIndex + 1) * SIGN_IN_USERNAME_PROMOTION_RATIO)
+    );
+    const targetIndex = Math.max(0, currentIndex - promotionDistance);
+    const promotedUsernames = recentUsernames.filter((username) => username !== selectedUsername);
 
-    remainingUsernames.splice(targetIndex, 0, username);
-    return remainingUsernames;
+    promotedUsernames.splice(targetIndex, 0, selectedUsername);
+    return promotedUsernames;
   }
 
   /**
@@ -3804,51 +3788,48 @@ class SignInModal {
    * @returns {void}
    */
   recordRecentSignInUsername(username) {
-    const selectedUsername = typeof username === 'string' ? username.trim() : '';
-    if (!selectedUsername) {
-      return;
-    }
-
     const { netid } = network;
     const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
     const netidAccounts = accounts.netids[netid];
-    if (!netidAccounts?.usernames?.[selectedUsername]) {
-      return;
-    }
+    assert(netidAccounts?.usernames?.[username], `Account registry missing ${username}`);
 
     const usernames = Object.keys(netidAccounts.usernames);
+    const rankedUsernames = this.getRecentSignInUsernames(usernames, netidAccounts);
     netidAccounts[SIGN_IN_RECENT_USERNAME_KEY] = this.promoteRecentSignInUsername(
-      this.getRecentSignInUsernames(usernames, netidAccounts),
-      selectedUsername
+      rankedUsernames,
+      username
     );
     localStorage.setItem('accounts', stringify(accounts));
   }
 
+  /**
+   * Check whether the active network has a custom sign-in username order.
+   * @returns {boolean} True when recent sign-in order is stored.
+   */
   hasRecentSignInUsernameOverrides() {
-    const { netid } = network;
-    const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
-    return Object.prototype.hasOwnProperty.call(
-      accounts.netids[netid] || {},
-      SIGN_IN_RECENT_USERNAME_KEY
-    );
+    const { netidAccounts } = this.getSignInUsernames();
+    return Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_RECENT_USERNAME_KEY);
   }
 
+  /**
+   * Update reset button visibility from the active network account registry.
+   * @returns {void}
+   */
   updateRecentSignInResetButtonVisibility() {
-    if (!this.resetRecentUsernamesButton) {
-      return;
-    }
-
     this.resetRecentUsernamesButton.hidden = !this.hasRecentSignInUsernameOverrides();
   }
 
+  /**
+   * Reset the active network sign-in username order back to registry order.
+   * @returns {void}
+   */
   handleResetRecentSignInUsernames() {
     const { netid } = network;
     const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
     const netidAccounts = accounts.netids[netid];
+    assert(netidAccounts, 'Active network account registry is missing');
 
-    if (!Object.prototype.hasOwnProperty.call(netidAccounts || {}, SIGN_IN_RECENT_USERNAME_KEY)) {
-      showToast('Sign-in order is already reset', 2000, 'info');
-      this.updateRecentSignInResetButtonVisibility();
+    if (!Object.prototype.hasOwnProperty.call(netidAccounts, SIGN_IN_RECENT_USERNAME_KEY)) {
       return;
     }
 

--- a/app.js
+++ b/app.js
@@ -3752,13 +3752,10 @@ class SignInModal {
     const normalizedUsernames = [];
     const seen = new Set();
     for (const username of storedUsernames) {
-      if (typeof username !== 'string' || !username) {
-        continue;
-      }
-      if (!seen.has(username) && availableUsernameSet.has(username)) {
-        seen.add(username);
-        normalizedUsernames.push(username);
-      }
+      if (typeof username !== 'string' || !username) continue;
+      if (seen.has(username) || !availableUsernameSet.has(username)) continue;
+      seen.add(username);
+      normalizedUsernames.push(username);
     }
 
     return normalizedUsernames;

--- a/app.js
+++ b/app.js
@@ -3712,6 +3712,12 @@ class SignInModal {
     return { usernames, netidAccounts: netidAccounts || { usernames: {} } };
   }
 
+  /**
+   * Normalize recent sign-in usernames, de-duping entries and optionally dropping stale accounts.
+   * @param {Array} usernames Stored recent username values.
+   * @param {Set<string>|null} [availableUsernameSet=null] Usernames still available for the active network.
+   * @returns {string[]} Clean recent username list.
+   */
   normalizeRecentSignInUsernameList(usernames, availableUsernameSet = null) {
     if (!Array.isArray(usernames)) {
       return [];
@@ -3734,6 +3740,12 @@ class SignInModal {
     return normalizedUsernames;
   }
 
+  /**
+   * Build the ranked sign-in username list from saved recent order plus current registry order.
+   * @param {string[]} usernames Current network usernames in registry order.
+   * @param {Object} netidAccounts Current network account registry.
+   * @returns {string[]} Usernames ordered by recent sign-in preference.
+   */
   getRecentSignInUsernames(usernames, netidAccounts) {
     const rankedUsernames = [];
     const seen = new Set();
@@ -3755,6 +3767,12 @@ class SignInModal {
     return rankedUsernames;
   }
 
+  /**
+   * Move the selected username halfway closer to the front, matching emoji picker promotion.
+   * @param {string[]} recentUsernames Current recent sign-in username order.
+   * @param {string} selectedUsername Username selected for sign-in.
+   * @returns {string[]} Updated recent sign-in username order.
+   */
   promoteRecentSignInUsername(recentUsernames, selectedUsername) {
     const username = typeof selectedUsername === 'string' ? selectedUsername.trim() : '';
     if (!username) {
@@ -3775,6 +3793,11 @@ class SignInModal {
     return remainingUsernames;
   }
 
+  /**
+   * Persist a valid sign-in selection to the active network's recent username order.
+   * @param {string} username Username selected for sign-in.
+   * @returns {void}
+   */
   recordRecentSignInUsername(username) {
     const selectedUsername = typeof username === 'string' ? username.trim() : '';
     if (!selectedUsername) {

--- a/app.js
+++ b/app.js
@@ -3608,6 +3608,7 @@ class SignInModal {
   load () {
     this.modal = document.getElementById('signInModal');
     this.accountList = document.getElementById('signInAccountList');
+    this.resetRecentUsernamesButton = document.getElementById('resetSignInRecentUsernames');
     this.backButton = document.getElementById('closeSignInModal');
     this.actionSheetOverlay = document.getElementById('signInActionSheetOverlay');
     this.actionSheetTitle = document.getElementById('signInActionSheetTitle');
@@ -3615,7 +3616,10 @@ class SignInModal {
     this.actionRecreateButton = document.getElementById('signInActionRecreate');
     this.actionRemoveButton = document.getElementById('signInActionRemove');
     this.closeActionSheetButton = document.getElementById('closeSignInActionSheet');
-    assert(this.modal && this.accountList && this.actionSheetOverlay, 'SignInModal DOM is incomplete');
+    assert(
+      this.modal && this.accountList && this.resetRecentUsernamesButton && this.actionSheetOverlay,
+      'SignInModal DOM is incomplete'
+    );
 
     this.accountList.addEventListener('click', (event) => {
       const item = event.target.closest('.sign-in-account-item');
@@ -3629,6 +3633,7 @@ class SignInModal {
       if (event.target === this.actionSheetOverlay) this.closeActionSheet();
     });
     this.closeActionSheetButton.addEventListener('click', () => this.closeActionSheet());
+    this.resetRecentUsernamesButton.addEventListener('click', () => this.handleResetRecentSignInUsernames());
 
     const enableActionButtons = () => {
       this.actionRecreateButton.disabled = false;
@@ -3819,6 +3824,45 @@ class SignInModal {
     localStorage.setItem('accounts', stringify(accounts));
   }
 
+  hasRecentSignInUsernameOverrides() {
+    const { netid } = network;
+    const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+    return Object.prototype.hasOwnProperty.call(
+      accounts.netids[netid] || {},
+      SIGN_IN_RECENT_USERNAME_KEY
+    );
+  }
+
+  updateRecentSignInResetButtonVisibility() {
+    if (!this.resetRecentUsernamesButton) {
+      return;
+    }
+
+    this.resetRecentUsernamesButton.hidden = !this.hasRecentSignInUsernameOverrides();
+  }
+
+  handleResetRecentSignInUsernames() {
+    const { netid } = network;
+    const accounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+    const netidAccounts = accounts.netids[netid];
+
+    if (!Object.prototype.hasOwnProperty.call(netidAccounts || {}, SIGN_IN_RECENT_USERNAME_KEY)) {
+      showToast('Sign-in order is already reset', 2000, 'info');
+      this.updateRecentSignInResetButtonVisibility();
+      return;
+    }
+
+    const confirmed = confirm('Reset sign-in account order?');
+    if (!confirmed) {
+      return;
+    }
+
+    delete netidAccounts[SIGN_IN_RECENT_USERNAME_KEY];
+    localStorage.setItem('accounts', stringify(accounts));
+    this.renderAccountList();
+    showToast('Sign-in order reset', 2000, 'success');
+  }
+
   /**
    * Render the account list with notification indicators and sort by notification status.
    * @returns {string[]} Usernames for the current network (registry order, not display order)
@@ -3887,6 +3931,7 @@ class SignInModal {
       sections.push(...privateRemaining.map(renderListItem));
     }
     this.accountList.innerHTML = sections.join('');
+    this.updateRecentSignInResetButtonVisibility();
 
     return usernames;
   }

--- a/index.html
+++ b/index.html
@@ -680,6 +680,7 @@
         <div class="modal-header">
           <button class="back-button" id="closeSignInModal"></button>
           <div class="modal-title">Sign In</div>
+          <button class="sign-in-account-reset" id="resetSignInRecentUsernames" type="button" aria-label="Reset sign-in order" hidden>Reset</button>
         </div>
         <div class="modal-content">
           <div class="form-container">

--- a/index.html
+++ b/index.html
@@ -680,7 +680,13 @@
         <div class="modal-header">
           <button class="back-button" id="closeSignInModal"></button>
           <div class="modal-title">Sign In</div>
-          <button class="sign-in-account-reset" id="resetSignInRecentUsernames" type="button" aria-label="Reset sign-in order" hidden>Reset</button>
+          <button
+            class="sign-in-account-reset"
+            id="resetSignInRecentUsernames"
+            type="button"
+            aria-label="Reset sign-in order"
+            hidden
+          >Reset</button>
         </div>
         <div class="modal-content">
           <div class="form-container">

--- a/styles.css
+++ b/styles.css
@@ -3175,6 +3175,23 @@ input[type='number'].form-control::-webkit-inner-spin-button {
 }
 
 /* Sign In Modal account list */
+#signInModal .modal-title {
+  padding: 0 76px;
+}
+
+#signInModal .sign-in-account-reset {
+  position: absolute;
+  right: 16px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text-color);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
 #signInModal .sign-in-account-list {
   list-style: none;
   padding: 0;

--- a/styles.css
+++ b/styles.css
@@ -3174,7 +3174,7 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   accent-color: var(--primary-color, #007bff);
 }
 
-/* Sign In Modal account list */
+/* Sign In Modal */
 #signInModal .modal-title {
   padding: 0 76px;
 }


### PR DESCRIPTION
## What Changed

This PR favors recently used sign-in profiles without adding manual favorite controls.

- `SignInModal` persists sign-in preference per network in `signInUsernameOrder.public` and `signInUsernameOrder.private`, matching the two visible account sections.
- Successful sign-ins promote the selected profile 50 percent closer to the top of its visible group, so private accounts move up among private accounts instead of climbing through hidden public rows.
- Notification-matched accounts still render above normal public/private ordering, and the reset control clears the stored order for the active network.
- New public or private accounts are appended to the end of their correct group until their first successful sign-in promotes them.

## Fixed Flow

1. The user opens the sign-in modal with multiple local profiles.
2. The modal reads the account registry, derives public/private groups from account data, and applies stored order inside each group.
3. The user successfully signs in to a profile.
4. The selected profile is promoted within its public or private group and persisted for the next modal render.
5. Notification-prioritized profiles still appear first, and failed/taken/unavailable selections do not alter ordering.

## Why

The base sign-in list used registry order, with notification matches first and private accounts grouped under their own section. Storing public and private order separately makes the new preference data match that UI shape, so a private profile promotes predictably within the private section instead of being ranked through the full public/private list.

## Validation

- `node --check app.js`
- `git diff --check -- app.js signin-profile-ordering-implementation.md`

Closes #1334