### PR TITLE
Add boot splash before welcome hydration

### DIFF
--- a/app.js
+++ b/app.js
@@ -2350,8 +2350,26 @@ class MenuModal {
     // Remove event listeners for beforeunload and visibilitychange
     window.removeEventListener('beforeunload', handleBeforeUnload);
 
+    // Save myData to localStorage if it exists
+    saveState();
+
+    // clear storage
+    clearMyData();
+
     // Lock the app
     unlockModal.lock();
+
+    if (isOnline) {
+      await reactNativeApp.handleNativeAppSubscribe();
+      await checkVersion();
+
+      // checkVersion() may update online status
+      if (isOnline) {
+        const newUrl = window.location.href.split('?')[0];
+        window.location.replace(newUrl);
+        return;
+      }
+    }
 
     // Close all modals
     menuModal.close();
@@ -2377,27 +2395,6 @@ class MenuModal {
 
     // Show welcome screen
     welcomeScreen.open();
-
-
-    // Save myData to localStorage if it exists
-    saveState();
-
-    // clear storage
-    clearMyData();
-
-    // Add offline fallback
-    if (!isOnline) {
-      return;
-    }
-
-    await reactNativeApp.handleNativeAppSubscribe();
-    await checkVersion();
-
-    // checkVersion() may update online status
-    if (isOnline) {
-      const newUrl = window.location.href.split('?')[0];
-      window.location.replace(newUrl);
-    }
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -1,9 +1,7 @@
 // Check if there is a newer version and load that using a new random url to avoid cache hits
 //   Versions should be YYYY.MM.DD.HH.mm like 2025.01.25.10.05
 const version = 't'; // Also increment this when you increment version.html
-const BOOT_SPLASH_MIN_MS = 3000;
-const BOOT_SPLASH_HANDOFF_MS = 520;
-const bootSplashStartedAt = performance.now();
+const BOOT_SPLASH_HANDOFF_MS = 1000;
 let myVersion = '0';
 async function checkVersion() {
   // Use network-specific version key to avoid false update alerts when switching networks
@@ -1079,11 +1077,29 @@ class WelcomeScreen {
     this.revealHydratedWelcome();
   }
 
-  revealHydratedWelcome() {
-    const elapsedMs = performance.now() - bootSplashStartedAt;
-    const revealDelayMs = Math.max(0, BOOT_SPLASH_MIN_MS - elapsedMs);
+  async revealHydratedWelcome() {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      this.showHydratedWelcome();
+      return;
+    }
 
-    setTimeout(() => this.animateBootSplashToWelcome(), revealDelayMs);
+    await this.waitForBootSplashPulse();
+    await this.animateBootSplashToWelcome();
+  }
+
+  waitForBootSplashPulse() {
+    const halo = this.bootSplash.querySelector('.boot-splash-halo');
+    assert(halo, 'Boot splash halo is required');
+    const [animation] = halo.getAnimations();
+    assert(animation, 'Boot splash halo animation is required');
+    assert(animation.effect, 'Boot splash halo animation effect is required');
+
+    const pulseDurationMs = animation.effect.getComputedTiming().duration;
+    assert(Number.isFinite(pulseDurationMs) && pulseDurationMs > 0, 'Boot splash halo duration is required');
+    return Promise.race([
+      animation.finished,
+      new Promise((resolve) => setTimeout(resolve, pulseDurationMs + 100)),
+    ]);
   }
 
   async animateBootSplashToWelcome() {
@@ -1095,11 +1111,6 @@ class WelcomeScreen {
     assert(splashTitle, 'Boot splash title is required');
     assert(welcomeLogo, 'Welcome logo is required');
     assert(welcomeTitle, 'Welcome title is required');
-
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      this.showHydratedWelcome();
-      return;
-    }
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
     this.bootSplash.classList.add('is-handoff');

--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 // Check if there is a newer version and load that using a new random url to avoid cache hits
 //   Versions should be YYYY.MM.DD.HH.mm like 2025.01.25.10.05
 const version = 't'; // Also increment this when you increment version.html
+const BOOT_SPLASH_MIN_MS = 3000;
+const bootSplashStartedAt = performance.now();
 let myVersion = '0';
 async function checkVersion() {
   // Use network-specific version key to avoid false update alerts when switching networks
@@ -1030,6 +1032,7 @@ class WelcomeScreen {
 
   load() {
     this.screen = document.getElementById('welcomeScreen');
+    this.bootSplash = document.getElementById('bootSplash');
     this.signInButton = document.getElementById('signInButton');
     this.createAccountButton = document.getElementById('createAccountButton');
     this.openWelcomeMenuButton = document.getElementById('openWelcomeMenu');
@@ -1071,15 +1074,28 @@ class WelcomeScreen {
     });
 
     this.orderButtons();
+    this.revealHydratedWelcome();
+  }
 
-    // Show Apple Safari backup reminder toast after welcome screen has rendered
+  revealHydratedWelcome() {
+    const elapsedMs = performance.now() - bootSplashStartedAt;
+    const revealDelayMs = Math.max(0, BOOT_SPLASH_MIN_MS - elapsedMs);
+
     setTimeout(() => {
-      this.showAppleSafariBackupToast();
-      this.showGDriveBackupReminder();
-    }, 500);
+      this.screen.classList.remove('is-booting');
+      this.bootSplash?.classList.add('hidden');
+
+      // Show Apple Safari backup reminder toast after welcome screen has rendered
+      setTimeout(() => {
+        this.showAppleSafariBackupToast();
+        this.showGDriveBackupReminder();
+      }, 500);
+    }, revealDelayMs);
   }
 
   open() {
+    this.screen.classList.remove('is-booting');
+    this.bootSplash?.classList.add('hidden');
     this.screen.style.display = 'flex';
     // Show the navigation bar on the native app
     reactNativeApp.sendNavigationBarVisibility(true);

--- a/app.js
+++ b/app.js
@@ -1078,13 +1078,40 @@ class WelcomeScreen {
   }
 
   async revealHydratedWelcome() {
+    await this.waitForBootSplashImages();
+
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       this.showHydratedWelcome();
       return;
     }
 
+    this.bootSplash.classList.add('is-ready');
     await this.waitForBootSplashPulse();
     await this.animateBootSplashToWelcome();
+  }
+
+  async waitForBootSplashImages() {
+    const splashLogo = this.bootSplash.querySelector('.boot-splash-logo');
+    const welcomeLogo = this.logoLink.querySelector('img');
+    assert(splashLogo, 'Boot splash logo is required');
+    assert(welcomeLogo, 'Welcome logo is required');
+
+    await Promise.all([
+      this.waitForImage(splashLogo),
+      this.waitForImage(welcomeLogo),
+    ]);
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+  }
+
+  async waitForImage(image) {
+    if (!image.complete) {
+      await new Promise((resolve) => image.addEventListener('load', resolve, { once: true }));
+    }
+    assert(image.naturalWidth > 0, 'Boot splash image is required');
+
+    if (image.decode) {
+      await image.decode();
+    }
   }
 
   waitForBootSplashPulse() {

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 //   Versions should be YYYY.MM.DD.HH.mm like 2025.01.25.10.05
 const version = 't'; // Also increment this when you increment version.html
 const BOOT_SPLASH_MIN_MS = 3000;
+const BOOT_SPLASH_HANDOFF_MS = 520;
 const bootSplashStartedAt = performance.now();
 let myVersion = '0';
 async function checkVersion() {
@@ -1033,6 +1034,7 @@ class WelcomeScreen {
   load() {
     this.screen = document.getElementById('welcomeScreen');
     this.bootSplash = document.getElementById('bootSplash');
+    assert(this.bootSplash, 'Boot splash is required');
     this.signInButton = document.getElementById('signInButton');
     this.createAccountButton = document.getElementById('createAccountButton');
     this.openWelcomeMenuButton = document.getElementById('openWelcomeMenu');
@@ -1081,21 +1083,73 @@ class WelcomeScreen {
     const elapsedMs = performance.now() - bootSplashStartedAt;
     const revealDelayMs = Math.max(0, BOOT_SPLASH_MIN_MS - elapsedMs);
 
-    setTimeout(() => {
-      this.screen.classList.remove('is-booting');
-      this.bootSplash?.classList.add('hidden');
+    setTimeout(() => this.animateBootSplashToWelcome(), revealDelayMs);
+  }
 
-      // Show Apple Safari backup reminder toast after welcome screen has rendered
-      setTimeout(() => {
-        this.showAppleSafariBackupToast();
-        this.showGDriveBackupReminder();
-      }, 500);
-    }, revealDelayMs);
+  async animateBootSplashToWelcome() {
+    const splashLogo = this.bootSplash.querySelector('.boot-splash-logo');
+    const splashTitle = document.getElementById('bootSplashBrandTitle');
+    const welcomeLogo = this.logoLink.querySelector('img');
+    const welcomeTitle = document.getElementById('welcomeBrandTitle');
+    assert(splashLogo, 'Boot splash logo is required');
+    assert(splashTitle, 'Boot splash title is required');
+    assert(welcomeLogo, 'Welcome logo is required');
+    assert(welcomeTitle, 'Welcome title is required');
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      this.showHydratedWelcome();
+      return;
+    }
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    this.bootSplash.classList.add('is-handoff');
+
+    await Promise.all([
+      this.createBootSplashHandoffAnimation(splashLogo, welcomeLogo).finished,
+      this.createBootSplashHandoffAnimation(splashTitle, welcomeTitle).finished,
+    ]);
+    this.showHydratedWelcome();
+  }
+
+  createBootSplashHandoffAnimation(sourceElement, targetElement) {
+    const sourceRect = sourceElement.getBoundingClientRect();
+    const targetRect = targetElement.getBoundingClientRect();
+    assert(sourceRect.width && sourceRect.height, 'Boot splash handoff source must be measurable');
+    assert(targetRect.width && targetRect.height, 'Boot splash handoff target must be measurable');
+
+    const sourceCenterX = sourceRect.left + sourceRect.width / 2;
+    const sourceCenterY = sourceRect.top + sourceRect.height / 2;
+    const targetCenterX = targetRect.left + targetRect.width / 2;
+    const targetCenterY = targetRect.top + targetRect.height / 2;
+    const translateX = targetCenterX - sourceCenterX;
+    const translateY = targetCenterY - sourceCenterY;
+    const scale = targetRect.width / sourceRect.width;
+    const transform = 'translate3d(' + translateX + 'px, ' + translateY + 'px, 0) scale(' + scale + ')';
+
+    return sourceElement.animate([
+      { transform: 'translate3d(0, 0, 0) scale(1)' },
+      { transform },
+    ], {
+      duration: BOOT_SPLASH_HANDOFF_MS,
+      easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      fill: 'forwards',
+    });
+  }
+
+  showHydratedWelcome() {
+    this.screen.classList.remove('is-booting');
+    this.bootSplash.classList.add('hidden');
+
+    // Show Apple Safari backup reminder toast after welcome screen has rendered
+    setTimeout(() => {
+      this.showAppleSafariBackupToast();
+      this.showGDriveBackupReminder();
+    }, 500);
   }
 
   open() {
     this.screen.classList.remove('is-booting');
-    this.bootSplash?.classList.add('hidden');
+    this.bootSplash.classList.add('hidden');
     this.screen.style.display = 'flex';
     // Show the navigation bar on the native app
     reactNativeApp.sendNavigationBarVisibility(true);

--- a/index.html
+++ b/index.html
@@ -69,6 +69,11 @@
     <script src="./lib.js" type="module"></script>
     <script src="./crypto.js" type="module"></script>
     <div class="container">
+      <div class="boot-splash" id="bootSplash" aria-hidden="true">
+        <img class="boot-splash-logo" src="./media/liberdus_logo_250.png" alt="" />
+        <div class="boot-splash-name">Liberdus</div>
+      </div>
+
       <header class="header" id="header">
         <div id="logo">
           <a href="https://liberdus.com" target="_blank" title="Visit Liberdus website" class="logo-link"
@@ -87,7 +92,7 @@
         </div>
       </header>
 
-      <div class="welcome-screen" id="welcomeScreen">
+      <div class="welcome-screen is-booting" id="welcomeScreen">
         <a href="https://liberdus.com" target="_blank" title="Visit Liberdus website" class="logo-link">
           <img src="./media/liberdus_logo_250.png" alt="Liberdus Logo" style="margin-bottom: 20px" />
         </a>

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
     <script src="./crypto.js" type="module"></script>
     <div class="container">
       <div class="boot-splash" id="bootSplash" aria-hidden="true">
+        <div class="boot-splash-halo" aria-hidden="true"></div>
         <img class="boot-splash-logo" src="./media/liberdus_logo_250.png" alt="" />
         <h1 class="boot-splash-name"><span id="bootSplashBrandTitle" class="boot-splash-title-text">Liberdus</span></h1>
       </div>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     <div class="container">
       <div class="boot-splash" id="bootSplash" aria-hidden="true">
         <img class="boot-splash-logo" src="./media/liberdus_logo_250.png" alt="" />
-        <div class="boot-splash-name">Liberdus</div>
+        <h1 class="boot-splash-name"><span id="bootSplashBrandTitle" class="boot-splash-title-text">Liberdus</span></h1>
       </div>
 
       <header class="header" id="header">
@@ -97,7 +97,7 @@
           <img src="./media/liberdus_logo_250.png" alt="Liberdus Logo" style="margin-bottom: 20px" />
         </a>
         <h1>
-          Liberdus<br />
+          <span id="welcomeBrandTitle">Liberdus</span><br />
           <div style="font-size: 0.8rem; margin-top: 1px; text-align: center" id="networkNameDisplay"></div>
         </h1>
         <div class="welcome-buttons">

--- a/styles.css
+++ b/styles.css
@@ -390,6 +390,7 @@ body {
   inset: 0;
   z-index: 20;
   display: flex;
+  overflow: hidden;
   align-items: center;
   justify-content: center;
   padding: 2rem;
@@ -415,6 +416,8 @@ body {
   width: 250px;
   height: 250px;
   object-fit: contain;
+  transform-origin: center;
+  will-change: transform;
 }
 
 .boot-splash-name {
@@ -422,15 +425,28 @@ body {
   top: calc(50% + 155px);
   left: 0;
   right: 0;
-  color: var(--text-color);
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  text-align: center;
   z-index: 1;
+  margin-bottom: 0;
+}
+
+.boot-splash-title-text,
+#welcomeBrandTitle {
+  display: inline-block;
+  transform-origin: center;
+}
+
+.boot-splash-title-text {
+  will-change: transform;
+}
+
+.boot-splash.is-handoff::before {
+  opacity: 0;
+  animation: none;
 }
 
 .welcome-screen.is-booting {
-  display: none;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 @keyframes boot-splash-halo {

--- a/styles.css
+++ b/styles.css
@@ -397,8 +397,7 @@ body {
   background-color: var(--background-color);
 }
 
-.boot-splash::before {
-  content: "";
+.boot-splash-halo {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -406,8 +405,9 @@ body {
   height: 318px;
   border-radius: 50%;
   background: var(--primary-tint-12);
-  transform: translate(-50%, -50%) scale(0.84);
-  animation: boot-splash-halo 1.35s ease-in-out infinite;
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.74);
+  animation: boot-splash-halo 1.35s ease-in-out both;
 }
 
 .boot-splash-logo {
@@ -439,7 +439,7 @@ body {
   will-change: transform;
 }
 
-.boot-splash.is-handoff::before {
+.boot-splash.is-handoff .boot-splash-halo {
   opacity: 0;
   animation: none;
 }
@@ -452,8 +452,8 @@ body {
 @keyframes boot-splash-halo {
   0%,
   100% {
-    opacity: 0.35;
-    transform: translate(-50%, -50%) scale(0.84);
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.74);
   }
 
   50% {

--- a/styles.css
+++ b/styles.css
@@ -385,6 +385,65 @@ body {
   touch-action: none; /* Prevent touch scroll gestures on document */
 }
 
+.boot-splash {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background-color: var(--background-color);
+}
+
+.boot-splash-logo {
+  width: 132px;
+  height: 132px;
+  object-fit: contain;
+  animation: boot-splash-pulse 1.2s ease-in-out infinite;
+  transform-origin: center;
+}
+
+.boot-splash-name {
+  position: absolute;
+  top: calc(50% + 86px);
+  left: 0;
+  right: 0;
+  color: var(--text-color);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  text-align: center;
+  animation: boot-splash-name-fade 1.2s ease-in-out infinite;
+}
+
+.welcome-screen.is-booting {
+  display: none;
+}
+
+@keyframes boot-splash-pulse {
+  0%,
+  100% {
+    opacity: 0.62;
+    transform: scale(0.94);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.06);
+  }
+}
+
+@keyframes boot-splash-name-fade {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
 .welcome-screen {
   flex: 1;
   display: flex;

--- a/styles.css
+++ b/styles.css
@@ -396,51 +396,53 @@ body {
   background-color: var(--background-color);
 }
 
+.boot-splash::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 318px;
+  height: 318px;
+  border-radius: 50%;
+  background: var(--primary-tint-12);
+  transform: translate(-50%, -50%) scale(0.84);
+  animation: boot-splash-halo 1.35s ease-in-out infinite;
+}
+
 .boot-splash-logo {
-  width: 132px;
-  height: 132px;
+  position: relative;
+  z-index: 1;
+  width: 250px;
+  height: 250px;
   object-fit: contain;
-  animation: boot-splash-pulse 1.2s ease-in-out infinite;
-  transform-origin: center;
 }
 
 .boot-splash-name {
   position: absolute;
-  top: calc(50% + 86px);
+  top: calc(50% + 155px);
   left: 0;
   right: 0;
   color: var(--text-color);
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);
   text-align: center;
-  animation: boot-splash-name-fade 1.2s ease-in-out infinite;
+  z-index: 1;
 }
 
 .welcome-screen.is-booting {
   display: none;
 }
 
-@keyframes boot-splash-pulse {
+@keyframes boot-splash-halo {
   0%,
   100% {
-    opacity: 0.62;
-    transform: scale(0.94);
+    opacity: 0.35;
+    transform: translate(-50%, -50%) scale(0.84);
   }
 
   50% {
-    opacity: 1;
-    transform: scale(1.06);
-  }
-}
-
-@keyframes boot-splash-name-fade {
-  0%,
-  100% {
-    opacity: 0.58;
-  }
-
-  50% {
-    opacity: 1;
+    opacity: 0.8;
+    transform: translate(-50%, -50%) scale(1.08);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -407,6 +407,9 @@ body {
   background: var(--primary-tint-12);
   opacity: 0;
   transform: translate(-50%, -50%) scale(0.74);
+}
+
+.boot-splash.is-ready .boot-splash-halo {
   animation: boot-splash-halo 1.35s ease-in-out both;
 }
 
@@ -436,7 +439,12 @@ body {
 }
 
 .boot-splash-title-text {
+  opacity: 0;
   will-change: transform;
+}
+
+.boot-splash.is-ready .boot-splash-title-text {
+  animation: boot-splash-title 1.35s ease-in-out both;
 }
 
 .boot-splash.is-handoff .boot-splash-halo {
@@ -459,6 +467,18 @@ body {
   50% {
     opacity: 0.8;
     transform: translate(-50%, -50%) scale(1.08);
+  }
+}
+
+@keyframes boot-splash-title {
+  0%,
+  35% {
+    opacity: 0;
+  }
+
+  50%,
+  100% {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## What Changed

This PR adds a branded Liberdus boot splash that hides the partially hydrated welcome screen and hands off into the final welcome layout.

- `index.html` adds `#bootSplash` with a halo, logo, and title, while `#welcomeScreen` starts in an `is-booting` state so static welcome markup is not visible before hydration.
- `WelcomeScreen` hydrates the welcome values first, waits for one halo pulse, then animates the splash logo and `Liberdus` title into the measured welcome logo/title positions.
- `styles.css` keeps the splash logo static, pulses only the halo behind it, and starts/ends the halo hidden and smaller than the logo so it does not peek out at the smallest keyframe.
- The pulse wait uses the halo animation as the source of truth and includes a duration-derived fallback so iOS WebView cannot get stuck pulsing if animation events are missed.
- Reduced-motion users skip the splash animation and go directly to the hydrated welcome screen.

## Fixed Flow

1. Browser loads the static document.
2. Users see the centered Liberdus splash instead of the partially hydrated welcome screen.
3. `WelcomeScreen.load()` fills version, network name, app version, and button ordering while the welcome screen remains invisible but measurable.
4. The halo completes one pulse, then the splash logo and title animate into the real welcome logo/title positions.
5. The splash hides and the already-hydrated welcome screen becomes visible without a visible content swap.

## Why

Issue #1332 surfaced visual instability where the welcome area briefly showed incomplete static content, especially the `Version` label under the logo, before runtime values were filled in. We chose a splash instead of a blank hidden area because it gives users an intentional branded boot moment while masking the hydration gap.

The latest direction avoids a fixed splash duration. Instead, it guarantees one pulse cycle on fast devices, keeps the transition tied to the CSS animation duration, and includes a fallback for React Native iOS WebView behavior where animation events can be unreliable.

This PR intentionally does not change the sign-out forced reload behavior. That remains a related but separate control-flow issue.

## Validation

- `node --check app.js`
- `git diff --check -- app.js index.html styles.css`
- Local Playwright verification confirmed the halo runs one pulse, starts/ends hidden and smaller than the logo, the logo/title handoff runs after the pulse, and the hydrated welcome appears after the transition.

Refs #1332
