### PR TITLE
Reorder sign-in usernames by preference

### DIFF
--- a/app.js
+++ b/app.js
@@ -3773,8 +3773,8 @@ class SignInModal {
     const orderedUsernameSet = new Set(orderedUsernames);
 
     return [
-      ...orderedUsernames,
       ...usernames.filter((username) => !orderedUsernameSet.has(username)),
+      ...orderedUsernames,
     ];
   }
 


### PR DESCRIPTION
## Summary
- Adjusts sign-in username ordering in  so persisted favorites are appended after new/unsorted usernames.

This keeps recently used usernames from staying front-loaded and moves ordering preference to lower priority than fresh registry order.

## Files changed
- app.js
