### PR TITLE
Guard sign-in option actions while busy

### DIFF
--- a/app.js
+++ b/app.js
@@ -3708,7 +3708,6 @@ class SignInModal {
     this.selectedUsername = null;
     this.isSigningIn = false;
     this.signInLoadingToastId = null;
-    this.accountClickSeq = 0;
   }
 
   setSigningInBusy(isBusy) {
@@ -4117,7 +4116,6 @@ class SignInModal {
   }
 
   close() {
-    this.accountClickSeq++;
     this.selectedUsername = null;
     this.setSigningInBusy(false);
     this.preselectedUsername = null;
@@ -4225,7 +4223,6 @@ class SignInModal {
    * @returns {Promise<string|null>} Availability result from checkUsernameAvailability
    */
   async handleAccountClick(username) {
-    const clickSeq = ++this.accountClickSeq;
     this.closeActionSheet();
 
     const { netid } = network;
@@ -4236,7 +4233,6 @@ class SignInModal {
     }
 
     this.setSigningInBusy(true);
-
 
     try {
       this.selectedUsername = username;
@@ -4253,9 +4249,8 @@ class SignInModal {
           logsModal.log(`[SignInModal] After 3 attempts username '${username}' still reported as available.`);
         }
       }
-
-      // Ignore stale results if the user tapped a different account or closed the modal while we were waiting.
-      if (clickSeq !== this.accountClickSeq || !this.isActive()) return null;
+      // Ignore results if the modal closed while we were waiting.
+      if (!this.isActive()) return null;
 
       switch (availability) {
         case 'mine':
@@ -4279,7 +4274,7 @@ class SignInModal {
 
       return availability;
     } catch (error) {
-      if (clickSeq === this.accountClickSeq && this.isActive()) {
+      if (this.isActive()) {
         console.error('[SignInModal] Account sign-in check failed:', error);
         showToast('Unable to sign in right now. Please try again.', 5000, 'error');
       }

--- a/app.js
+++ b/app.js
@@ -3707,6 +3707,7 @@ class SignInModal {
     this.preselectedUsername = null;
     this.selectedUsername = null;
     this.isSigningIn = false;
+    this.isSignInCommitted = false;
     this.signInLoadingToastId = null;
     this.accountClickSeq = 0;
   }
@@ -3777,6 +3778,7 @@ class SignInModal {
     this.actionRemoveButton.addEventListener('click', runSheetAction((username) => removeAccountModal.removeAccount(username)));
 
     this.backButton.addEventListener('click', () => {
+      if (this.isSignInCommitted) return;
       if (this.actionSheetOverlay.classList.contains('active')) {
         this.closeActionSheet();
         return;
@@ -4129,93 +4131,101 @@ class SignInModal {
     const username = this.selectedUsername;
     assert(username, 'Sign-in requires selected account');
 
-    history.pushState({state:1}, "", ".")
-    window.addEventListener('popstate', handleBrowserBackButton);
-    enterFullscreen();
-
-    const { netid } = network;
-    const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
-    assert(existingAccounts.netids[netid]?.usernames?.[username], `Account registry missing ${username}`);
-
-    myData = loadState(`${username}_${netid}`);
-    assert(myData, `Account data missing for ${username}`);
-    myAccount = myData.account;
-    logsModal.log(`SignIn as ${username}_${netid}`)
-    this.recordRecentSignInUsername(username);
-
-    // One-time migration: convert legacy friend status to connection
-    if (migrateFriendStatusToConnection(myData)) {
-      saveState();
-    }
-
-
-    // One-time migration: extract attachment encryption keys to encKey field
-    if (await migrateAttachmentKeysToEncKey(myData)) {
-      saveState();
-    }
-
-    // One-time migration: split deleted state into local-only vs for-all
-    if (migrateDeletedMessageStates(myData)) {
-      saveState();
-    }
-
-    // Clear notification address for this account when signing in
-    // Notification storage is only for accounts the user is NOT signed in to
-    if (reactNativeApp.isReactNativeWebView && myAccount?.keys?.address) {
-      const addressToClear = myAccount.keys.address;
-      reactNativeApp.clearNotificationAddress(addressToClear);
-      reactNativeApp.sendClearNotifications(addressToClear);
-    }
-
-    /* requestNotificationPermission(); */
-    if (useLongPolling) {
-      setTimeout(longPoll, 10);
-    }
-    if (!checkPendingTransactionsIntervalId) {
-      checkPendingTransactionsIntervalId = setInterval(checkPendingTransactions, 5000);
-    }
-    if (!getSystemNoticeIntervalId) {
-      getSystemNoticeIntervalId = setInterval(getSystemNotice, 15000);
-    }
-
-    // Register events that will saveState if the browser is closed without proper signOut
-    // Add beforeunload handler to save myData; don't use unload event, it is getting depricated
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    reactNativeApp.handleNativeAppUnsubscribe();
-    reactNativeApp.sendNavigationBarVisibility(false);
-
-    // Refresh wallet balance on sign-in so fee-dependent flows (e.g. Toll modal) have fresh data.
+    // Sign-in is committed past this point; Back must not close the modal mid-flight.
+    this.isSignInCommitted = true;
+    this.backButton.disabled = true;
     try {
-      myData.wallet.timestamp = 0;
-      await walletScreen.updateWalletBalances();
-    } catch (error) {
-      console.error('Failed to refresh wallet balances after sign-in:', error);
-    }
+      history.pushState({state:1}, "", ".")
+      window.addEventListener('popstate', handleBrowserBackButton);
+      enterFullscreen();
 
-    // Close modal and proceed to app
-    this.close();
-    welcomeScreen.close();
-    
-    // Log storage information after successful sign-in
-    try {
-      const storageInfo = localStorageMonitor.getStorageInfo();
-      logsModal.log(`💾 Storage Status: ${storageInfo.usageMB}MB used, ${storageInfo.availableMB}MB available (${storageInfo.percentageUsed}% used)`);
-    } catch (error) {
-      logsModal.log('⚠️ Could not retrieve storage information');
+      const { netid } = network;
+      const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+      assert(existingAccounts.netids[netid]?.usernames?.[username], `Account registry missing ${username}`);
+
+      myData = loadState(`${username}_${netid}`);
+      assert(myData, `Account data missing for ${username}`);
+      myAccount = myData.account;
+      logsModal.log(`SignIn as ${username}_${netid}`)
+      this.recordRecentSignInUsername(username);
+
+      // One-time migration: convert legacy friend status to connection
+      if (migrateFriendStatusToConnection(myData)) {
+        saveState();
+      }
+
+
+      // One-time migration: extract attachment encryption keys to encKey field
+      if (await migrateAttachmentKeysToEncKey(myData)) {
+        saveState();
+      }
+
+      // One-time migration: split deleted state into local-only vs for-all
+      if (migrateDeletedMessageStates(myData)) {
+        saveState();
+      }
+
+      // Clear notification address for this account when signing in
+      // Notification storage is only for accounts the user is NOT signed in to
+      if (reactNativeApp.isReactNativeWebView && myAccount?.keys?.address) {
+        const addressToClear = myAccount.keys.address;
+        reactNativeApp.clearNotificationAddress(addressToClear);
+        reactNativeApp.sendClearNotifications(addressToClear);
+      }
+
+      /* requestNotificationPermission(); */
+      if (useLongPolling) {
+        setTimeout(longPoll, 10);
+      }
+      if (!checkPendingTransactionsIntervalId) {
+        checkPendingTransactionsIntervalId = setInterval(checkPendingTransactions, 5000);
+      }
+      if (!getSystemNoticeIntervalId) {
+        getSystemNoticeIntervalId = setInterval(getSystemNotice, 15000);
+      }
+
+      // Register events that will saveState if the browser is closed without proper signOut
+      // Add beforeunload handler to save myData; don't use unload event, it is getting depricated
+      window.addEventListener('beforeunload', handleBeforeUnload);
+
+      reactNativeApp.handleNativeAppUnsubscribe();
+      reactNativeApp.sendNavigationBarVisibility(false);
+
+      // Refresh wallet balance on sign-in so fee-dependent flows (e.g. Toll modal) have fresh data.
+      try {
+        myData.wallet.timestamp = 0;
+        await walletScreen.updateWalletBalances();
+      } catch (error) {
+        console.error('Failed to refresh wallet balances after sign-in:', error);
+      }
+
+      // Close modal and proceed to app
+      this.close();
+      welcomeScreen.close();
+
+      // Log storage information after successful sign-in
+      try {
+        const storageInfo = localStorageMonitor.getStorageInfo();
+        logsModal.log(`💾 Storage Status: ${storageInfo.usageMB}MB used, ${storageInfo.availableMB}MB available (${storageInfo.percentageUsed}% used)`);
+      } catch (error) {
+        logsModal.log('⚠️ Could not retrieve storage information');
+      }
+
+      await footer.switchView('chats'); // Default view
+
+      // Restore wallet/history notification dots if there are unread transfers
+      if (myData?.wallet?.history && Array.isArray(myData.wallet.history) && myData.wallet.history.length > 0) {
+        restoreWalletNotificationDots();
+      }
+
+      // Initialize upcoming calls icon and start periodic refresh
+      callsModal.refreshCalls();
+      header.updateCallsIcon();
+      callsModal.startPeriodicCallsRefresh();
+    } finally {
+      this.isSignInCommitted = false;
+      this.backButton.disabled = false;
     }
-    
-    await footer.switchView('chats'); // Default view
-    
-    // Restore wallet/history notification dots if there are unread transfers
-    if (myData?.wallet?.history && Array.isArray(myData.wallet.history) && myData.wallet.history.length > 0) {
-      restoreWalletNotificationDots();
-    }
-    
-    // Initialize upcoming calls icon and start periodic refresh
-    callsModal.refreshCalls();
-    header.updateCallsIcon();
-    callsModal.startPeriodicCallsRefresh();
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -3711,31 +3711,20 @@ class SignInModal {
     this.accountClickSeq = 0;
   }
 
-  setSigningInBusy(isBusy, toastMessage = 'Signing in...') {
-    if (this.accountList) {
-      this.accountList.classList.toggle('is-disabled', isBusy);
-    }
-
-    if (this.actionRecreateButton) {
-      this.actionRecreateButton.disabled = isBusy;
-    }
-
-    if (this.actionRemoveButton) {
-      this.actionRemoveButton.disabled = isBusy;
-    }
-
-    if (this.resetRecentUsernamesButton) {
-      this.resetRecentUsernamesButton.disabled = isBusy;
-    }
+  setSigningInBusy(isBusy) {
+    [this.actionRecreateButton, this.actionRemoveButton, this.resetRecentUsernamesButton]
+      .forEach((button) => {
+        if (button) button.disabled = isBusy;
+      });
+    this.accountList?.classList.toggle('is-disabled', isBusy);
+    this.isSigningIn = isBusy;
 
     if (isBusy && !this.signInLoadingToastId) {
-      this.signInLoadingToastId = showToast(toastMessage, 0, 'loading');
+      this.signInLoadingToastId = showToast('Signing in...', 0, 'loading');
     } else if (!isBusy && this.signInLoadingToastId) {
       hideToast(this.signInLoadingToastId);
       this.signInLoadingToastId = null;
     }
-
-    this.isSigningIn = isBusy;
   }
 
   load () {
@@ -3767,7 +3756,6 @@ class SignInModal {
     });
     this.closeActionSheetButton.addEventListener('click', () => this.closeActionSheet());
     this.resetRecentUsernamesButton.addEventListener('click', () => {
-      if (this.isSigningIn) return;
       this.handleResetRecentSignInUsernames();
     });
 
@@ -3781,11 +3769,9 @@ class SignInModal {
       enableActionButtons,
       () => {
         assert(this.selectedUsername, 'Sign-in action sheet requires selected account');
-        this.setSigningInBusy(true, 'Applying sign-in option...');
+        this.setSigningInBusy(true);
         return Promise.resolve(action(this.selectedUsername))
-          .finally(() => {
-            this.setSigningInBusy(false);
-          });
+          .finally(() => this.setSigningInBusy(false));
       }
     );
     this.actionRecreateButton.addEventListener('click', runSheetAction((username) => this.openRecreateFlow(username)));
@@ -4249,13 +4235,13 @@ class SignInModal {
       return null;
     }
 
-    this.setSigningInBusy(true, 'Signing in...');
-    let availability = null;
+    this.setSigningInBusy(true);
+
 
     try {
       this.selectedUsername = username;
       const address = netidAccounts.usernames[username].address;
-      availability = await checkUsernameAvailability(username, address);
+      let availability = await checkUsernameAvailability(username, address);
       // Retry when network says 'available' but local account data still exists (propagation delay).
       if (availability === 'available' && localStorage.getItem(`${username}_${netid}`)) {
         for (let attempt = 2; attempt <= 3 && availability === 'available'; attempt++) {

--- a/app.js
+++ b/app.js
@@ -3768,7 +3768,8 @@ class SignInModal {
       () => {
         assert(this.selectedUsername, 'Sign-in action sheet requires selected account');
         this.setSigningInBusy(true);
-        return Promise.resolve(action(this.selectedUsername))
+        return Promise.resolve()
+          .then(() => action(this.selectedUsername))
           .finally(() => this.setSigningInBusy(false));
       }
     );
@@ -4275,13 +4276,15 @@ class SignInModal {
 
       return availability;
     } catch (error) {
-      if (this.isActive()) {
+      if (clickSeq === this.accountClickSeq && this.isActive()) {
         console.error('[SignInModal] Account sign-in check failed:', error);
         showToast('Unable to sign in right now. Please try again.', 5000, 'error');
       }
       return null;
     } finally {
-      this.setSigningInBusy(false);
+      if (clickSeq === this.accountClickSeq) {
+        this.setSigningInBusy(false);
+      }
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -3707,7 +3707,7 @@ class SignInModal {
     this.preselectedUsername = null;
     this.selectedUsername = null;
     this.isSigningIn = false;
-    this.isSignInCommitted = false;
+    this.isCompletingSignIn = false;
     this.signInLoadingToastId = null;
     this.accountClickSeq = 0;
   }
@@ -3726,6 +3726,11 @@ class SignInModal {
       hideToast(this.signInLoadingToastId);
       this.signInLoadingToastId = null;
     }
+  }
+
+  setCompletingSignIn(isCompleting) {
+    this.isCompletingSignIn = isCompleting;
+    if (this.backButton) this.backButton.disabled = isCompleting;
   }
 
   load () {
@@ -3778,7 +3783,7 @@ class SignInModal {
     this.actionRemoveButton.addEventListener('click', runSheetAction((username) => removeAccountModal.removeAccount(username)));
 
     this.backButton.addEventListener('click', () => {
-      if (this.isSignInCommitted) return;
+      if (this.isCompletingSignIn) return;
       if (this.actionSheetOverlay.classList.contains('active')) {
         this.closeActionSheet();
         return;
@@ -4086,6 +4091,7 @@ class SignInModal {
   async open(preselectedUsername) {
     this.preselectedUsername = preselectedUsername;
     this.selectedUsername = null;
+    this.setCompletingSignIn(false);
     this.setSigningInBusy(false);
     this.closeActionSheet();
 
@@ -4106,7 +4112,16 @@ class SignInModal {
       // Auto-select after account creation; network may not have propagated yet.
       if (preselectedUsername && usernames.includes(preselectedUsername)) {
         const availability = await this.handleAccountClick(preselectedUsername);
-        if (availability === 'available') await this.handleSignIn();
+        if (availability === 'available') {
+          this.setSigningInBusy(true);
+          this.setCompletingSignIn(true);
+          try {
+            await this.handleSignIn();
+          } finally {
+            this.setCompletingSignIn(false);
+            this.setSigningInBusy(false);
+          }
+        }
         return;
       }
 
@@ -4120,6 +4135,7 @@ class SignInModal {
   close() {
     this.accountClickSeq++;
     this.selectedUsername = null;
+    this.setCompletingSignIn(false);
     this.setSigningInBusy(false);
     this.preselectedUsername = null;
     this.closeActionSheet();
@@ -4131,101 +4147,93 @@ class SignInModal {
     const username = this.selectedUsername;
     assert(username, 'Sign-in requires selected account');
 
-    // Sign-in is committed past this point; Back must not close the modal mid-flight.
-    this.isSignInCommitted = true;
-    this.backButton.disabled = true;
-    try {
-      history.pushState({state:1}, "", ".")
-      window.addEventListener('popstate', handleBrowserBackButton);
-      enterFullscreen();
+    history.pushState({state:1}, "", ".")
+    window.addEventListener('popstate', handleBrowserBackButton);
+    enterFullscreen();
 
-      const { netid } = network;
-      const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
-      assert(existingAccounts.netids[netid]?.usernames?.[username], `Account registry missing ${username}`);
+    const { netid } = network;
+    const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+    assert(existingAccounts.netids[netid]?.usernames?.[username], `Account registry missing ${username}`);
 
-      myData = loadState(`${username}_${netid}`);
-      assert(myData, `Account data missing for ${username}`);
-      myAccount = myData.account;
-      logsModal.log(`SignIn as ${username}_${netid}`)
-      this.recordRecentSignInUsername(username);
+    myData = loadState(`${username}_${netid}`);
+    assert(myData, `Account data missing for ${username}`);
+    myAccount = myData.account;
+    logsModal.log(`SignIn as ${username}_${netid}`)
+    this.recordRecentSignInUsername(username);
 
-      // One-time migration: convert legacy friend status to connection
-      if (migrateFriendStatusToConnection(myData)) {
-        saveState();
-      }
-
-
-      // One-time migration: extract attachment encryption keys to encKey field
-      if (await migrateAttachmentKeysToEncKey(myData)) {
-        saveState();
-      }
-
-      // One-time migration: split deleted state into local-only vs for-all
-      if (migrateDeletedMessageStates(myData)) {
-        saveState();
-      }
-
-      // Clear notification address for this account when signing in
-      // Notification storage is only for accounts the user is NOT signed in to
-      if (reactNativeApp.isReactNativeWebView && myAccount?.keys?.address) {
-        const addressToClear = myAccount.keys.address;
-        reactNativeApp.clearNotificationAddress(addressToClear);
-        reactNativeApp.sendClearNotifications(addressToClear);
-      }
-
-      /* requestNotificationPermission(); */
-      if (useLongPolling) {
-        setTimeout(longPoll, 10);
-      }
-      if (!checkPendingTransactionsIntervalId) {
-        checkPendingTransactionsIntervalId = setInterval(checkPendingTransactions, 5000);
-      }
-      if (!getSystemNoticeIntervalId) {
-        getSystemNoticeIntervalId = setInterval(getSystemNotice, 15000);
-      }
-
-      // Register events that will saveState if the browser is closed without proper signOut
-      // Add beforeunload handler to save myData; don't use unload event, it is getting depricated
-      window.addEventListener('beforeunload', handleBeforeUnload);
-
-      reactNativeApp.handleNativeAppUnsubscribe();
-      reactNativeApp.sendNavigationBarVisibility(false);
-
-      // Refresh wallet balance on sign-in so fee-dependent flows (e.g. Toll modal) have fresh data.
-      try {
-        myData.wallet.timestamp = 0;
-        await walletScreen.updateWalletBalances();
-      } catch (error) {
-        console.error('Failed to refresh wallet balances after sign-in:', error);
-      }
-
-      // Close modal and proceed to app
-      this.close();
-      welcomeScreen.close();
-
-      // Log storage information after successful sign-in
-      try {
-        const storageInfo = localStorageMonitor.getStorageInfo();
-        logsModal.log(`💾 Storage Status: ${storageInfo.usageMB}MB used, ${storageInfo.availableMB}MB available (${storageInfo.percentageUsed}% used)`);
-      } catch (error) {
-        logsModal.log('⚠️ Could not retrieve storage information');
-      }
-
-      await footer.switchView('chats'); // Default view
-
-      // Restore wallet/history notification dots if there are unread transfers
-      if (myData?.wallet?.history && Array.isArray(myData.wallet.history) && myData.wallet.history.length > 0) {
-        restoreWalletNotificationDots();
-      }
-
-      // Initialize upcoming calls icon and start periodic refresh
-      callsModal.refreshCalls();
-      header.updateCallsIcon();
-      callsModal.startPeriodicCallsRefresh();
-    } finally {
-      this.isSignInCommitted = false;
-      this.backButton.disabled = false;
+    // One-time migration: convert legacy friend status to connection
+    if (migrateFriendStatusToConnection(myData)) {
+      saveState();
     }
+
+
+    // One-time migration: extract attachment encryption keys to encKey field
+    if (await migrateAttachmentKeysToEncKey(myData)) {
+      saveState();
+    }
+
+    // One-time migration: split deleted state into local-only vs for-all
+    if (migrateDeletedMessageStates(myData)) {
+      saveState();
+    }
+
+    // Clear notification address for this account when signing in
+    // Notification storage is only for accounts the user is NOT signed in to
+    if (reactNativeApp.isReactNativeWebView && myAccount?.keys?.address) {
+      const addressToClear = myAccount.keys.address;
+      reactNativeApp.clearNotificationAddress(addressToClear);
+      reactNativeApp.sendClearNotifications(addressToClear);
+    }
+
+    /* requestNotificationPermission(); */
+    if (useLongPolling) {
+      setTimeout(longPoll, 10);
+    }
+    if (!checkPendingTransactionsIntervalId) {
+      checkPendingTransactionsIntervalId = setInterval(checkPendingTransactions, 5000);
+    }
+    if (!getSystemNoticeIntervalId) {
+      getSystemNoticeIntervalId = setInterval(getSystemNotice, 15000);
+    }
+
+    // Register events that will saveState if the browser is closed without proper signOut
+    // Add beforeunload handler to save myData; don't use unload event, it is getting depricated
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    reactNativeApp.handleNativeAppUnsubscribe();
+    reactNativeApp.sendNavigationBarVisibility(false);
+
+    // Refresh wallet balance on sign-in so fee-dependent flows (e.g. Toll modal) have fresh data.
+    try {
+      myData.wallet.timestamp = 0;
+      await walletScreen.updateWalletBalances();
+    } catch (error) {
+      console.error('Failed to refresh wallet balances after sign-in:', error);
+    }
+
+    // Close modal and proceed to app
+    this.close();
+    welcomeScreen.close();
+    
+    // Log storage information after successful sign-in
+    try {
+      const storageInfo = localStorageMonitor.getStorageInfo();
+      logsModal.log(`💾 Storage Status: ${storageInfo.usageMB}MB used, ${storageInfo.availableMB}MB available (${storageInfo.percentageUsed}% used)`);
+    } catch (error) {
+      logsModal.log('⚠️ Could not retrieve storage information');
+    }
+    
+    await footer.switchView('chats'); // Default view
+    
+    // Restore wallet/history notification dots if there are unread transfers
+    if (myData?.wallet?.history && Array.isArray(myData.wallet.history) && myData.wallet.history.length > 0) {
+      restoreWalletNotificationDots();
+    }
+    
+    // Initialize upcoming calls icon and start periodic refresh
+    callsModal.refreshCalls();
+    header.updateCallsIcon();
+    callsModal.startPeriodicCallsRefresh();
   }
 
   /**
@@ -4266,6 +4274,7 @@ class SignInModal {
 
       switch (availability) {
         case 'mine':
+          this.setCompletingSignIn(true);
           await this.handleSignIn();
           this.preselectedUsername = null;
           break;
@@ -4293,6 +4302,7 @@ class SignInModal {
       return null;
     } finally {
       if (clickSeq === this.accountClickSeq) {
+        this.setCompletingSignIn(false);
         this.setSigningInBusy(false);
       }
     }

--- a/app.js
+++ b/app.js
@@ -3708,6 +3708,7 @@ class SignInModal {
     this.selectedUsername = null;
     this.isSigningIn = false;
     this.signInLoadingToastId = null;
+    this.accountClickSeq = 0;
   }
 
   setSigningInBusy(isBusy) {
@@ -4114,6 +4115,7 @@ class SignInModal {
   }
 
   close() {
+    this.accountClickSeq++;
     this.selectedUsername = null;
     this.setSigningInBusy(false);
     this.preselectedUsername = null;
@@ -4221,6 +4223,7 @@ class SignInModal {
    * @returns {Promise<string|null>} Availability result from checkUsernameAvailability
    */
   async handleAccountClick(username) {
+    const clickSeq = ++this.accountClickSeq;
     this.closeActionSheet();
 
     const { netid } = network;
@@ -4247,8 +4250,8 @@ class SignInModal {
           logsModal.log(`[SignInModal] After 3 attempts username '${username}' still reported as available.`);
         }
       }
-      // Ignore results if the modal closed while we were waiting.
-      if (!this.isActive()) return null;
+      // Ignore stale results if the user tapped a different account or closed the modal while we were waiting.
+      if (clickSeq !== this.accountClickSeq || !this.isActive()) return null;
 
       switch (availability) {
         case 'mine':

--- a/app.js
+++ b/app.js
@@ -3754,9 +3754,7 @@ class SignInModal {
       if (event.target === this.actionSheetOverlay) this.closeActionSheet();
     });
     this.closeActionSheetButton.addEventListener('click', () => this.closeActionSheet());
-    this.resetRecentUsernamesButton.addEventListener('click', () => {
-      this.handleResetRecentSignInUsernames();
-    });
+    this.resetRecentUsernamesButton.addEventListener('click', () => this.handleResetRecentSignInUsernames());
 
     const enableActionButtons = () => {
       this.actionRecreateButton.disabled = false;

--- a/app.js
+++ b/app.js
@@ -3707,7 +3707,31 @@ class SignInModal {
     this.preselectedUsername = null;
     this.selectedUsername = null;
     this.isSigningIn = false;
+    this.signInLoadingToastId = null;
     this.accountClickSeq = 0;
+  }
+
+  setSigningInBusy(isBusy, toastMessage = 'Signing in...') {
+    if (this.accountList) {
+      this.accountList.classList.toggle('is-disabled', isBusy);
+    }
+
+    if (this.actionRecreateButton) {
+      this.actionRecreateButton.disabled = isBusy;
+    }
+
+    if (this.actionRemoveButton) {
+      this.actionRemoveButton.disabled = isBusy;
+    }
+
+    if (isBusy && !this.signInLoadingToastId) {
+      this.signInLoadingToastId = showToast(toastMessage, 0, 'loading');
+    } else if (!isBusy && this.signInLoadingToastId) {
+      hideToast(this.signInLoadingToastId);
+      this.signInLoadingToastId = null;
+    }
+
+    this.isSigningIn = isBusy;
   }
 
   load () {
@@ -3731,7 +3755,7 @@ class SignInModal {
       if (!item || this.isSigningIn) return;
       const username = item.dataset.username;
       assert(username, 'Sign-in account item is missing username');
-      this.handleAccountClick(username);
+      void this.handleAccountClick(username);
     });
 
     this.actionSheetOverlay.addEventListener('click', (event) => {
@@ -3750,7 +3774,11 @@ class SignInModal {
       enableActionButtons,
       () => {
         assert(this.selectedUsername, 'Sign-in action sheet requires selected account');
-        action(this.selectedUsername);
+        this.setSigningInBusy(true, 'Applying sign-in option...');
+        return Promise.resolve(action(this.selectedUsername))
+          .finally(() => {
+            this.setSigningInBusy(false);
+          });
       }
     );
     this.actionRecreateButton.addEventListener('click', runSheetAction((username) => this.openRecreateFlow(username)));
@@ -4064,7 +4092,7 @@ class SignInModal {
   async open(preselectedUsername) {
     this.preselectedUsername = preselectedUsername;
     this.selectedUsername = null;
-    this.isSigningIn = false;
+    this.setSigningInBusy(false);
     this.closeActionSheet();
 
     // Render account list before opening modal.
@@ -4098,7 +4126,7 @@ class SignInModal {
   close() {
     this.accountClickSeq++;
     this.selectedUsername = null;
-    this.isSigningIn = false;
+    this.setSigningInBusy(false);
     this.preselectedUsername = null;
     this.closeActionSheet();
     this.accountList.innerHTML = '';
@@ -4214,49 +4242,58 @@ class SignInModal {
       return null;
     }
 
-    this.selectedUsername = username;
-    const address = netidAccounts.usernames[username].address;
-    let availability = await checkUsernameAvailability(username, address);
-    // Retry when network says 'available' but local account data still exists (propagation delay).
-    if (availability === 'available' && localStorage.getItem(`${username}_${netid}`)) {
-      for (let attempt = 2; attempt <= 3 && availability === 'available'; attempt++) {
-        logsModal.log(`[SignInModal] Retry ${attempt}/3 username availability for '${username}' because local data exists but network returned 'available'.`);
-        await new Promise((resolve) => setTimeout(resolve, 200));
-        availability = await checkUsernameAvailability(username, address);
-      }
-      if (availability === 'available') {
-        logsModal.log(`[SignInModal] After 3 attempts username '${username}' still reported as available.`);
-      }
-    }
-    // Ignore stale results if the user tapped a different account or closed the modal while we were waiting.
-    if (clickSeq !== this.accountClickSeq || !this.isActive()) return null;
+    this.setSigningInBusy(true, 'Signing in...');
+    let availability = null;
 
-    switch (availability) {
-      case 'mine':
-        this.isSigningIn = true;
-        try {
-          await this.handleSignIn();
-        } finally {
-          this.isSigningIn = false;
+    try {
+      this.selectedUsername = username;
+      const address = netidAccounts.usernames[username].address;
+      availability = await checkUsernameAvailability(username, address);
+      // Retry when network says 'available' but local account data still exists (propagation delay).
+      if (availability === 'available' && localStorage.getItem(`${username}_${netid}`)) {
+        for (let attempt = 2; attempt <= 3 && availability === 'available'; attempt++) {
+          logsModal.log(`[SignInModal] Retry ${attempt}/3 username availability for '${username}' because local data exists but network returned 'available'.`);
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          availability = await checkUsernameAvailability(username, address);
         }
-        this.preselectedUsername = null;
-        break;
-      case 'taken':
-        this.openActionSheet(username, 'taken');
-        break;
-      case 'available':
-        // Post-creation preselect may sign in locally without showing the sheet.
-        if (this.preselectedUsername !== username) this.openActionSheet(username, 'not-found');
-        break;
-      case 'error':
-      case 'error2':
-        this.openActionSheet(username, 'network-error');
-        break;
-      default:
-        assert(false, `Unknown username availability: ${availability}`);
-    }
+        if (availability === 'available') {
+          logsModal.log(`[SignInModal] After 3 attempts username '${username}' still reported as available.`);
+        }
+      }
 
-    return availability;
+      // Ignore stale results if the user tapped a different account or closed the modal while we were waiting.
+      if (clickSeq !== this.accountClickSeq || !this.isActive()) return null;
+
+      switch (availability) {
+        case 'mine':
+          await this.handleSignIn();
+          this.preselectedUsername = null;
+          break;
+        case 'taken':
+          this.openActionSheet(username, 'taken');
+          break;
+        case 'available':
+          // Post-creation preselect may sign in locally without showing the sheet.
+          if (this.preselectedUsername !== username) this.openActionSheet(username, 'not-found');
+          break;
+        case 'error':
+        case 'error2':
+          this.openActionSheet(username, 'network-error');
+          break;
+        default:
+          assert(false, `Unknown username availability: ${availability}`);
+      }
+
+      return availability;
+    } catch (error) {
+      if (clickSeq === this.accountClickSeq && this.isActive()) {
+        console.error('[SignInModal] Account sign-in check failed:', error);
+        showToast('Unable to sign in right now. Please try again.', 5000, 'error');
+      }
+      return null;
+    } finally {
+      this.setSigningInBusy(false);
+    }
   }
 
   isActive() {

--- a/app.js
+++ b/app.js
@@ -3724,6 +3724,10 @@ class SignInModal {
       this.actionRemoveButton.disabled = isBusy;
     }
 
+    if (this.resetRecentUsernamesButton) {
+      this.resetRecentUsernamesButton.disabled = isBusy;
+    }
+
     if (isBusy && !this.signInLoadingToastId) {
       this.signInLoadingToastId = showToast(toastMessage, 0, 'loading');
     } else if (!isBusy && this.signInLoadingToastId) {
@@ -3762,7 +3766,10 @@ class SignInModal {
       if (event.target === this.actionSheetOverlay) this.closeActionSheet();
     });
     this.closeActionSheetButton.addEventListener('click', () => this.closeActionSheet());
-    this.resetRecentUsernamesButton.addEventListener('click', () => this.handleResetRecentSignInUsernames());
+    this.resetRecentUsernamesButton.addEventListener('click', () => {
+      if (this.isSigningIn) return;
+      this.handleResetRecentSignInUsernames();
+    });
 
     const enableActionButtons = () => {
       this.actionRecreateButton.disabled = false;

--- a/styles.css
+++ b/styles.css
@@ -3298,6 +3298,15 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   gap: 10px;
 }
 
+#signInModal .sign-in-account-list.is-disabled {
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+#signInModal .sign-in-account-list.is-disabled .sign-in-account-item {
+  cursor: default;
+}
+
 #signInModal .sign-in-account-item {
   list-style: none;
   margin: 0;

--- a/styles.css
+++ b/styles.css
@@ -3291,7 +3291,6 @@ input[type='number'].form-control::-webkit-inner-spin-button {
 
 #signInModal .sign-in-account-reset:disabled {
   opacity: 0.5;
-  cursor: default;
 }
 
 #signInModal .sign-in-account-list {
@@ -3308,7 +3307,8 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   opacity: 0.7;
 }
 
-#signInModal .sign-in-account-list.is-disabled .sign-in-account-item {
+#signInModal .sign-in-account-list.is-disabled .sign-in-account-item,
+#signInModal .sign-in-account-reset:disabled {
   cursor: default;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3293,6 +3293,11 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   opacity: 0.5;
 }
 
+#signInModal .back-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 #signInModal .sign-in-account-list {
   list-style: none;
   padding: 0;

--- a/styles.css
+++ b/styles.css
@@ -3289,10 +3289,7 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   cursor: pointer;
 }
 
-#signInModal .sign-in-account-reset:disabled {
-  opacity: 0.5;
-}
-
+#signInModal .sign-in-account-reset:disabled,
 #signInModal .back-button:disabled {
   opacity: 0.5;
   cursor: default;
@@ -3312,8 +3309,7 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   opacity: 0.7;
 }
 
-#signInModal .sign-in-account-list.is-disabled .sign-in-account-item,
-#signInModal .sign-in-account-reset:disabled {
+#signInModal .sign-in-account-list.is-disabled .sign-in-account-item {
   cursor: default;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3289,6 +3289,11 @@ input[type='number'].form-control::-webkit-inner-spin-button {
   cursor: pointer;
 }
 
+#signInModal .sign-in-account-reset:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 #signInModal .sign-in-account-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## What changed

- Added a centralized `setSigningInBusy()` helper for the sign-in modal.
- Disabled sign-in account options, reset order, recreate, and remove actions while a sign-in/account action is in flight.
- Added a loading toast during busy sign-in work and cleanup in `finally` blocks.
- Kept account click sequence tracking so stale async checks cannot update newer sign-in state.
- Blocked the sign-in modal Back action only after sign-in has committed inside `handleSignIn()`.
- Added disabled styling for the sign-in account list, reset action, and sign-in Back button.

## Why

Pressing sign-in options repeatedly could start overlapping availability checks or action-sheet work. This keeps the UI in a single in-flight state so only one sign-in option action is processed at a time, while still allowing the user to back out during the availability check before sign-in is committed.

Fixes #1342

## User impact

Users get immediate loading feedback after pressing a sign-in option, and additional sign-in option/reset/recreate/remove presses are ignored or disabled until the current work finishes. The Back button still works during the availability check, but is blocked once `handleSignIn()` has started so the modal cannot close while sign-in completes.

## Validation

- `node --check app.js`