### PR TITLE
Adjust attachment upload UX in composer

### DIFF
--- a/app.js
+++ b/app.js
@@ -17143,23 +17143,6 @@ class ChatModal {
             this.revalidateSendButtonState();
 
             this.addAttachmentButton.disabled = this.isEditingMessage() || this.blockedByRecipient;
-            if (activeChatMatchesUpload) {
-              showToast(
-                `Attached "${file.name}" to ${uploadContactName}`,
-                3000,
-                'success',
-                false,
-                { dedupe: false }
-              );
-            } else {
-              showToast(
-                `Uploaded "${file.name}" for ${uploadContactName}; saved to that draft`,
-                3000,
-                'success',
-                false,
-                { dedupe: false }
-              );
-            }
             refreshChatsScreenIfActive();
             resolve(); // Successfully completed upload
           } catch (fetchError) {
@@ -17278,10 +17261,12 @@ class ChatModal {
    */
   showAttachmentPreview() {
     const preview = document.getElementById('attachmentPreview');
+    const divider = document.getElementById('attachmentInputDivider');
     
     if (!this.fileAttachments || this.fileAttachments.length === 0) {
       preview.innerHTML = '';
       preview.style.display = 'none';
+      if (divider) divider.style.display = 'none';
       this.toggleSendButtonVisibility();
       return;
     }
@@ -17309,6 +17294,7 @@ class ChatModal {
     });
 
     preview.style.display = 'block';
+    if (divider) divider.style.display = 'block';
     // Toggle button visibility when attachments are added
     this.toggleSendButtonVisibility();
     // Check if user was at the bottom before showing preview

--- a/app.js
+++ b/app.js
@@ -17261,12 +17261,10 @@ class ChatModal {
    */
   showAttachmentPreview() {
     const preview = document.getElementById('attachmentPreview');
-    const divider = document.getElementById('attachmentInputDivider');
     
     if (!this.fileAttachments || this.fileAttachments.length === 0) {
       preview.innerHTML = '';
       preview.style.display = 'none';
-      if (divider) divider.style.display = 'none';
       this.toggleSendButtonVisibility();
       return;
     }
@@ -17294,7 +17292,6 @@ class ChatModal {
     });
 
     preview.style.display = 'block';
-    if (divider) divider.style.display = 'block';
     // Toggle button visibility when attachments are added
     this.toggleSendButtonVisibility();
     // Check if user was at the bottom before showing preview

--- a/index.html
+++ b/index.html
@@ -1194,10 +1194,6 @@
         </div>
         <div class="message-input-container">
           <div class="message-byte-counter"></div>
-          <!-- Add attachment preview container -->
-          <div class="attachment-preview" id="attachmentPreview" style="display: none;">
-            <!-- Will be populated by JavaScript -->
-          </div>
           <div class="reply-preview" id="replyPreview" style="display: none;">
             <div class="reply-preview-content">
               <div class="reply-preview-label">Replying to:</div>
@@ -1215,6 +1211,11 @@
             <!-- Cancel Edit button (shown only when editing a message) -->
             <button class="icon-button cancel-edit-button" id="cancelEditButton" aria-label="Cancel edit" style="display: none;"></button>
             <div class="message-input-wrapper">
+              <!-- Add attachment preview container -->
+              <div class="attachment-preview" id="attachmentPreview" style="display: none;">
+                <!-- Will be populated by JavaScript -->
+              </div>
+              <div class="attachment-input-divider" id="attachmentInputDivider" style="display: none;"></div>
               <textarea class="message-input" placeholder="Type a message..."></textarea>
               <button class="icon-button voice-record-button" id="voiceRecordButton" aria-label="Record voice message"></button>
               <button class="send-button" id="handleSendMessage">

--- a/index.html
+++ b/index.html
@@ -1215,7 +1215,6 @@
               <div class="attachment-preview" id="attachmentPreview" style="display: none;">
                 <!-- Will be populated by JavaScript -->
               </div>
-              <div class="attachment-input-divider" id="attachmentInputDivider" style="display: none;"></div>
               <textarea class="message-input" placeholder="Type a message..."></textarea>
               <button class="icon-button voice-record-button" id="voiceRecordButton" aria-label="Record voice message"></button>
               <button class="send-button" id="handleSendMessage">

--- a/styles.css
+++ b/styles.css
@@ -6436,13 +6436,7 @@ small {
 /* File attachment preview */
 .attachment-preview {
   padding: 8px 16px 0;
-}
-
-.attachment-input-divider {
-  height: 1px;
-  margin: 0 16px;
-  background: var(--border-color);
-  pointer-events: none;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .attachment-item {

--- a/styles.css
+++ b/styles.css
@@ -2199,8 +2199,9 @@ input[type='file'].form-control::file-selector-button {
 .message-input {
   width: 100%;
   padding: 12px 56px 12px 16px; /* Right padding for buttons */
-  border: 1px solid var(--border-color);
-  border-radius: 24px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   font-size: var(--font-size-base);
   font-family: var(--font-primary);
   resize: none;
@@ -2221,8 +2222,6 @@ input[type='file'].form-control::file-selector-button {
 
 .message-input:focus {
   outline: none;
-  border-color: var(--primary-color);
-  box-shadow: var(--focus-ring-primary);
 }
 
 .send-button {
@@ -2421,13 +2420,22 @@ input[type='file'].form-control::file-selector-button {
   word-break: break-word;
 }
 
-/* Wrapper for the message input and inline action buttons */
+/* Wrapper for the message input, attachment preview, and inline action buttons */
 .message-input-wrapper {
   position: relative;
   flex: 1;
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: stretch;
+  border-radius: 24px;
+  background: white;
+  box-shadow: inset 0 0 0 1px var(--border-color);
+  overflow: hidden;
   pointer-events: auto;
+}
+
+.message-input-wrapper:focus-within {
+  box-shadow: inset 0 0 0 1px var(--primary-color), var(--focus-ring-primary);
 }
 
 #chatModal .chat-toll-container {
@@ -6427,7 +6435,14 @@ small {
 
 /* File attachment preview */
 .attachment-preview {
-  padding: 0px 16px 0;
+  padding: 8px 16px 0;
+}
+
+.attachment-input-divider {
+  height: 1px;
+  margin: 0 16px;
+  background: var(--border-color);
+  pointer-events: none;
 }
 
 .attachment-item {


### PR DESCRIPTION
## What Changed

This PR adjusts the attachment upload composer experience so uploaded attachments appear as part of the input surface without an extra success toast.

- `ChatModal` no longer shows success toasts after attachment upload completion.
- `attachmentPreview` now lives inside the message input wrapper, above the textarea.
- The composer wrapper owns the border, rounded corners, focus ring, and divider between attachment previews and the input row.

## Fixed Flow

1. User attaches a file from the chat composer.
2. Upload/encryption still reports loading and error states.
3. On success, the attachment preview appears above the input row with a divider.
4. The composer returns to its normal ready state without an additional success toast.

## Why

Successful attachment upload is part of the normal compose flow, so the extra success toast adds noise. Moving the existing preview into the input wrapper matches the requested layout while keeping the current preview behavior unchanged.

## Validation

- `git diff origin/main...HEAD --check`

Closes #1344
