### PR TITLE
Improve voice recording microphone permission toast

### DIFF
--- a/app.js
+++ b/app.js
@@ -9839,6 +9839,9 @@ function showToast(message, duration = 2000, type = 'default', isHTML = false, o
   
   const toast = document.createElement('div');
   toast.className = `toast ${type}`;
+  if (options?.className) {
+    toast.classList.add(...String(options.className).split(/\s+/).filter(Boolean));
+  }
   
   if (isHTML) {
     toast.innerHTML = message;
@@ -24820,7 +24823,13 @@ class VoiceRecordingModal {
       
     } catch (error) {
       console.error('Error starting voice recording:', error);
-      showToast('Microphone permission was denied. Enable microphone access in your browser or device settings, then try again.', 0, 'warning');
+      showToast(
+        'Microphone permission was denied. Enable microphone access in your browser or device settings, then try again.',
+        0,
+        'warning',
+        false,
+        { className: 'toast-left-aligned' }
+      );
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -24820,7 +24820,7 @@ class VoiceRecordingModal {
       
     } catch (error) {
       console.error('Error starting voice recording:', error);
-      showToast('Could not access microphone. Please check permissions.', 0, 'error');
+      showToast('Microphone permission was denied. Enable microphone access in your browser or device settings, then try again.', 0, 'warning');
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -4329,6 +4329,10 @@ mark {
   word-break: break-word;
 }
 
+.toast-left-aligned {
+  text-align: left;
+}
+
 /* Sticky (duration <= 0) toasts get space for the close button + are clickable */
 .toast.sticky {
   padding-top: 32px;


### PR DESCRIPTION
## What Changed

This PR updates the voice recording microphone permission failure feedback to be clearer and less severe.

- `VoiceRecordingModal.startVoiceRecording()` now shows a warning toast when microphone access cannot be granted.
- The toast copy tells users that microphone permission was denied and points them to browser or device settings.
- Successful recording behavior is unchanged.

## Fixed Flow

1. User opens the voice recording modal and taps `Start Recording`.
2. The browser requests microphone access through `getUserMedia`.
3. If permission is denied or blocked, recording does not start.
4. The user sees a warning toast with settings guidance instead of a generic error toast.

## Why

Denied microphone access is usually a browser or device permission state rather than an application failure. The warning toast gives clearer recovery guidance and matches the intended permission UX from issue #1349.
<img width="587" height="1049" alt="image" src="https://github.com/user-attachments/assets/bd576aa7-c72e-4d60-a52c-8401b87fb033" />

## Validation

- `node --check app.js`

Closes #1349
