### PR TITLE
Open shared locations in Google Maps web

### DIFF
--- a/app.js
+++ b/app.js
@@ -16884,26 +16884,7 @@ class ChatModal {
     const lat = this.formatLocationCoordinate(latitude);
     const lng = this.formatLocationCoordinate(longitude);
     const query = encodeURIComponent(`${lat},${lng}`);
-    const platform = navigator.platform || '';
-    const useAppleMaps = isIOS() || /Mac/i.test(platform);
-    if (useAppleMaps) {
-      return `https://maps.apple.com/?ll=${lat},${lng}&q=Shared%20Location`;
-    }
-    return `https://www.google.com/maps/search/?api=1&query=${query}`;
-  }
-
-  /**
-   * Toggles an inline mini map for a rendered location message.
-   * @param {HTMLElement|null} locationMessage
-   * @returns {void}
-   */
-  toggleLocationMiniMap(locationMessage) {
-    if (!locationMessage) return;
-    const isExpanded = locationMessage.classList.toggle('location-message-expanded');
-    const map = locationMessage.querySelector('.location-mini-map');
-    const summary = locationMessage.querySelector('.location-message-summary');
-    if (map) map.hidden = !isExpanded;
-    if (summary) summary.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    return `https://maps.google.com/?q=${query}`;
   }
 
   renderChatMessageHTML(item, { contact, lastReadTs }) {
@@ -17089,24 +17070,15 @@ class ChatModal {
           const mapUrl = this.getLocationMapUrl(latitude, longitude);
           messageTextHTML = `
               <div class="location-message">
-                <button type="button" class="location-message-summary" aria-expanded="false">
+                <a class="location-message-summary" href="${mapUrl}" target="_blank" rel="noopener noreferrer">
                   <span class="location-message-icon" aria-hidden="true"></span>
                   <span class="location-message-body">
                     <span class="location-message-title">Shared location</span>
                     <span class="location-message-coordinates">${escapeHtml(coordinates)}</span>
                     ${accuracy ? `<span class="location-message-accuracy">${escapeHtml(accuracy)}</span>` : ''}
-                    <span class="location-message-link">View mini map</span>
+                    <span class="location-message-link">Open in Google Maps</span>
                   </span>
-                </button>
-                <div class="location-mini-map" hidden>
-                  <div class="location-mini-map-grid" aria-hidden="true">
-                    <span class="location-mini-map-pin"></span>
-                  </div>
-                  <div class="location-mini-map-footer">
-                    <span>${escapeHtml(coordinates)}</span>
-                    <a href="${mapUrl}" target="_blank" rel="noopener noreferrer">Open in Maps</a>
-                  </div>
-                </div>
+                </a>
               </div>`;
         }
         break;
@@ -18460,14 +18432,6 @@ class ChatModal {
    * @param {Event} e - Click event
    */
   async handleMessageClick(e) {
-    const locationSummary = e.target.closest('.location-message-summary');
-    if (locationSummary) {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      this.toggleLocationMiniMap(locationSummary.closest('.location-message'));
-      return;
-    }
-
     const attachmentRow = e.target.closest('.attachment-row');
     if (attachmentRow) {
       e.preventDefault();

--- a/styles.css
+++ b/styles.css
@@ -7553,6 +7553,8 @@ small {
   color: inherit;
   text-align: left;
   cursor: pointer;
+  text-decoration: none;
+  box-sizing: border-box;
 }
 
 .location-message-summary:hover {
@@ -7585,72 +7587,6 @@ small {
   margin-top: 2px;
 }
 
-.location-mini-map {
-  padding: 0 10px 10px;
-}
-
-.location-mini-map-grid {
-  position: relative;
-  height: 132px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  overflow: hidden;
-  background:
-    linear-gradient(90deg, rgba(61, 61, 206, 0.08) 1px, transparent 1px) 0 0 / 28px 28px,
-    linear-gradient(rgba(61, 61, 206, 0.08) 1px, transparent 1px) 0 0 / 28px 28px,
-    linear-gradient(135deg, #e7f0ff 0%, #f7fbff 44%, #e8f6ee 100%);
-}
-
-.location-mini-map-pin {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 30px;
-  height: 30px;
-  transform: translate(-50%, -50%);
-  background-image: var(--icon-location-white);
-  background-color: var(--primary-color);
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 18px;
-  border-radius: 50%;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.24);
-}
-
-.location-mini-map-pin::after {
-  content: "";
-  position: absolute;
-  inset: 8px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.18);
-}
-
-.location-mini-map-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-top: 8px;
-  font-size: var(--font-size-xs);
-  color: var(--secondary-text-color);
-}
-
-.location-mini-map-footer span {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-.location-mini-map-footer a {
-  flex-shrink: 0;
-  color: var(--primary-color);
-  font-weight: var(--font-weight-medium);
-  text-decoration: none;
-}
-
-.location-mini-map-footer a:hover {
-  text-decoration: underline;
-}
-
 .message.sent .location-message {
   background: rgba(255, 255, 255, 0.14);
 }
@@ -7658,9 +7594,7 @@ small {
 .message.sent .location-message-title,
 .message.sent .location-message-coordinates,
 .message.sent .location-message-accuracy,
-.message.sent .location-message-link,
-.message.sent .location-mini-map-footer,
-.message.sent .location-mini-map-footer a {
+.message.sent .location-message-link {
   color: white;
 }
 
@@ -7670,10 +7604,6 @@ small {
 
 .message.sent .location-message-summary:hover {
   background: rgba(255, 255, 255, 0.08);
-}
-
-.message.sent .location-mini-map-grid {
-  border-color: rgba(255, 255, 255, 0.22);
 }
 
 .call-message-phone-button {


### PR DESCRIPTION
## Summary
- remove the inline shared-location mini-map and iframe from chat messages
- make the shared-location card open the Google Maps website in a new tab using the message coordinates
- remove Apple Maps/device-app deep-linking so location opens consistently in the browser

Closes #1352

## Validation
- node --check app.js
- node --check lib.js
- git diff --check
- controlled Chrome smoke test rendered a location message and verified the card is an anchor to `https://maps.google.com/?q=32.674632%2C-97.414606`, opens with `target="_blank"`, keeps `noopener noreferrer`, and renders no mini-map or iframe