### PR TITLE
Fix abandoned location retry cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -16602,9 +16602,10 @@ class ChatModal {
   /**
    * Stores and displays a pending location before it is sent.
    * @param {GeolocationPosition} position
+   * @param {{ retryTxId?: string }} options
    * @returns {void}
    */
-  showPendingLocation(position) {
+  showPendingLocation(position, { retryTxId = '' } = {}) {
     const latitude = Number(position?.coords?.latitude);
     const longitude = Number(position?.coords?.longitude);
     const accuracy = Number(position?.coords?.accuracy);
@@ -16618,7 +16619,9 @@ class ChatModal {
     this.pendingLocation = {
       latitude,
       longitude,
-      accuracy: Number.isFinite(accuracy) && accuracy >= 0 ? accuracy : null
+      accuracy: Number.isFinite(accuracy) && accuracy >= 0 ? accuracy : null,
+      retryTxId,
+      retryAddress: retryTxId ? this.address : null
     };
     this.renderLocationSharePanel();
   }
@@ -16663,7 +16666,18 @@ class ChatModal {
    * @returns {void}
    */
   clearPendingLocation() {
+    const retryTxId = this.pendingLocation?.retryTxId || '';
+    const retryAddress = this.pendingLocation?.retryAddress || this.address;
     this.pendingLocation = null;
+    if (retryTxId) {
+      if (this.retryOfTxId?.value === retryTxId) {
+        this.retryOfTxId.value = '';
+      }
+      const contact = retryAddress ? myData.contacts[retryAddress] : null;
+      if (contact?.draftRetryTxid === retryTxId) {
+        this.clearRetryState(contact);
+      }
+    }
     if (this.locationSharePanel) {
       this.locationSharePanel.style.display = 'none';
       this.locationSharePanel.style.left = '';
@@ -16694,7 +16708,7 @@ class ChatModal {
 
   /**
    * Sends a standalone encrypted location chat message.
-   * @param {{latitude: number, longitude: number, accuracy: number|null}} location
+   * @param {{latitude: number, longitude: number, accuracy: number|null, retryTxId?: string}} location
    * @returns {Promise<void>}
    */
   async sendLocationMessage(location) {
@@ -16725,6 +16739,7 @@ class ChatModal {
       showToast('You cannot send a location to yourself.', 3000, 'error');
       return;
     }
+    const retryTxId = location.retryTxId || this.retryOfTxId?.value || '';
 
     const keys = myAccount.keys;
     if (!keys) {
@@ -16777,10 +16792,15 @@ class ChatModal {
       );
       txid = builtTxid;
 
-      const retryTxId = this.retryOfTxId.value;
+      const contact = myData.contacts[currentAddress];
       if (retryTxId) {
         removeFailedTx(retryTxId, currentAddress);
-        this.retryOfTxId.value = '';
+        if (this.retryOfTxId?.value === retryTxId) {
+          this.retryOfTxId.value = '';
+        }
+        if (contact?.draftRetryTxid === retryTxId) {
+          this.clearRetryState(contact);
+        }
       }
 
       const newMessage = {
@@ -16796,7 +16816,6 @@ class ChatModal {
         status: 'sent'
       };
 
-      const contact = myData.contacts[currentAddress];
       insertSorted(contact.messages, newMessage, 'timestamp');
 
       const chatIndex = myData.chats.findIndex((chat) => chat.address === currentAddress);
@@ -24472,6 +24491,9 @@ class FailedMessageMenu {
   handleMenuAction(e) {
     const option = e.target.closest('.context-menu-option');
     if (!option || !this.currentMessageEl) return;
+
+    e.preventDefault();
+    e.stopPropagation();
     
     const action = option.dataset.action;
     const messageEl = this.currentMessageEl;
@@ -24563,7 +24585,7 @@ class FailedMessageMenu {
           longitude,
           accuracy: Number.isFinite(accuracy) && accuracy >= 0 ? accuracy : null
         }
-      });
+      }, { retryTxId: txid });
       return;
     }
 

--- a/app.js
+++ b/app.js
@@ -16602,10 +16602,10 @@ class ChatModal {
   /**
    * Stores and displays a pending location before it is sent.
    * @param {GeolocationPosition} position
-   * @param {{ retryTxId?: string }} options
+   * @param {string} [retryTxId]
    * @returns {void}
    */
-  showPendingLocation(position, { retryTxId = '' } = {}) {
+  showPendingLocation(position, retryTxId = '') {
     const latitude = Number(position?.coords?.latitude);
     const longitude = Number(position?.coords?.longitude);
     const accuracy = Number(position?.coords?.accuracy);
@@ -24586,7 +24586,7 @@ class FailedMessageMenu {
           longitude,
           accuracy: Number.isFinite(accuracy) && accuracy >= 0 ? accuracy : null
         }
-      }, { retryTxId: txid });
+      }, txid);
       return;
     }
 

--- a/app.js
+++ b/app.js
@@ -24498,6 +24498,7 @@ class FailedMessageMenu {
     const action = option.dataset.action;
     const messageEl = this.currentMessageEl;
     this.hide();
+    chatModal.clearPendingLocation();
 
     switch (action) {
       case 'retry':


### PR DESCRIPTION
## What changed
- Track retry metadata on staged location messages when retrying a failed location send.
- Clear matching `retryOfTxId` and saved `draftRetryTxid` when an abandoned location retry is canceled or cleared.
- Capture the retry txid before async location-send work so confirmed retries still remove the old failed tx even if the panel is cleared while sending.
- Stop failed-message menu option clicks from bubbling into the location outside-click handler, which was immediately clearing the staged retry panel.

## Why
Failed location retries set `retryOfTxId` before the user confirms the staged location send. Canceling or closing the panel could leave that retry id around, allowing a later unrelated send to remove the old failed location tx.

The retry menu click also bubbled to the document-level outside-click handler, so the location panel could be opened and cleared in the same click.

## Validation
- `node --check app.js`
- `git diff --check -- app.js`
- `git diff --check HEAD~1 HEAD -- app.js`

Fixes #1353
