### PR TITLE
Add Chat settings modal UI shell

### DIFF
--- a/app.js
+++ b/app.js
@@ -803,6 +803,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Settings Modal
   settingsModal.load();
 
+  // Display Modal
+  displayModal.load();
+
   // Manage Contacts Modal
   manageContactsModal.load();
 
@@ -3058,6 +3061,9 @@ class SettingsModal {
     this.contactsButton = document.getElementById('openManageContactsModal');
     this.contactsButton.addEventListener('click', () => manageContactsModal.open());
     
+    this.displayButton = document.getElementById('openDisplayModal');
+    this.displayButton.addEventListener('click', () => displayModal.open());
+    
     this.profileButton = document.getElementById('openAccountForm');
     this.profileButton.addEventListener('click', () => myProfileModal.open());
     
@@ -3111,6 +3117,34 @@ class SettingsModal {
 }
 
 const settingsModal = new SettingsModal();
+
+class DisplayModal {
+  constructor() { }
+
+  load() {
+    this.modal = document.getElementById('displayModal');
+    this.closeButton = document.getElementById('closeDisplayModal');
+    this.closeButton.addEventListener('click', () => this.handleClose());
+  }
+
+  open() {
+    this.modal.classList.add('active');
+  }
+
+  handleClose() {
+    this.close();
+  }
+
+  close() {
+    this.modal.classList.remove('active');
+  }
+
+  isActive() {
+    return this.modal.classList.contains('active');
+  }
+}
+
+const displayModal = new DisplayModal();
 
 /**
  * Manage Contacts Modal
@@ -31141,6 +31175,9 @@ function closeTopModal(topModal){
       break;
     case 'settingsModal':
       settingsModal.close();
+      break;
+    case 'displayModal':
+      displayModal.handleClose();
       break;
     case 'sendAssetFormModal':
       sendAssetFormModal.close();

--- a/app.js
+++ b/app.js
@@ -803,8 +803,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Settings Modal
   settingsModal.load();
 
-  // Display Modal
-  displayModal.load();
+  // Chat Settings Modal
+  chatSettingsModal.load();
 
   // Manage Contacts Modal
   manageContactsModal.load();
@@ -3061,8 +3061,8 @@ class SettingsModal {
     this.contactsButton = document.getElementById('openManageContactsModal');
     this.contactsButton.addEventListener('click', () => manageContactsModal.open());
     
-    this.displayButton = document.getElementById('openDisplayModal');
-    this.displayButton.addEventListener('click', () => displayModal.open());
+    this.chatSettingsButton = document.getElementById('openChatSettingsModal');
+    this.chatSettingsButton.addEventListener('click', () => chatSettingsModal.open());
 
     this.profileButton = document.getElementById('openAccountForm');
     this.profileButton.addEventListener('click', () => myProfileModal.open());
@@ -3118,7 +3118,7 @@ class SettingsModal {
 
 const settingsModal = new SettingsModal();
 
-class DisplayModal {
+class ChatSettingsModal {
   constructor() {
     this.defaultFontSizePx = 16;
     this.savedFontSizePx = this.defaultFontSizePx;
@@ -3127,11 +3127,11 @@ class DisplayModal {
   }
 
   load() {
-    this.modal = document.getElementById('displayModal');
-    this.closeButton = document.getElementById('closeDisplayModal');
-    this.preview = document.getElementById('displayFontPreview');
-    this.fontSizeSlider = document.getElementById('displayFontSizeSlider');
-    this.saveButton = document.getElementById('saveDisplaySettingsButton');
+    this.modal = document.getElementById('chatSettingsModal');
+    this.closeButton = document.getElementById('closeChatSettingsModal');
+    this.preview = document.getElementById('chatSettingsFontPreview');
+    this.fontSizeSlider = document.getElementById('chatSettingsFontSizeSlider');
+    this.saveButton = document.getElementById('saveChatSettingsButton');
 
     this.closeButton.addEventListener('click', () => this.handleClose());
     this.fontSizeSlider.addEventListener('input', () => this.handleSliderInput());
@@ -3159,7 +3159,7 @@ class DisplayModal {
   }
 
   updatePreview() {
-    this.preview.style.setProperty('--display-preview-message-font-size', this.draftFontSizePx + 'px');
+    this.preview.style.setProperty('--chat-settings-preview-message-font-size', this.draftFontSizePx + 'px');
   }
 
   hasUnsavedChanges() {
@@ -3189,7 +3189,7 @@ class DisplayModal {
   }
 }
 
-const displayModal = new DisplayModal();
+const chatSettingsModal = new ChatSettingsModal();
 
 /**
  * Manage Contacts Modal
@@ -31221,8 +31221,8 @@ function closeTopModal(topModal){
     case 'settingsModal':
       settingsModal.close();
       break;
-    case 'displayModal':
-      displayModal.handleClose();
+    case 'chatSettingsModal':
+      chatSettingsModal.handleClose();
       break;
     case 'sendAssetFormModal':
       sendAssetFormModal.close();

--- a/app.js
+++ b/app.js
@@ -3063,7 +3063,7 @@ class SettingsModal {
     
     this.displayButton = document.getElementById('openDisplayModal');
     this.displayButton.addEventListener('click', () => displayModal.open());
-    
+
     this.profileButton = document.getElementById('openAccountForm');
     this.profileButton.addEventListener('click', () => myProfileModal.open());
     
@@ -3123,6 +3123,7 @@ class DisplayModal {
     this.defaultFontSizePx = 16;
     this.savedFontSizePx = this.defaultFontSizePx;
     this.draftFontSizePx = this.defaultFontSizePx;
+    this.warningShown = false;
   }
 
   load() {
@@ -3139,6 +3140,7 @@ class DisplayModal {
 
   open() {
     this.draftFontSizePx = this.savedFontSizePx;
+    this.warningShown = false;
     this.fontSizeSlider.value = String(this.draftFontSizePx);
     this.updatePreview();
     this.modal.classList.add('active');
@@ -3146,11 +3148,13 @@ class DisplayModal {
 
   handleSliderInput() {
     this.draftFontSizePx = Number(this.fontSizeSlider.value);
+    this.warningShown = false;
     this.updatePreview();
   }
 
   save() {
     this.savedFontSizePx = this.draftFontSizePx;
+    this.warningShown = false;
     this.close();
   }
 
@@ -3158,12 +3162,26 @@ class DisplayModal {
     this.preview.style.setProperty('--display-preview-message-font-size', this.draftFontSizePx + 'px');
   }
 
+  hasUnsavedChanges() {
+    return this.draftFontSizePx !== this.savedFontSizePx;
+  }
+
   handleClose() {
+    if (this.hasUnsavedChanges() && !this.warningShown) {
+      this.warningShown = true;
+      showToast('Press back again to discard changes.', 5000, 'warning');
+      return;
+    }
+
     this.close();
   }
 
   close() {
     this.modal.classList.remove('active');
+    this.draftFontSizePx = this.savedFontSizePx;
+    this.warningShown = false;
+    this.fontSizeSlider.value = String(this.savedFontSizePx);
+    this.updatePreview();
   }
 
   isActive() {

--- a/app.js
+++ b/app.js
@@ -3119,16 +3119,43 @@ class SettingsModal {
 const settingsModal = new SettingsModal();
 
 class DisplayModal {
-  constructor() { }
+  constructor() {
+    this.defaultFontSizePx = 16;
+    this.savedFontSizePx = this.defaultFontSizePx;
+    this.draftFontSizePx = this.defaultFontSizePx;
+  }
 
   load() {
     this.modal = document.getElementById('displayModal');
     this.closeButton = document.getElementById('closeDisplayModal');
+    this.preview = document.getElementById('displayFontPreview');
+    this.fontSizeSlider = document.getElementById('displayFontSizeSlider');
+    this.saveButton = document.getElementById('saveDisplaySettingsButton');
+
     this.closeButton.addEventListener('click', () => this.handleClose());
+    this.fontSizeSlider.addEventListener('input', () => this.handleSliderInput());
+    this.saveButton.addEventListener('click', () => this.save());
   }
 
   open() {
+    this.draftFontSizePx = this.savedFontSizePx;
+    this.fontSizeSlider.value = String(this.draftFontSizePx);
+    this.updatePreview();
     this.modal.classList.add('active');
+  }
+
+  handleSliderInput() {
+    this.draftFontSizePx = Number(this.fontSizeSlider.value);
+    this.updatePreview();
+  }
+
+  save() {
+    this.savedFontSizePx = this.draftFontSizePx;
+    this.close();
+  }
+
+  updatePreview() {
+    this.preview.style.setProperty('--display-preview-message-font-size', this.draftFontSizePx + 'px');
   }
 
   handleClose() {

--- a/index.html
+++ b/index.html
@@ -437,6 +437,7 @@
             <li class="menu-item" id="openCallsModal" data-icon="call">Calls</li>
             <li class="menu-item" id="openAccountForm" data-icon="user">Profile</li>
             <li class="menu-item" id="openManageContactsModal" data-icon="contacts">Contacts</li>
+            <li class="menu-item" id="openDisplayModal" data-icon="display">Display</li>
             <li class="menu-item" id="openToll" data-icon="dollar-sign">Toll</li>
             <li class="menu-item" id="openLockModal" data-icon="lock">Lock</li>
             <li class="menu-item" id="openSecretModal" data-icon="key">Secret</li>
@@ -445,6 +446,19 @@
             <li class="menu-item" id="openLaunchUrl" data-icon="launch" style="display: none;">Launch</li>
             <li class="menu-item sign-out" id="handleSignOutSettings" data-icon="log-out">Sign Out</li>
           </ul>
+        </div>
+        <a class="last-item" href="#"> </a>
+      </div>
+
+      <!-- Display Modal -->
+      <div class="modal fixed-header" id="displayModal">
+        <div class="modal-header">
+          <button class="back-button" id="closeDisplayModal"></button>
+          <div class="modal-title">Display</div>
+        </div>
+        <div class="modal-content">
+          <div class="form-container display-settings-form">
+          </div>
         </div>
         <a class="last-item" href="#"> </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -458,7 +458,7 @@
         </div>
         <div class="modal-content">
           <div class="form-container chat-settings-form">
-            <div class="chat-settings-font-section">
+            <div class="chat-settings-font-section form--narrow">
               <div class="chat-settings-section-title">Chat font size</div>
 
               <div class="chat-settings-preview" id="chatSettingsFontPreview">

--- a/index.html
+++ b/index.html
@@ -458,6 +458,38 @@
         </div>
         <div class="modal-content">
           <div class="form-container display-settings-form">
+            <div class="display-font-section">
+              <div class="display-section-title">Chat font size</div>
+
+              <div class="display-chat-preview" id="displayFontPreview">
+                <div class="display-preview-label">Preview</div>
+                <div class="display-preview-list" aria-live="polite">
+                  <div class="message received display-preview-message">
+                    <div class="message-content">Hey, can you read this comfortably?</div>
+                    <div class="message-time">10:32</div>
+                  </div>
+                  <div class="message sent display-preview-message">
+                    <div class="message-content">This is the size chats will use.</div>
+                    <div class="message-time">10:33</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="display-font-slider-row">
+                <span class="display-font-label display-font-label-small">Aa</span>
+                <input type="range" id="displayFontSizeSlider" min="14" max="20" step="1" value="16" aria-label="Chat font size" />
+                <span class="display-font-label display-font-label-large">Aa</span>
+              </div>
+              <div class="display-slider-labels" aria-hidden="true">
+                <span>Small</span>
+                <span>Default</span>
+                <span>Large</span>
+              </div>
+
+              <div class="form-actions display-actions">
+                <button type="button" id="saveDisplaySettingsButton" class="btn btn--primary btn--pill btn--full">Save Changes</button>
+              </div>
+            </div>
           </div>
         </div>
         <a class="last-item" href="#"> </a>

--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
             <li class="menu-item" id="openCallsModal" data-icon="call">Calls</li>
             <li class="menu-item" id="openAccountForm" data-icon="user">Profile</li>
             <li class="menu-item" id="openManageContactsModal" data-icon="contacts">Contacts</li>
-            <li class="menu-item" id="openDisplayModal" data-icon="display">Display</li>
+            <li class="menu-item" id="openChatSettingsModal" data-icon="chat">Chat</li>
             <li class="menu-item" id="openToll" data-icon="dollar-sign">Toll</li>
             <li class="menu-item" id="openLockModal" data-icon="lock">Lock</li>
             <li class="menu-item" id="openSecretModal" data-icon="key">Secret</li>
@@ -450,44 +450,44 @@
         <a class="last-item" href="#"> </a>
       </div>
 
-      <!-- Display Modal -->
-      <div class="modal fixed-header" id="displayModal">
+      <!-- Chat Settings Modal -->
+      <div class="modal fixed-header" id="chatSettingsModal">
         <div class="modal-header">
-          <button class="back-button" id="closeDisplayModal"></button>
-          <div class="modal-title">Display</div>
+          <button class="back-button" id="closeChatSettingsModal"></button>
+          <div class="modal-title">Chat</div>
         </div>
         <div class="modal-content">
-          <div class="form-container display-settings-form">
-            <div class="display-font-section">
-              <div class="display-section-title">Chat font size</div>
+          <div class="form-container chat-settings-form">
+            <div class="chat-settings-font-section">
+              <div class="chat-settings-section-title">Chat font size</div>
 
-              <div class="display-chat-preview" id="displayFontPreview">
-                <div class="display-preview-label">Preview</div>
-                <div class="display-preview-list" aria-live="polite">
-                  <div class="message received display-preview-message">
+              <div class="chat-settings-preview" id="chatSettingsFontPreview">
+                <div class="chat-settings-preview-label">Preview</div>
+                <div class="chat-settings-preview-list" aria-live="polite">
+                  <div class="message received chat-settings-preview-message">
                     <div class="message-content">Hey, can you read this comfortably?</div>
                     <div class="message-time">10:32</div>
                   </div>
-                  <div class="message sent display-preview-message">
+                  <div class="message sent chat-settings-preview-message">
                     <div class="message-content">This is the size chats will use.</div>
                     <div class="message-time">10:33</div>
                   </div>
                 </div>
               </div>
 
-              <div class="display-font-slider-row">
-                <span class="display-font-label display-font-label-small">Aa</span>
-                <input type="range" id="displayFontSizeSlider" min="14" max="20" step="1" value="16" aria-label="Chat font size" />
-                <span class="display-font-label display-font-label-large">Aa</span>
+              <div class="chat-settings-font-slider-row">
+                <span class="chat-settings-font-label chat-settings-font-label-small">Aa</span>
+                <input type="range" id="chatSettingsFontSizeSlider" min="14" max="20" step="1" value="16" aria-label="Chat font size" />
+                <span class="chat-settings-font-label chat-settings-font-label-large">Aa</span>
               </div>
-              <div class="display-slider-labels" aria-hidden="true">
+              <div class="chat-settings-slider-labels" aria-hidden="true">
                 <span>Small</span>
                 <span>Default</span>
                 <span>Large</span>
               </div>
 
-              <div class="form-actions display-actions">
-                <button type="button" id="saveDisplaySettingsButton" class="btn btn--primary btn--pill btn--full">Save Changes</button>
+              <div class="form-actions chat-settings-actions">
+                <button type="button" id="saveChatSettingsButton" class="btn btn--primary btn--pill btn--full">Save Changes</button>
               </div>
             </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -2423,6 +2423,106 @@ input[type='file'].form-control::file-selector-button {
   word-break: break-word;
 }
 
+.display-settings-form {
+  max-width: 480px;
+  margin: 0 auto;
+  padding-bottom: 24px;
+}
+
+.display-font-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.display-section-title {
+  color: var(--text-color);
+  font-family: var(--font-primary);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.2;
+}
+
+.display-chat-preview {
+  --display-preview-message-font-size: 16px;
+  background: var(--hover-background);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.display-preview-label {
+  color: var(--secondary-text-color);
+  font-family: var(--font-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  margin-bottom: 14px;
+}
+
+.display-preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.display-chat-preview .message {
+  cursor: default;
+  margin-bottom: 0;
+  max-width: 82%;
+}
+
+.display-chat-preview .message:hover {
+  filter: none;
+}
+
+.display-chat-preview .message-content {
+  font-size: var(--display-preview-message-font-size);
+  line-height: 1.35;
+}
+
+.display-font-slider-row {
+  align-items: center;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.display-font-label {
+  color: var(--text-color);
+  font-family: var(--font-primary);
+  line-height: 1;
+}
+
+.display-font-label-small {
+  font-size: var(--font-size-sm);
+}
+
+.display-font-label-large {
+  font-size: var(--font-size-lg);
+}
+
+#displayFontSizeSlider {
+  accent-color: var(--primary-color);
+  margin: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+.display-slider-labels {
+  color: var(--secondary-text-color);
+  display: grid;
+  font-family: var(--font-primary);
+  font-size: var(--font-size-xs);
+  grid-template-columns: repeat(3, 1fr);
+  padding: 0 34px;
+  text-align: center;
+}
+
+.display-actions .btn--full {
+  margin: 0;
+  width: 100%;
+}
+
 /* Wrapper for the message input, attachment preview, and inline action buttons */
 .message-input-wrapper {
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -6340,6 +6340,10 @@ small {
   background-image: var(--icon-contacts);
 }
 
+.menu-item[data-icon="display"]::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='14' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='8' y1='21' x2='16' y2='21'%3E%3C/line%3E%3Cline x1='12' y1='18' x2='12' y2='21'%3E%3C/line%3E%3C/svg%3E");
+}
+
 .menu-item[data-icon="arrow-right-arrow-left"]::before {
   background-image: var(--icon-bridge);
 }

--- a/styles.css
+++ b/styles.css
@@ -2518,11 +2518,6 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-.display-actions .btn--full {
-  margin: 0;
-  width: 100%;
-}
-
 /* Wrapper for the message input, attachment preview, and inline action buttons */
 .message-input-wrapper {
   position: relative;

--- a/styles.css
+++ b/styles.css
@@ -2423,19 +2423,19 @@ input[type='file'].form-control::file-selector-button {
   word-break: break-word;
 }
 
-.display-settings-form {
+.chat-settings-form {
   max-width: 480px;
   margin: 0 auto;
   padding-bottom: 24px;
 }
 
-.display-font-section {
+.chat-settings-font-section {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.display-section-title {
+.chat-settings-section-title {
   color: var(--text-color);
   font-family: var(--font-primary);
   font-size: var(--font-size-lg);
@@ -2443,15 +2443,15 @@ input[type='file'].form-control::file-selector-button {
   line-height: 1.2;
 }
 
-.display-chat-preview {
-  --display-preview-message-font-size: 16px;
+.chat-settings-preview {
+  --chat-settings-preview-message-font-size: 16px;
   background: var(--hover-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 16px;
 }
 
-.display-preview-label {
+.chat-settings-preview-label {
   color: var(--secondary-text-color);
   font-family: var(--font-primary);
   font-size: var(--font-size-sm);
@@ -2459,56 +2459,56 @@ input[type='file'].form-control::file-selector-button {
   margin-bottom: 14px;
 }
 
-.display-preview-list {
+.chat-settings-preview-list {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.display-chat-preview .message {
+.chat-settings-preview .message {
   cursor: default;
   margin-bottom: 0;
   max-width: 82%;
 }
 
-.display-chat-preview .message:hover {
+.chat-settings-preview .message:hover {
   filter: none;
 }
 
-.display-chat-preview .message-content {
-  font-size: var(--display-preview-message-font-size);
+.chat-settings-preview .message-content {
+  font-size: var(--chat-settings-preview-message-font-size);
   line-height: 1.35;
 }
 
-.display-font-slider-row {
+.chat-settings-font-slider-row {
   align-items: center;
   display: grid;
   gap: 12px;
   grid-template-columns: auto minmax(0, 1fr) auto;
 }
 
-.display-font-label {
+.chat-settings-font-label {
   color: var(--text-color);
   font-family: var(--font-primary);
   line-height: 1;
 }
 
-.display-font-label-small {
+.chat-settings-font-label-small {
   font-size: var(--font-size-sm);
 }
 
-.display-font-label-large {
+.chat-settings-font-label-large {
   font-size: var(--font-size-lg);
 }
 
-#displayFontSizeSlider {
+#chatSettingsFontSizeSlider {
   accent-color: var(--primary-color);
   margin: 0;
   min-width: 0;
   width: 100%;
 }
 
-.display-slider-labels {
+.chat-settings-slider-labels {
   color: var(--secondary-text-color);
   display: grid;
   font-family: var(--font-primary);
@@ -6435,8 +6435,8 @@ small {
   background-image: var(--icon-contacts);
 }
 
-.menu-item[data-icon="display"]::before {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='14' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='8' y1='21' x2='16' y2='21'%3E%3C/line%3E%3Cline x1='12' y1='18' x2='12' y2='21'%3E%3C/line%3E%3C/svg%3E");
+.menu-item[data-icon="chat"]::before {
+  background-image: var(--icon-chat);
 }
 
 .menu-item[data-icon="arrow-right-arrow-left"]::before {


### PR DESCRIPTION
## What Changed

This PR adds the first UI-only step for issue #1357: a Settings entry and Chat modal for previewing chat font size.

- `Settings` now includes a `Chat` item after `Contacts`.
- `chatSettingsModal` provides a full-screen modal with static chat bubble previews, a font-size slider, and a Save Changes button.
- `ChatSettingsModal` keeps saved and draft font sizes in memory for the current page session only.
- Back behavior uses the existing toast/double-back discard pattern for unsaved slider changes.

## Fixed Flow

1. Open Settings.
2. Choose Chat.
3. Move the chat font-size slider to update the preview only.
4. Save stores the selection in memory for the current session, while backing out with unsaved changes warns once before discarding.

## Why

This keeps PR 1 focused on the Chat settings modal shell and preview UX without adding persistence or changing real chat message rendering. The next PR can wire the saved device preference into actual chat bubbles.

## Validation

- `node --check app.js`
- `git diff --check`

Refs #1357