### PR TITLE
Persist Chat font size setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -3120,7 +3120,10 @@ const settingsModal = new SettingsModal();
 
 class ChatSettingsModal {
   constructor() {
+    this.storageKey = 'chat_font_size_px';
     this.defaultFontSizePx = 16;
+    this.minFontSizePx = 14;
+    this.maxFontSizePx = 20;
     this.savedFontSizePx = this.defaultFontSizePx;
     this.draftFontSizePx = this.defaultFontSizePx;
     this.warningShown = false;
@@ -3136,6 +3139,12 @@ class ChatSettingsModal {
     this.closeButton.addEventListener('click', () => this.handleClose());
     this.fontSizeSlider.addEventListener('input', () => this.handleSliderInput());
     this.saveButton.addEventListener('click', () => this.save());
+
+    this.savedFontSizePx = this.readSavedFontSize();
+    this.draftFontSizePx = this.savedFontSizePx;
+    this.fontSizeSlider.value = String(this.savedFontSizePx);
+    this.updatePreview();
+    this.applyChatFontSize();
   }
 
   open() {
@@ -3147,19 +3156,36 @@ class ChatSettingsModal {
   }
 
   handleSliderInput() {
-    this.draftFontSizePx = Number(this.fontSizeSlider.value);
+    this.draftFontSizePx = this.clampFontSize(Number(this.fontSizeSlider.value));
     this.warningShown = false;
     this.updatePreview();
   }
 
   save() {
     this.savedFontSizePx = this.draftFontSizePx;
+    localStorage.setItem(this.storageKey, String(this.savedFontSizePx));
+    this.applyChatFontSize();
     this.warningShown = false;
     this.close();
   }
 
   updatePreview() {
     this.preview.style.setProperty('--chat-settings-preview-message-font-size', this.draftFontSizePx + 'px');
+  }
+
+  applyChatFontSize() {
+    document.documentElement.style.setProperty('--chat-message-font-size', this.savedFontSizePx + 'px');
+  }
+
+  readSavedFontSize() {
+    const storedValue = localStorage.getItem(this.storageKey);
+    if (storedValue === null) return this.defaultFontSizePx;
+    return this.clampFontSize(Number(storedValue));
+  }
+
+  clampFontSize(value) {
+    if (!Number.isFinite(value)) return this.defaultFontSizePx;
+    return Math.min(this.maxFontSizePx, Math.max(this.minFontSizePx, Math.round(value)));
   }
 
   hasUnsavedChanges() {

--- a/app.js
+++ b/app.js
@@ -3122,8 +3122,8 @@ class ChatSettingsModal {
   constructor() {
     this.storageKey = 'chat_font_size_px';
     this.defaultFontSizePx = 16;
-    this.minFontSizePx = 14;
-    this.maxFontSizePx = 20;
+    this.minFontSizePx = 12;
+    this.maxFontSizePx = 30;
     this.savedFontSizePx = this.defaultFontSizePx;
     this.draftFontSizePx = this.defaultFontSizePx;
     this.warningShown = false;
@@ -3142,7 +3142,7 @@ class ChatSettingsModal {
 
     this.savedFontSizePx = this.readSavedFontSize();
     this.draftFontSizePx = this.savedFontSizePx;
-    this.fontSizeSlider.value = String(this.savedFontSizePx);
+    this.setSliderValue(this.savedFontSizePx);
     this.updatePreview();
     this.applyChatFontSize();
   }
@@ -3150,13 +3150,14 @@ class ChatSettingsModal {
   open() {
     this.draftFontSizePx = this.savedFontSizePx;
     this.warningShown = false;
-    this.fontSizeSlider.value = String(this.draftFontSizePx);
+    this.setSliderValue(this.draftFontSizePx);
     this.updatePreview();
     this.modal.classList.add('active');
   }
 
   handleSliderInput() {
     this.draftFontSizePx = this.clampFontSize(Number(this.fontSizeSlider.value));
+    this.syncSliderPosition(this.draftFontSizePx);
     this.warningShown = false;
     this.updatePreview();
   }
@@ -3172,6 +3173,17 @@ class ChatSettingsModal {
   updatePreview() {
     this.preview.style.setProperty('--chat-settings-preview-message-font-size', this.draftFontSizePx + 'px');
     this.preview.style.setProperty('--chat-settings-preview-message-meta-font-size', this.metaFontSizePx(this.draftFontSizePx) + 'px');
+  }
+
+  setSliderValue(value) {
+    this.fontSizeSlider.value = String(value);
+    this.syncSliderPosition(value);
+  }
+
+  syncSliderPosition(value) {
+    const range = this.maxFontSizePx - this.minFontSizePx;
+    const position = range === 0 ? 0 : ((value - this.minFontSizePx) / range) * 100;
+    this.fontSizeSlider.style.setProperty('--chat-settings-slider-position', position + '%');
   }
 
   applyChatFontSize() {
@@ -3217,7 +3229,7 @@ class ChatSettingsModal {
     this.modal.classList.remove('active');
     this.draftFontSizePx = this.savedFontSizePx;
     this.warningShown = false;
-    this.fontSizeSlider.value = String(this.savedFontSizePx);
+    this.setSliderValue(this.savedFontSizePx);
     this.updatePreview();
   }
 

--- a/app.js
+++ b/app.js
@@ -3171,10 +3171,13 @@ class ChatSettingsModal {
 
   updatePreview() {
     this.preview.style.setProperty('--chat-settings-preview-message-font-size', this.draftFontSizePx + 'px');
+    this.preview.style.setProperty('--chat-settings-preview-message-meta-font-size', this.metaFontSizePx(this.draftFontSizePx) + 'px');
   }
 
   applyChatFontSize() {
     document.documentElement.style.setProperty('--chat-message-font-size', this.savedFontSizePx + 'px');
+    document.documentElement.style.setProperty('--chat-message-detail-font-size', this.detailFontSizePx(this.savedFontSizePx) + 'px');
+    document.documentElement.style.setProperty('--chat-message-meta-font-size', this.metaFontSizePx(this.savedFontSizePx) + 'px');
   }
 
   readSavedFontSize() {
@@ -3186,6 +3189,14 @@ class ChatSettingsModal {
   clampFontSize(value) {
     if (!Number.isFinite(value)) return this.defaultFontSizePx;
     return Math.min(this.maxFontSizePx, Math.max(this.minFontSizePx, Math.round(value)));
+  }
+
+  detailFontSizePx(value) {
+    return Math.round(value * 0.875);
+  }
+
+  metaFontSizePx(value) {
+    return Math.round(value * 0.75);
   }
 
   hasUnsavedChanges() {
@@ -17113,10 +17124,10 @@ class ChatModal {
                     ${hasThumbnail ? '<div class="attachment-preview-hint">Click for options</div>' : ''}
                   </div>
                   <div style="min-width:0;">
-                    <span class="attachment-label" style="font-weight:500;color:#222;font-size:0.7em;display:block;word-wrap:break-word;">
+                    <span class="attachment-label" style="font-weight:500;color:#222;display:block;word-wrap:break-word;">
                       ${fileName}
                     </span><br>
-                    <span style="font-size: 0.93em; color: #888;">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
+                    <span class="attachment-meta" style="color: #888;">${fileType}${fileType && fileSize ? ' · ' : ''}${fileSize}</span>
                   </div>
                 </div>
               `;

--- a/index.html
+++ b/index.html
@@ -477,12 +477,12 @@
 
               <div class="chat-settings-font-slider-row">
                 <span class="chat-settings-font-label chat-settings-font-label-small">Aa</span>
-                <input type="range" id="chatSettingsFontSizeSlider" min="14" max="20" step="1" value="16" aria-label="Chat font size" />
+                <input type="range" id="chatSettingsFontSizeSlider" min="12" max="30" step="1" value="16" aria-label="Chat font size" />
                 <span class="chat-settings-font-label chat-settings-font-label-large">Aa</span>
               </div>
               <div class="chat-settings-slider-labels" aria-hidden="true">
                 <span>Small</span>
-                <span>Default</span>
+                <span>Medium</span>
                 <span>Large</span>
               </div>
 

--- a/styles.css
+++ b/styles.css
@@ -2507,10 +2507,70 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #chatSettingsFontSizeSlider {
-  accent-color: var(--primary-color);
+  --chat-settings-slider-position: 22.222%;
+  --chat-settings-slider-tick-color: rgba(31, 36, 48, 0.28);
+  appearance: none;
+  -webkit-appearance: none;
+  background:
+    repeating-linear-gradient(
+      to right,
+      var(--chat-settings-slider-tick-color) 0 1px,
+      transparent 1px calc(100% / 18)
+    ) center / 100% 14px no-repeat,
+    linear-gradient(
+      to right,
+      var(--primary-color) 0 var(--chat-settings-slider-position),
+      var(--border-color) var(--chat-settings-slider-position) 100%
+    ) center / 100% 4px no-repeat;
+  border-radius: 999px;
+  height: 28px;
   margin: 0;
   min-width: 0;
   width: 100%;
+}
+
+#chatSettingsFontSizeSlider:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 4px;
+}
+
+#chatSettingsFontSizeSlider::-webkit-slider-runnable-track {
+  background: transparent;
+  border: 0;
+  height: 28px;
+}
+
+#chatSettingsFontSizeSlider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--primary-color);
+  border: 0;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgba(31, 36, 48, 0.22);
+  cursor: pointer;
+  height: 22px;
+  margin-top: 3px;
+  width: 22px;
+}
+
+#chatSettingsFontSizeSlider::-moz-range-track {
+  background: transparent;
+  border: 0;
+  height: 28px;
+}
+
+#chatSettingsFontSizeSlider::-moz-range-progress {
+  background: transparent;
+}
+
+#chatSettingsFontSizeSlider::-moz-range-thumb {
+  background: var(--primary-color);
+  border: 0;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgba(31, 36, 48, 0.22);
+  cursor: pointer;
+  height: 22px;
+  width: 22px;
 }
 
 .chat-settings-slider-labels {

--- a/styles.css
+++ b/styles.css
@@ -2416,6 +2416,10 @@ input[type='file'].form-control::file-selector-button {
   hyphens: auto; /* Add hyphens at line breaks */
 }
 
+.messages-list .message-content {
+  font-size: var(--chat-message-font-size, var(--font-size-base));
+}
+
 .message-content a,
 .payment-memo,
 .payment-memo a {

--- a/styles.css
+++ b/styles.css
@@ -2416,10 +2416,6 @@ input[type='file'].form-control::file-selector-button {
   hyphens: auto; /* Add hyphens at line breaks */
 }
 
-.messages-list .message-content {
-  font-size: var(--chat-message-font-size, var(--font-size-base));
-}
-
 .message-content a,
 .payment-memo,
 .payment-memo a {
@@ -2449,6 +2445,7 @@ input[type='file'].form-control::file-selector-button {
 
 .chat-settings-preview {
   --chat-settings-preview-message-font-size: 16px;
+  --chat-settings-preview-message-meta-font-size: 12px;
   background: var(--hover-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -2482,6 +2479,10 @@ input[type='file'].form-control::file-selector-button {
 .chat-settings-preview .message-content {
   font-size: var(--chat-settings-preview-message-font-size);
   line-height: 1.35;
+}
+
+.chat-settings-preview .message-time {
+  font-size: var(--chat-settings-preview-message-meta-font-size);
 }
 
 .chat-settings-font-slider-row {
@@ -7840,6 +7841,39 @@ small {
 /* Make time display white on sent messages */
 .message.sent .voice-message-time-display {
   color: rgba(255, 255, 255, 0.9);
+}
+
+.messages-list .message-content,
+.messages-list .payment-header,
+.messages-list .payment-direction,
+.messages-list .payment-amount,
+.messages-list .attachment-label,
+.messages-list .call-message-text,
+.messages-list .voice-message-text,
+.messages-list .location-message-title,
+.message-input-container .message-input {
+  font-size: var(--chat-message-font-size, var(--font-size-base));
+}
+
+.messages-list .deleted-content,
+.messages-list .payment-memo,
+.messages-list .reply-quote-text,
+.messages-list .attachment-meta,
+.messages-list .call-message-schedule,
+.messages-list .voice-message-time-display,
+.message-input-container .attachment-item,
+.message-input-container .reply-preview-text {
+  font-size: var(--chat-message-detail-font-size, var(--font-size-sm));
+}
+
+.messages-list .message-time,
+.messages-list .reply-quote-label,
+.messages-list .attachment-preview-hint,
+.messages-list .location-message-coordinates,
+.messages-list .location-message-accuracy,
+.messages-list .location-message-link,
+.message-input-container .reply-preview-label {
+  font-size: var(--chat-message-meta-font-size, var(--font-size-xs));
 }
 
 /* Hide pulse rings when not recording */

--- a/styles.css
+++ b/styles.css
@@ -7936,6 +7936,10 @@ small {
   font-size: var(--chat-message-meta-font-size, var(--font-size-xs));
 }
 
+.messages-list .voice-message-time-display {
+  font-size: min(var(--chat-message-detail-font-size, var(--font-size-sm)), var(--font-size-sm));
+}
+
 /* Hide pulse rings when not recording */
 .recording-indicator:not(.recording) .pulse-ring {
   display: none;


### PR DESCRIPTION
## What Changed

This PR completes issue #1357 by saving the Chat font-size setting on the device and applying it to active chat-session text.

- `ChatSettingsModal` loads the saved font size from `localStorage`, clamps it to the slider range, and initializes the preview from that value.
- The Chat font-size slider now supports `12px` through `30px` in `1px` steps, with tick marks on the slider track to make each step easier to see.
- Saving the Chat setting writes the selected size back to `localStorage` and applies it immediately through chat font-size CSS variables.
- Active Chat modal text now uses the saved size across message bodies, timestamps, deleted text, payment text/memos, reply quotes, attachment row text, call labels/schedules, voice labels/capped durations, location message text, composer reply/attachment previews, and the message input.
- Main Chats list preview snippets remain out of scope and are tracked separately in #1360.

## Fixed Flow

1. Open Settings, then Chat.
2. Move the font-size slider and save the selection.
3. Existing and future active chat-session text uses the selected size on this device.
4. Reloading the app restores the saved value and applies it before chats are opened.

## Why

The first PR added the Chat settings modal and preview-only state. This keeps the second PR focused on device-local persistence and the active Chat modal rendering hookup without syncing the setting through account data or changing chat list preview rows.

## Validation

- `node --check app.js`
- `git diff --check`
- `git diff --check origin/main..HEAD`

Closes #1357