### PR TITLE
Compact chat message spacing

### DIFF
--- a/app.js
+++ b/app.js
@@ -17336,6 +17336,7 @@ class ChatModal {
 
     // Replace the list once to avoid one DOM mutation per message.
     this.messagesList.innerHTML = range.html;
+    this.syncAllRenderedReactionChips();
     const shouldKeepBottomAnchored = !skipAutoScroll && !highlightNewMessage;
 
     // --- 4.5. Load thumbnails for image attachments (async, non-blocking) ---
@@ -17358,7 +17359,6 @@ class ChatModal {
         if (!skipAutoScroll) {
           this.ensureScrollableChatRenderWindow();
         }
-        this.syncAllRenderedReactionChips();
       });
     });
 

--- a/app.js
+++ b/app.js
@@ -19109,6 +19109,7 @@ class ChatModal {
     if (existingContainer) {
       existingContainer.remove();
     }
+    messageEl.classList.remove('has-reactions');
 
     const messageRecord = this.getMessageRecordFromElement(messageEl);
     if (messageRecord && isDeleted(messageRecord)) {
@@ -19118,6 +19119,7 @@ class ChatModal {
     const reactionHtml = this.buildReactionChipsHTML(reactionsForTarget);
     if (!reactionHtml) return;
 
+    messageEl.classList.add('has-reactions');
     messageEl.insertAdjacentHTML('beforeend', reactionHtml);
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2277,7 +2277,7 @@ input[type='file'].form-control::file-selector-button {
 .messages-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.25rem;
   flex: 0 0 auto;
   min-height: 100%;
   padding-top: 1rem;
@@ -2292,10 +2292,14 @@ input[type='file'].form-control::file-selector-button {
   padding: 0.75rem 1rem;
   border-radius: 1rem;
   position: relative;
-  margin-bottom: 16px;
+  margin-bottom: 0;
   text-align: left;
   cursor: pointer;
   transition: filter 0.2s ease;
+}
+
+.message.has-reactions {
+  margin-bottom: 0.75rem;
 }
 
 .message:hover {


### PR DESCRIPTION
## What Changed

This PR tightens chat message spacing while preserving room for reaction chips only when a message has reactions.

- `.messages-list` uses a smaller default gap so more chat messages fit in the modal.
- `syncReactionChipsForMessage` toggles `has-reactions`, so only messages with visible reaction chips reserve extra space below the bubble.
- `appendChatModal` syncs existing reaction chips immediately after replacing the message list, before scroll anchoring and jump calculations run.

## Fixed Flow

1. A chat opens or re-renders with messages that already have reactions.
2. Reaction chips are attached and `has-reactions` spacing is applied before scroll height and offset measurements.
3. Bottom anchoring, auto-expand, and highlight/jump positioning use the final message layout.
4. Compact spacing is preserved for normal messages without clipping reaction chips.

## Why

The spacing change made reacted messages reserve extra height, but applying that height after scroll calculations could leave the chat slightly off the intended bottom or target message. Moving the existing chip sync earlier fixes the timing issue without changing the reaction rendering/update model; live reaction changes still use the targeted sync path.

## Validation

- `node --check app.js`

Closes #1361