### PR TITLE
Copy Google Maps URLs from location messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -18723,7 +18723,7 @@ class ChatModal {
       if (replyOption) replyOption.style.display = 'flex';
       if (editOption) editOption.style.display = 'none';
     } else if (isLocation) {
-      if (copyOption) copyOption.style.display = 'none';
+      if (copyOption) copyOption.style.display = 'flex';
       if (inviteOption) inviteOption.style.display = 'none';
       if (joinOption) joinOption.style.display = 'none';
       if (replyOption) replyOption.style.display = 'flex';
@@ -20636,6 +20636,23 @@ class ChatModal {
     }
 
     const isPayment = messageEl.classList.contains('payment-info');
+    const locationLink = messageEl.querySelector('.location-message-summary');
+    if (locationLink) {
+      const mapUrl = locationLink.getAttribute('href')?.trim();
+      if (!mapUrl) {
+        return showToast('No location URL to copy', 2000, 'info');
+      }
+
+      try {
+        await navigator.clipboard.writeText(mapUrl);
+        showToast('Location URL copied to clipboard', 2000, 'success');
+      } catch (err) {
+        console.error('Failed to copy:', err);
+        showToast('Failed to copy location URL', 0, 'error');
+      }
+      return;
+    }
+
     const selector = isPayment ? '.payment-memo' : '.message-content';
     const contentType = isPayment ? 'Memo' : 'Message';
     const contentEl = messageEl.querySelector(selector);

--- a/app.js
+++ b/app.js
@@ -18656,6 +18656,7 @@ class ChatModal {
     // If this is a call message, show call-specific options and hide copy
     const isCall = !!messageEl.querySelector('.call-message');
     const isVoice = !!messageEl.querySelector('.voice-message');
+    const isLocation = !!messageEl.querySelector('.location-message');
     const copyOption = this.contextMenu.querySelector('[data-action="copy"]');
     const joinOption = this.contextMenu.querySelector('[data-action="join"]');
     const inviteOption = this.contextMenu.querySelector('[data-action="call-invite"]');
@@ -18720,6 +18721,13 @@ class ChatModal {
       if (inviteOption) inviteOption.style.display = 'none';
       if (joinOption) joinOption.style.display = 'none';
       if (replyOption) replyOption.style.display = 'flex';
+      if (editOption) editOption.style.display = 'none';
+    } else if (isLocation) {
+      if (copyOption) copyOption.style.display = 'none';
+      if (inviteOption) inviteOption.style.display = 'none';
+      if (joinOption) joinOption.style.display = 'none';
+      if (replyOption) replyOption.style.display = 'flex';
+      if (editResendOption) editResendOption.style.display = 'none';
       if (editOption) editOption.style.display = 'none';
     } else {
       if (copyOption) copyOption.style.display = 'flex';


### PR DESCRIPTION
## What Changed

This PR keeps location-message Copy available and makes it copy the Google Maps URL for the shared location.

- `showMessageContextMenu` now shows `Copy` for rendered location messages while continuing to hide `Edit` and other non-applicable actions.
- `copyMessageContent` detects `.location-message-summary` and copies its `href`, so the clipboard receives the same Google Maps URL that the location card opens.
- Direct clicks on the location card still open Google Maps, and Reply/Delete behavior remains unchanged.

## Fixed Flow

1. User opens the context menu on a location message.
2. The menu identifies the message as a location message.
3. `Copy` remains available while `Edit` stays hidden.
4. Selecting `Copy` writes the location card Google Maps URL to the clipboard for sharing elsewhere.

## Why

Location messages are rendered as a Google Maps link rather than editable text. Hiding `Edit` prevents an unsupported action, but keeping `Copy` is useful when users want to share the same map URL outside the chat.

## Validation

- `node --check app.js`

Closes #1364