### PR TITLE
Persist update_toll_required events in chat history

### DIFF
--- a/app.js
+++ b/app.js
@@ -6833,8 +6833,8 @@ function getUpdateTollRequiredPreviewText(item, contact) {
   const statusLabel = getRequiredStatusLabel(item.required);
   const contactName = getContactDisplayName(contact);
   return item.my
-    ? `You changed status to ${statusLabel}`
-    : `${contactName} changed status to ${statusLabel}`;
+    ? `You changed ${contactName}'s status to ${statusLabel}`
+    : `${contactName} changed your status to ${statusLabel}`;
 }
 
 function buildUpdateTollRequiredHistoryItem(tx, txid, currentUserAddress) {
@@ -7335,7 +7335,9 @@ async function processChats(chats, keys) {
           const statusContact = myData.contacts[statusContactAddress];
           const alreadyExists = statusContact.messages.some((messageTx) => messageTx.txid === txidHex);
           const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, txidHex, currentUserAddress);
-          applyUpdateTollRequiredState(statusContact, statusHistoryItem);
+          if (!statusHistoryItem.my) {
+            applyUpdateTollRequiredState(statusContact, statusHistoryItem);
+          }
 
           if (!alreadyExists) {
             insertSorted(statusContact.messages, statusHistoryItem, 'timestamp');
@@ -7344,8 +7346,10 @@ async function processChats(chats, keys) {
           }
 
           if (chatModal.isActive() && chatModal.address === statusContactAddress) {
-            chatModal.blockedByRecipient = Number(statusContact.tollRequiredToSend) === 2;
-            chatModal.updateTollAmountUI(statusContactAddress);
+            if (!statusHistoryItem.my) {
+              chatModal.blockedByRecipient = Number(statusContact.tollRequiredToSend) === 2;
+              chatModal.updateTollAmountUI(statusContactAddress);
+            }
             chatModal.appendChatModal();
           }
 

--- a/app.js
+++ b/app.js
@@ -6839,20 +6839,15 @@ function getUpdateTollRequiredPreviewText(item, contact) {
 
 function buildUpdateTollRequiredHistoryItem(tx, txid, currentUserAddress) {
   const required = Number(tx.required);
-  const chatTimestamp = Number(tx.chatTimestamp) || 0;
   const item = {
     type: 'update_toll_required',
     txid,
-    timestamp: chatTimestamp || Number(tx.timestamp) || 0,
+    timestamp: Number(tx.timestamp) || 0,
     my: normalizeAddress(tx.from) === currentUserAddress,
     from: normalizeAddress(tx.from),
     to: normalizeAddress(tx.to),
     required
   };
-
-  if (chatTimestamp) {
-    item.chatTimestamp = chatTimestamp;
-  }
 
   if (isValidRequiredValue(tx.previousRequired)) {
     item.previousRequired = Number(tx.previousRequired);

--- a/app.js
+++ b/app.js
@@ -1763,6 +1763,8 @@ class ChatsScreen {
         previewHTML = `<span><i>Voice message</i></span>`;
       } else if (latestActivity.type === 'location') {
         previewHTML = `<span><i>Shared location</i></span>`;
+      } else if (latestActivity.type === 'update_toll_required') {
+        previewHTML = truncateMessage(escapeHtml(getUpdateTollRequiredPreviewText(latestActivity, contact)), 50);
       } else if ((!latestActivity.message || String(latestActivity.message).trim() === '') && latestActivity.xattach) {
         previewHTML = `<span><i>Attachment</i></span>`;
       } else if (latestActivity.xattach && latestActivity.message && String(latestActivity.message).trim() !== '') {
@@ -6772,6 +6774,10 @@ function getReactionTargetPreviewText(message) {
     return getDeletedPlaceholderText(message);
   }
 
+  if (message.type === 'update_toll_required') {
+    return 'status change';
+  }
+
   if (message.type === 'call') {
     return 'call';
   }
@@ -6798,6 +6804,67 @@ function getReactionTargetPreviewText(message) {
   }
 
   return '[message]';
+}
+
+function isValidRequiredValue(required) {
+  if (required === null || typeof required === 'undefined') {
+    return false;
+  }
+  if (typeof required === 'string' && required.trim() === '') {
+    return false;
+  }
+  const requiredNum = Number(required);
+  return Number.isInteger(requiredNum) && [0, 1, 2].includes(requiredNum);
+}
+
+function requiredToFriendStatus(required) {
+  const requiredNum = Number(required);
+  return requiredNum === 0 ? 2 : requiredNum === 2 ? 0 : 1;
+}
+
+function getRequiredStatusLabel(required) {
+  const requiredNum = Number(required);
+  if (requiredNum === 0) return 'Connection';
+  if (requiredNum === 2) return 'Blocked';
+  return 'Other';
+}
+
+function getUpdateTollRequiredPreviewText(item, contact) {
+  const statusLabel = getRequiredStatusLabel(item.required);
+  const contactName = getContactDisplayName(contact);
+  return item.my
+    ? `You changed status to ${statusLabel}`
+    : `${contactName} changed status to ${statusLabel}`;
+}
+
+function buildUpdateTollRequiredHistoryItem(tx, txid, currentUserAddress) {
+  const required = Number(tx.required);
+  const item = {
+    type: 'update_toll_required',
+    txid,
+    timestamp: Number(tx.timestamp) || 0,
+    my: normalizeAddress(tx.from) === currentUserAddress,
+    from: normalizeAddress(tx.from),
+    to: normalizeAddress(tx.to),
+    required
+  };
+
+  if (isValidRequiredValue(tx.previousRequired)) {
+    item.previousRequired = Number(tx.previousRequired);
+  }
+
+  return item;
+}
+
+function applyUpdateTollRequiredState(contact, historyItem) {
+  if (historyItem.my) {
+    contact.tollRequiredToReceive = historyItem.required;
+    contact.friend = requiredToFriendStatus(historyItem.required);
+    contact.friendOld = contact.friend;
+    return;
+  }
+
+  contact.tollRequiredToSend = historyItem.required;
 }
 
 /**
@@ -7157,6 +7224,7 @@ async function processChats(chats, keys) {
       const pendingReactionControls = [];
       let didApplyPendingReaction = false;
       let didChangeReactionPreview = false;
+      let didApplyStatusChange = false;
       const touchedReactionTargetTxids = new Set();
 
       // This check determines if we're currently chatting with the sender
@@ -7182,6 +7250,55 @@ async function processChats(chats, keys) {
             useTxTimestamp = true;
           }
         }
+
+        if (tx.type === 'update_toll_required') {
+          if (!isValidRequiredValue(tx.required)) {
+            console.warn('Ignoring update_toll_required with unknown required value', tx);
+            continue;
+          }
+          if (tx.previousRequired !== undefined && !isValidRequiredValue(tx.previousRequired)) {
+            console.warn('Ignoring update_toll_required with unknown previousRequired value', tx);
+            continue;
+          }
+          if (tx.chatId && tx.chatId !== chats[sender]) {
+            console.warn('Ignoring update_toll_required with mismatched chatId', tx);
+            continue;
+          }
+
+          const txFrom = normalizeAddress(tx.from);
+          const txTo = normalizeAddress(tx.to);
+          if (txFrom !== currentUserAddress && txTo !== currentUserAddress) {
+            continue;
+          }
+
+          const statusContactAddress = txFrom === currentUserAddress ? txTo : txFrom;
+          if (!statusContactAddress || statusContactAddress === currentUserAddress) {
+            continue;
+          }
+          if (!myData.contacts[statusContactAddress]) {
+            createNewContact(statusContactAddress, undefined, 1, false);
+          }
+
+          const statusContact = myData.contacts[statusContactAddress];
+          const alreadyExists = statusContact.messages.some((messageTx) => messageTx.txid === txidHex);
+          const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, txidHex, currentUserAddress);
+          applyUpdateTollRequiredState(statusContact, statusHistoryItem);
+
+          if (!alreadyExists) {
+            insertSorted(statusContact.messages, statusHistoryItem, 'timestamp');
+            syncChatLatestActivityTimestamp(statusContactAddress, statusContact);
+            didApplyStatusChange = true;
+          }
+
+          if (chatModal.isActive() && chatModal.address === statusContactAddress) {
+            chatModal.blockedByRecipient = Number(statusContact.tollRequiredToSend) === 2;
+            chatModal.updateTollAmountUI(statusContactAddress);
+            chatModal.appendChatModal();
+          }
+
+          continue;
+        }
+
         if (tx.type == 'message') {
           // Handle messages without xmessage (same as transfer handling)
           // Ensure payload is always an object, even if xmessage is null/undefined
@@ -7836,6 +7953,10 @@ async function processChats(chats, keys) {
       }
 
       if (didChangeReactionPreview && chatsScreen.isActive() && !inActiveChatWithSender) {
+        chatsScreen.updateChatList();
+      }
+
+      if (didApplyStatusChange && chatsScreen.isActive()) {
         chatsScreen.updateChatList();
       }
 
@@ -17064,6 +17185,10 @@ class ChatModal {
     // Add txid attribute if available
     const txidAttribute = item.txid ? `data-txid="${item.txid}"` : '';
     const statusAttribute = item.status ? `data-status="${item.status}"` : '';
+
+    if (item.type === 'update_toll_required') {
+      return '';
+    }
 
     // Check if it's a payment based on the presence of the amount property (BigInt)
     if (typeof item.amount === 'bigint') {

--- a/app.js
+++ b/app.js
@@ -15941,6 +15941,10 @@ class ChatModal {
 
     // Find the last relevant message
     const lastChatMessage = contact.messages.find((message) => {
+      if (message.type === 'update_toll_required') {
+        return false;
+      }
+
       // Skip payment-only messages
       if (message.amount) {
         return false;

--- a/app.js
+++ b/app.js
@@ -7278,6 +7278,8 @@ async function processChats(chats, keys) {
       let didApplyPendingReaction = false;
       let didChangeReactionPreview = false;
       let didApplyStatusChange = false;
+      let needsStatusChatRefresh = false;
+      const contactStatusStateUpdates = new Map();
       const touchedReactionTargetTxids = new Set();
 
       // This check determines if we're currently chatting with the sender
@@ -7335,8 +7337,15 @@ async function processChats(chats, keys) {
           const statusContact = myData.contacts[statusContactAddress];
           const alreadyExists = statusContact.messages.some((messageTx) => messageTx.txid === txidHex);
           const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, txidHex, currentUserAddress);
-          if (!statusHistoryItem.my) {
-            applyUpdateTollRequiredState(statusContact, statusHistoryItem);
+          if (!statusHistoryItem.my && !alreadyExists) {
+            const existingStatusUpdate = contactStatusStateUpdates.get(statusContactAddress);
+            if (
+              !existingStatusUpdate ||
+              statusHistoryItem.timestamp > existingStatusUpdate.timestamp ||
+              (statusHistoryItem.timestamp === existingStatusUpdate.timestamp && statusHistoryItem.txid > existingStatusUpdate.txid)
+            ) {
+              contactStatusStateUpdates.set(statusContactAddress, statusHistoryItem);
+            }
           }
 
           if (!alreadyExists) {
@@ -7346,11 +7355,7 @@ async function processChats(chats, keys) {
           }
 
           if (chatModal.isActive() && chatModal.address === statusContactAddress) {
-            if (!statusHistoryItem.my) {
-              chatModal.blockedByRecipient = Number(statusContact.tollRequiredToSend) === 2;
-              chatModal.updateTollAmountUI(statusContactAddress);
-            }
-            chatModal.appendChatModal();
+            needsStatusChatRefresh = true;
           }
 
           continue;
@@ -7932,6 +7937,22 @@ async function processChats(chats, keys) {
             hasNewTransfer = true;
           }
         }
+      }
+
+      for (const [statusContactAddress, statusHistoryItem] of contactStatusStateUpdates) {
+        const statusContact = myData.contacts[statusContactAddress];
+        if (!statusContact) {
+          continue;
+        }
+        applyUpdateTollRequiredState(statusContact, statusHistoryItem);
+        if (chatModal.isActive() && chatModal.address === statusContactAddress) {
+          chatModal.blockedByRecipient = Number(statusContact.tollRequiredToSend) === 2;
+          chatModal.updateTollAmountUI(statusContactAddress);
+        }
+      }
+
+      if (needsStatusChatRefresh && chatModal.isActive()) {
+        chatModal.appendChatModal();
       }
 
       if (pendingReactionControls.length > 0) {

--- a/app.js
+++ b/app.js
@@ -6867,47 +6867,15 @@ function applyUpdateTollRequiredState(contact, historyItem) {
   contact.tollRequiredToSend = historyItem.required;
 }
 
-function compareUpdateTollRequiredHistoryItems(left, right) {
-  const timestampDiff = Number(left?.timestamp || 0) - Number(right?.timestamp || 0);
-  if (timestampDiff !== 0) {
-    return timestampDiff;
-  }
-  return String(left?.txid || '').localeCompare(String(right?.txid || ''));
-}
-
-function upsertLatestUpdateTollRequiredHistoryItem(contact, historyItem) {
+function insertUpdateTollRequiredHistoryItem(contact, historyItem) {
   contact.messages ??= [];
 
-  const existingStatusItems = contact.messages.filter((message) => message.type === 'update_toll_required');
-  let newestStatusItem = historyItem;
-  for (const existingStatusItem of existingStatusItems) {
-    if (compareUpdateTollRequiredHistoryItems(existingStatusItem, newestStatusItem) > 0) {
-      newestStatusItem = existingStatusItem;
-    }
-  }
-
-  const previousMessages = contact.messages;
-  let keptStatusItem = false;
-  contact.messages = previousMessages.filter((message) => {
-    if (message.type !== 'update_toll_required') {
-      return true;
-    }
-    if (!keptStatusItem && message.txid === newestStatusItem.txid) {
-      keptStatusItem = true;
-      return true;
-    }
+  if (contact.messages.some((message) => message.txid === historyItem.txid)) {
     return false;
-  });
-
-  if (!keptStatusItem) {
-    insertSorted(contact.messages, newestStatusItem, 'timestamp');
   }
 
-  return {
-    didChange: previousMessages.length !== contact.messages.length || !keptStatusItem,
-    incomingIsNewest: newestStatusItem.txid === historyItem.txid,
-    storedItem: newestStatusItem
-  };
+  insertSorted(contact.messages, historyItem, 'timestamp');
+  return true;
 }
 
 function syncPendingUpdateTollRequiredSuccess(pendingTxInfo, receiptTx) {
@@ -6944,13 +6912,10 @@ function syncPendingUpdateTollRequiredSuccess(pendingTxInfo, receiptTx) {
   contact.messages ??= [];
 
   const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, pendingTxInfo.txid, currentUserAddress);
-  const statusHistoryUpdate = upsertLatestUpdateTollRequiredHistoryItem(contact, statusHistoryItem);
+  const didInsertStatusHistory = insertUpdateTollRequiredHistoryItem(contact, statusHistoryItem);
+  applyUpdateTollRequiredState(contact, statusHistoryItem);
 
-  if (statusHistoryUpdate.incomingIsNewest) {
-    applyUpdateTollRequiredState(contact, statusHistoryItem);
-  }
-
-  if (statusHistoryUpdate.didChange) {
+  if (didInsertStatusHistory) {
     syncChatLatestActivityTimestamp(contactAddress, contact);
   }
 
@@ -7381,8 +7346,8 @@ async function processChats(chats, keys) {
 
           const statusContact = myData.contacts[statusContactAddress];
           const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, txidHex, currentUserAddress);
-          const statusHistoryUpdate = upsertLatestUpdateTollRequiredHistoryItem(statusContact, statusHistoryItem);
-          if (!statusHistoryItem.my && statusHistoryUpdate.incomingIsNewest) {
+          const didInsertStatusHistory = insertUpdateTollRequiredHistoryItem(statusContact, statusHistoryItem);
+          if (!statusHistoryItem.my && didInsertStatusHistory) {
             const existingStatusUpdate = contactStatusStateUpdates.get(statusContactAddress);
             if (
               !existingStatusUpdate ||
@@ -7393,7 +7358,7 @@ async function processChats(chats, keys) {
             }
           }
 
-          if (statusHistoryUpdate.didChange) {
+          if (didInsertStatusHistory) {
             syncChatLatestActivityTimestamp(statusContactAddress, statusContact);
             didApplyStatusChange = true;
           }

--- a/app.js
+++ b/app.js
@@ -6867,6 +6867,59 @@ function applyUpdateTollRequiredState(contact, historyItem) {
   contact.tollRequiredToSend = historyItem.required;
 }
 
+function syncPendingUpdateTollRequiredSuccess(pendingTxInfo, receiptTx) {
+  const receiptHasStatusTx = receiptTx?.type === 'update_toll_required'
+    && isValidRequiredValue(receiptTx.required)
+    && receiptTx.from
+    && receiptTx.to;
+  const tx = receiptHasStatusTx
+    ? receiptTx
+    : pendingTxInfo.updateTollRequiredTx;
+
+  if (!tx || !isValidRequiredValue(tx.required)) {
+    const contact = myData.contacts?.[pendingTxInfo.to];
+    if (contact) {
+      contact.friendOld = contact.friend;
+    }
+    return;
+  }
+
+  const currentUserAddress = normalizeAddress(myAccount.keys.address);
+  const txFrom = normalizeAddress(tx.from);
+  const txTo = normalizeAddress(tx.to);
+  const contactAddress = txFrom === currentUserAddress ? txTo : txFrom;
+
+  if (!contactAddress || contactAddress === currentUserAddress) {
+    return;
+  }
+
+  if (!myData.contacts[contactAddress]) {
+    createNewContact(contactAddress, undefined, 1, false);
+  }
+
+  const contact = myData.contacts[contactAddress];
+  contact.messages ??= [];
+
+  const alreadyExists = contact.messages.some((messageTx) => messageTx.txid === pendingTxInfo.txid);
+  const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, pendingTxInfo.txid, currentUserAddress);
+  applyUpdateTollRequiredState(contact, statusHistoryItem);
+
+  if (!alreadyExists) {
+    insertSorted(contact.messages, statusHistoryItem, 'timestamp');
+    syncChatLatestActivityTimestamp(contactAddress, contact);
+  }
+
+  if (chatModal.isActive() && chatModal.address === contactAddress) {
+    chatModal.blockedByRecipient = Number(contact.tollRequiredToSend) === 2;
+    chatModal.updateTollAmountUI(contactAddress);
+    chatModal.appendChatModal();
+  }
+
+  if (chatsScreen.isActive()) {
+    chatsScreen.updateChatList();
+  }
+}
+
 /**
  * Returns the newest valid reaction activity for chat-list preview purposes.
  * @param {Object} contact
@@ -8408,6 +8461,9 @@ async function injectTx(tx, txid) {
         pendingTxData.address = tx.from; // User's address (longAddress form)
       } else if (tx.type === 'update_toll_required' || tx.type === 'reclaim_toll') {
         pendingTxData.to = normalizeAddress(tx.to);
+        if (tx.type === 'update_toll_required') {
+          pendingTxData.updateTollRequiredTx = tx;
+        }
       } else if (tx.type === 'read') {
         pendingTxData.oldContactTimestamp = tx.oldContactTimestamp;
       } else if (tx.type === 'message' || tx.type === 'transfer') {
@@ -29649,7 +29705,7 @@ async function checkPendingTransactions() {
         if (type === 'update_toll_required') {
           // log used by e2e tests do not delete
           console.log(`DEBUG: update_toll_required transaction successfully processed!`);
-          myData.contacts[pendingTxInfo.to].friendOld = myData.contacts[pendingTxInfo.to].friend;
+          syncPendingUpdateTollRequiredSuccess(pendingTxInfo, res.transaction);
         }
 
         if (type === 'read') {

--- a/app.js
+++ b/app.js
@@ -6867,6 +6867,49 @@ function applyUpdateTollRequiredState(contact, historyItem) {
   contact.tollRequiredToSend = historyItem.required;
 }
 
+function compareUpdateTollRequiredHistoryItems(left, right) {
+  const timestampDiff = Number(left?.timestamp || 0) - Number(right?.timestamp || 0);
+  if (timestampDiff !== 0) {
+    return timestampDiff;
+  }
+  return String(left?.txid || '').localeCompare(String(right?.txid || ''));
+}
+
+function upsertLatestUpdateTollRequiredHistoryItem(contact, historyItem) {
+  contact.messages ??= [];
+
+  const existingStatusItems = contact.messages.filter((message) => message.type === 'update_toll_required');
+  let newestStatusItem = historyItem;
+  for (const existingStatusItem of existingStatusItems) {
+    if (compareUpdateTollRequiredHistoryItems(existingStatusItem, newestStatusItem) > 0) {
+      newestStatusItem = existingStatusItem;
+    }
+  }
+
+  const previousMessages = contact.messages;
+  let keptStatusItem = false;
+  contact.messages = previousMessages.filter((message) => {
+    if (message.type !== 'update_toll_required') {
+      return true;
+    }
+    if (!keptStatusItem && message.txid === newestStatusItem.txid) {
+      keptStatusItem = true;
+      return true;
+    }
+    return false;
+  });
+
+  if (!keptStatusItem) {
+    insertSorted(contact.messages, newestStatusItem, 'timestamp');
+  }
+
+  return {
+    didChange: previousMessages.length !== contact.messages.length || !keptStatusItem,
+    incomingIsNewest: newestStatusItem.txid === historyItem.txid,
+    storedItem: newestStatusItem
+  };
+}
+
 function syncPendingUpdateTollRequiredSuccess(pendingTxInfo, receiptTx) {
   const receiptHasStatusTx = receiptTx?.type === 'update_toll_required'
     && isValidRequiredValue(receiptTx.required)
@@ -6900,12 +6943,14 @@ function syncPendingUpdateTollRequiredSuccess(pendingTxInfo, receiptTx) {
   const contact = myData.contacts[contactAddress];
   contact.messages ??= [];
 
-  const alreadyExists = contact.messages.some((messageTx) => messageTx.txid === pendingTxInfo.txid);
   const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, pendingTxInfo.txid, currentUserAddress);
-  applyUpdateTollRequiredState(contact, statusHistoryItem);
+  const statusHistoryUpdate = upsertLatestUpdateTollRequiredHistoryItem(contact, statusHistoryItem);
 
-  if (!alreadyExists) {
-    insertSorted(contact.messages, statusHistoryItem, 'timestamp');
+  if (statusHistoryUpdate.incomingIsNewest) {
+    applyUpdateTollRequiredState(contact, statusHistoryItem);
+  }
+
+  if (statusHistoryUpdate.didChange) {
     syncChatLatestActivityTimestamp(contactAddress, contact);
   }
 
@@ -7335,9 +7380,9 @@ async function processChats(chats, keys) {
           }
 
           const statusContact = myData.contacts[statusContactAddress];
-          const alreadyExists = statusContact.messages.some((messageTx) => messageTx.txid === txidHex);
           const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, txidHex, currentUserAddress);
-          if (!statusHistoryItem.my && !alreadyExists) {
+          const statusHistoryUpdate = upsertLatestUpdateTollRequiredHistoryItem(statusContact, statusHistoryItem);
+          if (!statusHistoryItem.my && statusHistoryUpdate.incomingIsNewest) {
             const existingStatusUpdate = contactStatusStateUpdates.get(statusContactAddress);
             if (
               !existingStatusUpdate ||
@@ -7348,8 +7393,7 @@ async function processChats(chats, keys) {
             }
           }
 
-          if (!alreadyExists) {
-            insertSorted(statusContact.messages, statusHistoryItem, 'timestamp');
+          if (statusHistoryUpdate.didChange) {
             syncChatLatestActivityTimestamp(statusContactAddress, statusContact);
             didApplyStatusChange = true;
           }

--- a/app.js
+++ b/app.js
@@ -6856,11 +6856,24 @@ function buildUpdateTollRequiredHistoryItem(tx, txid, currentUserAddress) {
   return item;
 }
 
-function applyUpdateTollRequiredState(contact, historyItem) {
+function isNewerUpdateTollRequiredHistoryItem(candidate, current) {
+  if (!current) return true;
+  if (candidate.timestamp !== current.timestamp) {
+    return candidate.timestamp > current.timestamp;
+  }
+  return candidate.txid > current.txid;
+}
+
+function applyUpdateTollRequiredState(contact, historyItem, options = {}) {
   if (historyItem.my) {
+    const { preservePendingFriend = false } = options;
     contact.tollRequiredToReceive = historyItem.required;
-    contact.friend = requiredToFriendStatus(historyItem.required);
-    contact.friendOld = contact.friend;
+    if (preservePendingFriend && contact.friend !== contact.friendOld) {
+      return;
+    }
+    const friendStatus = requiredToFriendStatus(historyItem.required);
+    contact.friend = friendStatus;
+    contact.friendOld = friendStatus;
     return;
   }
 
@@ -7289,7 +7302,8 @@ async function processChats(chats, keys) {
       let didChangeReactionPreview = false;
       let didApplyStatusChange = false;
       let needsStatusChatRefresh = false;
-      const contactStatusStateUpdates = new Map();
+      let myStatusUpdate = null;
+      let contactStatusUpdate = null;
       const touchedReactionTargetTxids = new Set();
 
       // This check determines if we're currently chatting with the sender
@@ -7347,14 +7361,11 @@ async function processChats(chats, keys) {
           const statusContact = myData.contacts[statusContactAddress];
           const statusHistoryItem = buildUpdateTollRequiredHistoryItem(tx, txidHex, currentUserAddress);
           const didInsertStatusHistory = insertUpdateTollRequiredHistoryItem(statusContact, statusHistoryItem);
-          if (!statusHistoryItem.my && didInsertStatusHistory) {
-            const existingStatusUpdate = contactStatusStateUpdates.get(statusContactAddress);
-            if (
-              !existingStatusUpdate ||
-              statusHistoryItem.timestamp > existingStatusUpdate.timestamp ||
-              (statusHistoryItem.timestamp === existingStatusUpdate.timestamp && statusHistoryItem.txid > existingStatusUpdate.txid)
-            ) {
-              contactStatusStateUpdates.set(statusContactAddress, statusHistoryItem);
+          if (didInsertStatusHistory) {
+            if (statusHistoryItem.my && isNewerUpdateTollRequiredHistoryItem(statusHistoryItem, myStatusUpdate)) {
+              myStatusUpdate = statusHistoryItem;
+            } else if (!statusHistoryItem.my && isNewerUpdateTollRequiredHistoryItem(statusHistoryItem, contactStatusUpdate)) {
+              contactStatusUpdate = statusHistoryItem;
             }
           }
 
@@ -7948,15 +7959,24 @@ async function processChats(chats, keys) {
         }
       }
 
-      for (const [statusContactAddress, statusHistoryItem] of contactStatusStateUpdates) {
-        const statusContact = myData.contacts[statusContactAddress];
-        if (!statusContact) {
-          continue;
+      if (myStatusUpdate || contactStatusUpdate) {
+        const previousFriend = contact.friend;
+
+        if (myStatusUpdate) {
+          applyUpdateTollRequiredState(contact, myStatusUpdate, { preservePendingFriend: true });
         }
-        applyUpdateTollRequiredState(statusContact, statusHistoryItem);
-        if (chatModal.isActive() && chatModal.address === statusContactAddress) {
-          chatModal.blockedByRecipient = Number(statusContact.tollRequiredToSend) === 2;
-          chatModal.updateTollAmountUI(statusContactAddress);
+
+        if (contactStatusUpdate) {
+          applyUpdateTollRequiredState(contact, contactStatusUpdate);
+        }
+
+        if (chatModal.isActive() && chatModal.address === from) {
+          chatModal.blockedByRecipient = Number(contact.tollRequiredToSend) === 2;
+          chatModal.updateTollAmountUI(from);
+
+          if (myStatusUpdate && contact.friend !== previousFriend) {
+            friendModal.updateFriendButton(contact, 'addFriendButtonChat');
+          }
         }
       }
 

--- a/app.js
+++ b/app.js
@@ -6839,15 +6839,20 @@ function getUpdateTollRequiredPreviewText(item, contact) {
 
 function buildUpdateTollRequiredHistoryItem(tx, txid, currentUserAddress) {
   const required = Number(tx.required);
+  const chatTimestamp = Number(tx.chatTimestamp) || 0;
   const item = {
     type: 'update_toll_required',
     txid,
-    timestamp: Number(tx.timestamp) || 0,
+    timestamp: chatTimestamp || Number(tx.timestamp) || 0,
     my: normalizeAddress(tx.from) === currentUserAddress,
     from: normalizeAddress(tx.from),
     to: normalizeAddress(tx.to),
     required
   };
+
+  if (chatTimestamp) {
+    item.chatTimestamp = chatTimestamp;
+  }
 
   if (isValidRequiredValue(tx.previousRequired)) {
     item.previousRequired = Number(tx.previousRequired);

--- a/app.js
+++ b/app.js
@@ -6826,7 +6826,7 @@ function getRequiredStatusLabel(required) {
   const requiredNum = Number(required);
   if (requiredNum === 0) return 'Connection';
   if (requiredNum === 2) return 'Blocked';
-  return 'Other';
+  return 'Tolled';
 }
 
 function getUpdateTollRequiredPreviewText(item, contact) {


### PR DESCRIPTION
## Summary
- handle backend-returned update_toll_required txs in processChats before encrypted message/transfer handling
- validate and store status events in contact.messages with txid, timestamp, my/from/to, required, and previousRequired
- update local toll/friend state and chat latest activity without incrementing unread counts, notification badges, or sounds
- keep status events from rendering as empty chat bubbles until the companion rendering issue lands

## Verification
- node --check app.js
- git diff --check

Closes #1373
Related to #1300
Backend support: Liberdus/server#88