### PR TITLE
Render update_toll_required status dividers

### DIFF
--- a/app.js
+++ b/app.js
@@ -17265,7 +17265,12 @@ class ChatModal {
     const statusAttribute = item.status ? `data-status="${item.status}"` : '';
 
     if (item.type === 'update_toll_required') {
-      return '';
+      const statusText = escapeHtml(getUpdateTollRequiredPreviewText(item, contact));
+      return `
+          <div class="update-toll-required-divider" ${timestampAttribute} ${txidAttribute} role="status">
+            <span class="update-toll-required-text">${statusText}</span>
+          </div>
+        `;
     }
 
     // Check if it's a payment based on the presence of the amount property (BigInt)

--- a/styles.css
+++ b/styles.css
@@ -2287,6 +2287,44 @@ input[type='file'].form-control::file-selector-button {
   margin-top: auto;
 }
 
+.messages-list > .update-toll-required-divider:first-child {
+  margin-top: auto;
+}
+
+.update-toll-required-divider {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 100%;
+  margin: 0.5rem 0;
+  color: var(--secondary-text-color);
+  cursor: default;
+  text-align: center;
+  user-select: text;
+}
+
+.update-toll-required-divider::before,
+.update-toll-required-divider::after {
+  content: '';
+  flex: 1 1 auto;
+  min-width: 1.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.update-toll-required-text {
+  flex: 0 1 auto;
+  max-width: min(80%, 420px);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.update-toll-required-divider.highlighted .update-toll-required-text {
+  color: var(--text-color);
+}
+
 .message {
   max-width: 80%;
   padding: 0.75rem 1rem;


### PR DESCRIPTION
## Summary
- render saved update_toll_required history items as centered status dividers instead of chat bubbles
- reuse the status preview copy for Connection/Other/Blocked labels with escaped render output
- style dividers with muted text and horizontal rules while keeping them outside normal message actions

## Review notes
- This is stacked on #1375, which persists the backend-returned events and updates chat-list previews/local state for #1373.
- Status dividers intentionally do not use the .message class, so reactions/edit/delete/context-menu/attachments do not attach.

## Verification
- node --check app.js
- git diff --check

Closes #1374
Depends on #1375
Related to #1300
Backend support: Liberdus/server#88