### PR TITLE
Preserve composer state when staging locations

### DIFF
--- a/app.js
+++ b/app.js
@@ -15037,8 +15037,8 @@ class ChatModal {
       if (this.headerContextMenu && !this.headerContextMenu.contains(e.target) && this.headerMenuButton && !this.headerMenuButton.contains(e.target)) {
         this.closeHeaderContextMenu();
       }
-      this.handleLocationUiOutsideClick(e);
     });
+    document.addEventListener('click', (e) => this.handleLocationUiOutsideClick(e), true);
     this.sendButton.addEventListener('click', withButtonCooldown(
       this.sendButton,
       BUTTON_COOLDOWN_MS,
@@ -16454,12 +16454,13 @@ class ChatModal {
   handleLocationUiOutsideClick(e) {
     const target = e.target;
     if (!(target instanceof Element)) return;
+    if (this.locationSharePanel?.style.display === 'none') return;
     if (this.attachmentOptionsContextMenu?.contains(target)) return;
     if (this.locationSharePanel?.contains(target)) return;
 
-    if (this.locationSharePanel?.style.display !== 'none') {
-      this.clearPendingLocation();
-    }
+    this.clearPendingLocation();
+    e.preventDefault();
+    e.stopPropagation();
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -15101,9 +15101,6 @@ class ChatModal {
       if (this.reactionSheetOverlay.classList.contains('active')) {
         requestAnimationFrame(() => this.updateReactionSheetViewport());
       }
-      if (this.locationSharePanel?.style.display !== 'none') {
-        requestAnimationFrame(() => this.positionLocationSharePanel());
-      }
     });
 
     // Add focus event listener for message input to handle scrolling
@@ -16456,7 +16453,8 @@ class ChatModal {
     if (!(target instanceof Element)) return;
     if (this.locationSharePanel?.style.display === 'none') return;
     if (this.attachmentOptionsContextMenu?.contains(target)) return;
-    if (this.locationSharePanel?.contains(target)) return;
+    const locationShareContent = this.locationSharePanel?.querySelector('.location-share-content');
+    if (locationShareContent?.contains(target)) return;
 
     this.clearPendingLocation();
     e.preventDefault();
@@ -16469,45 +16467,6 @@ class ChatModal {
    */
   showLocationPermissionDeniedToast() {
     showToast(LOCATION_PERMISSION_DENIED_MESSAGE, 0, 'warning');
-  }
-
-  /**
-   * Positions the staged location popover centered over the chat composer.
-   * @returns {void}
-   */
-  positionLocationSharePanel() {
-    if (!this.locationSharePanel) return;
-
-    const composer = this.modal?.querySelector('.message-input-container');
-    const composerRect = composer?.getBoundingClientRect();
-    const anchorRect = composerRect && composerRect.width > 0
-      ? composerRect
-      : { left: 0, right: window.innerWidth, top: 0, bottom: window.innerHeight, width: window.innerWidth, height: window.innerHeight };
-    const inset = 10;
-    const maxPanelWidth = Math.max(1, anchorRect.width - (inset * 2));
-
-    this.locationSharePanel.style.maxWidth = `${maxPanelWidth}px`;
-    const previousAnimation = this.locationSharePanel.style.animation;
-    this.locationSharePanel.style.animation = 'none';
-    const panelRect = this.locationSharePanel.getBoundingClientRect();
-
-    const minLeft = inset;
-    const maxLeft = window.innerWidth - panelRect.width - inset;
-    const desiredLeft = anchorRect.left + ((anchorRect.width - panelRect.width) / 2);
-    const left = Math.min(Math.max(desiredLeft, minLeft), Math.max(minLeft, maxLeft));
-
-    let top = anchorRect.top - panelRect.height - 8;
-    if (top < inset) {
-      top = anchorRect.bottom + 8;
-    }
-    if (top + panelRect.height > window.innerHeight - inset) {
-      top = window.innerHeight - panelRect.height - inset;
-    }
-    top = Math.max(inset, top);
-
-    this.locationSharePanel.style.left = `${left - anchorRect.left}px`;
-    this.locationSharePanel.style.top = `${top - anchorRect.top}px`;
-    this.locationSharePanel.style.animation = previousAnimation;
   }
 
   /**
@@ -16632,7 +16591,6 @@ class ChatModal {
       this.locationShareAccuracy.style.display = accuracyText ? '' : 'none';
     }
     this.locationSharePanel.style.display = 'flex';
-    this.positionLocationSharePanel();
     this.setLocationPanelBusy(this.locationRequestInProgress);
   }
 
@@ -16655,8 +16613,6 @@ class ChatModal {
     }
     if (this.locationSharePanel) {
       this.locationSharePanel.style.display = 'none';
-      this.locationSharePanel.style.left = '';
-      this.locationSharePanel.style.top = '';
     }
     if (this.locationShareCoordinates) this.locationShareCoordinates.textContent = '';
     if (this.locationShareAccuracy) this.locationShareAccuracy.textContent = '';

--- a/app.js
+++ b/app.js
@@ -15040,9 +15040,6 @@ class ChatModal {
       }
     });
     this.locationSharePanel?.addEventListener('click', (e) => this.handleLocationUiOutsideClick(e));
-    this.locationSharePanel
-      ?.querySelector('.location-share-content')
-      ?.addEventListener('click', (e) => e.stopPropagation());
     this.sendButton.addEventListener('click', withButtonCooldown(
       this.sendButton,
       BUTTON_COOLDOWN_MS,
@@ -16455,9 +16452,9 @@ class ChatModal {
   handleLocationUiOutsideClick(e) {
     if (e.target !== this.locationSharePanel) return;
 
-    this.clearPendingLocation();
     e.preventDefault();
     e.stopPropagation();
+    this.clearPendingLocation();
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -14932,6 +14932,7 @@ class ChatModal {
     this.locationSharePanel = document.getElementById('locationSharePanel');
     this.locationShareCoordinates = document.getElementById('locationShareCoordinates');
     this.locationShareAccuracy = document.getElementById('locationShareAccuracy');
+    this.locationShareMapLink = document.getElementById('locationShareMapLink');
     this.cancelLocationShareButton = document.getElementById('cancelLocationShareButton');
     this.sendLocationShareButton = document.getElementById('sendLocationShareButton');
     
@@ -16590,6 +16591,12 @@ class ChatModal {
       this.locationShareAccuracy.textContent = accuracyText;
       this.locationShareAccuracy.style.display = accuracyText ? '' : 'none';
     }
+    if (this.locationShareMapLink) {
+      this.locationShareMapLink.href = this.getLocationMapUrl(
+        this.pendingLocation.latitude,
+        this.pendingLocation.longitude
+      );
+    }
     this.locationSharePanel.style.display = 'flex';
     this.setLocationPanelBusy(this.locationRequestInProgress);
   }
@@ -16616,6 +16623,7 @@ class ChatModal {
     }
     if (this.locationShareCoordinates) this.locationShareCoordinates.textContent = '';
     if (this.locationShareAccuracy) this.locationShareAccuracy.textContent = '';
+    if (this.locationShareMapLink) this.locationShareMapLink.removeAttribute('href');
     this.setLocationPanelBusy(false);
   }
 

--- a/app.js
+++ b/app.js
@@ -15039,7 +15039,7 @@ class ChatModal {
         this.closeHeaderContextMenu();
       }
     });
-    document.addEventListener('click', (e) => this.handleLocationUiOutsideClick(e), true);
+    this.locationSharePanel?.addEventListener('click', (e) => this.handleLocationUiOutsideClick(e));
     this.sendButton.addEventListener('click', withButtonCooldown(
       this.sendButton,
       BUTTON_COOLDOWN_MS,
@@ -16450,12 +16450,7 @@ class ChatModal {
    * @returns {void}
    */
   handleLocationUiOutsideClick(e) {
-    const target = e.target;
-    if (!(target instanceof Element)) return;
-    if (this.locationSharePanel?.style.display === 'none') return;
-    if (this.attachmentOptionsContextMenu?.contains(target)) return;
-    const locationShareContent = this.locationSharePanel?.querySelector('.location-share-content');
-    if (locationShareContent?.contains(target)) return;
+    if (e.target !== this.locationSharePanel) return;
 
     this.clearPendingLocation();
     e.preventDefault();

--- a/app.js
+++ b/app.js
@@ -15040,6 +15040,9 @@ class ChatModal {
       }
     });
     this.locationSharePanel?.addEventListener('click', (e) => this.handleLocationUiOutsideClick(e));
+    this.locationSharePanel
+      ?.querySelector('.location-share-content')
+      ?.addEventListener('click', (e) => e.stopPropagation());
     this.sendButton.addEventListener('click', withButtonCooldown(
       this.sendButton,
       BUTTON_COOLDOWN_MS,

--- a/index.html
+++ b/index.html
@@ -1258,6 +1258,7 @@
                   <div class="location-share-details">
                     <div class="location-share-coordinates" id="locationShareCoordinates"></div>
                     <div class="location-share-accuracy" id="locationShareAccuracy"></div>
+                    <a class="location-message-link location-share-map-link" id="locationShareMapLink" target="_blank" rel="noopener noreferrer">Open in Google Maps</a>
                   </div>
                 </div>
                 <div class="voice-recording-controls">

--- a/index.html
+++ b/index.html
@@ -1248,24 +1248,20 @@
             <button class="reply-preview-close" id="replyPreviewClose" aria-label="Cancel reply" type="button"></button>
           </div>
           <div class="location-share-panel" id="locationSharePanel" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="locationShareTitle">
-            <div class="voice-recording-content location-share-content">
+            <div class="voice-recording-content">
               <div class="voice-recording-header">
                 <h3 id="locationShareTitle">Share Location</h3>
               </div>
               <div class="voice-recording-body">
-                <div class="voice-recording-visual location-share-visual">
+                <div class="voice-recording-visual">
                   <div class="location-share-icon" aria-hidden="true"></div>
-                  <div class="location-share-details">
-                    <div class="location-share-coordinates" id="locationShareCoordinates"></div>
-                    <div class="location-share-accuracy" id="locationShareAccuracy"></div>
-                    <a class="location-message-link location-share-map-link" id="locationShareMapLink" target="_blank" rel="noopener noreferrer">Open in Google Maps</a>
-                  </div>
+                  <div class="location-share-coordinates" id="locationShareCoordinates"></div>
+                  <div class="location-share-accuracy" id="locationShareAccuracy"></div>
+                  <a class="location-message-link location-share-map-link" id="locationShareMapLink" target="_blank" rel="noopener noreferrer">Open in Google Maps</a>
                 </div>
-                <div class="voice-recording-controls">
-                  <div class="initial-controls location-share-actions">
-                    <button type="button" class="voice-btn voice-btn-secondary" id="cancelLocationShareButton">Cancel</button>
-                    <button type="button" class="voice-btn voice-btn-primary" id="sendLocationShareButton">Send</button>
-                  </div>
+                <div class="voice-recording-controls location-share-actions">
+                  <button type="button" class="voice-btn voice-btn-secondary" id="cancelLocationShareButton">Cancel</button>
+                  <button type="button" class="voice-btn voice-btn-primary" id="sendLocationShareButton">Send</button>
                 </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -1247,16 +1247,26 @@
             </div>
             <button class="reply-preview-close" id="replyPreviewClose" aria-label="Cancel reply" type="button"></button>
           </div>
-          <div class="location-share-panel" id="locationSharePanel" style="display: none;">
-            <div class="location-share-icon" aria-hidden="true"></div>
-            <div class="location-share-details">
-              <div class="location-share-title">Share current location</div>
-              <div class="location-share-coordinates" id="locationShareCoordinates"></div>
-              <div class="location-share-accuracy" id="locationShareAccuracy"></div>
-            </div>
-            <div class="location-share-actions">
-              <button type="button" class="location-share-action" id="cancelLocationShareButton">Cancel</button>
-              <button type="button" class="location-share-action location-share-action-primary" id="sendLocationShareButton">Send</button>
+          <div class="location-share-panel" id="locationSharePanel" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="locationShareTitle">
+            <div class="voice-recording-content location-share-content">
+              <div class="voice-recording-header">
+                <h3 id="locationShareTitle">Share Location</h3>
+              </div>
+              <div class="voice-recording-body">
+                <div class="voice-recording-visual location-share-visual">
+                  <div class="location-share-icon" aria-hidden="true"></div>
+                  <div class="location-share-details">
+                    <div class="location-share-coordinates" id="locationShareCoordinates"></div>
+                    <div class="location-share-accuracy" id="locationShareAccuracy"></div>
+                  </div>
+                </div>
+                <div class="voice-recording-controls">
+                  <div class="initial-controls location-share-actions">
+                    <button type="button" class="voice-btn voice-btn-secondary" id="cancelLocationShareButton">Cancel</button>
+                    <button type="button" class="voice-btn voice-btn-primary" id="sendLocationShareButton">Send</button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div class="toll-container chat-toll-container">

--- a/styles.css
+++ b/styles.css
@@ -6756,6 +6756,11 @@ small {
   text-align: center;
 }
 
+.location-share-map-link {
+  display: inline-block;
+  margin-top: 8px;
+}
+
 .location-share-actions {
   gap: 1rem;
 }

--- a/styles.css
+++ b/styles.css
@@ -6711,14 +6711,6 @@ small {
   background-image: var(--icon-file);
 }
 
-.voice-recording-content.location-share-content {
-  width: min(400px, calc(100vw - 32px));
-}
-
-.location-share-visual {
-  margin-bottom: 1.5rem;
-}
-
 .location-share-icon {
   width: 80px;
   height: 80px;
@@ -6741,10 +6733,6 @@ small {
   background-repeat: no-repeat;
   background-size: 18px;
   flex-shrink: 0;
-}
-
-.location-share-details {
-  min-width: 0;
 }
 
 .location-share-coordinates,

--- a/styles.css
+++ b/styles.css
@@ -6711,26 +6711,26 @@ small {
   background-image: var(--icon-file);
 }
 
-.location-share-panel {
-  position: absolute;
-  width: min(320px, calc(100vw - 20px));
-  z-index: var(--overlay-z-index-high);
-  pointer-events: auto;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin: 0;
-  padding: 10px;
-  background: var(--background-color);
-  border: 1px solid var(--border-color);
-  border-radius: 14px;
-  box-shadow: var(--overlay-shadow-large);
-  backdrop-filter: blur(20px);
-  animation: contextMenuAppear 0.2s ease-out;
-  min-width: 0;
+.voice-recording-content.location-share-content {
+  width: min(400px, calc(100vw - 32px));
 }
 
-.location-share-icon,
+.location-share-visual {
+  margin-bottom: 1.5rem;
+}
+
+.location-share-icon {
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 1rem;
+  border-radius: 50%;
+  background-color: var(--primary-color);
+  background-image: var(--icon-location-white);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 40px;
+}
+
 .location-message-icon {
   width: 32px;
   height: 32px;
@@ -6744,70 +6744,20 @@ small {
 }
 
 .location-share-details {
-  flex: 1;
   min-width: 0;
-}
-
-.location-share-title {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--text-color);
-  line-height: 1.3;
 }
 
 .location-share-coordinates,
 .location-share-accuracy {
   margin-top: 2px;
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-sm);
   color: var(--secondary-text-color);
   overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .location-share-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 6px;
-  width: 100%;
-}
-
-.location-share-action {
-  min-height: 32px;
-  padding: 0 10px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--button-background);
-  color: var(--button-text);
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
-  cursor: pointer;
-}
-
-.location-share-action:hover:not(:disabled) {
-  background: var(--button-hover-background);
-}
-
-.location-share-action:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.location-share-action-primary {
-  border-color: var(--primary-color);
-  background: var(--primary-color);
-  color: white;
-}
-
-.location-share-action-primary:hover:not(:disabled) {
-  background: var(--primary-hover);
-}
-
-@media (max-width: 480px) {
-  .location-share-panel {
-    width: calc(100vw - 20px);
-    align-items: flex-start;
-  }
+  gap: 1rem;
 }
 
 .attachment-name {
@@ -7416,8 +7366,9 @@ small {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' fill='currentColor'%3E%3Cpath d='m439.5,236c0-11.3-9.1-20.4-20.4-20.4s-20.4,9.1-20.4,20.4c0,70-64,126.9-142.7,126.9-78.7,0-142.7-56.9-142.7-126.9 0-11.3-9.1-20.4-20.4-20.4s-20.4,9.1-20.4,20.4c0,86.2 71.5,157.4 163.1,166.7v57.5h-23.6c-11.3,0-20.4,9.1-20.4,20.4 0,11.3 9.1,20.4 20.4,20.4h88c11.3,0 20.4-9.1 20.4-20.4 0-11.3-9.1-20.4-20.4-20.4h-23.6v-57.5c91.6-9.3 163.1-80.5 163.1-166.7z'/%3E%3Cpath d='m256,323.5c51,0 92.3-41.3 92.3-92.3v-127.9c0-51-41.3-92.3-92.3-92.3s-92.3,41.3-92.3,92.3v127.9c0,51 41.3,92.3 92.3,92.3zm-52.3-220.2c0-28.8 23.5-52.3 52.3-52.3s52.3,23.5 52.3,52.3v127.9c0,28.8-23.5,52.3-52.3,52.3s-52.3-23.5-52.3-52.3v-127.9z'/%3E%3C/svg%3E");
 }
 
-/* Voice recording modal */
-#voiceRecordingModal {
+/* Voice recording and staged location modal shells */
+#voiceRecordingModal,
+.location-share-panel {
   position: fixed;
   top: 0;
   left: 0;

--- a/styles.css
+++ b/styles.css
@@ -7384,6 +7384,7 @@ small {
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: auto;
 }
 
 .voice-recording-content {


### PR DESCRIPTION
## What Changed

This PR keeps location sharing scoped to the staged location confirmation UI so other composer state is not silently consumed.

- `locationSharePanel` now uses the same modal shell pattern as voice recording, with explicit Cancel and Send actions isolated from the composer row.
- `handleLocationUiOutsideClick` now only dismisses when the location backdrop itself is clicked, and it consumes that click so it cannot leak into chat or composer handlers.
- The location confirmation now includes an `Open in Google Maps` preview link using the staged coordinates, then clears only that link and staged location state on cancel/send cleanup.
- The chosen policy for mixed staged items is now modal-first: once location confirmation is open, the user resolves that modal before returning to attachments or normal composer sends, matching the voice recording interaction model.

## Fixed Flow

1. The user has typed text, staged files, or opened voice recording state in the chat composer.
2. The user stages a current location for confirmation.
3. The location confirmation opens as its own modal-style layer instead of behaving like a composer popover.
4. Sending or canceling the location clears only `pendingLocation`, leaving unrelated composer state alone.
5. Attachment/file sends cannot implicitly cancel the staged location because the modal must be resolved first.

## Why

Issue #1368 asks for location send to behave as a standalone action and not silently discard typed text, staged files, or unsent voice work. Issue #1365 asks for consistent behavior when both files and location are staged.

This PR takes the cleaner route for the current codebase: keep location staging isolated from the composer and reuse the established voice-modal presentation shell. That avoids coupling `VoiceRecordingModal.recordedBlob` into chat composer state, avoids adding a destructive confirmation path for a send action that should not be destructive, and makes the location UI own only `pendingLocation`.

For #1365 specifically, this intentionally chooses the same interaction model as voice recording: when a modal composer action is open, the user sends or cancels that modal before continuing with other composer actions. That removes the previous inconsistent order-dependent behavior without trying to support parallel file/location staging in the same composer surface.

## Validation

- `node --check app.js`
- `git diff e019c78f4dd5de2060af84af33e7a4cd44ab68b1 --check`

Closes #1368
Closes #1365
