### PR TITLE
Guard repeated delete-for-all clicks

### DIFF
--- a/app.js
+++ b/app.js
@@ -6913,98 +6913,62 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
   );
 }
 
-const pendingDeleteForAllTargetKeys = new Set();
+const DELETE_FOR_ALL_ACTION_GUARD_MS = 9000;
+const recentDeleteForAllTargetKeys = new Map();
 
 /**
- * Builds the in-memory key used to block duplicate delete-for-all starts before a txid exists.
+ * Builds the in-memory key used to block repeated delete actions for a delete-for-all target.
  * @param {string} contactAddress
  * @param {string} targetTxid
  * @returns {string}
  */
-function getPendingDeleteForAllTargetKey(contactAddress, targetTxid) {
-  assert(contactAddress, 'Pending delete contact address is required');
-  assert(targetTxid, 'Pending delete target txid is required');
+function getDeleteForAllTargetKey(contactAddress, targetTxid) {
+  assert(contactAddress, 'Delete guard contact address is required');
+  assert(targetTxid, 'Delete guard target txid is required');
   return `${normalizeAddress(contactAddress)}:${targetTxid}`;
 }
 
 /**
- * Checks if a pending delete-for-all target marker exists in the in-memory pending transactions.
+ * Checks if a recent delete-for-all guard exists for a message target.
  * @param {string} contactAddress
  * @param {string} targetTxid
  * @returns {boolean}
  */
-function hasPendingDeleteForAllForTarget(contactAddress, targetTxid) {
+function hasRecentDeleteForAllForTarget(contactAddress, targetTxid) {
   if (!contactAddress || !targetTxid) {
     return false;
   }
 
-  const normalizedContactAddress = normalizeAddress(contactAddress);
-  if (pendingDeleteForAllTargetKeys.has(getPendingDeleteForAllTargetKey(normalizedContactAddress, targetTxid))) {
-    return true;
-  }
-
-  if (!Array.isArray(myData?.pending)) {
-    return false;
-  }
-
-  return myData.pending.some((pendingTx) =>
-    pendingTx.type === 'message' &&
-    pendingTx.to === normalizedContactAddress &&
-    pendingTx.deletePending &&
-    pendingTx.deletePending.targetTxid === targetTxid
-  );
+  return recentDeleteForAllTargetKeys.has(getDeleteForAllTargetKey(contactAddress, targetTxid));
 }
 
 /**
- * Tracks an accepted delete-for-all control message.
- * @param {string} deleteTxid
+ * Temporarily blocks repeated delete actions for a delete-for-all target.
  * @param {string} contactAddress
  * @param {string} targetTxid
  * @returns {void}
  */
-function trackPendingDeleteForAll(deleteTxid, contactAddress, targetTxid) {
-  assert(deleteTxid, 'Pending delete txid is required');
-  assert(contactAddress, 'Pending delete contact address is required');
-  assert(targetTxid, 'Pending delete target txid is required');
-
-  myData.pending ??= [];
-  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === deleteTxid);
-  if (pendingTxInfo) {
-    pendingTxInfo.to = normalizeAddress(contactAddress);
-    pendingTxInfo.deletePending = { targetTxid };
+function markRecentDeleteForAllForTarget(contactAddress, targetTxid) {
+  if (!contactAddress || !targetTxid) {
     return;
   }
 
-  myData.pending.push({
-    txid: deleteTxid,
-    type: 'message',
-    submittedts: getCorrectedTimestamp(),
-    checkedts: 0,
-    to: normalizeAddress(contactAddress),
-    deletePending: { targetTxid },
-  });
+  const key = getDeleteForAllTargetKey(contactAddress, targetTxid);
+  clearTimeout(recentDeleteForAllTargetKeys.get(key));
+  const timeoutId = setTimeout(() => {
+    recentDeleteForAllTargetKeys.delete(key);
+  }, DELETE_FOR_ALL_ACTION_GUARD_MS);
+  recentDeleteForAllTargetKeys.set(key, timeoutId);
 }
 
-/**
- * Removes a pending delete-for-all target marker from the in-memory pending transactions.
- * @param {string} contactAddress
- * @param {string} targetTxid
- * @returns {void}
- */
-function removePendingDeleteForAllForTarget(contactAddress, targetTxid) {
-  if (!Array.isArray(myData?.pending) || !contactAddress || !targetTxid) {
-    return;
-  }
+function setContextMenuOptionDisabled(option, disabled) {
+  if (!option) return;
+  option.classList.toggle('is-disabled', disabled);
+  option.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+}
 
-  const normalizedContactAddress = normalizeAddress(contactAddress);
-  myData.pending = myData.pending.filter((pendingTx) =>
-    !(
-      pendingTx.type === 'message' &&
-      pendingTx.to === normalizedContactAddress &&
-      pendingTx.deletePending &&
-      pendingTx.deletePending.targetTxid === targetTxid
-    )
-  );
+function isContextMenuOptionDisabled(option) {
+  return option?.classList?.contains('is-disabled') || option?.getAttribute('aria-disabled') === 'true';
 }
 
 /**
@@ -7408,7 +7372,6 @@ async function processChats(chats, keys) {
                   if (didDeleteMessage) {
                     purgeContactReactionsForTarget(contact, messageToDelete.txid);
                     purgePendingReactionsForTarget(from, messageToDelete.txid);
-                    removePendingDeleteForAllForTarget(from, messageToDelete.txid);
                     syncChatLatestActivityTimestamp(from, contact);
                     didChangeReactionPreview = true;
                     if (wasUnreadIncomingMessage) {
@@ -15061,8 +15024,9 @@ class ChatModal {
         void this.handleReactionPickerClick(reactionButton);
         return;
       }
-      if (e.target.closest('.context-menu-option')) {
-        const action = e.target.closest('.context-menu-option').dataset.action;
+      const option = e.target.closest('.context-menu-option');
+      if (option && !isContextMenuOptionDisabled(option)) {
+        const action = option.dataset.action;
         this.handleContextMenuAction(action);
       }
     });
@@ -15077,7 +15041,7 @@ class ChatModal {
           return;
         }
         const option = e.target.closest('.context-menu-option');
-        if (!option) return;
+        if (!option || isContextMenuOptionDisabled(option)) return;
         const action = option.dataset.action;
         this.handleImageAttachmentContextMenuAction(action);
       });
@@ -18767,6 +18731,7 @@ class ChatModal {
       if (editResendOption) editResendOption.style.display = 'none';
       if (deleteOption) deleteOption.style.display = 'none';
 
+      this.syncDeleteContextMenuDisabledState(this.contextMenu, messageEl, messageRecord);
       this.positionContextMenu(this.contextMenu, messageEl);
       this.contextMenu.style.display = 'block';
       return;
@@ -18836,6 +18801,7 @@ class ChatModal {
       if (editOption) editOption.style.display = 'none';
     }
     
+    this.syncDeleteContextMenuDisabledState(this.contextMenu, messageEl, messageRecord);
     this.positionContextMenu(this.contextMenu, messageEl);
     this.contextMenu.style.display = 'block';
   }
@@ -19376,6 +19342,21 @@ class ChatModal {
     }
 
     return true;
+  }
+
+  hasRecentDeleteForAllForMessage(messageEl, messageRecord = null) {
+    const message = messageRecord || this.getMessageRecordFromElement(messageEl);
+    return hasRecentDeleteForAllForTarget(this.address, message?.txid);
+  }
+
+  syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
+    const isDisabled = this.hasRecentDeleteForAllForMessage(messageEl, messageRecord);
+    setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete"]'), isDisabled);
+    setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete-for-all"]'), isDisabled);
+  }
+
+  isDeleteContextMenuActionDisabled(action, messageEl) {
+    return (action === 'delete' || action === 'delete-for-all') && this.hasRecentDeleteForAllForMessage(messageEl);
   }
 
   /**
@@ -19951,6 +19932,7 @@ class ChatModal {
     );
     this.syncReactionPickerActiveState(this.imageAttachmentContextMenuReactions, messageEl);
 
+    this.syncDeleteContextMenuDisabledState(this.imageAttachmentContextMenu, messageEl);
     this.positionContextMenu(this.imageAttachmentContextMenu, attachmentRow);
     this.imageAttachmentContextMenu.style.display = 'block';
   }
@@ -19960,6 +19942,11 @@ class ChatModal {
     if (!row) return;
 
     const { messageEl } = this.getAttachmentContextFromRow(row);
+    if (this.isDeleteContextMenuActionDisabled(action, messageEl)) {
+      this.closeImageAttachmentContextMenu();
+      return;
+    }
+
     switch (action) {
       case 'import-contacts':
         void this.openImportContactsModal(row);
@@ -20086,6 +20073,10 @@ class ChatModal {
   handleContextMenuAction(action) {
     const messageEl = this.currentContextMessage;
     if (!messageEl) return;
+    if (this.isDeleteContextMenuActionDisabled(action, messageEl)) {
+      this.closeContextMenu();
+      return;
+    }
     
     switch (action) {
       case 'save':
@@ -20850,7 +20841,6 @@ class ChatModal {
    */
   async deleteMessageForAll(messageEl) {
     const { txid, messageTimestamp: timestamp } = messageEl.dataset;
-    let pendingTargetKey = '';
     
     if (!timestamp && !txid) return;
     
@@ -20876,13 +20866,12 @@ class ChatModal {
         return showToast('You can only delete your own messages for all', 0, 'error');
       }
 
-      if (hasPendingDeleteForAllForTarget(this.address, targetTxid)) {
-        return showToast('Delete is already pending', 3000, 'info');
+      if (hasRecentDeleteForAllForTarget(this.address, targetTxid)) {
+        return showToast('Delete is temporarily disabled', 2000, 'info');
       }
 
       if (!confirm('Delete this message for all participants?')) return;
-      pendingTargetKey = getPendingDeleteForAllTargetKey(this.address, targetTxid);
-      pendingDeleteForAllTargetKeys.add(pendingTargetKey);
+      markRecentDeleteForAllForTarget(this.address, targetTxid);
 
       // Create and send a "delete" message
       const keys = myAccount.keys;
@@ -20945,7 +20934,6 @@ class ChatModal {
         return showToast('Failed to delete message: ' + (response?.result?.reason || 'Unknown error'), 0, 'error');
       }
 
-      trackPendingDeleteForAll(deleteTxid, this.address, targetTxid);
       showToast('Delete request sent', 5000, 'loading');
       
       // Best effort delete attachments from server
@@ -20963,10 +20951,6 @@ class ChatModal {
     } catch (error) {
       console.error('Delete for all error:', error);
       showToast('Failed to delete message. Please try again.', 0, 'error');
-    } finally {
-      if (pendingTargetKey) {
-        pendingDeleteForAllTargetKeys.delete(pendingTargetKey);
-      }
     }
   }
 
@@ -29514,11 +29498,7 @@ async function checkPendingTransactions() {
     const pendingTxInfo = myData.pending[i];
     const { txid, type, submittedts } = pendingTxInfo;
     const reactionPending = pendingTxInfo.reactionPending;
-    const deletePending = pendingTxInfo.deletePending;
     if (reactionPending && reactionPending.status !== 'pending') {
-      continue;
-    }
-    if (deletePending?.txAccepted) {
       continue;
     }
 
@@ -29553,9 +29533,6 @@ async function checkPendingTransactions() {
       if (res?.transaction?.success === true) {
         if (reactionPending) {
           settleAndQueueReactionCleanup(pendingTxInfo, 'success');
-        } else if (deletePending) {
-          deletePending.txAccepted = true;
-          didMutatePendingState = true;
         } else {
           // comment out to test the pending txs removal logic
           myData.pending.splice(i, 1);

--- a/app.js
+++ b/app.js
@@ -6913,6 +6913,44 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
   );
 }
 
+const pendingDeleteForAllTargets = new Set();
+
+/**
+ * Builds the in-memory key used to block duplicate delete-for-all starts before a txid exists.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {string}
+ */
+function getPendingDeleteForAllTargetKey(contactAddress, targetTxid) {
+  assert(contactAddress, 'Pending delete contact address is required');
+  assert(targetTxid, 'Pending delete target txid is required');
+  return `${normalizeAddress(contactAddress)}:${targetTxid}`;
+}
+
+/**
+ * Marks a delete-for-all target as in-flight before async send preparation starts.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {void}
+ */
+function trackPendingDeleteForAllTarget(contactAddress, targetTxid) {
+  pendingDeleteForAllTargets.add(getPendingDeleteForAllTargetKey(contactAddress, targetTxid));
+}
+
+/**
+ * Clears the in-memory delete-for-all target marker.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {void}
+ */
+function removePendingDeleteForAllTarget(contactAddress, targetTxid) {
+  if (!contactAddress || !targetTxid) {
+    return;
+  }
+
+  pendingDeleteForAllTargets.delete(getPendingDeleteForAllTargetKey(contactAddress, targetTxid));
+}
+
 /**
  * Returns whether a delete-for-all control message is already pending for a message.
  * @param {string} contactAddress
@@ -6920,11 +6958,19 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
  * @returns {boolean}
  */
 function hasPendingDeleteForAllForTarget(contactAddress, targetTxid) {
-  if (!contactAddress || !targetTxid || !Array.isArray(myData?.pending)) {
+  if (!contactAddress || !targetTxid) {
     return false;
   }
 
   const normalizedContactAddress = normalizeAddress(contactAddress);
+  if (pendingDeleteForAllTargets.has(getPendingDeleteForAllTargetKey(normalizedContactAddress, targetTxid))) {
+    return true;
+  }
+
+  if (!Array.isArray(myData?.pending)) {
+    return false;
+  }
+
   return myData.pending.some((pendingTx) =>
     pendingTx.type === 'message' &&
     pendingTx.to === normalizedContactAddress &&
@@ -6978,7 +7024,9 @@ function removePendingDeleteForAll(deleteTxid) {
     pendingTx.txid === deleteTxid && pendingTx.deletePending
   );
   if (pendingIndex !== -1) {
+    const pendingTxInfo = myData.pending[pendingIndex];
     myData.pending.splice(pendingIndex, 1);
+    removePendingDeleteForAllTarget(pendingTxInfo.to, pendingTxInfo.deletePending?.targetTxid);
   }
 }
 
@@ -20827,6 +20875,8 @@ class ChatModal {
     const { txid, messageTimestamp: timestamp } = messageEl.dataset;
     let deleteTxid = '';
     let didInjectDelete = false;
+    let targetTxid = '';
+    let didTrackDeleteForAllTarget = false;
     
     if (!timestamp && !txid) return;
     
@@ -20842,7 +20892,7 @@ class ChatModal {
       if (messageIndex === -1) return;
       
       const message = contact.messages[messageIndex];
-      const targetTxid = message.txid;
+      targetTxid = message.txid;
       if (!targetTxid) {
         return showToast('Cannot delete message: missing message id', 0, 'error');
       }
@@ -20861,6 +20911,8 @@ class ChatModal {
       }
 
       if (!confirm('Delete this message for all participants?')) return;
+      trackPendingDeleteForAllTarget(this.address, targetTxid);
+      didTrackDeleteForAllTarget = true;
 
       // Create and send a "delete" message
       const keys = myAccount.keys;
@@ -20946,6 +20998,10 @@ class ChatModal {
       }
       console.error('Delete for all error:', error);
       showToast('Failed to delete message. Please try again.', 0, 'error');
+    } finally {
+      if (didTrackDeleteForAllTarget) {
+        removePendingDeleteForAllTarget(this.address, targetTxid);
+      }
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -18700,8 +18700,11 @@ class ChatModal {
     // Show/hide "Delete for all" option based on whether the message is from the current user
     const deleteForAllOption = this.contextMenu.querySelector('[data-action="delete-for-all"]');
     const canDeleteForAll = this.canDeleteMessageForAll(messageEl, messageRecord);
+    const deleteForAllTargetTxid = messageRecord?.txid || messageEl.dataset.txid || '';
+    const isDeleteForAllPending =
+      canDeleteForAll && hasPendingDeleteForAllForTarget(this.address, deleteForAllTargetTxid);
     if (deleteForAllOption) {
-      deleteForAllOption.style.display = canDeleteForAll ? 'flex' : 'none';
+      this.setDeleteForAllOptionState(deleteForAllOption, canDeleteForAll, isDeleteForAllPending);
     }
 
     // If this is a call message, show call-specific options and hide copy
@@ -19353,6 +19356,23 @@ class ChatModal {
   }
 
   /**
+   * Applies visibility and pending state to a delete-for-all context menu option.
+   * @param {HTMLElement} option
+   * @param {boolean} canDeleteForAll
+   * @param {boolean} isPending
+   * @returns {void}
+   */
+  setDeleteForAllOptionState(option, canDeleteForAll, isPending) {
+    option.style.display = canDeleteForAll ? 'flex' : 'none';
+    option.setAttribute('aria-disabled', isPending ? 'true' : 'false');
+    if (isPending) {
+      option.title = 'Delete is already pending';
+    } else {
+      option.removeAttribute('title');
+    }
+  }
+
+  /**
    * Removes cached thumbnails for any image attachments in an xattach array.
    * Safe to call even if thumbnails don't exist.
    * @param {any} xattach
@@ -19881,8 +19901,12 @@ class ChatModal {
 
     const deleteForAllOption = this.imageAttachmentContextMenu.querySelector('[data-action="delete-for-all"]');
     if (deleteForAllOption) {
-      const canDeleteForAll = this.canDeleteMessageForAll(messageEl);
-      deleteForAllOption.style.display = canDeleteForAll ? 'flex' : 'none';
+      const messageRecord = this.getMessageRecordFromElement(messageEl);
+      const canDeleteForAll = this.canDeleteMessageForAll(messageEl, messageRecord);
+      const deleteForAllTargetTxid = messageRecord?.txid || messageEl.dataset.txid || '';
+      const isDeleteForAllPending =
+        canDeleteForAll && hasPendingDeleteForAllForTarget(this.address, deleteForAllTargetTxid);
+      this.setDeleteForAllOptionState(deleteForAllOption, canDeleteForAll, isDeleteForAllPending);
     }
 
     const isImageAttachment = attachmentRow.dataset.imageAttachment === 'true';

--- a/app.js
+++ b/app.js
@@ -6914,6 +6914,75 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
 }
 
 /**
+ * Returns whether a delete-for-all control message is already pending for a message.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {boolean}
+ */
+function hasPendingDeleteForAllForTarget(contactAddress, targetTxid) {
+  if (!contactAddress || !targetTxid || !Array.isArray(myData?.pending)) {
+    return false;
+  }
+
+  const normalizedContactAddress = normalizeAddress(contactAddress);
+  return myData.pending.some((pendingTx) =>
+    pendingTx.type === 'message' &&
+    pendingTx.to === normalizedContactAddress &&
+    pendingTx.deletePending &&
+    pendingTx.deletePending.targetTxid === targetTxid
+  );
+}
+
+/**
+ * Tracks a delete-for-all control message before `/inject` confirms acceptance.
+ * @param {string} deleteTxid
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {void}
+ */
+function trackPendingDeleteForAllBeforeInject(deleteTxid, contactAddress, targetTxid) {
+  assert(deleteTxid, 'Pending delete txid is required');
+  assert(contactAddress, 'Pending delete contact address is required');
+  assert(targetTxid, 'Pending delete target txid is required');
+
+  myData.pending ??= [];
+  const deletePending = { targetTxid };
+  const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === deleteTxid);
+  if (pendingTxInfo) {
+    pendingTxInfo.to = normalizeAddress(contactAddress);
+    pendingTxInfo.deletePending = deletePending;
+    return;
+  }
+
+  myData.pending.push({
+    txid: deleteTxid,
+    type: 'message',
+    submittedts: getCorrectedTimestamp(),
+    checkedts: 0,
+    to: normalizeAddress(contactAddress),
+    deletePending,
+  });
+}
+
+/**
+ * Removes the pre-inject delete-for-all pending marker after an immediate send failure.
+ * @param {string} deleteTxid
+ * @returns {void}
+ */
+function removePendingDeleteForAll(deleteTxid) {
+  if (!deleteTxid || !Array.isArray(myData?.pending)) {
+    return;
+  }
+
+  const pendingIndex = myData.pending.findIndex((pendingTx) =>
+    pendingTx.txid === deleteTxid && pendingTx.deletePending
+  );
+  if (pendingIndex !== -1) {
+    myData.pending.splice(pendingIndex, 1);
+  }
+}
+
+/**
  * Restores local state captured before an optimistic message edit.
  * @param {string} pendingTxid
  * @param {string} contactAddress
@@ -20755,19 +20824,27 @@ class ChatModal {
    */
   async deleteMessageForAll(messageEl) {
     const { txid, messageTimestamp: timestamp } = messageEl.dataset;
+    let deleteTxid = '';
+    let didInjectDelete = false;
     
-    if (!timestamp || !confirm('Delete this message for all participants?')) return;
+    if (!timestamp && !txid) return;
     
     try {
       // Get the message object from contact.messages
       const contact = myData.contacts[this.address];
-      const messageIndex = contact?.messages?.findIndex(msg => 
+      if (!contact?.messages?.length) return;
+
+      const messageIndex = contact.messages.findIndex(msg =>
         msg.timestamp == timestamp || msg.txid === txid
       );
       
       if (messageIndex === -1) return;
       
       const message = contact.messages[messageIndex];
+      const targetTxid = message.txid;
+      if (!targetTxid) {
+        return showToast('Cannot delete message: missing message id', 0, 'error');
+      }
       
       if (isDeletedForAll(message)) {
         return showToast('Message already deleted for everyone', 2000, 'info');
@@ -20777,6 +20854,12 @@ class ChatModal {
       if (!message.my) {
         return showToast('You can only delete your own messages for all', 0, 'error');
       }
+
+      if (hasPendingDeleteForAllForTarget(this.address, targetTxid)) {
+        return showToast('Delete is already pending', 3000, 'info');
+      }
+
+      if (!confirm('Delete this message for all participants?')) return;
 
       // Create and send a "delete" message
       const keys = myAccount.keys;
@@ -20810,7 +20893,7 @@ class ChatModal {
       // Create delete message payload
       const deleteObj = {
         type: 'delete',
-        txid: txid  // ID of the message to delete
+        txid: targetTxid  // ID of the message to delete
       };
 
       // Encrypt the message
@@ -20829,16 +20912,22 @@ class ChatModal {
       // Prepare and send the delete message transaction
       const deleteMessageObj = await this.createChatMessage(this.address, payload, tollInLib, keys);
       await signObj(deleteMessageObj, keys);
-      const deleteTxid = getTxid(deleteMessageObj);
+      deleteTxid = getTxid(deleteMessageObj);
+      trackPendingDeleteForAllBeforeInject(deleteTxid, this.address, targetTxid);
+      saveState();
 
       // Send the delete transaction
       const response = await injectTx(deleteMessageObj, deleteTxid);
 
       if (!response || !response.result || !response.result.success) {
         console.error('Delete message failed to send', response);
+        removePendingDeleteForAll(deleteTxid);
+        saveState();
         return showToast('Failed to delete message: ' + (response?.result?.reason || 'Unknown error'), 0, 'error');
       }
 
+      didInjectDelete = true;
+      saveState();
       showToast('Delete request sent', 5000, 'loading');
       
       // Best effort delete attachments from server
@@ -20854,6 +20943,10 @@ class ChatModal {
       // The message will be deleted when we process the delete tx from the network
       
     } catch (error) {
+      if (deleteTxid && !didInjectDelete) {
+        removePendingDeleteForAll(deleteTxid);
+        saveState();
+      }
       console.error('Delete for all error:', error);
       showToast('Failed to delete message. Please try again.', 0, 'error');
     }

--- a/app.js
+++ b/app.js
@@ -6980,6 +6980,28 @@ function trackPendingDeleteForAll(deleteTxid, contactAddress, targetTxid) {
 }
 
 /**
+ * Removes a pending delete-for-all target marker from the in-memory pending transactions.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {void}
+ */
+function removePendingDeleteForAllForTarget(contactAddress, targetTxid) {
+  if (!Array.isArray(myData?.pending) || !contactAddress || !targetTxid) {
+    return;
+  }
+
+  const normalizedContactAddress = normalizeAddress(contactAddress);
+  myData.pending = myData.pending.filter((pendingTx) =>
+    !(
+      pendingTx.type === 'message' &&
+      pendingTx.to === normalizedContactAddress &&
+      pendingTx.deletePending &&
+      pendingTx.deletePending.targetTxid === targetTxid
+    )
+  );
+}
+
+/**
  * Restores local state captured before an optimistic message edit.
  * @param {string} pendingTxid
  * @param {string} contactAddress
@@ -7380,6 +7402,7 @@ async function processChats(chats, keys) {
                   if (didDeleteMessage) {
                     purgeContactReactionsForTarget(contact, messageToDelete.txid);
                     purgePendingReactionsForTarget(from, messageToDelete.txid);
+                    removePendingDeleteForAllForTarget(from, messageToDelete.txid);
                     syncChatLatestActivityTimestamp(from, contact);
                     didChangeReactionPreview = true;
                     if (wasUnreadIncomingMessage) {
@@ -29485,7 +29508,11 @@ async function checkPendingTransactions() {
     const pendingTxInfo = myData.pending[i];
     const { txid, type, submittedts } = pendingTxInfo;
     const reactionPending = pendingTxInfo.reactionPending;
+    const deletePending = pendingTxInfo.deletePending;
     if (reactionPending && reactionPending.status !== 'pending') {
+      continue;
+    }
+    if (deletePending?.txAccepted) {
       continue;
     }
 
@@ -29520,6 +29547,9 @@ async function checkPendingTransactions() {
       if (res?.transaction?.success === true) {
         if (reactionPending) {
           settleAndQueueReactionCleanup(pendingTxInfo, 'success');
+        } else if (deletePending) {
+          deletePending.txAccepted = true;
+          didMutatePendingState = true;
         } else {
           // comment out to test the pending txs removal logic
           myData.pending.splice(i, 1);

--- a/app.js
+++ b/app.js
@@ -20885,13 +20885,9 @@ class ChatModal {
       const contact = myData.contacts[this.address];
       if (!contact?.messages?.length) return;
 
-      const messageIndex = contact.messages.findIndex(msg =>
-        msg.timestamp == timestamp || msg.txid === txid
-      );
-      
-      if (messageIndex === -1) return;
-      
-      const message = contact.messages[messageIndex];
+      const message = this.getMessageRecordFromElement(messageEl);
+      if (!message) return;
+
       targetTxid = message.txid;
       if (!targetTxid) {
         return showToast('Cannot delete message: missing message id', 0, 'error');

--- a/app.js
+++ b/app.js
@@ -14440,7 +14440,7 @@ class ChatModal {
     this.dragCounter = 0;
     this.dropOverlay = null;
 
-    this.recentDeleteForAllTargetKeys = new Map();
+    this.recentDeleteForAllTargetTxids = new Set();
 
     this.chatRenderedOldestIndex = CHAT_INITIAL_RENDER_COUNT - 1;
   }
@@ -14971,10 +14971,9 @@ class ChatModal {
         return;
       }
       const option = e.target.closest('.context-menu-option');
-      if (option && !this.isContextMenuOptionDisabled(option)) {
-        const action = option.dataset.action;
-        this.handleContextMenuAction(action);
-      }
+      if (!option || option.getAttribute('aria-disabled') === 'true') return;
+      const action = option.dataset.action;
+      this.handleContextMenuAction(action);
     });
     // Add image attachment context menu option listeners
     if (this.imageAttachmentContextMenu) {
@@ -14987,7 +14986,7 @@ class ChatModal {
           return;
         }
         const option = e.target.closest('.context-menu-option');
-        if (!option || this.isContextMenuOptionDisabled(option)) return;
+        if (!option || option.getAttribute('aria-disabled') === 'true') return;
         const action = option.dataset.action;
         this.handleImageAttachmentContextMenuAction(action);
       });
@@ -19290,52 +19289,27 @@ class ChatModal {
     return true;
   }
 
-  getDeleteForAllTargetKey(contactAddress, targetTxid) {
-    assert(contactAddress, 'Delete guard contact address is required');
-    assert(targetTxid, 'Delete guard target txid is required');
-    return `${normalizeAddress(contactAddress)}:${targetTxid}`;
+  hasRecentDeleteForAllForTarget(targetTxid) {
+    return !!targetTxid && this.recentDeleteForAllTargetTxids.has(targetTxid);
   }
 
-  hasRecentDeleteForAllForTarget(contactAddress, targetTxid) {
-    if (!contactAddress || !targetTxid) {
-      return false;
-    }
-
-    return this.recentDeleteForAllTargetKeys.has(this.getDeleteForAllTargetKey(contactAddress, targetTxid));
-  }
-
-  markRecentDeleteForAllForTarget(contactAddress, targetTxid) {
-    if (!contactAddress || !targetTxid) {
+  markRecentDeleteForAllForTarget(targetTxid) {
+    if (!targetTxid) {
       return;
     }
 
-    const key = this.getDeleteForAllTargetKey(contactAddress, targetTxid);
-    clearTimeout(this.recentDeleteForAllTargetKeys.get(key));
-    const timeoutId = setTimeout(() => {
-      this.recentDeleteForAllTargetKeys.delete(key);
+    this.recentDeleteForAllTargetTxids.add(targetTxid);
+    setTimeout(() => {
+      this.recentDeleteForAllTargetTxids.delete(targetTxid);
     }, DELETE_FOR_ALL_ACTION_GUARD_MS);
-    this.recentDeleteForAllTargetKeys.set(key, timeoutId);
-  }
-
-  setContextMenuOptionDisabled(option, disabled) {
-    if (!option) return;
-    option.classList.toggle('is-disabled', disabled);
-    option.setAttribute('aria-disabled', disabled ? 'true' : 'false');
-  }
-
-  isContextMenuOptionDisabled(option) {
-    return option?.classList?.contains('is-disabled') || option?.getAttribute('aria-disabled') === 'true';
-  }
-
-  hasRecentDeleteForAllForMessage(messageEl, messageRecord = null) {
-    const message = messageRecord || this.getMessageRecordFromElement(messageEl);
-    return this.hasRecentDeleteForAllForTarget(this.address, message?.txid);
   }
 
   syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
-    const isDisabled = this.hasRecentDeleteForAllForMessage(messageEl, messageRecord);
-    this.setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete"]'), isDisabled);
-    this.setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete-for-all"]'), isDisabled);
+    const message = messageRecord || this.getMessageRecordFromElement(messageEl);
+    const isDisabled = this.hasRecentDeleteForAllForTarget(message?.txid);
+    menu?.querySelectorAll('[data-action="delete"], [data-action="delete-for-all"]').forEach((option) => {
+      option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+    });
   }
 
   /**
@@ -20836,10 +20810,10 @@ class ChatModal {
         return showToast('You can only delete your own messages for all', 0, 'error');
       }
 
-      if (this.hasRecentDeleteForAllForTarget(this.address, targetTxid)) return;
+      if (this.hasRecentDeleteForAllForTarget(targetTxid)) return;
 
       if (!confirm('Delete this message for all participants?')) return;
-      this.markRecentDeleteForAllForTarget(this.address, targetTxid);
+      this.markRecentDeleteForAllForTarget(targetTxid);
 
       // Create and send a "delete" message
       const keys = myAccount.keys;

--- a/app.js
+++ b/app.js
@@ -6913,7 +6913,7 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
   );
 }
 
-const pendingDeleteForAllTargets = new Set();
+const pendingDeleteForAllTargetKeys = new Set();
 
 /**
  * Builds the in-memory key used to block duplicate delete-for-all starts before a txid exists.
@@ -6927,43 +6927,13 @@ function getPendingDeleteForAllTargetKey(contactAddress, targetTxid) {
   return `${normalizeAddress(contactAddress)}:${targetTxid}`;
 }
 
-/**
- * Marks a delete-for-all target as in-flight before async send preparation starts.
- * @param {string} contactAddress
- * @param {string} targetTxid
- * @returns {void}
- */
-function trackPendingDeleteForAllTarget(contactAddress, targetTxid) {
-  pendingDeleteForAllTargets.add(getPendingDeleteForAllTargetKey(contactAddress, targetTxid));
-}
-
-/**
- * Clears the in-memory delete-for-all target marker.
- * @param {string} contactAddress
- * @param {string} targetTxid
- * @returns {void}
- */
-function removePendingDeleteForAllTarget(contactAddress, targetTxid) {
-  if (!contactAddress || !targetTxid) {
-    return;
-  }
-
-  pendingDeleteForAllTargets.delete(getPendingDeleteForAllTargetKey(contactAddress, targetTxid));
-}
-
-/**
- * Returns whether a delete-for-all control message is already pending for a message.
- * @param {string} contactAddress
- * @param {string} targetTxid
- * @returns {boolean}
- */
 function hasPendingDeleteForAllForTarget(contactAddress, targetTxid) {
   if (!contactAddress || !targetTxid) {
     return false;
   }
 
   const normalizedContactAddress = normalizeAddress(contactAddress);
-  if (pendingDeleteForAllTargets.has(getPendingDeleteForAllTargetKey(normalizedContactAddress, targetTxid))) {
+  if (pendingDeleteForAllTargetKeys.has(getPendingDeleteForAllTargetKey(normalizedContactAddress, targetTxid))) {
     return true;
   }
 
@@ -6980,23 +6950,22 @@ function hasPendingDeleteForAllForTarget(contactAddress, targetTxid) {
 }
 
 /**
- * Tracks a delete-for-all control message before `/inject` confirms acceptance.
+ * Tracks an accepted delete-for-all control message.
  * @param {string} deleteTxid
  * @param {string} contactAddress
  * @param {string} targetTxid
  * @returns {void}
  */
-function trackPendingDeleteForAllBeforeInject(deleteTxid, contactAddress, targetTxid) {
+function trackPendingDeleteForAll(deleteTxid, contactAddress, targetTxid) {
   assert(deleteTxid, 'Pending delete txid is required');
   assert(contactAddress, 'Pending delete contact address is required');
   assert(targetTxid, 'Pending delete target txid is required');
 
   myData.pending ??= [];
-  const deletePending = { targetTxid };
   const pendingTxInfo = myData.pending.find((pendingTx) => pendingTx.txid === deleteTxid);
   if (pendingTxInfo) {
     pendingTxInfo.to = normalizeAddress(contactAddress);
-    pendingTxInfo.deletePending = deletePending;
+    pendingTxInfo.deletePending = { targetTxid };
     return;
   }
 
@@ -7006,28 +6975,8 @@ function trackPendingDeleteForAllBeforeInject(deleteTxid, contactAddress, target
     submittedts: getCorrectedTimestamp(),
     checkedts: 0,
     to: normalizeAddress(contactAddress),
-    deletePending,
+    deletePending: { targetTxid },
   });
-}
-
-/**
- * Removes the pre-inject delete-for-all pending marker after an immediate send failure.
- * @param {string} deleteTxid
- * @returns {void}
- */
-function removePendingDeleteForAll(deleteTxid) {
-  if (!deleteTxid || !Array.isArray(myData?.pending)) {
-    return;
-  }
-
-  const pendingIndex = myData.pending.findIndex((pendingTx) =>
-    pendingTx.txid === deleteTxid && pendingTx.deletePending
-  );
-  if (pendingIndex !== -1) {
-    const pendingTxInfo = myData.pending[pendingIndex];
-    myData.pending.splice(pendingIndex, 1);
-    removePendingDeleteForAllTarget(pendingTxInfo.to, pendingTxInfo.deletePending?.targetTxid);
-  }
 }
 
 /**
@@ -19929,8 +19878,7 @@ class ChatModal {
 
     const deleteForAllOption = this.imageAttachmentContextMenu.querySelector('[data-action="delete-for-all"]');
     if (deleteForAllOption) {
-      const messageRecord = this.getMessageRecordFromElement(messageEl);
-      const canDeleteForAll = this.canDeleteMessageForAll(messageEl, messageRecord);
+      const canDeleteForAll = this.canDeleteMessageForAll(messageEl);
       deleteForAllOption.style.display = canDeleteForAll ? 'flex' : 'none';
     }
 
@@ -20873,22 +20821,19 @@ class ChatModal {
    */
   async deleteMessageForAll(messageEl) {
     const { txid, messageTimestamp: timestamp } = messageEl.dataset;
-    let deleteTxid = '';
-    let didInjectDelete = false;
-    let targetTxid = '';
-    let didTrackDeleteForAllTarget = false;
+    let pendingTargetKey = '';
     
     if (!timestamp && !txid) return;
     
     try {
       // Get the message object from contact.messages
       const contact = myData.contacts[this.address];
-      if (!contact?.messages?.length) return;
+      if (!contact) return;
 
       const message = this.getMessageRecordFromElement(messageEl);
       if (!message) return;
 
-      targetTxid = message.txid;
+      const targetTxid = message.txid;
       if (!targetTxid) {
         return showToast('Cannot delete message: missing message id', 0, 'error');
       }
@@ -20907,8 +20852,8 @@ class ChatModal {
       }
 
       if (!confirm('Delete this message for all participants?')) return;
-      trackPendingDeleteForAllTarget(this.address, targetTxid);
-      didTrackDeleteForAllTarget = true;
+      pendingTargetKey = getPendingDeleteForAllTargetKey(this.address, targetTxid);
+      pendingDeleteForAllTargetKeys.add(pendingTargetKey);
 
       // Create and send a "delete" message
       const keys = myAccount.keys;
@@ -20917,7 +20862,7 @@ class ChatModal {
         return;
       }
 
-      const tollInLib = myData.contacts[this.address].tollRequiredToSend == 0 ? 0n : getEffectiveTollLibWei(this.toll);
+      const tollInLib = contact.tollRequiredToSend == 0 ? 0n : getEffectiveTollLibWei(this.toll);
 
       const sufficientBalance = await validateBalance(tollInLib);
       if (!sufficientBalance) {
@@ -20928,8 +20873,8 @@ class ChatModal {
 
       // Ensure recipient keys are available
       const ok = await ensureContactKeys(this.address);
-      const recipientPubKey = myData.contacts[this.address]?.public;
-      const pqRecPubKey = myData.contacts[this.address]?.pqPublic;
+      const recipientPubKey = contact.public;
+      const pqRecPubKey = contact.pqPublic;
       if (!ok || !recipientPubKey || !pqRecPubKey) {
         console.warn(`No public/PQ key found for recipient ${this.address}`);
         showToast('Failed to get recipient key', 0, 'error');
@@ -20961,19 +20906,17 @@ class ChatModal {
       // Prepare and send the delete message transaction
       const deleteMessageObj = await this.createChatMessage(this.address, payload, tollInLib, keys);
       await signObj(deleteMessageObj, keys);
-      deleteTxid = getTxid(deleteMessageObj);
-      trackPendingDeleteForAllBeforeInject(deleteTxid, this.address, targetTxid);
+      const deleteTxid = getTxid(deleteMessageObj);
 
       // Send the delete transaction
       const response = await injectTx(deleteMessageObj, deleteTxid);
 
       if (!response || !response.result || !response.result.success) {
         console.error('Delete message failed to send', response);
-        removePendingDeleteForAll(deleteTxid);
         return showToast('Failed to delete message: ' + (response?.result?.reason || 'Unknown error'), 0, 'error');
       }
 
-      didInjectDelete = true;
+      trackPendingDeleteForAll(deleteTxid, this.address, targetTxid);
       showToast('Delete request sent', 5000, 'loading');
       
       // Best effort delete attachments from server
@@ -20989,14 +20932,11 @@ class ChatModal {
       // The message will be deleted when we process the delete tx from the network
       
     } catch (error) {
-      if (deleteTxid && !didInjectDelete) {
-        removePendingDeleteForAll(deleteTxid);
-      }
       console.error('Delete for all error:', error);
       showToast('Failed to delete message. Please try again.', 0, 'error');
     } finally {
-      if (didTrackDeleteForAllTarget) {
-        removePendingDeleteForAllTarget(this.address, targetTxid);
+      if (pendingTargetKey) {
+        pendingDeleteForAllTargetKeys.delete(pendingTargetKey);
       }
     }
   }

--- a/app.js
+++ b/app.js
@@ -6914,62 +6914,6 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
 }
 
 const DELETE_FOR_ALL_ACTION_GUARD_MS = 9000;
-const recentDeleteForAllTargetKeys = new Map();
-
-/**
- * Builds the in-memory key used to block repeated delete actions for a delete-for-all target.
- * @param {string} contactAddress
- * @param {string} targetTxid
- * @returns {string}
- */
-function getDeleteForAllTargetKey(contactAddress, targetTxid) {
-  assert(contactAddress, 'Delete guard contact address is required');
-  assert(targetTxid, 'Delete guard target txid is required');
-  return `${normalizeAddress(contactAddress)}:${targetTxid}`;
-}
-
-/**
- * Checks if a recent delete-for-all guard exists for a message target.
- * @param {string} contactAddress
- * @param {string} targetTxid
- * @returns {boolean}
- */
-function hasRecentDeleteForAllForTarget(contactAddress, targetTxid) {
-  if (!contactAddress || !targetTxid) {
-    return false;
-  }
-
-  return recentDeleteForAllTargetKeys.has(getDeleteForAllTargetKey(contactAddress, targetTxid));
-}
-
-/**
- * Temporarily blocks repeated delete actions for a delete-for-all target.
- * @param {string} contactAddress
- * @param {string} targetTxid
- * @returns {void}
- */
-function markRecentDeleteForAllForTarget(contactAddress, targetTxid) {
-  if (!contactAddress || !targetTxid) {
-    return;
-  }
-
-  const key = getDeleteForAllTargetKey(contactAddress, targetTxid);
-  clearTimeout(recentDeleteForAllTargetKeys.get(key));
-  const timeoutId = setTimeout(() => {
-    recentDeleteForAllTargetKeys.delete(key);
-  }, DELETE_FOR_ALL_ACTION_GUARD_MS);
-  recentDeleteForAllTargetKeys.set(key, timeoutId);
-}
-
-function setContextMenuOptionDisabled(option, disabled) {
-  if (!option) return;
-  option.classList.toggle('is-disabled', disabled);
-  option.setAttribute('aria-disabled', disabled ? 'true' : 'false');
-}
-
-function isContextMenuOptionDisabled(option) {
-  return option?.classList?.contains('is-disabled') || option?.getAttribute('aria-disabled') === 'true';
-}
 
 /**
  * Restores local state captured before an optimistic message edit.
@@ -14496,6 +14440,8 @@ class ChatModal {
     this.dragCounter = 0;
     this.dropOverlay = null;
 
+    this.recentDeleteForAllTargetKeys = new Map();
+
     this.chatRenderedOldestIndex = CHAT_INITIAL_RENDER_COUNT - 1;
   }
 
@@ -15025,7 +14971,7 @@ class ChatModal {
         return;
       }
       const option = e.target.closest('.context-menu-option');
-      if (option && !isContextMenuOptionDisabled(option)) {
+      if (option && !this.isContextMenuOptionDisabled(option)) {
         const action = option.dataset.action;
         this.handleContextMenuAction(action);
       }
@@ -15041,7 +14987,7 @@ class ChatModal {
           return;
         }
         const option = e.target.closest('.context-menu-option');
-        if (!option || isContextMenuOptionDisabled(option)) return;
+        if (!option || this.isContextMenuOptionDisabled(option)) return;
         const action = option.dataset.action;
         this.handleImageAttachmentContextMenuAction(action);
       });
@@ -19344,15 +19290,52 @@ class ChatModal {
     return true;
   }
 
+  getDeleteForAllTargetKey(contactAddress, targetTxid) {
+    assert(contactAddress, 'Delete guard contact address is required');
+    assert(targetTxid, 'Delete guard target txid is required');
+    return `${normalizeAddress(contactAddress)}:${targetTxid}`;
+  }
+
+  hasRecentDeleteForAllForTarget(contactAddress, targetTxid) {
+    if (!contactAddress || !targetTxid) {
+      return false;
+    }
+
+    return this.recentDeleteForAllTargetKeys.has(this.getDeleteForAllTargetKey(contactAddress, targetTxid));
+  }
+
+  markRecentDeleteForAllForTarget(contactAddress, targetTxid) {
+    if (!contactAddress || !targetTxid) {
+      return;
+    }
+
+    const key = this.getDeleteForAllTargetKey(contactAddress, targetTxid);
+    clearTimeout(this.recentDeleteForAllTargetKeys.get(key));
+    const timeoutId = setTimeout(() => {
+      this.recentDeleteForAllTargetKeys.delete(key);
+    }, DELETE_FOR_ALL_ACTION_GUARD_MS);
+    this.recentDeleteForAllTargetKeys.set(key, timeoutId);
+  }
+
+  setContextMenuOptionDisabled(option, disabled) {
+    if (!option) return;
+    option.classList.toggle('is-disabled', disabled);
+    option.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+  }
+
+  isContextMenuOptionDisabled(option) {
+    return option?.classList?.contains('is-disabled') || option?.getAttribute('aria-disabled') === 'true';
+  }
+
   hasRecentDeleteForAllForMessage(messageEl, messageRecord = null) {
     const message = messageRecord || this.getMessageRecordFromElement(messageEl);
-    return hasRecentDeleteForAllForTarget(this.address, message?.txid);
+    return this.hasRecentDeleteForAllForTarget(this.address, message?.txid);
   }
 
   syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
     const isDisabled = this.hasRecentDeleteForAllForMessage(messageEl, messageRecord);
-    setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete"]'), isDisabled);
-    setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete-for-all"]'), isDisabled);
+    this.setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete"]'), isDisabled);
+    this.setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete-for-all"]'), isDisabled);
   }
 
   isDeleteContextMenuActionDisabled(action, messageEl) {
@@ -20866,12 +20849,12 @@ class ChatModal {
         return showToast('You can only delete your own messages for all', 0, 'error');
       }
 
-      if (hasRecentDeleteForAllForTarget(this.address, targetTxid)) {
+      if (this.hasRecentDeleteForAllForTarget(this.address, targetTxid)) {
         return showToast('Delete is temporarily disabled', 2000, 'info');
       }
 
       if (!confirm('Delete this message for all participants?')) return;
-      markRecentDeleteForAllForTarget(this.address, targetTxid);
+      this.markRecentDeleteForAllForTarget(this.address, targetTxid);
 
       // Create and send a "delete" message
       const keys = myAccount.keys;

--- a/app.js
+++ b/app.js
@@ -6913,7 +6913,7 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
   );
 }
 
-const DELETE_FOR_ALL_ACTION_GUARD_MS = 9000;
+const DELETE_FOR_ALL_ACTION_GUARD_MS = 15000;
 
 /**
  * Restores local state captured before an optimistic message edit.

--- a/app.js
+++ b/app.js
@@ -18700,11 +18700,8 @@ class ChatModal {
     // Show/hide "Delete for all" option based on whether the message is from the current user
     const deleteForAllOption = this.contextMenu.querySelector('[data-action="delete-for-all"]');
     const canDeleteForAll = this.canDeleteMessageForAll(messageEl, messageRecord);
-    const deleteForAllTargetTxid = messageRecord?.txid || messageEl.dataset.txid || '';
-    const isDeleteForAllPending =
-      canDeleteForAll && hasPendingDeleteForAllForTarget(this.address, deleteForAllTargetTxid);
     if (deleteForAllOption) {
-      this.setDeleteForAllOptionState(deleteForAllOption, canDeleteForAll, isDeleteForAllPending);
+      deleteForAllOption.style.display = canDeleteForAll ? 'flex' : 'none';
     }
 
     // If this is a call message, show call-specific options and hide copy
@@ -19356,23 +19353,6 @@ class ChatModal {
   }
 
   /**
-   * Applies visibility and pending state to a delete-for-all context menu option.
-   * @param {HTMLElement} option
-   * @param {boolean} canDeleteForAll
-   * @param {boolean} isPending
-   * @returns {void}
-   */
-  setDeleteForAllOptionState(option, canDeleteForAll, isPending) {
-    option.style.display = canDeleteForAll ? 'flex' : 'none';
-    option.setAttribute('aria-disabled', isPending ? 'true' : 'false');
-    if (isPending) {
-      option.title = 'Delete is already pending';
-    } else {
-      option.removeAttribute('title');
-    }
-  }
-
-  /**
    * Removes cached thumbnails for any image attachments in an xattach array.
    * Safe to call even if thumbnails don't exist.
    * @param {any} xattach
@@ -19903,10 +19883,7 @@ class ChatModal {
     if (deleteForAllOption) {
       const messageRecord = this.getMessageRecordFromElement(messageEl);
       const canDeleteForAll = this.canDeleteMessageForAll(messageEl, messageRecord);
-      const deleteForAllTargetTxid = messageRecord?.txid || messageEl.dataset.txid || '';
-      const isDeleteForAllPending =
-        canDeleteForAll && hasPendingDeleteForAllForTarget(this.address, deleteForAllTargetTxid);
-      this.setDeleteForAllOptionState(deleteForAllOption, canDeleteForAll, isDeleteForAllPending);
+      deleteForAllOption.style.display = canDeleteForAll ? 'flex' : 'none';
     }
 
     const isImageAttachment = attachmentRow.dataset.imageAttachment === 'true';

--- a/app.js
+++ b/app.js
@@ -20836,9 +20836,7 @@ class ChatModal {
         return showToast('You can only delete your own messages for all', 0, 'error');
       }
 
-      if (this.hasRecentDeleteForAllForTarget(this.address, targetTxid)) {
-        return showToast('Delete is temporarily disabled', 2000, 'info');
-      }
+      if (this.hasRecentDeleteForAllForTarget(this.address, targetTxid)) return;
 
       if (!confirm('Delete this message for all participants?')) return;
       this.markRecentDeleteForAllForTarget(this.address, targetTxid);

--- a/app.js
+++ b/app.js
@@ -6927,6 +6927,12 @@ function getPendingDeleteForAllTargetKey(contactAddress, targetTxid) {
   return `${normalizeAddress(contactAddress)}:${targetTxid}`;
 }
 
+/**
+ * Checks if a pending delete-for-all target marker exists in the in-memory pending transactions.
+ * @param {string} contactAddress
+ * @param {string} targetTxid
+ * @returns {boolean}
+ */
 function hasPendingDeleteForAllForTarget(contactAddress, targetTxid) {
   if (!contactAddress || !targetTxid) {
     return false;

--- a/app.js
+++ b/app.js
@@ -20915,7 +20915,6 @@ class ChatModal {
       await signObj(deleteMessageObj, keys);
       deleteTxid = getTxid(deleteMessageObj);
       trackPendingDeleteForAllBeforeInject(deleteTxid, this.address, targetTxid);
-      saveState();
 
       // Send the delete transaction
       const response = await injectTx(deleteMessageObj, deleteTxid);
@@ -20923,12 +20922,10 @@ class ChatModal {
       if (!response || !response.result || !response.result.success) {
         console.error('Delete message failed to send', response);
         removePendingDeleteForAll(deleteTxid);
-        saveState();
         return showToast('Failed to delete message: ' + (response?.result?.reason || 'Unknown error'), 0, 'error');
       }
 
       didInjectDelete = true;
-      saveState();
       showToast('Delete request sent', 5000, 'loading');
       
       // Best effort delete attachments from server
@@ -20946,7 +20943,6 @@ class ChatModal {
     } catch (error) {
       if (deleteTxid && !didInjectDelete) {
         removePendingDeleteForAll(deleteTxid);
-        saveState();
       }
       console.error('Delete for all error:', error);
       showToast('Failed to delete message. Please try again.', 0, 'error');

--- a/app.js
+++ b/app.js
@@ -19338,10 +19338,6 @@ class ChatModal {
     this.setContextMenuOptionDisabled(menu?.querySelector('[data-action="delete-for-all"]'), isDisabled);
   }
 
-  isDeleteContextMenuActionDisabled(action, messageEl) {
-    return (action === 'delete' || action === 'delete-for-all') && this.hasRecentDeleteForAllForMessage(messageEl);
-  }
-
   /**
    * Removes cached thumbnails for any image attachments in an xattach array.
    * Safe to call even if thumbnails don't exist.
@@ -19925,11 +19921,6 @@ class ChatModal {
     if (!row) return;
 
     const { messageEl } = this.getAttachmentContextFromRow(row);
-    if (this.isDeleteContextMenuActionDisabled(action, messageEl)) {
-      this.closeImageAttachmentContextMenu();
-      return;
-    }
-
     switch (action) {
       case 'import-contacts':
         void this.openImportContactsModal(row);
@@ -20056,10 +20047,6 @@ class ChatModal {
   handleContextMenuAction(action) {
     const messageEl = this.currentContextMessage;
     if (!messageEl) return;
-    if (this.isDeleteContextMenuActionDisabled(action, messageEl)) {
-      this.closeContextMenu();
-      return;
-    }
     
     switch (action) {
       case 'save':

--- a/styles.css
+++ b/styles.css
@@ -6911,8 +6911,17 @@ small {
   background: rgba(255, 255, 255, 0.1);
 }
 
+.context-menu-option[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.context-menu-option[aria-disabled="true"]:hover {
+  background: transparent;
+}
+
 .context-menu-option[data-action="delete"]:hover,
-.context-menu-option[data-action="delete-for-all"]:hover {
+.context-menu-option[data-action="delete-for-all"]:not([aria-disabled="true"]):hover {
   background: rgba(255, 59, 48, 0.2);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -6911,6 +6911,21 @@ small {
   background: rgba(255, 255, 255, 0.1);
 }
 
+.context-menu-option.is-disabled,
+.context-menu-option[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.context-menu-option.is-disabled:hover,
+.context-menu-option.is-disabled[data-action="delete"]:hover,
+.context-menu-option.is-disabled[data-action="delete-for-all"]:hover,
+.context-menu-option[aria-disabled="true"]:hover,
+.context-menu-option[aria-disabled="true"][data-action="delete"]:hover,
+.context-menu-option[aria-disabled="true"][data-action="delete-for-all"]:hover {
+  background: transparent;
+}
+
 .context-menu-option[data-action="delete"]:hover,
 .context-menu-option[data-action="delete-for-all"]:hover {
   background: rgba(255, 59, 48, 0.2);

--- a/styles.css
+++ b/styles.css
@@ -6911,17 +6911,8 @@ small {
   background: rgba(255, 255, 255, 0.1);
 }
 
-.context-menu-option[aria-disabled="true"] {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.context-menu-option[aria-disabled="true"]:hover {
-  background: transparent;
-}
-
 .context-menu-option[data-action="delete"]:hover,
-.context-menu-option[data-action="delete-for-all"]:not([aria-disabled="true"]):hover {
+.context-menu-option[data-action="delete-for-all"]:hover {
   background: rgba(255, 59, 48, 0.2);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -6911,24 +6911,18 @@ small {
   background: rgba(255, 255, 255, 0.1);
 }
 
-.context-menu-option.is-disabled,
+.context-menu-option[data-action="delete"]:hover,
+.context-menu-option[data-action="delete-for-all"]:hover {
+  background: rgba(255, 59, 48, 0.2);
+}
+
 .context-menu-option[aria-disabled="true"] {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.context-menu-option.is-disabled:hover,
-.context-menu-option.is-disabled[data-action="delete"]:hover,
-.context-menu-option.is-disabled[data-action="delete-for-all"]:hover,
-.context-menu-option[aria-disabled="true"]:hover,
-.context-menu-option[aria-disabled="true"][data-action="delete"]:hover,
-.context-menu-option[aria-disabled="true"][data-action="delete-for-all"]:hover {
+.context-menu-option[aria-disabled="true"]:hover {
   background: transparent;
-}
-
-.context-menu-option[data-action="delete"]:hover,
-.context-menu-option[data-action="delete-for-all"]:hover {
-  background: rgba(255, 59, 48, 0.2);
 }
 
 .context-menu-option[data-action="delete"] .context-menu-text,


### PR DESCRIPTION
## What Changed

This PR adds a short-lived UI guard for repeated delete-for-all actions on the same message.

- `deleteMessageForAll` now resolves the backing message record, validates the target txid, and skips repeat delete-for-all attempts while the recent-action guard is active.
- Context menu delete actions are disabled visually and behaviorally when the current message has a recent delete-for-all request.
- The same disabled state is applied to regular message menus and attachment context menus.

## Fixed Flow

1. A user chooses delete-for-all on one of their messages.
2. After confirmation, the target message txid is marked in a short-lived in-memory guard.
3. Reopening the message or attachment context menu during that window shows delete actions disabled and ignores clicks.
4. Once the guard expires, the action becomes available again if the message has not yet been processed as deleted.

## Why

We intentionally kept this as a simple request-sent guard instead of durable pending transaction state. The delete request is treated like the existing loading toast: after the user confirms, we assume the request is in progress and briefly prevent duplicate clicks. If the request does not go through or the page is reloaded, the button can become available again rather than being locked behind persisted pending metadata.

## Validation

- `node --check app.js`
- `git diff --check 0e79197f664c0c2150cf0f622c958b64abc10e89`

Fixes #1378