### PR TITLE
Fix restored account count

### DIFF
--- a/app.js
+++ b/app.js
@@ -12477,32 +12477,11 @@ class RestoreAccountModal {
       }
     }
 
-    // Ensure we have local accounts registry
-    const existingAccounts = parse(localStorage.getItem('accounts') || '{"netids":{}}');
-
-    // Merge accounts registry first
-    const backupAccountsRegistry = parse(backupData.accounts || '{"netids":{}}');
-    Object.keys(backupAccountsRegistry.netids || {}).forEach(netid => {
-      if (!existingAccounts.netids[netid]) existingAccounts.netids[netid] = { usernames: {} };
-      const usernames = backupAccountsRegistry.netids[netid].usernames || {};
-      Object.keys(usernames).forEach(username => {
-        if (overwrite || !existingAccounts.netids[netid].usernames[username]) {
-          existingAccounts.netids[netid].usernames[username] = usernames[username];
-        }
-      });
-    });
-    localStorage.setItem('accounts', stringify(existingAccounts));
-
-
     // Iterate over keys in backupData and copy account entries
-    let restoredCount = 0;
-    for (const key of Object.keys(backupData)) {
-      const parts = key.split('_');
-      if (parts.length !== 2) continue;
-      const username = parts[0];
-      const netid = parts[1];
-      // basic netid check
-      if (netid.length !== 64 || !/^[a-f0-9]+$/.test(netid)) continue;
+    const restoredAccountKeys = new Set();
+    const backupAccountsRegistry = this.parseBackupAccountsRegistry(backupData);
+    const backupAccountEntries = this.getBackupAccountEntries(backupData, backupAccountsRegistry);
+    for (const { key, username, netid, registryAccount } of backupAccountEntries) {
 
       const localKey = `${username}_${netid}`;
       const exists = localStorage.getItem(localKey) !== null;
@@ -12517,7 +12496,7 @@ class RestoreAccountModal {
 
       if (locksMatch) {
         localStorage.setItem(localKey, value);
-        restoredCount++;
+        restoredAccountKeys.add(localKey);
         decryptedAccount = this.tryDecryptWithLocalLock(value);
       } else {
         // Need to decrypt with backupEncKey if available
@@ -12555,11 +12534,13 @@ class RestoreAccountModal {
         }
 
         localStorage.setItem(localKey, finalValue);
-        restoredCount++;
+        restoredAccountKeys.add(localKey);
       }
 
       if (decryptedAccount) {
         this.updateAccountRegistryAddress(netid, username, decryptedAccount);
+      } else if (registryAccount?.address) {
+        this.updateAccountRegistryFromBackup(netid, username, registryAccount);
       }
     }
 
@@ -12581,7 +12562,7 @@ class RestoreAccountModal {
       }
     }
 
-    return restoredCount;
+    return restoredAccountKeys.size;
   }
 
   async handleSubmit(event) {
@@ -12658,16 +12639,19 @@ class RestoreAccountModal {
       if (restoredCount === false) {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
-      showToast(`${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`, 3000, 'success');
+      const successToastId = showToast(`${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`, 0, 'success');
       
       // handleNativeAppSubscription()
 
-      // Reset form and close modal after delay
-      setTimeout(() => {
+      const finishRestore = () => {
         this.close();
         clearMyData(); // since we already saved to localStore, we want to make sure beforeunload calling saveState does not also save
         window.location.reload(); // need to go through Sign In to make sure imported account exists on network
-      }, 2000);
+      };
+      const successToast = document.getElementById(successToastId);
+      if (successToast) {
+        successToast.addEventListener('click', finishRestore, { once: true });
+      }
     } catch (error) {
       showToast(error.message || 'Import failed. Please check file and password.', 0, 'error');
     }
@@ -12716,6 +12700,54 @@ class RestoreAccountModal {
     cleanup(this.newStringSelect);
   }
 
+  parseBackupAccountsRegistry(backupData) {
+    try {
+      if (!backupData?.accounts) return { netids: {} };
+      const registry = typeof backupData.accounts === 'string'
+        ? parse(backupData.accounts)
+        : backupData.accounts;
+      return registry && typeof registry === 'object' ? registry : { netids: {} };
+    } catch (e) {
+      return { netids: {} };
+    }
+  }
+
+  parseBackupAccountKey(key) {
+    const parts = key.split('_');
+    if (parts.length !== 2) return null;
+
+    const [username, netid] = parts;
+    if (!username || netid.length !== 64 || !/^[a-f0-9]+$/.test(netid)) {
+      return null;
+    }
+
+    return { username, netid };
+  }
+
+  getBackupAccountEntries(backupData, backupAccountsRegistry) {
+    const registryNetids = backupAccountsRegistry?.netids || {};
+    const hasRegistryAccounts = Object.keys(registryNetids).length > 0;
+
+    return Object.keys(backupData)
+      .map(key => {
+        const parsedKey = this.parseBackupAccountKey(key);
+        if (!parsedKey) return null;
+
+        const registryAccount = registryNetids[parsedKey.netid]?.usernames?.[parsedKey.username];
+        if (hasRegistryAccounts && !registryAccount) {
+          return null;
+        }
+
+        return {
+          key,
+          username: parsedKey.username,
+          netid: parsedKey.netid,
+          registryAccount
+        };
+      })
+      .filter(Boolean);
+  }
+
   extractAddress(maybeJson) {
     try {
       const obj = typeof maybeJson === 'string' ? parse(maybeJson) : maybeJson;
@@ -12732,6 +12764,13 @@ class RestoreAccountModal {
     const accountsObj = parse(localStorage.getItem('accounts') || '{"netids":{}}');
     if (!accountsObj.netids[netid]) accountsObj.netids[netid] = { usernames: {} };
     accountsObj.netids[netid].usernames[username] = { address };
+    localStorage.setItem('accounts', stringify(accountsObj));
+  }
+
+  updateAccountRegistryFromBackup(netid, username, registryAccount) {
+    const accountsObj = parse(localStorage.getItem('accounts') || '{"netids":{}}');
+    if (!accountsObj.netids[netid]) accountsObj.netids[netid] = { usernames: {} };
+    accountsObj.netids[netid].usernames[username] = registryAccount;
     localStorage.setItem('accounts', stringify(accountsObj));
   }
 

--- a/app.js
+++ b/app.js
@@ -12639,12 +12639,12 @@ class RestoreAccountModal {
       if (restoredCount === false) {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
+      clearMyData(); // Prevent stale signed-in state from saving over restored localStorage before refresh.
       let restoreSuccessToast = null;
       const finishRestore = () => {
         document.removeEventListener('click', handleRestoreOutsideClick, true);
         hideToast(successToastId);
         this.close();
-        clearMyData(); // since we already saved to localStore, we want to make sure beforeunload calling saveState does not also save
         window.location.reload(); // need to go through Sign In to make sure imported account exists on network
       };
       function handleRestoreOutsideClick(event) {

--- a/app.js
+++ b/app.js
@@ -12639,6 +12639,7 @@ class RestoreAccountModal {
       if (restoredCount === false) {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
+      let restoreSuccessToast = null;
       const finishRestore = () => {
         document.removeEventListener('click', handleRestoreOutsideClick, true);
         hideToast(successToastId);
@@ -12646,6 +12647,10 @@ class RestoreAccountModal {
         clearMyData(); // since we already saved to localStore, we want to make sure beforeunload calling saveState does not also save
         window.location.reload(); // need to go through Sign In to make sure imported account exists on network
       };
+      function handleRestoreOutsideClick(event) {
+        if (restoreSuccessToast?.contains(event.target)) return;
+        finishRestore();
+      }
       const successToastId = showToast(
         `${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`,
         0,
@@ -12653,24 +12658,28 @@ class RestoreAccountModal {
         false,
         { className: 'toast-requires-action' }
       );
-      const successToast = document.getElementById(successToastId);
-      const refreshButton = successToast?.querySelector('.toast-close-btn');
-      if (!successToast || !refreshButton) {
-        finishRestore();
-        return;
-      }
+      const setupRestoreRefreshAction = (attempt = 0) => {
+        const successToast = document.getElementById(successToastId);
+        const refreshButton = successToast?.querySelector('.toast-close-btn');
+        if (!successToast || !refreshButton) {
+          if (attempt < 5) {
+            setTimeout(() => setupRestoreRefreshAction(attempt + 1), 10);
+            return;
+          }
+          finishRestore();
+          return;
+        }
 
-      refreshButton.className = 'toast-action-btn';
-      refreshButton.textContent = 'Refresh';
-      refreshButton.setAttribute('aria-label', 'Refresh to finish restore');
-      refreshButton.addEventListener('click', finishRestore, { once: true });
-      successToast.onclick = (event) => event.stopPropagation();
+        restoreSuccessToast = successToast;
+        refreshButton.className = 'toast-action-btn';
+        refreshButton.textContent = 'Refresh';
+        refreshButton.setAttribute('aria-label', 'Refresh to finish restore');
+        refreshButton.addEventListener('click', finishRestore, { once: true });
+        successToast.onclick = (event) => event.stopPropagation();
 
-      function handleRestoreOutsideClick(event) {
-        if (successToast.contains(event.target)) return;
-        finishRestore();
-      }
-      setTimeout(() => document.addEventListener('click', handleRestoreOutsideClick, true), 0);
+        setTimeout(() => document.addEventListener('click', handleRestoreOutsideClick, true), 0);
+      };
+      setupRestoreRefreshAction();
 
       // handleNativeAppSubscription()
     } catch (error) {

--- a/app.js
+++ b/app.js
@@ -12640,15 +12640,46 @@ class RestoreAccountModal {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
       clearMyData(); // Prevent stale signed-in state from saving over restored localStorage before refresh.
-      showToast(`${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`, 0, 'success');
+      const successToastId = showToast(`${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`, 0, 'success');
+      let restoreFinished = false;
+      const finishRestore = () => {
+        if (restoreFinished) return;
+        restoreFinished = true;
+        document.removeEventListener('click', handleRestoreOutsideClick, true);
+        hideToast(successToastId);
+        this.close();
+        setTimeout(() => {
+          window.location.reload(); // need to go through Sign In to make sure imported account exists on network
+        }, 300);
+      };
+      function handleRestoreOutsideClick(event) {
+        const successToast = document.getElementById(successToastId);
+        if (successToast?.contains(event.target)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        finishRestore();
+      }
+      const setupRestoreDismissAction = (attempt = 0) => {
+        const successToast = document.getElementById(successToastId);
+        if (!successToast || !successToast.classList.contains('sticky')) {
+          if (attempt < 5) {
+            setTimeout(() => setupRestoreDismissAction(attempt + 1), 10);
+            return;
+          }
+          finishRestore();
+          return;
+        }
+
+        successToast.onclick = (event) => {
+          event.stopPropagation();
+          finishRestore();
+        };
+        setTimeout(() => document.addEventListener('click', handleRestoreOutsideClick, true), 0);
+      };
+      setupRestoreDismissAction();
 
       // handleNativeAppSubscription()
-
-      // Reset form and close modal after delay
-      setTimeout(() => {
-        this.close();
-        window.location.reload(); // need to go through Sign In to make sure imported account exists on network
-      }, 2000);
     } catch (error) {
       showToast(error.message || 'Import failed. Please check file and password.', 0, 'error');
     }

--- a/app.js
+++ b/app.js
@@ -10195,6 +10195,9 @@ function showToast(message, duration = 2000, type = 'default', isHTML = false, o
   if (dedupeEnabled) {
     const existingToast = document.querySelector(`[data-deduplicate-key="${deduplicateKey}"]`);
     if (existingToast) {
+      if (typeof options?.onHidden === 'function') {
+        existingToast.addEventListener('toast:hidden', options.onHidden, { once: true });
+      }
       // Toast with this key already exists, don't create another one
       return existingToast.id;
     }
@@ -10204,6 +10207,9 @@ function showToast(message, duration = 2000, type = 'default', isHTML = false, o
   toast.className = `toast ${type}`;
   if (options?.className) {
     toast.classList.add(...String(options.className).split(/\s+/).filter(Boolean));
+  }
+  if (typeof options?.onHidden === 'function') {
+    toast.addEventListener('toast:hidden', options.onHidden, { once: true });
   }
   
   if (isHTML) {
@@ -10267,6 +10273,7 @@ function hideToast(toastId) {
     const toastContainer = document.getElementById('toastContainer');
     if (toast.parentNode === toastContainer) {
       toastContainer.removeChild(toast);
+      toast.dispatchEvent(new Event('toast:hidden'));
     }
   }, 300); // Match transition duration
 }
@@ -12640,17 +12647,11 @@ class RestoreAccountModal {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
       clearMyData(); // Prevent stale signed-in state from saving over restored localStorage before refresh.
-      const successToastId = showToast(`${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`, 0, 'success');
-      let restoreFinished = false;
-      const finishRestore = () => {
-        if (restoreFinished) return;
-        restoreFinished = true;
+      let successToastId;
+      const refreshAfterRestoreToast = () => {
         document.removeEventListener('click', handleRestoreOutsideClick, true);
-        hideToast(successToastId);
         this.close();
-        setTimeout(() => {
-          window.location.reload(); // need to go through Sign In to make sure imported account exists on network
-        }, 300);
+        window.location.reload(); // need to go through Sign In to make sure imported account exists on network
       };
       function handleRestoreOutsideClick(event) {
         const successToast = document.getElementById(successToastId);
@@ -12658,26 +12659,16 @@ class RestoreAccountModal {
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
-        finishRestore();
+        hideToast(successToastId);
       }
-      const setupRestoreDismissAction = (attempt = 0) => {
-        const successToast = document.getElementById(successToastId);
-        if (!successToast || !successToast.classList.contains('sticky')) {
-          if (attempt < 5) {
-            setTimeout(() => setupRestoreDismissAction(attempt + 1), 10);
-            return;
-          }
-          finishRestore();
-          return;
-        }
-
-        successToast.onclick = (event) => {
-          event.stopPropagation();
-          finishRestore();
-        };
-        setTimeout(() => document.addEventListener('click', handleRestoreOutsideClick, true), 0);
-      };
-      setupRestoreDismissAction();
+      successToastId = showToast(
+        `${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`,
+        0,
+        'success',
+        false,
+        { onHidden: refreshAfterRestoreToast }
+      );
+      setTimeout(() => document.addEventListener('click', handleRestoreOutsideClick, true), 0);
 
       // handleNativeAppSubscription()
     } catch (error) {

--- a/app.js
+++ b/app.js
@@ -12640,48 +12640,15 @@ class RestoreAccountModal {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
       clearMyData(); // Prevent stale signed-in state from saving over restored localStorage before refresh.
-      let restoreSuccessToast = null;
-      const finishRestore = () => {
-        document.removeEventListener('click', handleRestoreOutsideClick, true);
-        hideToast(successToastId);
-        this.close();
-        window.location.reload(); // need to go through Sign In to make sure imported account exists on network
-      };
-      function handleRestoreOutsideClick(event) {
-        if (restoreSuccessToast?.contains(event.target)) return;
-        finishRestore();
-      }
-      const successToastId = showToast(
-        `${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`,
-        0,
-        'success',
-        false,
-        { className: 'toast-requires-action' }
-      );
-      const setupRestoreRefreshAction = (attempt = 0) => {
-        const successToast = document.getElementById(successToastId);
-        const refreshButton = successToast?.querySelector('.toast-close-btn');
-        if (!successToast || !refreshButton) {
-          if (attempt < 5) {
-            setTimeout(() => setupRestoreRefreshAction(attempt + 1), 10);
-            return;
-          }
-          finishRestore();
-          return;
-        }
-
-        restoreSuccessToast = successToast;
-        refreshButton.className = 'toast-action-btn';
-        refreshButton.textContent = 'Refresh';
-        refreshButton.setAttribute('aria-label', 'Refresh to finish restore');
-        refreshButton.addEventListener('click', finishRestore, { once: true });
-        successToast.onclick = (event) => event.stopPropagation();
-
-        setTimeout(() => document.addEventListener('click', handleRestoreOutsideClick, true), 0);
-      };
-      setupRestoreRefreshAction();
+      showToast(`${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`, 0, 'success');
 
       // handleNativeAppSubscription()
+
+      // Reset form and close modal after delay
+      setTimeout(() => {
+        this.close();
+        window.location.reload(); // need to go through Sign In to make sure imported account exists on network
+      }, 2000);
     } catch (error) {
       showToast(error.message || 'Import failed. Please check file and password.', 0, 'error');
     }

--- a/app.js
+++ b/app.js
@@ -10233,18 +10233,33 @@ function showToast(message, duration = 2000, type = 'default', isHTML = false, o
     // Duration determines behavior: <= 0 = sticky (requires close button), > 0 = auto-dismiss
     // Exception: loading toasts are never manually closable by user
     if (duration <= 0 && type !== 'loading') {
-      // Sticky toast - add close button and click handler (but not for loading toasts)
+      // Sticky toast - add close/action button and click handler (but not for loading toasts)
       toast.classList.add('sticky');
       const closeBtn = document.createElement('button');
-      closeBtn.className = 'toast-close-btn';
-      closeBtn.setAttribute('aria-label', 'Close');
-      closeBtn.innerHTML = '&times;';
+      closeBtn.className = options?.closeButtonClassName || 'toast-close-btn';
+      closeBtn.setAttribute('aria-label', options?.closeAriaLabel || 'Close');
+      if (options?.closeButtonLabel) {
+        closeBtn.textContent = options.closeButtonLabel;
+      } else {
+        closeBtn.innerHTML = '&times;';
+      }
       toast.appendChild(closeBtn);
 
-      // Make the whole toast clickable to close
-      toast.onclick = () => {
+      closeBtn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        if (typeof options?.onClose === 'function') {
+          options.onClose(toastId);
+          return;
+        }
         hideToast(toastId);
-      };
+      }, { once: true });
+
+      if (options?.closeOnToastClick !== false) {
+        // Make the whole toast clickable to close
+        toast.onclick = () => {
+          hideToast(toastId);
+        };
+      }
     } else if (duration > 0) {
       // Auto-dismiss toast - no close button needed
       setTimeout(() => {
@@ -12639,19 +12654,48 @@ class RestoreAccountModal {
       if (restoredCount === false) {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
-      const successToastId = showToast(`${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`, 0, 'success');
-      
-      // handleNativeAppSubscription()
-
+      let successToastId = null;
+      let restoreFinished = false;
+      let handleRestoreOutsideClick = null;
       const finishRestore = () => {
+        if (restoreFinished) return;
+        restoreFinished = true;
+        if (handleRestoreOutsideClick) {
+          document.removeEventListener('click', handleRestoreOutsideClick, true);
+        }
+        if (successToastId) {
+          hideToast(successToastId);
+        }
         this.close();
         clearMyData(); // since we already saved to localStore, we want to make sure beforeunload calling saveState does not also save
         window.location.reload(); // need to go through Sign In to make sure imported account exists on network
       };
-      const successToast = document.getElementById(successToastId);
-      if (successToast) {
-        successToast.addEventListener('click', finishRestore, { once: true });
-      }
+      successToastId = showToast(
+        `${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`,
+        0,
+        'success',
+        false,
+        {
+          className: 'toast-requires-action',
+          closeButtonClassName: 'toast-action-btn',
+          closeButtonLabel: 'Refresh',
+          closeAriaLabel: 'Refresh to finish restore',
+          closeOnToastClick: false,
+          onClose: finishRestore
+        }
+      );
+      handleRestoreOutsideClick = (event) => {
+        const successToast = document.getElementById(successToastId);
+        if (successToast?.contains(event.target)) return;
+        finishRestore();
+      };
+      setTimeout(() => {
+        if (!restoreFinished) {
+          document.addEventListener('click', handleRestoreOutsideClick, true);
+        }
+      }, 0);
+
+      // handleNativeAppSubscription()
     } catch (error) {
       showToast(error.message || 'Import failed. Please check file and password.', 0, 'error');
     }

--- a/app.js
+++ b/app.js
@@ -10233,33 +10233,18 @@ function showToast(message, duration = 2000, type = 'default', isHTML = false, o
     // Duration determines behavior: <= 0 = sticky (requires close button), > 0 = auto-dismiss
     // Exception: loading toasts are never manually closable by user
     if (duration <= 0 && type !== 'loading') {
-      // Sticky toast - add close/action button and click handler (but not for loading toasts)
+      // Sticky toast - add close button and click handler (but not for loading toasts)
       toast.classList.add('sticky');
       const closeBtn = document.createElement('button');
-      closeBtn.className = options?.closeButtonClassName || 'toast-close-btn';
-      closeBtn.setAttribute('aria-label', options?.closeAriaLabel || 'Close');
-      if (options?.closeButtonLabel) {
-        closeBtn.textContent = options.closeButtonLabel;
-      } else {
-        closeBtn.innerHTML = '&times;';
-      }
+      closeBtn.className = 'toast-close-btn';
+      closeBtn.setAttribute('aria-label', 'Close');
+      closeBtn.innerHTML = '&times;';
       toast.appendChild(closeBtn);
 
-      closeBtn.addEventListener('click', (event) => {
-        event.stopPropagation();
-        if (typeof options?.onClose === 'function') {
-          options.onClose(toastId);
-          return;
-        }
+      // Make the whole toast clickable to close
+      toast.onclick = () => {
         hideToast(toastId);
-      }, { once: true });
-
-      if (options?.closeOnToastClick !== false) {
-        // Make the whole toast clickable to close
-        toast.onclick = () => {
-          hideToast(toastId);
-        };
-      }
+      };
     } else if (duration > 0) {
       // Auto-dismiss toast - no close button needed
       setTimeout(() => {
@@ -12654,46 +12639,38 @@ class RestoreAccountModal {
       if (restoredCount === false) {
         return; // merge failed — keep modal open and do not proceed to reset/close
       }
-      let successToastId = null;
-      let restoreFinished = false;
-      let handleRestoreOutsideClick = null;
       const finishRestore = () => {
-        if (restoreFinished) return;
-        restoreFinished = true;
-        if (handleRestoreOutsideClick) {
-          document.removeEventListener('click', handleRestoreOutsideClick, true);
-        }
-        if (successToastId) {
-          hideToast(successToastId);
-        }
+        document.removeEventListener('click', handleRestoreOutsideClick, true);
+        hideToast(successToastId);
         this.close();
         clearMyData(); // since we already saved to localStore, we want to make sure beforeunload calling saveState does not also save
         window.location.reload(); // need to go through Sign In to make sure imported account exists on network
       };
-      successToastId = showToast(
+      const successToastId = showToast(
         `${restoredCount} account${restoredCount === 1 ? '' : 's'} restored`,
         0,
         'success',
         false,
-        {
-          className: 'toast-requires-action',
-          closeButtonClassName: 'toast-action-btn',
-          closeButtonLabel: 'Refresh',
-          closeAriaLabel: 'Refresh to finish restore',
-          closeOnToastClick: false,
-          onClose: finishRestore
-        }
+        { className: 'toast-requires-action' }
       );
-      handleRestoreOutsideClick = (event) => {
-        const successToast = document.getElementById(successToastId);
-        if (successToast?.contains(event.target)) return;
+      const successToast = document.getElementById(successToastId);
+      const refreshButton = successToast?.querySelector('.toast-close-btn');
+      if (!successToast || !refreshButton) {
         finishRestore();
-      };
-      setTimeout(() => {
-        if (!restoreFinished) {
-          document.addEventListener('click', handleRestoreOutsideClick, true);
-        }
-      }, 0);
+        return;
+      }
+
+      refreshButton.className = 'toast-action-btn';
+      refreshButton.textContent = 'Refresh';
+      refreshButton.setAttribute('aria-label', 'Refresh to finish restore');
+      refreshButton.addEventListener('click', finishRestore, { once: true });
+      successToast.onclick = (event) => event.stopPropagation();
+
+      function handleRestoreOutsideClick(event) {
+        if (successToast.contains(event.target)) return;
+        finishRestore();
+      }
+      setTimeout(() => document.addEventListener('click', handleRestoreOutsideClick, true), 0);
 
       // handleNativeAppSubscription()
     } catch (error) {

--- a/app.js
+++ b/app.js
@@ -12477,7 +12477,7 @@ class RestoreAccountModal {
       }
     }
 
-    // Iterate over keys in backupData and copy account entries
+    // Iterate over account payloads and copy account entries.
     const restoredAccountKeys = new Set();
     const backupAccountsRegistry = this.parseBackupAccountsRegistry(backupData);
     const backupAccountEntries = this.getBackupAccountEntries(backupData, backupAccountsRegistry);
@@ -12756,26 +12756,43 @@ class RestoreAccountModal {
 
   getBackupAccountEntries(backupData, backupAccountsRegistry) {
     const registryNetids = backupAccountsRegistry?.netids || {};
-    const hasRegistryAccounts = Object.keys(registryNetids).length > 0;
+    const entries = [];
+    const queuedKeys = new Set();
 
-    return Object.keys(backupData)
-      .map(key => {
+    Object.keys(registryNetids).forEach(netid => {
+      const usernames = registryNetids[netid]?.usernames || {};
+      Object.keys(usernames).forEach(username => {
+        const key = `${username}_${netid}`;
+        if (!Object.prototype.hasOwnProperty.call(backupData, key)) return;
         const parsedKey = this.parseBackupAccountKey(key);
-        if (!parsedKey) return null;
+        if (!parsedKey) return;
 
-        const registryAccount = registryNetids[parsedKey.netid]?.usernames?.[parsedKey.username];
-        if (hasRegistryAccounts && !registryAccount) {
-          return null;
-        }
-
-        return {
+        queuedKeys.add(key);
+        entries.push({
           key,
-          username: parsedKey.username,
-          netid: parsedKey.netid,
-          registryAccount
-        };
-      })
-      .filter(Boolean);
+          username,
+          netid,
+          registryAccount: usernames[username]
+        });
+      });
+    });
+
+    Object.keys(backupData).forEach(key => {
+      if (queuedKeys.has(key)) return;
+
+      const parsedKey = this.parseBackupAccountKey(key);
+      if (!parsedKey) return;
+
+      queuedKeys.add(key);
+      entries.push({
+        key,
+        username: parsedKey.username,
+        netid: parsedKey.netid,
+        registryAccount: registryNetids[parsedKey.netid]?.usernames?.[parsedKey.username]
+      });
+    });
+
+    return entries;
   }
 
   extractAddress(maybeJson) {

--- a/styles.css
+++ b/styles.css
@@ -197,6 +197,25 @@
   outline: none;
 }
 
+.toast-action-btn {
+  display: block;
+  margin: 8px auto 0;
+  padding: 6px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--button-background);
+  color: var(--button-text);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.toast-action-btn:hover,
+.toast-action-btn:focus {
+  background: var(--button-hover-background);
+  outline: none;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -4541,6 +4560,12 @@ mark {
   padding-bottom: 32px;
   cursor: pointer;
   pointer-events: auto;
+}
+
+.toast.sticky.toast-requires-action {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  cursor: default;
 }
 
 /* Toast type styles */

--- a/styles.css
+++ b/styles.css
@@ -197,25 +197,6 @@
   outline: none;
 }
 
-.toast-action-btn {
-  display: block;
-  margin: 8px auto 0;
-  padding: 6px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  background: var(--button-background);
-  color: var(--button-text);
-  font: inherit;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.toast-action-btn:hover,
-.toast-action-btn:focus {
-  background: var(--button-hover-background);
-  outline: none;
-}
-
 * {
   margin: 0;
   padding: 0;
@@ -4560,12 +4541,6 @@ mark {
   padding-bottom: 32px;
   cursor: pointer;
   pointer-events: auto;
-}
-
-.toast.sticky.toast-requires-action {
-  padding-top: 16px;
-  padding-bottom: 16px;
-  cursor: default;
 }
 
 /* Toast type styles */


### PR DESCRIPTION
## Summary
- Count restored accounts from account records actually written to localStorage instead of merging/counting backup metadata up front.
- Filter backup account keys through the backup account registry when one exists, so stale account-shaped keys are not counted or restored.
- Keep the restore-success toast open until the user dismisses it, then close/reset/reload the restore flow.

Closes #1380

## Validation
- `node --check app.js`
- `git diff --check`
- Targeted Playwright restore validation:
  - backup contained one registered account plus one stale account-shaped key
  - restore toast showed: `1 account restored`
  - success toast stayed sticky and had a close button after 3.5s
  - valid account was stored
  - stale account key was not stored
  - registry contained only the restored account