### PR TITLE
Fix remove accounts orphan detection

### DIFF
--- a/app.js
+++ b/app.js
@@ -10979,14 +10979,12 @@ class RemoveAccountsModal {
       let state = null;
       try {
         state = loadState(storageKey);
-        
-        // If loadState returned null, it could be decryption failure
-        if (!state) {
-          console.warn('Failed to load orphaned account', storageKey, '- likely decryption failure');
-        }
       } catch (e) {
         console.warn('Error loading orphaned account', storageKey, e);
-        result.push({ username, netid, contactsCount: -1, messagesCount: -1, orphan: true });
+        continue;
+      }
+
+      if (state?.account?.username !== username || state?.account?.netid !== netid) {
         continue;
       }
       


### PR DESCRIPTION
## What Changed

This PR keeps the Remove Accounts modal from listing localStorage metadata keys as orphan accounts.

- `RemoveAccountsModal.getAllAccountsData()` now validates orphan candidates by loading the stored value and requiring matching `state.account.username` and `state.account.netid`.
- Account-shaped metadata keys such as `version_<netid>` are skipped instead of rendered as broken orphan accounts.
- Registered accounts still render even when their stored account data cannot be loaded, preserving the existing "unable to load data" behavior.

## Fixed Flow

1. localStorage contains a real account key and metadata key like `version_<netid>`.
2. The Remove Accounts modal scans for unregistered account-shaped keys.
3. The scan only keeps candidates whose stored value parses as matching account state.
4. The modal shows real accounts and real orphan accounts, but not version metadata.

## Why

The previous orphan scan trusted the localStorage key shape alone. Since per-network version metadata uses the same `<name>_<64-char netid>` shape, the modal could show a fake `version` account and inflate the section count.

## Validation

- `node --check app.js`
- `git diff --check`
- Browser validation with seeded localStorage:
  - `1ups_<netid>` + `orphan_<netid>` + `version_<netid>` showed only `1ups` and `orphan`, count `2`.
  - A registered `broken` account with no stored state still showed `unable to load data`.

Closes #1382
