### PR TITLE
Make search results full width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4273,6 +4273,10 @@ button.about-link {
   display: flex;
 }
 
+.search-modal .form-container {
+  padding: 0;
+}
+
 /* Remove any conflicting styles */
 #messageSearch,
 #contactSearch {


### PR DESCRIPTION
## What Changed

This PR makes chat and contact search results span the same width as the main chat and contacts lists.

- Scoped `.search-modal .form-container` to remove the inherited `16px` padding only inside search modals.
- Kept the global `.form-container` padding unchanged for other forms and modal content.
- Search bars keep their existing padded gutter through `.search-bar-container`.

## Why

The normal chat and contacts lists are direct full-width list surfaces, but search results were nested inside `.form-container`, which made them 16px narrower on each side. Scoping the override to search modals fixes the list width without changing unrelated form layouts.

## Validation

- `git diff --check --cached`
- `git diff --check origin/main...HEAD`