### PR TITLE
Render friend status updates optimistically

### DIFF
--- a/app.js
+++ b/app.js
@@ -5037,8 +5037,10 @@ class FriendModal {
       }
       return { result: { success: false, reason }, toastAlreadyShown: true };
     }
-    res.updateTollRequiredTx = tx;
-    return res;
+    return {
+      ...res,
+      updateTollRequiredTx: tx
+    };
   }
 
   /**

--- a/app.js
+++ b/app.js
@@ -5141,8 +5141,6 @@ class FriendModal {
       await chatsScreen.updateChatList();
     }
 
-    saveState();
-
     // Close the friend modal (skip warning since form was submitted)
     this.close(true);
   }

--- a/app.js
+++ b/app.js
@@ -6918,7 +6918,7 @@ function insertUpdateTollRequiredHistoryItem(contact, historyItem) {
 function removeUpdateTollRequiredHistoryItem(contactAddress, txid) {
   const contact = myData.contacts?.[contactAddress];
   if (!contact?.messages || !txid) {
-    return;
+    return false;
   }
 
   const previousLength = contact.messages.length;
@@ -6927,10 +6927,25 @@ function removeUpdateTollRequiredHistoryItem(contactAddress, txid) {
   );
 
   if (contact.messages.length === previousLength) {
-    return;
+    return false;
   }
 
   syncChatLatestActivityTimestamp(contactAddress, contact);
+  return true;
+}
+
+function updateRevertedFriendStatusButtons(contactAddress, contact) {
+  if (!contact) {
+    return;
+  }
+
+  if (chatModal.isActive() && chatModal.address === contactAddress) {
+    friendModal.updateFriendButton(contact, 'addFriendButtonChat');
+  }
+
+  if (contactInfoModal.isActive() && contactInfoModal.currentContactAddress === contactAddress) {
+    friendModal.updateFriendButton(contact, 'addFriendButtonContactInfo');
+  }
 }
 
 function revertPendingUpdateTollRequired(pendingTxInfo) {
@@ -6938,15 +6953,18 @@ function revertPendingUpdateTollRequired(pendingTxInfo) {
   const contact = myData.contacts?.[contactAddress];
   const currentFriendStatus = Number(contact?.friend);
   const previousFriendStatus = Number(contact?.friendOld);
-  removeUpdateTollRequiredHistoryItem(contactAddress, pendingTxInfo.txid);
+  const didRemoveStatusHistory = removeUpdateTollRequiredHistoryItem(contactAddress, pendingTxInfo.txid);
 
   if (contact) {
     contact.friend = contact.friendOld;
   }
 
+  updateRevertedFriendStatusButtons(contactAddress, contact);
+
   return {
     currentFriendStatus,
-    previousFriendStatus
+    previousFriendStatus,
+    didRemoveStatusHistory
   };
 }
 
@@ -29843,9 +29861,12 @@ async function checkPendingTransactions() {
           showToast('Edit timed out and was reverted', 0, 'error');
         }
         if (type === 'update_toll_required') {
-          revertPendingUpdateTollRequired(pendingTxInfo);
+          const { currentFriendStatus, previousFriendStatus, didRemoveStatusHistory } = revertPendingUpdateTollRequired(pendingTxInfo);
           showToast('Update contact status timed out. Reverting contact to old status.', 0, 'error');
           await contactsScreen.updateContactsList();
+          if (didRemoveStatusHistory || currentFriendStatus === 0 || previousFriendStatus === 0) {
+            await chatsScreen.updateChatList();
+          }
           chatModal.refreshCurrentView(txid);
         }
         // remove the pending tx from the pending array
@@ -29960,11 +29981,11 @@ async function checkPendingTransactions() {
             }
           } else if (type === 'update_toll_required') {
             showToast(`Update contact status failed: ${userFailureReason}. Reverting contact to old status.`, 0, 'error');
-            const { currentFriendStatus, previousFriendStatus } = revertPendingUpdateTollRequired(pendingTxInfo);
+            const { currentFriendStatus, previousFriendStatus, didRemoveStatusHistory } = revertPendingUpdateTollRequired(pendingTxInfo);
             // update contact list since friend status was reverted
             await contactsScreen.updateContactsList();
-            // Only refresh chats list if the revert enters or exits "blocked"
-            if (currentFriendStatus === 0 || previousFriendStatus === 0) {
+            // Refresh when removing the optimistic divider or when the revert enters/exits "blocked"
+            if (didRemoveStatusHistory || currentFriendStatus === 0 || previousFriendStatus === 0) {
               await chatsScreen.updateChatList();
             }
           } else if (type === 'read') {

--- a/app.js
+++ b/app.js
@@ -5037,6 +5037,7 @@ class FriendModal {
       }
       return { result: { success: false, reason }, toastAlreadyShown: true };
     }
+    res.updateTollRequiredTx = tx;
     return res;
   }
 
@@ -5051,6 +5052,7 @@ class FriendModal {
     const contact = myData.contacts[this.currentContactAddress];
     const selectedStatus = this.friendForm.querySelector('input[name="friendStatus"]:checked')?.value;
     const prevFriendStatus = Number(contact?.friend);
+    let updateTollRequiredResponse = null;
 
     if (selectedStatus == null || Number(selectedStatus) === contact.friend) {
       console.log('No change in friend status or no status selected.');
@@ -5073,6 +5075,7 @@ class FriendModal {
           }
           return;
         }
+        updateTollRequiredResponse = res;
       } catch (error) {
         console.error('Error sending transaction to update chat toll:', error);
         showToast('Failed to update friend status. Please try again.', 0, 'error');
@@ -5089,6 +5092,22 @@ class FriendModal {
     }
     // Update friend status based on selected value
     contact.friend = Number(selectedStatus);
+    let didInsertOptimisticStatus = false;
+    if (updateTollRequiredResponse) {
+      assert(
+        updateTollRequiredResponse.updateTollRequiredTx && updateTollRequiredResponse.txid,
+        'Missing update_toll_required transaction after inject success'
+      );
+      const statusHistoryItem = buildUpdateTollRequiredHistoryItem(
+        updateTollRequiredResponse.updateTollRequiredTx,
+        updateTollRequiredResponse.txid,
+        normalizeAddress(myAccount.keys.address)
+      );
+      didInsertOptimisticStatus = insertUpdateTollRequiredHistoryItem(contact, statusHistoryItem);
+      if (didInsertOptimisticStatus) {
+        syncChatLatestActivityTimestamp(this.currentContactAddress, contact);
+      }
+    }
     if (contact.friend === 0 && prevFriendStatus !== 0) {
       await this.clearContactAvatar(contact);
     }
@@ -5113,11 +5132,16 @@ class FriendModal {
 
     // Update the contact list
     await contactsScreen.updateContactsList();
+    if (didInsertOptimisticStatus && chatModal.isActive() && chatModal.address === this.currentContactAddress) {
+      chatModal.appendChatModal();
+    }
     // Only refresh chats list if the change enters or exits "blocked"
     const nextFriendStatus = Number(selectedStatus);
-    if (prevFriendStatus === 0 || nextFriendStatus === 0) {
+    if (didInsertOptimisticStatus || prevFriendStatus === 0 || nextFriendStatus === 0) {
       await chatsScreen.updateChatList();
     }
+
+    saveState();
 
     // Close the friend modal (skip warning since form was submitted)
     this.close(true);
@@ -6889,6 +6913,41 @@ function insertUpdateTollRequiredHistoryItem(contact, historyItem) {
 
   insertSorted(contact.messages, historyItem, 'timestamp');
   return true;
+}
+
+function removeUpdateTollRequiredHistoryItem(contactAddress, txid) {
+  const contact = myData.contacts?.[contactAddress];
+  if (!contact?.messages || !txid) {
+    return;
+  }
+
+  const previousLength = contact.messages.length;
+  contact.messages = contact.messages.filter((message) =>
+    !(message.type === 'update_toll_required' && message.txid === txid)
+  );
+
+  if (contact.messages.length === previousLength) {
+    return;
+  }
+
+  syncChatLatestActivityTimestamp(contactAddress, contact);
+}
+
+function revertPendingUpdateTollRequired(pendingTxInfo) {
+  const contactAddress = pendingTxInfo.to;
+  const contact = myData.contacts?.[contactAddress];
+  const currentFriendStatus = Number(contact?.friend);
+  const previousFriendStatus = Number(contact?.friendOld);
+  removeUpdateTollRequiredHistoryItem(contactAddress, pendingTxInfo.txid);
+
+  if (contact) {
+    contact.friend = contact.friendOld;
+  }
+
+  return {
+    currentFriendStatus,
+    previousFriendStatus
+  };
 }
 
 function syncPendingUpdateTollRequiredSuccess(pendingTxInfo, receiptTx) {
@@ -29783,6 +29842,12 @@ async function checkPendingTransactions() {
           reconcilePendingMessageEdit(pendingTxInfo);
           showToast('Edit timed out and was reverted', 0, 'error');
         }
+        if (type === 'update_toll_required') {
+          revertPendingUpdateTollRequired(pendingTxInfo);
+          showToast('Update contact status timed out. Reverting contact to old status.', 0, 'error');
+          await contactsScreen.updateContactsList();
+          chatModal.refreshCurrentView(txid);
+        }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
         didMutatePendingState = true;
@@ -29895,10 +29960,7 @@ async function checkPendingTransactions() {
             }
           } else if (type === 'update_toll_required') {
             showToast(`Update contact status failed: ${userFailureReason}. Reverting contact to old status.`, 0, 'error');
-            const currentFriendStatus = Number(myData.contacts?.[pendingTxInfo.to]?.friend);
-            const previousFriendStatus = Number(myData.contacts?.[pendingTxInfo.to]?.friendOld);
-            // revert the local myData.contacts[toAddress].friend to the old value
-            myData.contacts[pendingTxInfo.to].friend = myData.contacts[pendingTxInfo.to].friendOld;
+            const { currentFriendStatus, previousFriendStatus } = revertPendingUpdateTollRequired(pendingTxInfo);
             // update contact list since friend status was reverted
             await contactsScreen.updateContactsList();
             // Only refresh chats list if the revert enters or exits "blocked"


### PR DESCRIPTION
## What Changed

This PR renders friend-status change dividers immediately after a successful `update_toll_required` inject instead of waiting for the transaction receipt.

- `postUpdateTollRequired` keeps the signed status transaction on the inject response so the submit path can build the same history item shape used by receipt/chat processing.
- `handleFriendSubmit` inserts the optimistic divider into `contact.messages`, refreshes the active chat/list UI, and persists state through `saveState()`.
- Pending failure and timeout handling remove the optimistic divider by txid and revert the local friend status.

## Fixed Flow

1. User changes a contact's friend status.
2. The `update_toll_required` transaction injects successfully and is added to pending.
3. The chat session shows the final-looking status divider immediately.
4. Later receipt success dedupes by txid; receipt failure or timeout removes the divider and reverts local state.

## Why

Previously the status divider only appeared after the receipt or later chat processing returned the transaction, so the chat did not reflect a successful submit right away. The optimistic insert uses the same txid-backed history shape as the confirmed flow, keeping duplicate processing and cleanup tied to the existing transaction identity.

## Validation

- `node --check app.js`
- `git diff --check -- app.js`

Closes #1387