### PR TITLE
Refresh active modal balance displays

### DIFF
--- a/app.js
+++ b/app.js
@@ -8301,7 +8301,9 @@ The main difference between a chat message and an asset transfer is
         * However, this does not gaurantee that the recipient has not already downloaded the message and may read it later
 `;
 
-async function postAssetTransfer(to, amount, memo, keys) {
+async function postAssetTransfer(to, amount, memo, keys, assetIndex) {
+  assert(Number.isInteger(assetIndex) && assetIndex >= 0, 'Transfer assetIndex must be a non-negative integer');
+
   const toAddr = longAddress(to);
   const fromAddr = longAddress(keys.address);
   await getNetworkParams();
@@ -8322,6 +8324,13 @@ async function postAssetTransfer(to, amount, memo, keys) {
 
   const txid = await signObj(tx, keys);
   const res = await injectTx(tx, txid);
+  if (res?.result?.success) {
+    const pendingTx = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+    assert(pendingTx, 'Accepted transfer missing pending entry');
+    pendingTx.amount = tx.amount;
+    pendingTx.fee = tx.fee;
+    pendingTx.assetIndex = assetIndex;
+  }
   return res;
 }
 
@@ -27260,7 +27269,7 @@ class SendAssetConfirmModal {
     }
 
     const wallet = myData.wallet;
-    const assetIndex = sendAssetFormModal.assetSelectDropdown.value; // TODO include the asset id and symbol in the tx
+    const assetIndex = Number(sendAssetFormModal.assetSelectDropdown.value);
     const amount = bigxnum2big(wei, sendAssetFormModal.amountInput.value);
     const memoIn = sendAssetFormModal.memoInput.value || '';
     const memo = memoIn.trim();
@@ -27398,7 +27407,7 @@ class SendAssetConfirmModal {
 
     try {
       // Send the transaction using postAssetTransfer
-      const response = await postAssetTransfer(toAddress, amount, payload, keys);
+      const response = await postAssetTransfer(toAddress, amount, payload, keys, assetIndex);
 
       if (!response || !response.result || !response.result.success) {
         const str = response.result.reason;

--- a/app.js
+++ b/app.js
@@ -2144,7 +2144,7 @@ class WalletScreen {
   }
 
   // refresh wallet balance
-  async updateWalletBalances() {
+  async updateWalletBalances(forceRefresh = false) {
     if (!myAccount || !myData || !myData.wallet || !myData.wallet.assets) {
       console.error('No wallet data available');
       return;
@@ -2160,7 +2160,7 @@ class WalletScreen {
     if (!myData.wallet.timestamp) {
       myData.wallet.timestamp = 0;
     }
-    if (now - myData.wallet.timestamp < 5000) {
+    if (!forceRefresh && now - myData.wallet.timestamp < 5000) {
       return;
     }
 
@@ -29818,12 +29818,12 @@ async function checkPendingTransaction(txid, submittedts){
   return null;
 }
 
-async function refreshActiveBalanceDisplays() {
+async function refreshActiveBalanceDisplays(forceWalletRefresh) {
   if (createAccountModal.isActive()) {
     return;
   }
 
-  await walletScreen.updateWalletBalances();
+  await walletScreen.updateWalletBalances(forceWalletRefresh);
 
   if (sendAssetFormModal.isActive()) {
     await sendAssetFormModal.updateAvailableBalance();
@@ -30070,10 +30070,12 @@ async function checkPendingTransactions() {
   for (const chain of resolvedReactionChains) {
     cleanupResolvedReactionChain(chain.contactAddress, chain.targetTxid);
   }
-  await refreshActiveBalanceDisplays();
+
+  const didSettlePendingState = startingPendingCount !== myData.pending.length || didMutatePendingState;
+  await refreshActiveBalanceDisplays(didSettlePendingState);
 
   // save state if pending transactions were processed
-  if (startingPendingCount !== myData.pending.length || didMutatePendingState) {
+  if (didSettlePendingState) {
     saveState();
   }
 }

--- a/app.js
+++ b/app.js
@@ -30080,11 +30080,16 @@ async function checkPendingTransactions() {
   }
 
   const didSettlePendingState = startingPendingCount !== myData.pending.length || didMutatePendingState;
-  await refreshActiveBalanceDisplays(didSettlePendingState);
 
   // save state if pending transactions were processed
   if (didSettlePendingState) {
     saveState();
+  }
+
+  try {
+    await refreshActiveBalanceDisplays(didSettlePendingState);
+  } catch (error) {
+    console.error('Error refreshing active balance displays:', error);
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -29818,6 +29818,22 @@ async function checkPendingTransaction(txid, submittedts){
   return null;
 }
 
+async function refreshActiveBalanceDisplays() {
+  if (createAccountModal.isActive()) {
+    return;
+  }
+
+  await walletScreen.updateWalletBalances();
+
+  if (sendAssetFormModal.isActive()) {
+    await sendAssetFormModal.updateAvailableBalance();
+  }
+
+  if (stakeValidatorModal.isActive()) {
+    await stakeValidatorModal.updateStakeBalanceDisplay();
+  }
+}
+
 /**
  * Check pending transactions that are at least 5 seconds old
  * @returns {Promise<void>}
@@ -30054,10 +30070,7 @@ async function checkPendingTransactions() {
   for (const chain of resolvedReactionChains) {
     cleanupResolvedReactionChain(chain.contactAddress, chain.targetTxid);
   }
-  // if createAccountModal is open, skip balance change
-  if (!createAccountModal.isActive()) {
-    walletScreen.updateWalletBalances();
-  }
+  await refreshActiveBalanceDisplays();
 
   // save state if pending transactions were processed
   if (startingPendingCount !== myData.pending.length || didMutatePendingState) {

--- a/app.js
+++ b/app.js
@@ -2144,7 +2144,7 @@ class WalletScreen {
   }
 
   // refresh wallet balance
-  async updateWalletBalances(forceRefresh = false) {
+  async updateWalletBalances() {
     if (!myAccount || !myData || !myData.wallet || !myData.wallet.assets) {
       console.error('No wallet data available');
       return;
@@ -2160,7 +2160,7 @@ class WalletScreen {
     if (!myData.wallet.timestamp) {
       myData.wallet.timestamp = 0;
     }
-    if (!forceRefresh && now - myData.wallet.timestamp < 5000) {
+    if (now - myData.wallet.timestamp < 5000) {
       return;
     }
 
@@ -29818,12 +29818,20 @@ async function checkPendingTransaction(txid, submittedts){
   return null;
 }
 
-async function refreshActiveBalanceDisplays(forceWalletRefresh) {
+async function refreshActiveBalanceDisplays(didSettlePendingState) {
   if (createAccountModal.isActive()) {
     return;
   }
 
-  await walletScreen.updateWalletBalances(forceWalletRefresh);
+  if (didSettlePendingState) {
+    myData.wallet.timestamp = 0;
+  }
+
+  if (walletScreen.isActive()) {
+    await walletScreen.updateWalletView();
+  } else {
+    await walletScreen.updateWalletBalances();
+  }
 
   if (sendAssetFormModal.isActive()) {
     await sendAssetFormModal.updateAvailableBalance();

--- a/app.js
+++ b/app.js
@@ -26720,6 +26720,18 @@ class SendAssetFormModal {
   async handleSendFormSubmit(event) {
     event.preventDefault();
 
+    const hasPendingTransfer =
+      Array.isArray(myData?.pending) &&
+      myData.pending.some((pendingTx) => pendingTx?.type === 'transfer');
+    if (hasPendingTransfer) {
+      showToast(
+        'You already have a pending asset transfer. Wait for it to finish before sending another.',
+        5000,
+        'warning'
+      );
+      return;
+    }
+
     // Get form values
     const assetSymbol = this.assetSelectDropdown.options[this.assetSelectDropdown.selectedIndex].text;
     const amount = this.amountInput.value;


### PR DESCRIPTION
## What Changed

This PR refreshes active modal balance displays after pending transaction checks refresh wallet balances.

- `checkPendingTransactions` now awaits a shared balance-display refresh step after processing pending transactions.
- `refreshActiveBalanceDisplays` preserves the existing create-account modal guard, then refreshes wallet balances before repainting active send/stake modal balances.
- Send asset and stake modals update their rendered `Available` / `Fee` text without closing, reopening, or resetting form state.

## Fixed Flow

1. A pending transaction check runs while the send asset or stake modal is open.
2. Wallet balances refresh from the network.
3. The active modal repaints its displayed balance and fee values.
4. The user keeps the same modal state while seeing current balance data.

## Why

Previously, `checkPendingTransactions()` refreshed `myData.wallet` but did not repaint active modals that render wallet balance text, leaving stale `Available` / `Fee` values until the modal was reopened or otherwise refreshed.

## Validation

- `node --check app.js`
- `git diff --check codex/pending-transfer-toast...HEAD`

Closes #1397