### PR TITLE
Add stake validator active check

### DIFF
--- a/app.js
+++ b/app.js
@@ -14470,6 +14470,14 @@ class StakeValidatorModal {
     this.resetForm();
   }
 
+  /**
+   * Check if the stake modal is active
+   * @returns {boolean}
+   */
+  isActive() {
+    return this.modal?.classList.contains('active') || false;
+  }
+
   async handleSubmit(event) {
     event.preventDefault();
 


### PR DESCRIPTION
## What changed

- Added `StakeValidatorModal.isActive()` using the existing modal `active` class pattern.
- Left stake modal open and close behavior unchanged.

## Why

`refreshActiveBalanceDisplays()` calls `stakeValidatorModal.isActive()` during pending transaction polling. Without that method, polling throws a TypeError while trying to refresh active balance displays.

## Validation

- `node --check app.js`

Fixes #1402