### PR TITLE
Disable context menu during pending delete-for-all window

### DIFF
--- a/app.js
+++ b/app.js
@@ -19811,7 +19811,7 @@ class ChatModal {
     const message = messageRecord || this.getMessageRecordFromElement(messageEl);
     const isDisabled = this.isMessageInDeleteForAllGuard(messageEl, message);
     const guardedActions = '[data-action="delete"], [data-action="delete-for-all"], ' +
-      '[data-action="join"], [data-action="call-invite"]';
+      '[data-action="copy"], [data-action="reply"], [data-action="join"], [data-action="call-invite"]';
     menu?.querySelectorAll(guardedActions).forEach((option) => {
       option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
     });

--- a/app.js
+++ b/app.js
@@ -19814,7 +19814,8 @@ class ChatModal {
     const message = messageRecord || this.getMessageRecordFromElement(messageEl);
     const isDeleteGuardDisabled = this.isMessageInDeleteForAllGuard(messageEl, message);
     const guardedActions = '[data-action="delete"], [data-action="delete-for-all"], ' +
-      '[data-action="copy"], [data-action="reply"], [data-action="join"], [data-action="call-invite"]';
+      '[data-action="copy"], [data-action="reply"], [data-action="join"], [data-action="call-invite"], ' +
+      '[data-action="edit"]';
     menu?.querySelectorAll(guardedActions).forEach((option) => {
       const isOfflineDisabled =
         option.classList.contains('offline-disabled') ||

--- a/app.js
+++ b/app.js
@@ -15429,6 +15429,12 @@ class ChatModal {
       if (!phoneAnchor) return;
       const messageEl = phoneAnchor.closest('.message');
       if (!messageEl) return;
+      if (this.isMessageInDeleteForAllGuard(messageEl)) {
+        e.preventDefault();
+        e.stopPropagation();
+        showToast('This call is being deleted.', 2000, 'warning');
+        return false;
+      }
       if (this.gateScheduledCall(messageEl)) {
         e.preventDefault();
         e.stopPropagation();
@@ -19785,6 +19791,11 @@ class ChatModal {
     return !!targetTxid && this.recentDeleteForAllTargetTxids.has(targetTxid);
   }
 
+  isMessageInDeleteForAllGuard(messageEl, messageRecord = null) {
+    const message = messageRecord || this.getMessageRecordFromElement(messageEl);
+    return this.hasRecentDeleteForAllForTarget(message?.txid || messageEl?.dataset?.txid);
+  }
+
   markRecentDeleteForAllForTarget(targetTxid) {
     if (!targetTxid) {
       return;
@@ -19798,8 +19809,14 @@ class ChatModal {
 
   syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
     const message = messageRecord || this.getMessageRecordFromElement(messageEl);
-    const isDisabled = this.hasRecentDeleteForAllForTarget(message?.txid);
-    menu?.querySelectorAll('[data-action="delete"], [data-action="delete-for-all"]').forEach((option) => {
+    const isDisabled = this.isMessageInDeleteForAllGuard(messageEl, message);
+    const guardedActions = [
+      '[data-action="delete"]',
+      '[data-action="delete-for-all"]',
+      '[data-action="join"]',
+      '[data-action="call-invite"]'
+    ].join(', ');
+    menu?.querySelectorAll(guardedActions).forEach((option) => {
       option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
     });
   }
@@ -21226,6 +21243,11 @@ class ChatModal {
    * @param {HTMLElement} messageEl
    */
   handleJoinCall(messageEl) {
+    if (this.isMessageInDeleteForAllGuard(messageEl)) {
+      this.closeContextMenu();
+      return showToast('This call is being deleted.', 2000, 'warning');
+    }
+
     const callUrl = messageEl.querySelector('.call-message a')?.href;
     if (!callUrl) return showToast('Call link not found', 2000, 'error');
     // Gate future scheduled calls (context menu path)
@@ -22454,6 +22476,10 @@ class CallInviteModal {
     return this.getComparableCallUrl(anchorHref);
   }
 
+  isSourceCallInDeleteForAllGuard() {
+    return chatModal.isMessageInDeleteForAllGuard(this.messageEl);
+  }
+
   /**
    * Checks whether a contact already has this call URL in their call messages.
    * @param {Object} contact
@@ -22566,6 +22592,10 @@ class CallInviteModal {
    */
   async open(messageEl) {
     this.messageEl = messageEl;
+    if (this.isSourceCallInDeleteForAllGuard()) {
+      showToast('This call is being deleted.', 2000, 'warning');
+      return;
+    }
 
     this.contactsList.innerHTML = '';
     this.emptyState.style.display = 'none';
@@ -22632,6 +22662,12 @@ class CallInviteModal {
   }
 
   async sendInvites() {
+    if (this.isSourceCallInDeleteForAllGuard()) {
+      showToast('Call invite canceled because the call is being deleted.', 2500, 'warning');
+      this.close();
+      return;
+    }
+
     const selectedBoxes = Array.from(this.contactsList.querySelectorAll('.call-invite-checkbox:checked'));
     const addresses = selectedBoxes.map(cb => cb.value).slice(0,10);
     // get call link from original message up to the first # so we don't duplicate callUrlParams
@@ -22659,6 +22695,11 @@ class CallInviteModal {
         }
       };
       for (const addr of addresses) {
+        if (this.isSourceCallInDeleteForAllGuard()) {
+          showToast('Call invite canceled because the call is being deleted.', 2500, 'warning');
+          break;
+        }
+
         const keys = myAccount.keys;
         if (!keys) {
           addFailure('keysMissing');
@@ -22724,6 +22765,12 @@ class CallInviteModal {
           messageObj.callType = true
         }
         await signObj(messageObj, keys);
+
+        if (this.isSourceCallInDeleteForAllGuard()) {
+          showToast('Call invite canceled because the call is being deleted.', 2500, 'warning');
+          break;
+        }
+
         const txid = getTxid(messageObj);
 
         // Create new message object for local display immediately

--- a/app.js
+++ b/app.js
@@ -19810,12 +19810,8 @@ class ChatModal {
   syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
     const message = messageRecord || this.getMessageRecordFromElement(messageEl);
     const isDisabled = this.isMessageInDeleteForAllGuard(messageEl, message);
-    const guardedActions = [
-      '[data-action="delete"]',
-      '[data-action="delete-for-all"]',
-      '[data-action="join"]',
-      '[data-action="call-invite"]'
-    ].join(', ');
+    const guardedActions = '[data-action="delete"], [data-action="delete-for-all"], ' +
+      '[data-action="join"], [data-action="call-invite"]';
     menu?.querySelectorAll(guardedActions).forEach((option) => {
       option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
     });
@@ -22476,8 +22472,10 @@ class CallInviteModal {
     return this.getComparableCallUrl(anchorHref);
   }
 
-  isSourceCallInDeleteForAllGuard() {
-    return chatModal.isMessageInDeleteForAllGuard(this.messageEl);
+  cancelInviteIfSourceCallInDeleteForAllGuard() {
+    if (!chatModal.isMessageInDeleteForAllGuard(this.messageEl)) return false;
+    showToast('Call invite canceled because the call is being deleted.', 2500, 'warning');
+    return true;
   }
 
   /**
@@ -22592,7 +22590,7 @@ class CallInviteModal {
    */
   async open(messageEl) {
     this.messageEl = messageEl;
-    if (this.isSourceCallInDeleteForAllGuard()) {
+    if (chatModal.isMessageInDeleteForAllGuard(this.messageEl)) {
       showToast('This call is being deleted.', 2000, 'warning');
       return;
     }
@@ -22662,8 +22660,7 @@ class CallInviteModal {
   }
 
   async sendInvites() {
-    if (this.isSourceCallInDeleteForAllGuard()) {
-      showToast('Call invite canceled because the call is being deleted.', 2500, 'warning');
+    if (this.cancelInviteIfSourceCallInDeleteForAllGuard()) {
       this.close();
       return;
     }
@@ -22695,10 +22692,7 @@ class CallInviteModal {
         }
       };
       for (const addr of addresses) {
-        if (this.isSourceCallInDeleteForAllGuard()) {
-          showToast('Call invite canceled because the call is being deleted.', 2500, 'warning');
-          break;
-        }
+        if (this.cancelInviteIfSourceCallInDeleteForAllGuard()) break;
 
         const keys = myAccount.keys;
         if (!keys) {
@@ -22766,10 +22760,7 @@ class CallInviteModal {
         }
         await signObj(messageObj, keys);
 
-        if (this.isSourceCallInDeleteForAllGuard()) {
-          showToast('Call invite canceled because the call is being deleted.', 2500, 'warning');
-          break;
-        }
+        if (this.cancelInviteIfSourceCallInDeleteForAllGuard()) break;
 
         const txid = getTxid(messageObj);
 

--- a/app.js
+++ b/app.js
@@ -19812,11 +19812,14 @@ class ChatModal {
 
   syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
     const message = messageRecord || this.getMessageRecordFromElement(messageEl);
-    const isDisabled = this.isMessageInDeleteForAllGuard(messageEl, message);
+    const isDeleteGuardDisabled = this.isMessageInDeleteForAllGuard(messageEl, message);
     const guardedActions = '[data-action="delete"], [data-action="delete-for-all"], ' +
       '[data-action="copy"], [data-action="reply"], [data-action="join"], [data-action="call-invite"]';
     menu?.querySelectorAll(guardedActions).forEach((option) => {
-      option.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+      const isOfflineDisabled =
+        option.classList.contains('offline-disabled') ||
+        (option.dataset.requiresConnection === 'true' && !isOnline);
+      option.setAttribute('aria-disabled', (isDeleteGuardDisabled || isOfflineDisabled) ? 'true' : 'false');
     });
   }
 

--- a/app.js
+++ b/app.js
@@ -19674,7 +19674,7 @@ class ChatModal {
   }
 
   /**
-   * Applies active-state styling to the quick reaction tray based on stored reaction state.
+   * Applies active and disabled state to a reaction tray based on stored message state.
    * @param {HTMLElement | null} reactionTray
    * @param {HTMLElement | null} messageEl
    */
@@ -19682,6 +19682,7 @@ class ChatModal {
     if (!reactionTray) return;
 
     const activeEmoji = this.getCurrentUserReactionForMessage(messageEl);
+    const isDisabled = this.isMessageInDeleteForAllGuard(messageEl);
     const reactionButtons = reactionTray.querySelectorAll('.message-context-reaction-button');
     reactionButtons.forEach((button) => {
       const isMorePickerTrigger = button.dataset.reactionPickerTrigger === 'true';
@@ -19691,6 +19692,8 @@ class ChatModal {
       const isActive = !isMorePickerTrigger && !!activeEmoji && buttonEmoji === activeEmoji;
 
       button.classList.toggle('active', isActive);
+      button.disabled = isDisabled;
+      button.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
       button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
   }
@@ -20627,6 +20630,11 @@ class ChatModal {
   async handleReactionPickerSelection(reactionButton, messageEl, closeMenu) {
     if (!reactionButton) return;
     if (!messageEl) return;
+    if (this.isMessageInDeleteForAllGuard(messageEl)) {
+      closeMenu();
+      showToast('This message is being deleted.', 2000, 'warning');
+      return;
+    }
 
     if (reactionButton.dataset.reactionPickerTrigger === 'true') {
       closeMenu();


### PR DESCRIPTION
## What Changed

This PR reuses the existing 15-second delete-for-all guard to temporarily disable context menu actions for any message while a delete-for-all request is pending.

- `ChatModal.isMessageInDeleteForAllGuard` centralizes the existing recent delete-for-all target check.
- Context menu actions for copy, reply, edit, delete, delete-for-all, join, and call invite share the same temporary disabled state.
- Offline-disabled menu actions stay disabled when the delete-for-all guard state is synced.
- Quick reaction buttons are disabled during the same guard window and reaction submission has a defensive guard.
- Call phone clicks, call joins, invite modal opening, and invite sending now stop while the source call is inside that guard window.

## Fixed Flow

1. A user confirms delete-for-all on a message.
2. The existing recent target guard is marked for that message txid.
3. During the 15-second guard window, relevant context menu actions, quick reactions, and call join/invite paths are blocked.
4. Immediate duplicate or stale actions are prevented while the delete request is being submitted.

## Why

The short-term fix intentionally avoids adding pending transaction metadata or a longer delete lifecycle. It protects the common immediate race where a user deletes a message for everyone and quickly tries to interact with the same still-rendered message. Offline menu state remains a separate source of disabled state, so syncing the delete-for-all guard does not re-enable network-dependent actions while offline.

## Validation

- `node --check app.js`
- `git diff --check`

Closes #1407
