### PR TITLE
Clear delete-for-all guard on preflight failures

### DIFF
--- a/app.js
+++ b/app.js
@@ -7214,7 +7214,7 @@ function hasPendingEditForTarget(contactAddress, targetTxid) {
   );
 }
 
-const DELETE_FOR_ALL_ACTION_GUARD_MS = 15000;
+const DELETE_FOR_ALL_ACTION_GUARD_MS = 10000;
 
 /**
  * Restores local state captured before an optimistic message edit.

--- a/app.js
+++ b/app.js
@@ -14919,8 +14919,7 @@ class ChatModal {
     this.dragCounter = 0;
     this.dropOverlay = null;
 
-    this.recentDeleteForAllTargetTxids = new Set();
-    this.recentDeleteForAllGuardTimeouts = new Map();
+    this.recentDeleteForAllGuardsByTxid = new Map();
 
     this.chatRenderedOldestIndex = CHAT_INITIAL_RENDER_COUNT - 1;
   }
@@ -19792,7 +19791,7 @@ class ChatModal {
   }
 
   hasRecentDeleteForAllForTarget(targetTxid) {
-    return !!targetTxid && this.recentDeleteForAllTargetTxids.has(targetTxid);
+    return !!targetTxid && this.recentDeleteForAllGuardsByTxid.has(targetTxid);
   }
 
   isMessageInDeleteForAllGuard(messageEl, messageRecord = null) {
@@ -19801,27 +19800,30 @@ class ChatModal {
   }
 
   markRecentDeleteForAllForTarget(targetTxid) {
-    if (!targetTxid) {
-      return;
-    }
+    assert(targetTxid, 'Delete-for-all target txid is required');
 
-    this.recentDeleteForAllTargetTxids.add(targetTxid);
-    clearTimeout(this.recentDeleteForAllGuardTimeouts.get(targetTxid));
-    const timeoutId = setTimeout(() => {
-      this.recentDeleteForAllTargetTxids.delete(targetTxid);
-      this.recentDeleteForAllGuardTimeouts.delete(targetTxid);
+    const existingGuard = this.recentDeleteForAllGuardsByTxid.get(targetTxid);
+    clearTimeout(existingGuard?.timeoutId);
+
+    const guard = { targetTxid };
+    guard.timeoutId = setTimeout(() => {
+      if (this.recentDeleteForAllGuardsByTxid.get(targetTxid) !== guard) {
+        return;
+      }
+
+      this.recentDeleteForAllGuardsByTxid.delete(targetTxid);
     }, DELETE_FOR_ALL_ACTION_GUARD_MS);
-    this.recentDeleteForAllGuardTimeouts.set(targetTxid, timeoutId);
+    this.recentDeleteForAllGuardsByTxid.set(targetTxid, guard);
+    return guard;
   }
 
-  clearRecentDeleteForAllForTarget(targetTxid) {
-    if (!targetTxid) {
+  clearRecentDeleteForAllGuard(guard) {
+    if (this.recentDeleteForAllGuardsByTxid.get(guard.targetTxid) !== guard) {
       return;
     }
 
-    clearTimeout(this.recentDeleteForAllGuardTimeouts.get(targetTxid));
-    this.recentDeleteForAllGuardTimeouts.delete(targetTxid);
-    this.recentDeleteForAllTargetTxids.delete(targetTxid);
+    clearTimeout(guard.timeoutId);
+    this.recentDeleteForAllGuardsByTxid.delete(guard.targetTxid);
   }
 
   syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
@@ -21391,12 +21393,12 @@ class ChatModal {
       if (this.hasRecentDeleteForAllForTarget(targetTxid)) return;
 
       if (!confirm('Delete this message for all participants?')) return;
-      this.markRecentDeleteForAllForTarget(targetTxid);
+      const deleteForAllGuard = this.markRecentDeleteForAllForTarget(targetTxid);
 
       // Create and send a "delete" message
       const keys = myAccount.keys;
       if (!keys) {
-        this.clearRecentDeleteForAllForTarget(targetTxid);
+        this.clearRecentDeleteForAllGuard(deleteForAllGuard);
         showToast('Keys not found', 0, 'error');
         return;
       }
@@ -21405,7 +21407,7 @@ class ChatModal {
 
       const sufficientBalance = await validateBalance(tollInLib);
       if (!sufficientBalance) {
-        this.clearRecentDeleteForAllForTarget(targetTxid);
+        this.clearRecentDeleteForAllGuard(deleteForAllGuard);
         const msg = `Insufficient balance for fee${tollInLib > 0n ? ' and toll' : ''}. Go to the wallet to add more LIB.`;
         showToast(msg, 0, 'error');
         return;
@@ -21416,7 +21418,7 @@ class ChatModal {
       const recipientPubKey = contact.public;
       const pqRecPubKey = contact.pqPublic;
       if (!ok || !recipientPubKey || !pqRecPubKey) {
-        this.clearRecentDeleteForAllForTarget(targetTxid);
+        this.clearRecentDeleteForAllGuard(deleteForAllGuard);
         console.warn(`No public/PQ key found for recipient ${this.address}`);
         showToast('Failed to get recipient key', 0, 'error');
         return;

--- a/app.js
+++ b/app.js
@@ -14920,6 +14920,7 @@ class ChatModal {
     this.dropOverlay = null;
 
     this.recentDeleteForAllTargetTxids = new Set();
+    this.recentDeleteForAllGuardTimeouts = new Map();
 
     this.chatRenderedOldestIndex = CHAT_INITIAL_RENDER_COUNT - 1;
   }
@@ -19805,9 +19806,22 @@ class ChatModal {
     }
 
     this.recentDeleteForAllTargetTxids.add(targetTxid);
-    setTimeout(() => {
+    clearTimeout(this.recentDeleteForAllGuardTimeouts.get(targetTxid));
+    const timeoutId = setTimeout(() => {
       this.recentDeleteForAllTargetTxids.delete(targetTxid);
+      this.recentDeleteForAllGuardTimeouts.delete(targetTxid);
     }, DELETE_FOR_ALL_ACTION_GUARD_MS);
+    this.recentDeleteForAllGuardTimeouts.set(targetTxid, timeoutId);
+  }
+
+  clearRecentDeleteForAllForTarget(targetTxid) {
+    if (!targetTxid) {
+      return;
+    }
+
+    clearTimeout(this.recentDeleteForAllGuardTimeouts.get(targetTxid));
+    this.recentDeleteForAllGuardTimeouts.delete(targetTxid);
+    this.recentDeleteForAllTargetTxids.delete(targetTxid);
   }
 
   syncDeleteContextMenuDisabledState(menu, messageEl, messageRecord = null) {
@@ -21382,6 +21396,7 @@ class ChatModal {
       // Create and send a "delete" message
       const keys = myAccount.keys;
       if (!keys) {
+        this.clearRecentDeleteForAllForTarget(targetTxid);
         showToast('Keys not found', 0, 'error');
         return;
       }
@@ -21390,6 +21405,7 @@ class ChatModal {
 
       const sufficientBalance = await validateBalance(tollInLib);
       if (!sufficientBalance) {
+        this.clearRecentDeleteForAllForTarget(targetTxid);
         const msg = `Insufficient balance for fee${tollInLib > 0n ? ' and toll' : ''}. Go to the wallet to add more LIB.`;
         showToast(msg, 0, 'error');
         return;
@@ -21400,6 +21416,7 @@ class ChatModal {
       const recipientPubKey = contact.public;
       const pqRecPubKey = contact.pqPublic;
       if (!ok || !recipientPubKey || !pqRecPubKey) {
+        this.clearRecentDeleteForAllForTarget(targetTxid);
         console.warn(`No public/PQ key found for recipient ${this.address}`);
         showToast('Failed to get recipient key', 0, 'error');
         return;


### PR DESCRIPTION
## What Changed

This PR clears the delete-for-all action guard when deterministic preflight checks fail, so users can retry immediately after fixing local prerequisites.

- `recentDeleteForAllGuardsByTxid` now stores guard objects with timeout IDs so the active guard for a target message can be cleared explicitly.
- `clearRecentDeleteForAllGuard` removes only the current guard instance, avoiding stale timeout callbacks from clearing a newer guard for the same message.
- `deleteMessageForAll` clears the guard when keys are missing, balance validation fails, or recipient keys cannot be loaded.
- The guard window is reduced from 15 seconds to 10 seconds for successful send attempts.

## Fixed Flow

1. A user confirms delete-for-all for one of their messages.
2. The app marks that message as guarded before running send preflight checks.
3. If a deterministic preflight check fails, the app now clears the guard immediately.
4. The user can retry delete-for-all without waiting for the timeout window.

## Why

The previous guard always lived until its timeout after confirmation, even when the delete request never reached transaction creation because local prerequisites failed. That made valid follow-up attempts appear blocked by stale local state. Tracking the guard object lets the failure paths clear only the guard they created while preserving the duplicate-action protection for in-flight send attempts.

## Validation

- `node --check app.js`
- `git diff --check origin/main...HEAD`

Closes #1431