### PR TITLE
Phase 4.B: Proposal Status And Committee Review Backend Integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -3698,6 +3698,7 @@ const DAO_WITHHOLD_REASON_OPTIONS = [
   { value: 'Duplicate or already addressed', label: 'Duplicate or already addressed' },
   { value: DAO_CUSTOM_WITHHOLD_REASON, label: 'Custom reason' },
 ];
+const DAO_WITHHOLD_REASON_MAX_LENGTH = 1000;
 
 function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
@@ -3712,18 +3713,37 @@ function getDaoProposalReviewWindow(proposal) {
       end: 0,
       label: 'Review timing unavailable',
       canCommitteeVote: false,
+      canFinalizeReviewResult: false,
     };
   }
 
   const end = start + duration;
   const now = Date.now();
   if (now < start) {
-    return { start, end, label: 'Review has not started', canCommitteeVote: false };
+    return {
+      start,
+      end,
+      label: 'Review has not started',
+      canCommitteeVote: false,
+      canFinalizeReviewResult: false,
+    };
   }
   if (now <= end) {
-    return { start, end, label: 'In committee review', canCommitteeVote: true };
+    return {
+      start,
+      end,
+      label: 'In committee review',
+      canCommitteeVote: true,
+      canFinalizeReviewResult: false,
+    };
   }
-  return { start, end, label: 'Review window ended', canCommitteeVote: false };
+  return {
+    start,
+    end,
+    label: 'Review window ended',
+    canCommitteeVote: false,
+    canFinalizeReviewResult: true,
+  };
 }
 
 function formatDaoDetailTimestamp(ts) {
@@ -3737,6 +3757,10 @@ function formatDaoDetailValue(value) {
   if (Array.isArray(value)) return value.map(formatDaoDetailValue).join(', ');
   if (typeof value === 'object') return stringify(value);
   return String(value);
+}
+
+function getDaoBooleanCapability(proposal, key) {
+  return typeof proposal?.[key] === 'boolean' ? proposal[key] : null;
 }
 
 class ProposalInfoModal {
@@ -3754,15 +3778,25 @@ class ProposalInfoModal {
     this.customReasonGroup = document.getElementById('proposalWithholdCustomGroup');
     this.customReasonInput = document.getElementById('proposalWithholdCustomReason');
     this.submitButton = document.getElementById('proposalCommitteeSubmit');
+    this.reviewResultSection = document.getElementById('proposalReviewResultSection');
+    this.reviewResultHelp = document.getElementById('proposalReviewResultHelp');
+    this.reviewResultButton = document.getElementById('proposalReviewResultSubmit');
 
     this._currentProposalId = null;
     this.committeeChoice = 'accept';
+    this.currentCommitteeVote = '';
+    this.isSubmitting = false;
+    this.canSubmitCommitteeReview = false;
+    this.canSubmitReviewResult = false;
+    this.submitButtonLabel = this.submitButton?.textContent || 'Submit review';
+    this.reviewResultButtonLabel = this.reviewResultButton?.textContent || 'Finalize review result';
 
     if (this.closeButton) this.closeButton.addEventListener('click', () => this.close());
     if (this.acceptButton) this.acceptButton.addEventListener('click', () => this.handleCommitteeChoiceClick('accept'));
     if (this.withholdButton) this.withholdButton.addEventListener('click', () => this.handleCommitteeChoiceClick('withhold'));
     if (this.withholdReasonSelect) this.withholdReasonSelect.addEventListener('change', () => this.handleWithholdReasonChange());
     if (this.submitButton) this.submitButton.addEventListener('click', () => this.handleCommitteeSubmit());
+    if (this.reviewResultButton) this.reviewResultButton.addEventListener('click', () => this.handleReviewResultSubmit());
 
     if (this.withholdReasonSelect) {
       this.withholdReasonSelect.innerHTML = DAO_WITHHOLD_REASON_OPTIONS
@@ -3794,6 +3828,7 @@ class ProposalInfoModal {
       return;
     }
 
+    this.setSubmitting(false);
     this.committeeChoice = 'accept';
     this.renderProposal(p);
   }
@@ -3804,6 +3839,7 @@ class ProposalInfoModal {
       this.content.innerHTML = '<section class="proposal-info-section"><h3>Proposal not found</h3><p class="proposal-info-muted">The proposal data is unavailable.</p></section>';
     }
     this.hideCommitteeActions();
+    this.hideReviewResultAction();
   }
 
   renderProposal(proposal) {
@@ -3817,7 +3853,13 @@ class ProposalInfoModal {
     const withholdCount = committeeVotes.filter((vote) => vote?.vote === 'withhold' && committeeAddressSet.has(vote.memberAddress)).length;
     const currentAddress = getDaoCurrentAccountAddress();
     const currentVote = committeeVotes.find((vote) => vote?.memberAddress === currentAddress) || null;
-    const isCommitteeMember = Boolean(currentAddress && committeeAddressSet.has(currentAddress));
+    const capabilities = this.getReviewCapabilities({
+      proposal,
+      state,
+      reviewWindow,
+      currentAddress,
+      committeeAddressSet,
+    });
     const proposalType = proposal.proposalType || proposal.type;
 
     if (this.content) {
@@ -3836,19 +3878,49 @@ class ProposalInfoModal {
           ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
           ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
         ]),
+        this.renderProposalBody(proposal),
+        this.renderParameterChanges(proposal),
         this.renderSection('Committee Review', [
           ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
           ['Accept votes', String(acceptCount)],
           ['Withhold votes', String(withholdCount)],
-          ['Your vote', currentVote ? this.formatCommitteeVote(currentVote) : isCommitteeMember ? 'Not submitted' : 'Not a committee member'],
+          [
+            'Your vote',
+            currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
+            this.getCommitteeVoteTone(currentVote),
+          ],
           ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount)],
         ]),
-        this.renderProposalBody(proposal),
-        this.renderParameterChanges(proposal),
       ].join('');
     }
 
-    this.renderCommitteeActions({ isCommitteeMember, reviewWindow, currentVote, state });
+    this.renderCommitteeActions({ capabilities, reviewWindow, currentVote, state });
+    this.renderReviewResultAction({ capabilities, reviewWindow });
+  }
+
+  getReviewCapabilities({ proposal, state, reviewWindow, currentAddress, committeeAddressSet }) {
+    const backendCommitteeMember = getDaoBooleanCapability(proposal, 'isCommitteeMemberForProposal');
+    const isCommitteeMember = backendCommitteeMember ?? Boolean(currentAddress && committeeAddressSet.has(currentAddress));
+
+    const backendCanCommitteeVote = getDaoBooleanCapability(proposal, 'canCommitteeVote');
+    const canCommitteeVote = backendCanCommitteeVote ?? (
+      state === 'review' &&
+      reviewWindow.canCommitteeVote &&
+      isCommitteeMember
+    );
+
+    const backendCanFinalizeReviewResult = getDaoBooleanCapability(proposal, 'canFinalizeReviewResult');
+    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && (
+      backendCanFinalizeReviewResult ?? reviewWindow.canFinalizeReviewResult
+    );
+
+    return { isCommitteeMember, canCommitteeVote, canFinalizeReviewResult };
+  }
+
+  getCommitteeVoteTone(vote) {
+    if (vote?.vote === 'accept') return 'accept';
+    if (vote?.vote === 'withhold') return 'withhold';
+    return '';
   }
 
   renderProposalTitle(proposal) {
@@ -3864,17 +3936,28 @@ class ProposalInfoModal {
   }
 
   renderSection(title, rows) {
-    const rowHtml = rows
-      .map(([label, value]) => {
-        const displayValue = formatDaoDetailValue(value);
-        const rowClass = this.getSectionRowClass(label, displayValue);
-        return `
-        <div class="${rowClass}">
-          <span>${escapeHtml(label)}</span>
-          <strong>${escapeHtml(displayValue)}</strong>
+    const renderedRows = rows.map(([label, value, tone]) => {
+      const displayValue = formatDaoDetailValue(value);
+      const rowClass = this.getSectionRowClass(label, displayValue);
+      return {
+        label,
+        value: displayValue,
+        classes: [
+          rowClass,
+          tone ? `proposal-info-row--${tone}` : '',
+        ].filter(Boolean),
+        isFull: rowClass.includes('proposal-info-row--full'),
+      };
+    });
+    this.centerTwoCardRows(renderedRows);
+
+    const rowHtml = renderedRows
+      .map((row) => `
+        <div class="${row.classes.join(' ')}">
+          <span>${escapeHtml(row.label)}</span>
+          <strong>${escapeHtml(row.value)}</strong>
         </div>
-      `;
-      })
+      `)
       .join('');
 
     return `
@@ -3885,8 +3968,29 @@ class ProposalInfoModal {
     `;
   }
 
+  centerTwoCardRows(renderedRows) {
+    let row = [];
+    const flush = () => {
+      if (row.length === 2) row[0].classes.push('proposal-info-row--center-pair');
+      row = [];
+    };
+
+    for (const renderedRow of renderedRows) {
+      if (renderedRow.isFull) {
+        flush();
+        continue;
+      }
+      row.push(renderedRow);
+      if (row.length === 3) flush();
+    }
+    flush();
+  }
+
   getSectionRowClass(label, value) {
-    if (!['Description', 'Options'].includes(label)) {
+    if (label === 'Description') {
+      return 'proposal-info-row proposal-info-row--full';
+    }
+    if (label !== 'Options') {
       return 'proposal-info-row';
     }
 
@@ -3905,8 +4009,8 @@ class ProposalInfoModal {
       : 'Unavailable';
 
     return this.renderSection('Proposal Body', [
-      ['Emergency', proposal.emergency ? 'Yes' : 'No'],
       ['Description', proposal.description || proposal.summary || 'Unavailable'],
+      ['Emergency', proposal.emergency ? 'Yes' : 'No'],
       ['Options', options],
     ]);
   }
@@ -3977,33 +4081,78 @@ class ProposalInfoModal {
     return 'Waiting for committee review';
   }
 
-  renderCommitteeActions({ isCommitteeMember, reviewWindow, currentVote, state }) {
+  renderCommitteeActions({ capabilities, reviewWindow, currentVote, state }) {
     if (!this.committeeActionSection) return;
-    if (!isCommitteeMember) {
+    if (!capabilities.isCommitteeMember) {
       this.hideCommitteeActions();
       return;
     }
 
     this.committeeActionSection.classList.remove('hidden');
+    this.currentCommitteeVote = currentVote?.vote || '';
     this.setCommitteeChoice(currentVote?.vote === 'withhold' ? 'withhold' : 'accept');
 
-    const canSubmit = state === 'review' && reviewWindow.canCommitteeVote;
-    if (this.submitButton) this.submitButton.disabled = !canSubmit;
-    if (this.committeeActionHelp) {
-      this.committeeActionHelp.textContent = canSubmit
-        ? 'Choose a review decision, then submit. Submission is connected in Phase 4.B.'
-        : state === 'review'
-        ? `${reviewWindow.label}. Committee review submission is unavailable.`
-        : 'Committee review is only available while the proposal is in review.';
-    }
+    this.canSubmitCommitteeReview = state === 'review' && capabilities.canCommitteeVote;
+    this.updateSubmitButtons();
+    this.setCommitteeActionHelp(state, reviewWindow);
   }
 
   hideCommitteeActions() {
+    this.canSubmitCommitteeReview = false;
+    this.currentCommitteeVote = '';
     this.committeeActionSection?.classList.add('hidden');
-    if (this.submitButton) this.submitButton.disabled = true;
+    this.updateSubmitButtons();
+  }
+
+  renderReviewResultAction({ capabilities, reviewWindow }) {
+    if (!this.reviewResultSection) return;
+    if (!capabilities.canFinalizeReviewResult) {
+      this.hideReviewResultAction();
+      return;
+    }
+
+    this.canSubmitReviewResult = true;
+    this.reviewResultSection.classList.remove('hidden');
+    if (this.reviewResultHelp) {
+      this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to its next state.`;
+    }
+    this.updateSubmitButtons();
+  }
+
+  hideReviewResultAction() {
+    this.canSubmitReviewResult = false;
+    this.reviewResultSection?.classList.add('hidden');
+    this.updateSubmitButtons();
+  }
+
+  setSubmitting(isSubmitting) {
+    this.isSubmitting = Boolean(isSubmitting);
+    if (this.closeButton) this.closeButton.disabled = this.isSubmitting;
+    this.updateSubmitButtons();
+  }
+
+  updateSubmitButtons() {
+    const disableCommittee = this.isSubmitting || !this.canSubmitCommitteeReview;
+    const isSameVote = Boolean(this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote);
+    const disableResult = this.isSubmitting || !this.canSubmitReviewResult;
+
+    if (this.acceptButton) this.acceptButton.disabled = disableCommittee || this.currentCommitteeVote === 'accept';
+    if (this.withholdButton) this.withholdButton.disabled = disableCommittee || this.currentCommitteeVote === 'withhold';
+    if (this.withholdReasonSelect) this.withholdReasonSelect.disabled = disableCommittee || isSameVote;
+    if (this.customReasonInput) this.customReasonInput.disabled = disableCommittee || isSameVote;
+    if (this.submitButton) {
+      this.submitButton.disabled = disableCommittee || isSameVote;
+      this.submitButton.textContent = this.isSubmitting && this.canSubmitCommitteeReview ? 'Submitting...' : this.submitButtonLabel;
+    }
+    if (this.reviewResultButton) {
+      this.reviewResultButton.disabled = disableResult;
+      this.reviewResultButton.textContent = this.isSubmitting && this.canSubmitReviewResult ? 'Finalizing...' : this.reviewResultButtonLabel;
+    }
   }
 
   handleCommitteeChoiceClick(choice) {
+    if (this.isSubmitting || !this.canSubmitCommitteeReview) return;
+    if (choice === this.currentCommitteeVote) return;
     this.setCommitteeChoice(choice);
     this.scrollToCommitteeActionBottom();
   }
@@ -4017,11 +4166,33 @@ class ProposalInfoModal {
     this.withholdButton?.setAttribute('aria-checked', String(isWithhold));
     this.withholdFields?.classList.toggle('hidden', !isWithhold);
     this.renderWithholdReasonInput();
+    this.updateSubmitButtons();
+    this.setCommitteeActionHelp();
+  }
+
+  setCommitteeActionHelp(state, reviewWindow) {
+    if (!this.committeeActionHelp) return;
+    if (!this.canSubmitCommitteeReview) {
+      this.committeeActionHelp.textContent = state === 'review'
+        ? `${reviewWindow?.label || 'Committee review unavailable'}. Committee review submission is unavailable.`
+        : 'Committee review is only available while the proposal is in review.';
+      return;
+    }
+    if (this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote) {
+      const nextChoice = this.currentCommitteeVote === 'accept' ? 'withhold' : 'accept';
+      this.committeeActionHelp.textContent = `You already submitted ${this.formatCommitteeChoice(this.currentCommitteeVote)}. Choose ${this.formatCommitteeChoice(nextChoice)} to change your review decision.`;
+      return;
+    }
+    this.committeeActionHelp.textContent = 'Choose a review decision, then submit.';
+  }
+
+  formatCommitteeChoice(choice) {
+    return choice === 'withhold' ? 'Withhold' : 'Accept';
   }
 
   handleWithholdReasonChange() {
     this.renderWithholdReasonInput();
-    if (this.isCustomWithholdReason()) {
+    if (this.isCustomWithholdReason() && !this.customReasonInput?.disabled) {
       this.customReasonInput?.focus({ preventScroll: true });
       this.scrollToCommitteeActionBottom();
     }
@@ -4041,20 +4212,150 @@ class ProposalInfoModal {
     });
   }
 
-  handleCommitteeSubmit() {
+  getWithholdReason() {
+    return this.isCustomWithholdReason()
+      ? String(this.customReasonInput?.value || '').trim()
+      : String(this.withholdReasonSelect?.value || '').trim();
+  }
+
+  getCurrentProposal() {
+    return this._currentProposalId ? daoRepo.getProposalById(this._currentProposalId) : null;
+  }
+
+  async submitDaoTransaction(transaction) {
+    if (!myAccount?.keys) throw new Error('Wallet keys unavailable');
+    const txid = await signObj(transaction, myAccount.keys);
+    return injectTx(transaction, txid);
+  }
+
+  async refreshCurrentProposal() {
+    await daoRepo.refresh({ force: true });
+    if (daoModal?.isActive?.()) daoModal.render();
+
+    this.renderCurrentProposal();
+  }
+
+  async refreshAfterDaoAction(warningMessage) {
+    try {
+      await this.refreshCurrentProposal();
+    } catch (error) {
+      console.warn('Failed to refresh proposal after DAO action:', error);
+      showToast(warningMessage, 4000, 'warning');
+    }
+  }
+
+  renderCurrentProposal() {
+    const proposal = this.getCurrentProposal();
+    if (proposal) {
+      this.renderProposal(proposal);
+    } else {
+      this.renderNotFound();
+    }
+  }
+
+  async handleCommitteeSubmit() {
+    if (this.isSubmitting || !this.canSubmitCommitteeReview) return;
+    if (this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote) {
+      showToast(`You already submitted ${this.formatCommitteeChoice(this.currentCommitteeVote)}`, 2500, 'info');
+      return;
+    }
+
+    const proposal = this.getCurrentProposal();
+    if (!proposal) {
+      showToast('Proposal data is unavailable', 2500, 'warning');
+      return;
+    }
+    if (!myAccount?.keys?.address) {
+      showToast('Wallet keys unavailable', 2500, 'warning');
+      return;
+    }
+
+    let withheldReason;
     if (this.committeeChoice === 'withhold') {
-      const reason = this.isCustomWithholdReason()
-        ? String(this.customReasonInput?.value || '').trim()
-        : String(this.withholdReasonSelect?.value || '').trim();
-      if (!reason) {
+      withheldReason = this.getWithholdReason();
+      if (!withheldReason) {
         showToast('Choose a withhold reason', 2500, 'warning');
         return;
       }
+      if (withheldReason.length > DAO_WITHHOLD_REASON_MAX_LENGTH) {
+        showToast('Withhold reason must be 1000 characters or less', 2500, 'warning');
+        return;
+      }
     }
-    showToast('Committee review transactions are not connected yet', 3000, 'info');
+
+    this.setSubmitting(true);
+    const loadingToastId = showToast('Submitting committee review...', 0, 'loading');
+
+    try {
+      const result = await daoRepo.submitCommitteeVote({
+        from: getDaoCurrentAccountAddress(),
+        proposal,
+        vote: this.committeeChoice,
+        withheldReason,
+        timestamp: getTransactionTimestamp(),
+        networkId: network?.netid || '',
+        submitTransaction: (transaction) => this.submitDaoTransaction(transaction),
+      });
+
+      if (!result.ok) {
+        showToast(result.error || 'Committee review submission failed', 3000, 'warning');
+        return;
+      }
+
+      showToast('Committee review submitted', 3000, 'success');
+      await this.refreshAfterDaoAction('Committee review submitted, but proposal refresh failed');
+    } catch (error) {
+      console.warn('Failed to submit committee review:', error);
+      showToast(error?.message || 'Committee review submission failed', 3000, 'warning');
+    } finally {
+      if (loadingToastId) hideToast(loadingToastId);
+      this.setSubmitting(false);
+    }
+  }
+
+  async handleReviewResultSubmit() {
+    if (this.isSubmitting || !this.canSubmitReviewResult) return;
+
+    const proposal = this.getCurrentProposal();
+    if (!proposal) {
+      showToast('Proposal data is unavailable', 2500, 'warning');
+      return;
+    }
+    if (!myAccount?.keys?.address) {
+      showToast('Wallet keys unavailable', 2500, 'warning');
+      return;
+    }
+
+    this.setSubmitting(true);
+    const loadingToastId = showToast('Finalizing review result...', 0, 'loading');
+
+    try {
+      const result = await daoRepo.finalizeCommitteeResult({
+        from: getDaoCurrentAccountAddress(),
+        proposal,
+        timestamp: getTransactionTimestamp(),
+        networkId: network?.netid || '',
+        submitTransaction: (transaction) => this.submitDaoTransaction(transaction),
+      });
+
+      if (!result.ok) {
+        showToast(result.error || 'Review result finalization failed', 3000, 'warning');
+        return;
+      }
+
+      showToast('Review result finalized', 3000, 'success');
+      await this.refreshAfterDaoAction('Review result finalized, but proposal refresh failed');
+    } catch (error) {
+      console.warn('Failed to finalize review result:', error);
+      showToast(error?.message || 'Review result finalization failed', 3000, 'warning');
+    } finally {
+      if (loadingToastId) hideToast(loadingToastId);
+      this.setSubmitting(false);
+    }
   }
 
   close() {
+    if (this.isSubmitting) return;
     this.modal.classList.remove('active');
     enterFullscreen();
   }

--- a/app.js
+++ b/app.js
@@ -4083,7 +4083,7 @@ class ProposalInfoModal {
 
   renderCommitteeActions({ capabilities, reviewWindow, currentVote, state }) {
     if (!this.committeeActionSection) return;
-    if (!capabilities.isCommitteeMember) {
+    if (!capabilities.isCommitteeMember || capabilities.canFinalizeReviewResult) {
       this.hideCommitteeActions();
       return;
     }

--- a/app.js
+++ b/app.js
@@ -4090,11 +4090,16 @@ class ProposalInfoModal {
 
     this.committeeActionSection.classList.remove('hidden');
     this.currentCommitteeVote = currentVote?.vote || '';
-    this.setCommitteeChoice(currentVote?.vote === 'withhold' ? 'withhold' : 'accept');
+    this.setCommitteeChoice(this.getDefaultCommitteeChoice(currentVote));
 
     this.canSubmitCommitteeReview = state === 'review' && capabilities.canCommitteeVote;
     this.updateSubmitButtons();
     this.setCommitteeActionHelp(state, reviewWindow);
+  }
+
+  getDefaultCommitteeChoice(currentVote) {
+    if (currentVote?.vote === 'accept') return 'withhold';
+    return 'accept';
   }
 
   hideCommitteeActions() {

--- a/app.js
+++ b/app.js
@@ -80,6 +80,7 @@ import {
   buildDaoProposalCreateDraft,
   createDaoBackendFetcher,
   DAO_CONFIG_CHANGE_OPTIONS,
+  DAO_PROPOSAL_TITLE_MAX_LENGTH,
   daoRepo,
   DAO_STATES,
   getDaoStateLabel,
@@ -2465,22 +2466,14 @@ function formatDaoTimestamp(ts) {
   }
 }
 
-function formatDaoRowTimestampLabel(ts) {
+function formatDaoDate(ts) {
   const n = Number(ts || 0);
-  if (!n) return '—';
-  const date = new Date(n);
+  if (!n) return '';
   try {
-    const dateLabel = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-    const timeLabel = date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-    return `${dateLabel} ${timeLabel}`;
+    return new Date(n).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
   } catch {
-    return '—';
+    return '';
   }
-}
-
-function getDaoUiStateLabel(key) {
-  if (key === 'discussion') return 'Review';
-  return getDaoStateLabel(key);
 }
 
 class DaoModal {
@@ -2644,10 +2637,6 @@ class DaoModal {
     this.render();
   }
 
-  getProposals() {
-    return daoRepo.getProposalsForUi(this.selectedGroupKey);
-  }
-
   render() {
     const proposalsActive = daoRepo.getProposalsForUi('active');
     const proposalsArchived = daoRepo.getProposalsForUi('archived');
@@ -2663,7 +2652,7 @@ class DaoModal {
 
     // Update header title
     const groupLabel = this.selectedGroupKey === 'archived' ? 'Archived' : 'Active';
-    const label = getDaoUiStateLabel(this.selectedStateKey);
+    const label = getDaoStateLabel(this.selectedStateKey);
     if (this.titleEl) this.titleEl.textContent = `DAO - ${groupLabel} - ${label}`;
 
     // Update group toggle labels + selection
@@ -2683,7 +2672,7 @@ class DaoModal {
       const labelEl = document.getElementById(`daoStatusOption${s.label.replace(/\s+/g, '')}`);
       const countEl = option?.querySelector('.dao-status-count');
       const count = counts[s.key] || 0;
-      const displayLabel = getDaoUiStateLabel(s.key);
+      const displayLabel = getDaoStateLabel(s.key);
 
       if (labelEl) labelEl.textContent = displayLabel;
       if (countEl) {
@@ -2737,26 +2726,23 @@ class DaoModal {
       const li = document.createElement('li');
       li.classList.add('chat-item', 'dao-proposal-row');
 
-      const titleText = p.title || (p.number ? `Proposal #${p.number}` : 'Proposal');
-      const title = escapeHtml(titleText);
-      const updatedLabel = escapeHtml(formatDaoRowTimestampLabel(p.stateEnteredAt || p.createdAt));
-      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
+      const titleText = String(p.title || '').trim() || 'Proposal';
+      const rowTitleText = p.number ? `#${p.number}: ${titleText}` : titleText;
+      const title = escapeHtml(rowTitleText);
+      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType) || 'Proposal');
+      const previewHtml = this.renderProposalRowPreview(p);
 
       li.tabIndex = 0;
       li.setAttribute('role', 'button');
-      li.setAttribute('aria-label', `Open ${titleText}`);
+      li.setAttribute('aria-label', `Open ${rowTitleText}`);
       li.innerHTML = `
         <div class="dao-row-content">
           <div class="dao-row-title">${title}</div>
           <div class="dao-row-meta">
             <span class="dao-row-meta-item dao-row-meta-item--type">
-              <span class="dao-row-meta-label">Type</span>
-              <strong class="dao-row-meta-value">${typeLabel}</strong>
+              ${typeLabel}
             </span>
-            <span class="dao-row-meta-item dao-row-meta-item--updated">
-              <span class="dao-row-meta-label">Updated</span>
-              <strong class="dao-row-meta-value">${updatedLabel}</strong>
-            </span>
+            ${previewHtml}
           </div>
         </div>
       `;
@@ -2773,6 +2759,80 @@ class DaoModal {
     if (this.addButton) {
       this.addButton.classList.toggle('visible', this.isActive());
     }
+  }
+
+  renderProposalRowPreview(proposal) {
+    const chips = [];
+    const state = getEffectiveDaoState(proposal);
+    const result = getDaoProposalResultSummary(proposal);
+    const reward = getDaoProposalRewardSummary(proposal);
+
+    if (state === 'review') {
+      const reviewWindow = getDaoProposalReviewWindow(proposal);
+
+      chips.push({
+        value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,
+        tone: 'neutral',
+      });
+    } else if (state === 'voting') {
+      const now = Date.now();
+      const votingWindow = getDaoProposalVotingWindow(proposal, now);
+      const endDate = formatDaoDate(votingWindow.end);
+      const votingEnded = Boolean(votingWindow.end && now > votingWindow.end);
+
+      if (endDate && !votingEnded) {
+        chips.push({
+          value: `Ends ${endDate}`,
+          tone: 'neutral',
+        });
+      }
+      if (votingEnded) {
+        chips.push({
+          value: 'Ready to finalize',
+          tone: 'neutral',
+        });
+      }
+    } else {
+      const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward);
+      const claimAction = lifecycleActions.find((action) => action.kind === 'claim_reward');
+      const applyAction = lifecycleActions.find((action) => action.kind === 'apply_parameters');
+
+      if (claimAction) {
+        chips.push({
+          value: 'Ready to claim',
+          tone: reward?.statusTone,
+        });
+      }
+      if (lifecycleActions.some((action) => action.kind === 'burn_reward')) {
+        chips.push({
+          value: 'Ready to burn',
+          tone: 'neutral',
+        });
+      }
+      if (applyAction?.rowPreviewLabel) {
+        chips.push({
+          value: applyAction.rowPreviewLabel,
+          tone: 'neutral',
+        });
+      }
+    }
+    if (result) {
+      chips.push({
+        value: result.headline,
+        tone: result.tone,
+      });
+    }
+
+    if (chips.length === 0) return '';
+    return `
+      <div class="dao-row-previews">
+        ${chips.map((chip) => `
+          <span class="dao-row-preview dao-row-preview--${escapeDaoFormAttribute(chip.tone || 'neutral')}">
+            ${escapeHtml(chip.value)}
+          </span>
+        `).join('')}
+      </div>
+    `;
   }
 
   openProposal(proposal) {
@@ -2866,10 +2926,8 @@ class AddProposalModal {
     if (this.startDelayInput) this.startDelayInput.value = '0';
     if (this.gracePeriodInput) this.gracePeriodInput.value = '';
     this.renderOptions(['yes', 'no']);
-    this.renderProposalFee();
     this.renderGracePeriodDefaultHint();
     this.refreshProposalFee();
-    this.renderConfigLoadingState();
     this.refreshSelectedConfigOptions();
     setTimeout(() => {
       this.titleInput?.focus();
@@ -3182,12 +3240,11 @@ class AddProposalModal {
     return this.getConfigOptions().find((option) => option.key === key) || null;
   }
 
-  renderParameterChanges(rows = null) {
+  renderParameterChanges(rows) {
     if (!this.changesList) return;
 
     const options = this.getConfigOptions();
-    const sourceRows = rows || this.getParameterChanges();
-    const validRows = sourceRows
+    const validRows = rows
       .filter((row) => options.some((option) => option.key === row.key))
       .map((row) => ({ key: row.key, value: row.value }));
 
@@ -3383,6 +3440,10 @@ class AddProposalModal {
       this.showValidationError(this.createValidationError('Please enter a title', this.titleInput));
       return;
     }
+    if (title.length > DAO_PROPOSAL_TITLE_MAX_LENGTH) {
+      this.showValidationError(this.createValidationError(`Title must be ${DAO_PROPOSAL_TITLE_MAX_LENGTH} characters or less`, this.titleInput));
+      return;
+    }
     if (!DAO_CONFIG_CHANGE_OPTIONS[proposalType]) {
       this.showValidationError(this.createValidationError('Please select a DAO proposal type', this.typeSelect));
       return;
@@ -3417,7 +3478,6 @@ class AddProposalModal {
       confirmProposalModal.open(draft);
     } catch (e) {
       this.showValidationError(e);
-      return;
     }
   }
 }
@@ -3598,6 +3658,9 @@ class ConfirmProposalModal {
     const proposalType = tx.proposalType;
     const changes = Array.isArray(tx[proposalType]?.changes) ? tx[proposalType].changes : [];
     const gracePeriodSummary = formatDaoDurationSummary(tx.gracePeriod);
+    const formattedOptions = tx.options
+      .map((option, index) => `${index + 1}. ${option}`)
+      .join('\n');
 
     this.setTitle('Review Proposal');
     this.content.innerHTML = [
@@ -3606,11 +3669,11 @@ class ConfirmProposalModal {
         ['Initial state', 'Review after signing'],
       ]),
       this.renderSection('Proposal Body', [
-        ['Title', draft.displayTitle],
+        ['Title', tx.title || draft.displayTitle],
         ['Type', getDaoTypeLabel(proposalType)],
         ['Emergency', tx.emergency ? 'Yes' : 'No'],
         ['Description', tx.description],
-        ['Options', this.formatProposalOptions(tx.options)],
+        ['Options', formattedOptions],
         ['Review starts', formatDaoDurationSummary(draft.startDelayMs)],
         ['Grace period', gracePeriodSummary],
       ]),
@@ -3620,7 +3683,6 @@ class ConfirmProposalModal {
   }
 
   renderSection(title, rows) {
-    const gridClass = rows.length === 2 ? 'dao-confirm-grid dao-confirm-grid--two' : 'dao-confirm-grid';
     const rowHtml = rows
       .map(([label, value]) => {
         const displayValue = formatDaoConfirmValue(value);
@@ -3637,13 +3699,13 @@ class ConfirmProposalModal {
     return `
       <section class="dao-confirm-section">
         <h3>${escapeHtml(title)}</h3>
-        <div class="${gridClass}">${rowHtml}</div>
+        <div class="dao-confirm-grid">${rowHtml}</div>
       </section>
     `;
   }
 
   getSectionRowClass(label, value) {
-    const fullWidthLabels = ['Description', 'Options', 'from', 'description', 'options'];
+    const fullWidthLabels = ['Description', 'Options'];
     if (!fullWidthLabels.includes(label)) return 'dao-confirm-row';
 
     const text = String(value);
@@ -3655,21 +3717,15 @@ class ConfirmProposalModal {
     return 'dao-confirm-row';
   }
 
-  formatProposalOptions(options) {
-    return Array.isArray(options) && options.length
-      ? options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : options;
-  }
-
   renderChanges(changes) {
     const changeRows = changes.length
       ? changes.map((change, index) => `
           <div class="dao-confirm-change">
             <div class="dao-confirm-change-title">Change ${index + 1}: ${escapeHtml(change.key)}</div>
             <div class="dao-confirm-change-values">
-              <small>Current: ${escapeHtml(formatDaoConfirmValue(change.current))}</small>
+              <small><span>Current:</span><strong>${escapeHtml(formatDaoConfirmValue(change.current))}</strong></small>
               <span class="dao-confirm-change-arrow" aria-hidden="true">&rarr;</span>
-              <strong>New: ${escapeHtml(formatDaoConfirmValue(change.value))}</strong>
+              <small><span>New:</span><strong>${escapeHtml(formatDaoConfirmValue(change.value))}</strong></small>
             </div>
           </div>
         `).join('')
@@ -3699,13 +3755,17 @@ const DAO_WITHHOLD_REASON_OPTIONS = [
   { value: DAO_CUSTOM_WITHHOLD_REASON, label: 'Custom reason' },
 ];
 const DAO_WITHHOLD_REASON_MAX_LENGTH = 1000;
+const DAO_VOTE_WEIGHT_MAX = 1_000_000;
+const DAO_VOTE_WEIGHT_PRECISION = 1_000_000_000_000;
+const DAO_VOTE_WEIGHT_PRECISION_BIGINT = 1_000_000_000_000n;
+const DAO_CLAIM_REWARD_PRECISION = 10n ** 18n;
 
 function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
 }
 
 function getDaoProposalReviewWindow(proposal) {
-  const start = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const start = Number(proposal?.startTime || 0);
   const duration = Number(proposal?.reviewDuration);
   if (!start || !Number.isFinite(duration) || duration < 0) {
     return {
@@ -3746,9 +3806,533 @@ function getDaoProposalReviewWindow(proposal) {
   };
 }
 
+function getDaoProposalVotingWindow(proposal, now = Date.now()) {
+  const reviewStart = Number(proposal?.startTime || 0);
+  const reviewDuration = Number(proposal?.reviewDuration);
+  const votingDuration = Number(proposal?.votingDuration);
+  if (
+    !reviewStart ||
+    !Number.isFinite(reviewDuration) ||
+    reviewDuration < 0 ||
+    !Number.isFinite(votingDuration) ||
+    votingDuration < 0
+  ) {
+    return {
+      start: 0,
+      end: 0,
+      label: 'Voting timing unavailable',
+      canPreviewVote: false,
+      timeMultiplier: null,
+    };
+  }
+
+  const start = reviewStart + reviewDuration;
+  const end = start + votingDuration;
+  if (now < start) {
+    return {
+      start,
+      end,
+      label: 'Voting has not started',
+      canPreviewVote: false,
+      timeMultiplier: 1,
+    };
+  }
+  if (now <= end) {
+    return {
+      start,
+      end,
+      label: 'Voting open',
+      canPreviewVote: true,
+      timeMultiplier: getDaoVoteTimeMultiplier(now, start, end),
+    };
+  }
+  return {
+    start,
+    end,
+    label: 'Voting ended',
+    canPreviewVote: false,
+    timeMultiplier: 0,
+  };
+}
+
+function getDaoVoteTimeMultiplier(now, start, end) {
+  const halfDuration = (end - start) / 2;
+  if (!Number.isFinite(halfDuration) || halfDuration <= 0) return 1;
+  if (now - start <= halfDuration) return 1;
+  return Math.max(0, (end - now) / halfDuration);
+}
+
 function formatDaoDetailTimestamp(ts) {
   const formatted = formatDaoTimestamp(ts);
   return formatted ? formatted.replace(', ', '\n') : 'Unavailable';
+}
+
+function formatDaoShortNumber(value, decimals = 6) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 'Unavailable';
+  return Number(n.toFixed(decimals)).toLocaleString(undefined, { maximumFractionDigits: decimals });
+}
+
+function formatDaoScaledBigInt(value, scale, decimals = 3) {
+  if (typeof value !== 'bigint' || typeof scale !== 'bigint' || scale <= 0n) return null;
+  const sign = value < 0n ? '-' : '';
+  const absValue = value < 0n ? -value : value;
+  const factor = 10n ** BigInt(Math.max(0, decimals));
+  const rounded = (absValue * factor + (scale / 2n)) / scale;
+  const whole = rounded / factor;
+  const fraction = rounded % factor;
+  const wholeText = whole.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  if (decimals <= 0 || fraction === 0n) return `${sign}${wholeText}`;
+  const fractionText = fraction.toString().padStart(decimals, '0').replace(/0+$/, '');
+  return `${sign}${wholeText}.${fractionText}`;
+}
+
+function formatDaoVoteWeightUnits(value, suffix) {
+  const bigintValue = parseDaoUnsignedBigInt(value);
+  if (bigintValue === null) return 'Unavailable';
+  const formatted = formatDaoScaledBigInt(bigintValue, DAO_VOTE_WEIGHT_PRECISION_BIGINT, 3);
+  return formatted === null ? 'Unavailable' : `${formatted} ${suffix}`;
+}
+
+function formatDaoVotingPower(value) {
+  return formatDaoVoteWeightUnits(value, 'power');
+}
+
+function formatDaoEstimatedVotingPower(value) {
+  const formatted = formatDaoVotingPower(value);
+  return formatted === 'Unavailable' ? formatted : `~${formatted}`;
+}
+
+function formatDaoPercent(value) {
+  return `${formatDaoShortNumber(value * 100, 1)}%`;
+}
+
+function formatDaoLibWei(value) {
+  const weiValue = parseDaoUnsignedBigInt(value);
+  if (weiValue === null) return 'Unavailable';
+  return `${formatDaoShortNumber(EthNum.toStr(weiValue))} LIB`;
+}
+
+function parseDaoUnsignedBigInt(value) {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value === 'bigint') return value >= 0n ? value : null;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) return null;
+    return BigInt(Math.trunc(value));
+  }
+  if (typeof value === 'object') {
+    if (value.dataType !== 'bi') return null;
+    const hexText = String(value.value ?? '').trim();
+    if (!/^[0-9a-f]+$/i.test(hexText)) return null;
+    try {
+      return BigInt(`0x${hexText}`);
+    } catch {
+      return null;
+    }
+  }
+
+  const text = String(value).trim();
+  if (!text) return null;
+  try {
+    const parsed = BigInt(text);
+    return parsed >= 0n ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatDaoRewardAmount(value) {
+  return value === null ? 'Unavailable' : formatDaoLibWei(value);
+}
+
+function formatDaoBigIntPercent(part, total) {
+  if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return '0%';
+  const tenths = (part * 1000n + total / 2n) / total;
+  const whole = tenths / 10n;
+  const fraction = tenths % 10n;
+  return fraction === 0n ? `${whole}%` : `${whole}.${fraction}%`;
+}
+
+function getDaoProposalOptions(proposal) {
+  return proposal.options.map((option) => String(option));
+}
+
+function getDaoVoteTotals(proposal) {
+  const totalVote = proposal.totalVote;
+  if (totalVote.length === 0) return [];
+
+  const options = getDaoProposalOptions(proposal);
+  const rowCount = Math.max(options.length, totalVote.length);
+  return Array.from({ length: rowCount }, (_, index) => ({
+    index,
+    option: options[index] || `Option ${index + 1}`,
+    total: parseDaoUnsignedBigInt(totalVote[index]) ?? 0n,
+  }));
+}
+
+function getDaoVoteWinner(totals) {
+  const totalWeight = totals.reduce((sum, row) => sum + row.total, 0n);
+  if (totalWeight <= 0n) return { totalWeight, winner: null };
+
+  const winner = totals.reduce((current, row) => (row.total > current.total ? row : current), totals[0]);
+  return { totalWeight, winner };
+}
+
+function isDaoFinalResultState(state) {
+  return state === 'accepted' || state === 'rejected' || state === 'applied';
+}
+
+function getDaoFinalOutcome(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  const label = getDaoStateLabel(state) || state || 'Unavailable';
+  const tone = state === 'withheld' || state === 'rejected' ? 'rejected' : 'accepted';
+  return { label, tone };
+}
+
+function getDaoCommitteeReviewResultSummary(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  if (state !== 'withheld' && !(proposal?.emergency && isDaoFinalResultState(state))) return null;
+
+  const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
+  const committeeAddresses = Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : [];
+  const committeeAddressSet = new Set(committeeAddresses);
+  const acceptCount = committeeVotes.filter((vote) => vote?.vote === 'accept' && committeeAddressSet.has(vote.memberAddress)).length;
+  const withholdCount = committeeVotes.filter((vote) => vote?.vote === 'withhold' && committeeAddressSet.has(vote.memberAddress)).length;
+  const outcome = getDaoFinalOutcome(proposal);
+
+  return {
+    acceptCount,
+    committeeSize: committeeAddresses.length,
+    headline: outcome.label,
+    source: 'committee',
+    tone: outcome.tone,
+    withholdCount,
+  };
+}
+
+function getDaoVoteResultSummary(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  if (!isDaoFinalResultState(state)) return null;
+
+  const totals = getDaoVoteTotals(proposal);
+  if (totals.length === 0) return null;
+
+  const { totalWeight, winner } = getDaoVoteWinner(totals);
+  if (totalWeight <= 0n) return null;
+
+  const outcome = winner.index === 0 ? 'Accepted' : 'Rejected';
+  const tone = winner.index === 0 ? 'accepted' : 'rejected';
+
+  return { headline: outcome, outcome, source: 'vote', tone, totalWeight, totals, winner };
+}
+
+function getDaoProposalResultSummary(proposal) {
+  return getDaoCommitteeReviewResultSummary(proposal) || getDaoVoteResultSummary(proposal);
+}
+
+function normalizeDaoAddress(value) {
+  const text = String(value || '').trim();
+  if (!text) return '';
+  return normalizeAddress(text);
+}
+
+function getDaoVoterEntries(proposal) {
+  if (!Array.isArray(proposal?.voterList)) return [];
+  return proposal.voterList
+    .map((entry) => ({
+      address: normalizeDaoAddress(entry?.address),
+      timestamp: Number(entry?.timestamp || 0),
+    }))
+    .filter((entry) => entry.address && Number.isFinite(entry.timestamp) && entry.timestamp > 0);
+}
+
+function getDaoClaimList(proposal) {
+  if (!Array.isArray(proposal?.claimList)) return [];
+  return proposal.claimList.map(normalizeDaoAddress).filter(Boolean);
+}
+
+function getDaoProposalClaimWindow(proposal) {
+  const reviewStart = Number(proposal?.startTime || 0);
+  const reviewDuration = Number(proposal?.reviewDuration);
+  const votingDuration = Number(proposal?.votingDuration);
+  const claimDuration = Number(proposal?.claimDuration);
+  if (
+    !Number.isFinite(reviewStart) ||
+    !Number.isFinite(reviewDuration) ||
+    !Number.isFinite(votingDuration) ||
+    !Number.isFinite(claimDuration)
+  ) {
+    return { start: null, end: null, votingStart: null, votingDuration: null };
+  }
+
+  const votingStart = reviewStart + reviewDuration;
+  const votingEnd = proposal?.emergency ? votingStart : votingStart + votingDuration;
+  return {
+    start: votingEnd,
+    end: votingEnd + claimDuration,
+    votingStart,
+    votingDuration,
+  };
+}
+
+function getDaoProposalApplyWindow(proposal, now = Date.now()) {
+  if (proposal?.emergency) {
+    return { eligibleAt: null, isReady: true };
+  }
+
+  const backendEligibleAt = Number(proposal?.applyEligibleAt);
+  if (Number.isFinite(backendEligibleAt) && backendEligibleAt > 0) {
+    return { eligibleAt: backendEligibleAt, isReady: now >= backendEligibleAt };
+  }
+
+  const reviewStart = Number(proposal?.startTime || 0);
+  const reviewDuration = Number(proposal?.reviewDuration);
+  const votingDuration = Number(proposal?.votingDuration);
+  const gracePeriod = Number(proposal?.gracePeriod);
+  if (
+    !Number.isFinite(reviewStart) ||
+    !Number.isFinite(reviewDuration) ||
+    !Number.isFinite(votingDuration) ||
+    !Number.isFinite(gracePeriod)
+  ) {
+    return { eligibleAt: null, isReady: false };
+  }
+
+  const eligibleAt = reviewStart + reviewDuration + votingDuration + gracePeriod;
+  return { eligibleAt, isReady: now >= eligibleAt };
+}
+
+function isDaoParameterProposalType(proposal) {
+  const type = String(proposal?.proposalType || '').toLowerCase();
+  return type === 'governance' || type === 'economic' || type === 'protocol';
+}
+
+function isDaoProposalCommitteeMember(proposal, currentAddress) {
+  const normalizedAddress = normalizeDaoAddress(currentAddress);
+  if (!normalizedAddress || !Array.isArray(proposal?.committeeAddresses)) return false;
+  return proposal.committeeAddresses.some((address) => normalizeDaoAddress(address) === normalizedAddress);
+}
+
+function getDaoApplyParametersLifecycleAction(help, canSubmit, rowPreviewLabel = '') {
+  const action = {
+    kind: 'apply_parameters',
+    title: 'Apply parameters',
+    help,
+    buttonLabel: 'Apply parameters',
+    loadingLabel: 'Applying parameters...',
+    successMessage: 'Parameters applied',
+    refreshWarning: 'Parameters applied, but proposal or parameter refresh failed',
+    refreshNetworkParams: true,
+    canSubmit,
+  };
+  if (rowPreviewLabel) action.rowPreviewLabel = rowPreviewLabel;
+  return action;
+}
+
+function getDaoProposalApplyLifecycleAction(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+  if (getEffectiveDaoState(proposal) !== 'accepted') return null;
+
+  if (!isDaoParameterProposalType(proposal)) {
+    return getDaoApplyParametersLifecycleAction(
+      'This proposal type does not support parameter application.',
+      false,
+    );
+  }
+
+  if (proposal?.emergency && !isDaoProposalCommitteeMember(proposal, currentAddress)) {
+    return getDaoApplyParametersLifecycleAction(
+      'Emergency proposal parameters can only be applied by a proposal committee member.',
+      false,
+    );
+  }
+
+  const applyWindow = getDaoProposalApplyWindow(proposal, now);
+  if (!applyWindow.isReady) {
+    const eligibleAt = applyWindow.eligibleAt ? formatDaoTimestamp(applyWindow.eligibleAt) : '';
+    return getDaoApplyParametersLifecycleAction(
+      eligibleAt
+        ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
+        : 'Apply timing is unavailable until the proposal includes grace-period timing.',
+      false,
+    );
+  }
+
+  return getDaoApplyParametersLifecycleAction(
+    'This proposal is ready to apply. Submit the transaction to apply the accepted parameter changes.',
+    true,
+    'Ready to apply',
+  );
+}
+
+function formatDaoClaimWindowLabel(claimWindow, now) {
+  if (!claimWindow.start || !claimWindow.end) return 'Unavailable';
+  const start = formatDaoTimestamp(claimWindow.start) || 'Unavailable';
+  const end = formatDaoTimestamp(claimWindow.end) || 'Unavailable';
+  if (now < claimWindow.start) return `Opens ${start}\nEnds ${end}`;
+  if (now <= claimWindow.end) return `Open until ${end}`;
+  return `Ended ${end}`;
+}
+
+function getDaoClaimRewardEstimate({ pool, claimed, voterEntries, voterIndex, votingStart, votingDuration }) {
+  if (pool <= 0n || claimed >= pool || voterIndex < 0 || voterEntries.length === 0) return null;
+  if (!Number.isFinite(votingStart) || !Number.isFinite(votingDuration) || votingDuration <= 0) return null;
+
+  const voter = voterEntries[voterIndex];
+  const previousTimestamp = voterIndex === 0 ? votingStart : voterEntries[voterIndex - 1]?.timestamp;
+  if (!Number.isFinite(voter?.timestamp) || !Number.isFinite(previousTimestamp)) return null;
+
+  const timeDelta = BigInt(Math.max(0, Math.trunc(voter.timestamp - previousTimestamp)));
+  const duration = BigInt(Math.trunc(votingDuration));
+  const voterCount = BigInt(voterEntries.length);
+  const timePart = (timeDelta * DAO_CLAIM_REWARD_PRECISION) / duration;
+  const equalPart = DAO_CLAIM_REWARD_PRECISION / voterCount;
+  let reward = (pool * (timePart + equalPart)) / (2n * DAO_CLAIM_REWARD_PRECISION);
+  const remaining = pool > claimed ? pool - claimed : 0n;
+  if (reward > remaining) reward = remaining;
+  return reward;
+}
+
+function getDaoRewardClaimStatus({ state, currentAddress, voterIndex, hasClaimed, pool, claimed, claimWindow, now }) {
+  if (!currentAddress) return 'Sign in to check rewards';
+  if (state === 'withheld') return 'Reward pool burned';
+  if (voterIndex < 0) return 'Not eligible';
+  if (hasClaimed) return 'Already claimed';
+  if (pool <= 0n) return 'Reward pool empty';
+  if (claimed >= pool) return 'Reward pool fully claimed';
+  if (!claimWindow.end) return 'Claim timing unavailable';
+  if (now > claimWindow.end) return 'Claim window ended';
+  if (now < claimWindow.start) return 'Claim window not open';
+  return 'Claimable';
+}
+
+function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+  const state = getEffectiveDaoState(proposal);
+  const isRewardState = state === 'accepted' || state === 'rejected' || state === 'applied' || state === 'withheld';
+  if (!isRewardState) return null;
+
+  const pool = parseDaoUnsignedBigInt(proposal?.voterRewardPool);
+  const claimed = parseDaoUnsignedBigInt(proposal?.claimedReward);
+  const initialBurned = parseDaoUnsignedBigInt(proposal?.initialBurnedReward);
+  const finalBurned = parseDaoUnsignedBigInt(proposal?.finalBurnedReward);
+  const voterEntries = getDaoVoterEntries(proposal);
+  const claimList = getDaoClaimList(proposal);
+  const hasRewardData = (
+    pool !== null ||
+    claimed !== null ||
+    initialBurned !== null ||
+    finalBurned !== null ||
+    voterEntries.length > 0 ||
+    claimList.length > 0
+  );
+  if (!hasRewardData) return null;
+
+  const safePool = pool ?? 0n;
+  const safeClaimed = claimed ?? 0n;
+  const claimWindow = getDaoProposalClaimWindow(proposal);
+  const normalizedAddress = normalizeDaoAddress(currentAddress);
+  const voterIndex = normalizedAddress ? voterEntries.findIndex((entry) => entry.address === normalizedAddress) : -1;
+  const hasClaimed = normalizedAddress ? claimList.includes(normalizedAddress) : false;
+  const claimStatus = getDaoRewardClaimStatus({
+    state,
+    currentAddress: normalizedAddress,
+    voterIndex,
+    hasClaimed,
+    pool: safePool,
+    claimed: safeClaimed,
+    claimWindow,
+    now,
+  });
+  const claimEstimate = hasClaimed
+    ? null
+    : getDaoClaimRewardEstimate({
+        pool: safePool,
+        claimed: safeClaimed,
+        voterEntries,
+        voterIndex,
+        votingStart: claimWindow.votingStart,
+        votingDuration: claimWindow.votingDuration,
+      });
+  const unclaimed = pool !== null && claimed !== null
+    ? safePool > safeClaimed ? safePool - safeClaimed : 0n
+    : null;
+
+  return {
+    claimEstimate,
+    claimStatus,
+    claimWindowLabel: formatDaoClaimWindowLabel(claimWindow, now),
+    claimed,
+    finalBurned,
+    initialBurned,
+    pool,
+    unclaimed,
+    statusTone: claimStatus === 'Claimable' ? 'accept' : '',
+  };
+}
+
+function getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+  const state = getEffectiveDaoState(proposal);
+
+  if (state === 'voting') {
+    const votingWindow = getDaoProposalVotingWindow(proposal, now);
+    if (votingWindow.end && now > votingWindow.end) {
+      return [{
+        kind: 'vote_result',
+        title: 'Vote result',
+        help: 'Voting has ended. Finalize the vote result to move this proposal to accepted or rejected.',
+        buttonLabel: 'Finalize vote result',
+        loadingLabel: 'Finalizing vote result...',
+        successMessage: 'Vote result finalized',
+        refreshWarning: 'Vote result finalized, but proposal refresh failed',
+      }];
+    }
+    return [];
+  }
+
+  if (!isDaoFinalResultState(state)) return [];
+
+  const actions = [];
+  const claimWindow = getDaoProposalClaimWindow(proposal);
+  const pool = parseDaoUnsignedBigInt(proposal?.voterRewardPool) ?? 0n;
+  const claimed = parseDaoUnsignedBigInt(proposal?.claimedReward) ?? 0n;
+  const unclaimed = pool > claimed ? pool - claimed : 0n;
+
+  if (claimWindow.end && now > claimWindow.end && unclaimed > 0n) {
+    actions.push({
+      kind: 'burn_reward',
+      title: 'Reward burn',
+      help: 'The claim window has ended. Burn the unclaimed reward pool so the proposal accounting is finalized.',
+      buttonLabel: 'Burn unclaimed reward',
+      loadingLabel: 'Burning reward...',
+      successMessage: 'Unclaimed reward burned',
+      refreshWarning: 'Reward burned, but proposal refresh failed',
+    });
+  }
+
+  if (
+    claimWindow.start &&
+    claimWindow.end &&
+    now >= claimWindow.start &&
+    now <= claimWindow.end &&
+    unclaimed > 0n &&
+    currentAddress &&
+    rewardSummary?.claimStatus === 'Claimable'
+  ) {
+    actions.push({
+      kind: 'claim_reward',
+      title: 'Reward claim',
+      help: rewardSummary.claimEstimate === null
+        ? 'Your reward is claimable. Submit the claim and refresh proposal accounting.'
+        : `Your estimated claim is ${formatDaoLibWei(rewardSummary.claimEstimate)}. Submit the claim and refresh proposal accounting.`,
+      buttonLabel: 'Claim reward',
+      loadingLabel: 'Claiming reward...',
+      successMessage: 'Reward claimed',
+      refreshWarning: 'Reward claimed, but proposal refresh failed',
+    });
+  }
+
+  const applyAction = getDaoProposalApplyLifecycleAction(proposal, currentAddress, now);
+  if (applyAction) actions.push(applyAction);
+  return actions;
 }
 
 function formatDaoDetailValue(value) {
@@ -3759,8 +4343,37 @@ function formatDaoDetailValue(value) {
   return String(value);
 }
 
-function getDaoBooleanCapability(proposal, key) {
-  return typeof proposal?.[key] === 'boolean' ? proposal[key] : null;
+function parseDaoPositiveLibAmount(value) {
+  const text = String(value || '').trim();
+  if (!/^\d+(?:\.\d{1,18})?$/.test(text)) return null;
+  try {
+    const weiAmount = EthNum.toWei(text);
+    return weiAmount > 0n ? weiAmount : null;
+  } catch {
+    return null;
+  }
+}
+
+function getDaoUsdAsLibWei(usdValue) {
+  const usdText = String(usdValue ?? '').trim();
+  const stabilityText = String(parameters?.current?.stabilityFactorStr ?? '').trim();
+  if (!usdText || !stabilityText) return null;
+  try {
+    const weiAmount = EthNum.toWei(EthNum.div(usdText, stabilityText));
+    return weiAmount >= 0n ? weiAmount : null;
+  } catch {
+    return null;
+  }
+}
+
+function floorDaoVoteWeightEstimate(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return null;
+  try {
+    return BigInt(Math.floor(n));
+  } catch {
+    return null;
+  }
 }
 
 class ProposalInfoModal {
@@ -3769,6 +4382,7 @@ class ProposalInfoModal {
     this.closeButton = document.getElementById('closeProposalInfoModal');
     this.title = document.getElementById('proposalInfoModalTitle');
     this.content = document.getElementById('proposalInfoContent');
+    this.detailsContent = document.getElementById('proposalDetailsContent');
     this.committeeActionSection = document.getElementById('proposalCommitteeActionSection');
     this.committeeActionHelp = document.getElementById('proposalCommitteeActionHelp');
     this.acceptButton = document.getElementById('proposalCommitteeAccept');
@@ -3781,15 +4395,28 @@ class ProposalInfoModal {
     this.reviewResultSection = document.getElementById('proposalReviewResultSection');
     this.reviewResultHelp = document.getElementById('proposalReviewResultHelp');
     this.reviewResultButton = document.getElementById('proposalReviewResultSubmit');
+    this.lifecycleActionSection = document.getElementById('proposalLifecycleActionSection');
+    this.voteActionSection = document.getElementById('proposalVoteActionSection');
+    this.voteActionHelp = document.getElementById('proposalVoteActionHelp');
+    this.voteOptions = document.getElementById('proposalVoteOptions');
+    this.voteSpendInput = document.getElementById('proposalVoteSpend');
+    this.votePreview = document.getElementById('proposalVotePreview');
+    this.voteSubmitButton = document.getElementById('proposalVoteSubmit');
 
     this._currentProposalId = null;
     this.committeeChoice = 'accept';
     this.currentCommitteeVote = '';
+    this.voteWeights = [];
+    this.voteSpendLib = '';
     this.isSubmitting = false;
     this.canSubmitCommitteeReview = false;
     this.canSubmitReviewResult = false;
+    this.currentLifecycleActions = [];
+    this.submittingLifecycleAction = null;
+    this.canSubmitVote = false;
     this.submitButtonLabel = this.submitButton?.textContent || 'Submit review';
     this.reviewResultButtonLabel = this.reviewResultButton?.textContent || 'Finalize review result';
+    this.voteSubmitButtonLabel = this.voteSubmitButton?.textContent || 'Submit vote';
 
     if (this.closeButton) this.closeButton.addEventListener('click', () => this.close());
     if (this.acceptButton) this.acceptButton.addEventListener('click', () => this.handleCommitteeChoiceClick('accept'));
@@ -3797,6 +4424,10 @@ class ProposalInfoModal {
     if (this.withholdReasonSelect) this.withholdReasonSelect.addEventListener('change', () => this.handleWithholdReasonChange());
     if (this.submitButton) this.submitButton.addEventListener('click', () => this.handleCommitteeSubmit());
     if (this.reviewResultButton) this.reviewResultButton.addEventListener('click', () => this.handleReviewResultSubmit());
+    if (this.lifecycleActionSection) this.lifecycleActionSection.addEventListener('click', (event) => this.handleLifecycleActionClick(event));
+    if (this.voteSpendInput) this.voteSpendInput.addEventListener('input', () => this.handleVoteSpendInput());
+    if (this.voteOptions) this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
+    if (this.voteSubmitButton) this.voteSubmitButton.addEventListener('click', () => this.handleVoteSubmit());
 
     if (this.withholdReasonSelect) {
       this.withholdReasonSelect.innerHTML = DAO_WITHHOLD_REASON_OPTIONS
@@ -3830,6 +4461,7 @@ class ProposalInfoModal {
 
     this.setSubmitting(false);
     this.committeeChoice = 'accept';
+    this.resetVoteState(p);
     this.renderProposal(p);
   }
 
@@ -3838,8 +4470,13 @@ class ProposalInfoModal {
     if (this.content) {
       this.content.innerHTML = '<section class="proposal-info-section"><h3>Proposal not found</h3><p class="proposal-info-muted">The proposal data is unavailable.</p></section>';
     }
+    if (this.detailsContent) {
+      this.detailsContent.innerHTML = '';
+    }
     this.hideCommitteeActions();
     this.hideReviewResultAction();
+    this.hideLifecycleAction();
+    this.hideVoteActions();
   }
 
   renderProposal(proposal) {
@@ -3854,65 +4491,62 @@ class ProposalInfoModal {
     const currentAddress = getDaoCurrentAccountAddress();
     const currentVote = committeeVotes.find((vote) => vote?.memberAddress === currentAddress) || null;
     const capabilities = this.getReviewCapabilities({
-      proposal,
       state,
       reviewWindow,
       currentAddress,
       committeeAddressSet,
     });
-    const proposalType = proposal.proposalType || proposal.type;
+    const resultSummary = getDaoProposalResultSummary(proposal);
+    const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
+    const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
+    const committeeReviewSection = state === 'review'
+      ? this.renderSection('Committee Review', [
+        ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
+        ['Accept votes', String(acceptCount)],
+        ['Withhold votes', String(withholdCount)],
+        [
+          'Your vote',
+          currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
+          this.getCommitteeVoteTone(currentVote),
+        ],
+        ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
+      ])
+      : '';
 
     if (this.content) {
       this.content.innerHTML = [
         this.renderProposalTitle(proposal),
-        this.renderSection('Overview', [
-          ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
-          ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
-          ['Status', getDaoStateLabel(state) || state],
-          ['Creator', proposal.createdBy || proposal.from || 'Unavailable'],
-          ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
-          ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
-        ]),
-        this.renderSection('Review Timeline', [
-          ['Window state', reviewWindow.label],
-          ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
-          ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
-        ]),
-        this.renderProposalBody(proposal),
         this.renderParameterChanges(proposal),
-        this.renderSection('Committee Review', [
-          ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
-          ['Accept votes', String(acceptCount)],
-          ['Withhold votes', String(withholdCount)],
-          [
-            'Your vote',
-            currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
-            this.getCommitteeVoteTone(currentVote),
-          ],
-          ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount)],
-        ]),
-      ].join('');
+        state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
+        this.renderProposalResults(resultSummary),
+        state === 'review' ? this.renderProposalBody(proposal) : '',
+        committeeReviewSection,
+      ].filter(Boolean).join('');
+    }
+    if (this.detailsContent) {
+      this.detailsContent.innerHTML = this.renderProposalDetails({
+        proposal,
+        state,
+        reviewWindow,
+        rewardSummary,
+      });
     }
 
-    this.renderCommitteeActions({ capabilities, reviewWindow, currentVote, state });
-    this.renderReviewResultAction({ capabilities, reviewWindow });
+    if (state === 'review') {
+      this.renderCommitteeActions({ capabilities, reviewWindow, currentVote, state });
+      this.renderReviewResultAction({ capabilities, reviewWindow, proposal, acceptCount, withholdCount });
+    } else {
+      this.hideCommitteeActions();
+      this.hideReviewResultAction();
+    }
+    this.renderLifecycleActions(lifecycleActions);
+    this.renderVoteActions(proposal, state);
   }
 
-  getReviewCapabilities({ proposal, state, reviewWindow, currentAddress, committeeAddressSet }) {
-    const backendCommitteeMember = getDaoBooleanCapability(proposal, 'isCommitteeMemberForProposal');
-    const isCommitteeMember = backendCommitteeMember ?? Boolean(currentAddress && committeeAddressSet.has(currentAddress));
-
-    const backendCanCommitteeVote = getDaoBooleanCapability(proposal, 'canCommitteeVote');
-    const canCommitteeVote = backendCanCommitteeVote ?? (
-      state === 'review' &&
-      reviewWindow.canCommitteeVote &&
-      isCommitteeMember
-    );
-
-    const backendCanFinalizeReviewResult = getDaoBooleanCapability(proposal, 'canFinalizeReviewResult');
-    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && (
-      backendCanFinalizeReviewResult ?? reviewWindow.canFinalizeReviewResult
-    );
+  getReviewCapabilities({ state, reviewWindow, currentAddress, committeeAddressSet }) {
+    const isCommitteeMember = Boolean(currentAddress && committeeAddressSet.has(currentAddress));
+    const canCommitteeVote = state === 'review' && reviewWindow.canCommitteeVote && isCommitteeMember;
+    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && reviewWindow.canFinalizeReviewResult;
 
     return { isCommitteeMember, canCommitteeVote, canFinalizeReviewResult };
   }
@@ -3924,11 +4558,321 @@ class ProposalInfoModal {
   }
 
   renderProposalTitle(proposal) {
-    return `<h2 class="proposal-info-title">${escapeHtml(this.getProposalTitle(proposal))}</h2>`;
+    const description = proposal.description || '';
+    const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
+    const descriptionHtml = description
+      ? `<p class="proposal-info-description">${escapeHtml(description)}</p>`
+      : '';
+
+    return `
+      <div class="proposal-info-heading">
+        <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
+        ${descriptionHtml}
+      </div>
+    `;
   }
 
-  getProposalTitle(proposal) {
-    return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
+  renderCurrentVoteTotals(proposal) {
+    const votingWindow = getDaoProposalVotingWindow(proposal);
+    const rows = this.getCurrentVoteTotalRows(proposal);
+    if (rows.length === 0) return '';
+
+    const totalWeight = rows.reduce((sum, row) => sum + row.total, 0n);
+    const winnerIndex = totalWeight > 0n
+      ? rows.reduce((winner, row, index) => (row.total > rows[winner].total ? index : winner), 0)
+      : -1;
+    const labelLayout = rows.length === 2 ? 'balanced' : 'segmented';
+
+    const labels = rows
+      .map((row, index) => {
+        const position = index === 0 ? 'start' : index === rows.length - 1 ? 'end' : 'center';
+        const isWinner = index === winnerIndex;
+        const units = this.getCurrentVoteSegmentUnits(row.total, totalWeight);
+        const power = formatDaoVotingPower(row.total);
+        const percent = formatDaoBigIntPercent(row.total, totalWeight);
+        const valueLabel = totalWeight > 0n ? `${power} / ${percent}` : power;
+        const title = totalWeight > 0n
+          ? `${row.option}: ${power}, ${percent}`
+          : `${row.option}: ${power}`;
+
+        return `
+          <div
+            class="proposal-vote-current-label proposal-vote-current-label--${position}${isWinner ? ' proposal-vote-current-label--winner' : ''}"
+            style="--vote-total-segment-units: ${units};"
+            title="${escapeDaoFormAttribute(title)}"
+            aria-label="${escapeDaoFormAttribute(title)}"
+          >
+            <span>${escapeHtml(row.option)}</span>
+            <small>${escapeHtml(valueLabel)}</small>
+          </div>
+        `;
+      })
+      .join('');
+
+    const segments = rows
+      .map((row, index) => {
+        const isWinner = index === winnerIndex;
+        const units = this.getCurrentVoteSegmentUnits(row.total, totalWeight);
+        return `
+          <span
+            class="proposal-vote-current-segment${isWinner ? ' proposal-vote-current-segment--winner' : ''}${row.total === 0n ? ' proposal-vote-current-segment--empty' : ''}"
+            style="--vote-total-segment-units: ${units};"
+          ></span>
+        `;
+      })
+      .join('');
+
+    return `
+      <section class="proposal-info-section proposal-vote-current-section">
+        <h3>Current Vote</h3>
+        <div class="proposal-vote-current-meter" aria-label="Current vote totals">
+          <div class="proposal-vote-current-labels proposal-vote-current-labels--${labelLayout}">${labels}</div>
+          <div class="proposal-vote-current-track" aria-hidden="true">${segments}</div>
+        </div>
+        <div class="proposal-vote-status-grid proposal-vote-status-grid--current">
+          <div class="proposal-vote-status-card proposal-vote-status-card--deadline">
+            <span>Voting ends</span>
+            <strong>${escapeHtml(formatDaoDetailTimestamp(votingWindow.end))}</strong>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  getCurrentVoteTotalRows(proposal) {
+    const options = getDaoProposalOptions(proposal);
+    const totalVote = proposal.totalVote;
+    return options.map((option, index) => ({
+      option,
+      total: parseDaoUnsignedBigInt(totalVote[index]) ?? 0n,
+    }));
+  }
+
+  getCurrentVoteSegmentUnits(part, total) {
+    if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return 1;
+    if (part <= 0n) return 0;
+    const units = Number((part * 1000n) / total);
+    return Math.max(1, units);
+  }
+
+  renderProposalResults(result) {
+    if (!result) return '';
+    if (result.source === 'committee') {
+      return this.renderCommitteeResults(result);
+    }
+
+    const winnerLabel = result.winner ? `${result.winner.option} (${result.outcome})` : 'Unavailable';
+    const totalLabel = result.totalWeight > 0n ? formatDaoVotingPower(result.totalWeight) : 'No votes yet';
+    const labelLayout = result.totals.length === 2 ? 'balanced' : 'segmented';
+    const segments = result.totals
+      .map((row, rowPosition) => {
+        const isWinner = result.winner?.index === row.index;
+        const paletteClass = result.totals.length > 1
+          ? ` proposal-result-meter-label--palette-${rowPosition % 6}`
+          : '';
+        const units = this.getResultSegmentUnits(row.total, result.totalWeight);
+        const power = formatDaoVotingPower(row.total);
+        const displayPower = power.endsWith(' power') ? power.slice(0, -6) : power;
+        const percent = formatDaoBigIntPercent(row.total, result.totalWeight);
+        const position = rowPosition === 0
+          ? 'start'
+          : rowPosition === result.totals.length - 1
+            ? 'end'
+            : 'center';
+        const style = `--result-segment-units: ${units};`;
+        const label = `${row.option}: ${power}, ${percent}`;
+        return `
+          <div
+            class="proposal-result-meter-label proposal-result-meter-label--${position}${paletteClass}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
+            style="${escapeDaoFormAttribute(style)}"
+            title="${escapeDaoFormAttribute(label)}"
+            aria-label="${escapeDaoFormAttribute(label)}"
+          >
+            <span>${escapeHtml(row.option)}</span>
+            <small>${escapeHtml(displayPower)} / ${escapeHtml(percent)}</small>
+          </div>
+        `;
+      })
+      .join('');
+    const bars = result.totals
+      .map((row, rowPosition) => {
+        const paletteClass = result.totals.length > 1
+          ? ` proposal-result-meter-segment--palette-${rowPosition % 6}`
+          : ' proposal-result-meter-segment--palette-0';
+        const units = this.getResultSegmentUnits(row.total, result.totalWeight);
+        const style = `--result-segment-units: ${units};`;
+        return `
+          <span
+            class="proposal-result-meter-segment${paletteClass}${row.total === 0n ? ' proposal-result-meter-segment--empty' : ''}"
+            style="${escapeDaoFormAttribute(style)}"
+          ></span>
+        `;
+      })
+      .join('');
+
+    return `
+      <section class="proposal-info-section">
+        <h3>Results</h3>
+        <div class="proposal-result-overview">
+          <div class="proposal-result-card">
+            <span>Winner</span>
+            <span class="proposal-result-value">${escapeHtml(winnerLabel)}</span>
+          </div>
+          <div class="proposal-result-card">
+            <span>Total voting power</span>
+            <span class="proposal-result-value">${escapeHtml(totalLabel)}</span>
+          </div>
+        </div>
+        <div class="proposal-result-meter" aria-label="Vote result breakdown">
+          <div class="proposal-result-meter-labels proposal-result-meter-labels--${labelLayout}">${segments}</div>
+          <div class="proposal-result-meter-track" aria-hidden="true">${bars}</div>
+        </div>
+      </section>
+    `;
+  }
+
+  renderCommitteeResults(result) {
+    const acceptCount = Number(result.acceptCount || 0);
+    const withholdCount = Number(result.withholdCount || 0);
+    const submittedCount = acceptCount + withholdCount;
+    const committeeSize = Number(result.committeeSize || 0);
+    const committeeSizeLabel = committeeSize > 0 ? String(committeeSize) : 'Unavailable';
+    const acceptPercent = this.formatCountPercent(acceptCount, submittedCount);
+    const withholdPercent = this.formatCountPercent(withholdCount, submittedCount);
+    const acceptUnits = this.getCountResultSegmentUnits(acceptCount, submittedCount);
+    const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
+    const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
+    const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
+
+    return `
+      <section class="proposal-info-section">
+        <h3>Results</h3>
+        <div class="proposal-result-overview">
+          <div class="proposal-result-card">
+            <span>Outcome</span>
+            <span class="proposal-result-value">${escapeHtml(result.headline || 'Unavailable')}</span>
+          </div>
+          <div class="proposal-result-card">
+            <span>Committee size</span>
+            <span class="proposal-result-value">${escapeHtml(committeeSizeLabel)}</span>
+          </div>
+        </div>
+        <div class="proposal-result-meter" aria-label="Committee result breakdown">
+          <div class="proposal-result-meter-labels proposal-result-meter-labels--balanced">
+            <div
+              class="proposal-result-meter-label proposal-result-meter-label--start proposal-result-meter-label--accept${acceptWinnerClass}"
+              style="--result-segment-units: ${acceptUnits};"
+              title="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
+              aria-label="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
+            >
+              <span>Accept</span>
+              <small>${escapeHtml(`${acceptCount} / ${acceptPercent}`)}</small>
+            </div>
+            <div
+              class="proposal-result-meter-label proposal-result-meter-label--end proposal-result-meter-label--withhold${withholdWinnerClass}"
+              style="--result-segment-units: ${withholdUnits};"
+              title="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
+              aria-label="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
+            >
+              <span>Withhold</span>
+              <small>${escapeHtml(`${withholdCount} / ${withholdPercent}`)}</small>
+            </div>
+          </div>
+          <div class="proposal-result-meter-track" aria-hidden="true">
+            <span
+              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              style="--result-segment-units: ${acceptUnits};"
+            ></span>
+            <span
+              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              style="--result-segment-units: ${withholdUnits};"
+            ></span>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  getResultSegmentUnits(part, total) {
+    if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return 1;
+    const units = Number((part * 1000n + total / 2n) / total);
+    return Math.max(1, units);
+  }
+
+  getCountResultSegmentUnits(part, total) {
+    if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return 1;
+    if (part <= 0) return 0;
+    return Math.max(1, Math.round((part / total) * 1000));
+  }
+
+  formatCountPercent(part, total) {
+    if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return '0%';
+    return formatDaoPercent(part / total);
+  }
+
+  renderProposalRewards(reward) {
+    if (!reward) return '';
+    return this.renderSection('Rewards', [
+      ['Claim status', reward.claimStatus, reward.statusTone],
+      ['Claim estimate', reward.claimEstimate === null ? 'Unavailable' : formatDaoLibWei(reward.claimEstimate), reward.statusTone],
+      ['Claim window', reward.claimWindowLabel],
+      ['Reward pool', formatDaoRewardAmount(reward.pool)],
+      ['Claimed', formatDaoRewardAmount(reward.claimed)],
+      ['Unclaimed pool', formatDaoRewardAmount(reward.unclaimed)],
+      ['Initial burn', formatDaoRewardAmount(reward.initialBurned)],
+      ['Final burn', formatDaoRewardAmount(reward.finalBurned)],
+    ]);
+  }
+
+  renderVotingDetails(proposal) {
+    const votingWindow = getDaoProposalVotingWindow(proposal);
+    const totalVote = Array.isArray(proposal.totalVote) ? proposal.totalVote : [];
+    const options = getDaoProposalOptions(proposal);
+    const totalVoteText = totalVote.length
+      ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
+      : 'No votes yet';
+    return this.renderSection('Voting Details', [
+      ['Voting state', votingWindow.label],
+      ['Current totals', totalVoteText],
+    ]);
+  }
+
+  renderProposalDetails({ proposal, state, reviewWindow, rewardSummary }) {
+    const sections = [
+      this.renderSection('Overview', [
+        ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
+        ['Type', getDaoTypeLabel(proposal.proposalType) || 'Unavailable'],
+        ['Status', getDaoStateLabel(state) || state],
+        ['Created', formatDaoDetailTimestamp(proposal.created)],
+        ['Updated', formatDaoDetailTimestamp(proposal.state_changed)],
+      ]),
+      this.renderSection('Review Timeline', [
+        ['Window state', reviewWindow.label],
+        ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
+        ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
+      ]),
+      state === 'voting' ? this.renderVotingDetails(proposal) : '',
+      state === 'review' ? '' : this.renderProposalBody(proposal),
+      this.renderProposalRewards(rewardSummary),
+    ].filter(Boolean);
+
+    return `
+      <details class="proposal-more">
+        <summary>
+          <span class="proposal-more-title">Show proposal details</span>
+          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, rewardSummary))}</span>
+        </summary>
+        <div class="proposal-more-content">${sections.join('')}</div>
+      </details>
+    `;
+  }
+
+  getProposalDetailsSummary(state, rewardSummary) {
+    const parts = ['Overview', 'review timeline'];
+    if (state !== 'review') parts.push('proposal body');
+    if (state === 'voting') parts.push('voting totals');
+    if (rewardSummary) parts.push('reward accounting');
+    return parts.join(', ');
   }
 
   setTitle(title) {
@@ -3936,28 +4880,22 @@ class ProposalInfoModal {
   }
 
   renderSection(title, rows) {
-    const renderedRows = rows.map(([label, value, tone]) => {
-      const displayValue = formatDaoDetailValue(value);
-      const rowClass = this.getSectionRowClass(label, displayValue);
-      return {
-        label,
-        value: displayValue,
-        classes: [
+    const rowHtml = rows
+      .map(([label, value, tone]) => {
+        const displayValue = formatDaoDetailValue(value);
+        const rowClass = this.getSectionRowClass(label, displayValue);
+        const classes = [
           rowClass,
           tone ? `proposal-info-row--${tone}` : '',
-        ].filter(Boolean),
-        isFull: rowClass.includes('proposal-info-row--full'),
-      };
-    });
-    this.centerTwoCardRows(renderedRows);
+        ].filter(Boolean);
 
-    const rowHtml = renderedRows
-      .map((row) => `
-        <div class="${row.classes.join(' ')}">
-          <span>${escapeHtml(row.label)}</span>
-          <strong>${escapeHtml(row.value)}</strong>
+        return `
+        <div class="${classes.join(' ')}">
+          <span>${escapeHtml(label)}</span>
+          <span class="proposal-info-value">${escapeHtml(displayValue)}</span>
         </div>
-      `)
+      `;
+      })
       .join('');
 
     return `
@@ -3966,24 +4904,6 @@ class ProposalInfoModal {
         <div class="proposal-info-grid">${rowHtml}</div>
       </section>
     `;
-  }
-
-  centerTwoCardRows(renderedRows) {
-    let row = [];
-    const flush = () => {
-      if (row.length === 2) row[0].classes.push('proposal-info-row--center-pair');
-      row = [];
-    };
-
-    for (const renderedRow of renderedRows) {
-      if (renderedRow.isFull) {
-        flush();
-        continue;
-      }
-      row.push(renderedRow);
-      if (row.length === 3) flush();
-    }
-    flush();
   }
 
   getSectionRowClass(label, value) {
@@ -4004,21 +4924,17 @@ class ProposalInfoModal {
   }
 
   renderProposalBody(proposal) {
-    const options = Array.isArray(proposal.options) && proposal.options.length
-      ? proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : 'Unavailable';
+    const options = proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n');
 
     return this.renderSection('Proposal Body', [
-      ['Description', proposal.description || proposal.summary || 'Unavailable'],
       ['Emergency', proposal.emergency ? 'Yes' : 'No'],
       ['Options', options],
     ]);
   }
 
   renderParameterChanges(proposal) {
-    const fields = proposal.fields && typeof proposal.fields === 'object' ? proposal.fields : {};
     const payloads = ['governance', 'economic', 'protocol']
-      .map((key) => [key, proposal[key] || fields[key]])
+      .map((key) => [key, proposal[key]])
       .filter(([, payload]) => payload && typeof payload === 'object');
 
     if (payloads.length === 0) {
@@ -4026,12 +4942,14 @@ class ProposalInfoModal {
     }
 
     const payloadHtml = payloads
-      .map(([key, payload]) => `
+      .map(([key, payload]) => {
+        const payloadTitle = getDaoTypeLabel(key) || key;
+        return `
         <div class="proposal-payload">
-          <div class="proposal-payload-title">${escapeHtml(getDaoTypeLabel(key) || key)}</div>
-          ${this.renderPayloadRows(payload)}
+          ${this.renderPayloadRows(payload, payloadTitle)}
         </div>
-      `)
+      `;
+      })
       .join('');
 
     return `
@@ -4042,30 +4960,66 @@ class ProposalInfoModal {
     `;
   }
 
-  renderPayloadRows(payload) {
+  getParameterChangeRowClass(parts, isSingleRow) {
+    const normalizedParts = parts.map((part) => String(part ?? '').trim());
+    const shouldUseWideRow = normalizedParts.some((part) => part.length > 22)
+      || normalizedParts.join(' ').length > 52;
+    return [
+      'proposal-change-row',
+      shouldUseWideRow ? 'proposal-change-row--wide' : '',
+      !shouldUseWideRow && isSingleRow ? 'proposal-change-row--single' : '',
+    ].filter(Boolean).join(' ');
+  }
+
+  renderPayloadRows(payload, payloadTitle) {
+    const titleHtml = payloadTitle
+      ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
+      : '';
+
     if (Array.isArray(payload?.changes)) {
-      return payload.changes
-        .map((change) => `
-          <div class="proposal-change-row">
-            <span>${escapeHtml(change?.key || 'Unknown key')}</span>
+      const changes = payload.changes;
+      return changes
+        .map((change, index) => {
+          const key = change?.key || 'Unknown key';
+          const current = formatDaoDetailValue(change?.current);
+          const next = formatDaoDetailValue(change?.value);
+          const rowClass = this.getParameterChangeRowClass(
+            [key, `Current: ${current}`, `New: ${next}`],
+            index === changes.length - 1 && changes.length % 2 === 1,
+          );
+          return `
+          <div class="${rowClass}">
+            ${titleHtml}
+            <span>${escapeHtml(key)}</span>
             <div class="proposal-change-values">
-              <small>Current: ${escapeHtml(formatDaoDetailValue(change?.current))}</small>
+              <small><span>Current:</span><strong>${escapeHtml(current)}</strong></small>
               <span class="proposal-change-arrow" aria-hidden="true">&rarr;</span>
-              <strong>New: ${escapeHtml(formatDaoDetailValue(change?.value))}</strong>
+              <small><span>New:</span><strong>${escapeHtml(next)}</strong></small>
             </div>
           </div>
-        `)
+        `;
+        })
         .join('');
     }
 
-    return Object.entries(payload)
-      .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0)
-      .map(([key, value]) => `
-        <div class="proposal-change-row">
+    const entries = Object.entries(payload)
+      .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0);
+
+    return entries
+      .map(([key, value], index) => {
+        const displayValue = formatDaoDetailValue(value);
+        const rowClass = this.getParameterChangeRowClass(
+          [key, displayValue],
+          index === entries.length - 1 && entries.length % 2 === 1,
+        );
+        return `
+        <div class="${rowClass}">
+          ${titleHtml}
           <span>${escapeHtml(key)}</span>
-          <strong>${escapeHtml(formatDaoDetailValue(value))}</strong>
+          <strong>${escapeHtml(displayValue)}</strong>
         </div>
-      `)
+      `;
+      })
       .join('');
   }
 
@@ -4074,8 +5028,16 @@ class ProposalInfoModal {
     return vote.withheldReason ? `Withhold - ${vote.withheldReason}` : 'Withhold';
   }
 
-  getNextStateHint(proposal, acceptCount, withholdCount) {
+  getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount) {
+    if (withholdCount > acceptCount) return 'Withheld';
+    return proposal.emergency ? 'Accepted' : 'Voting';
+  }
+
+  getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow) {
     if (proposal.status && proposal.status !== 'review') return getDaoStateLabel(proposal.status) || proposal.status;
+    if (reviewWindow.canFinalizeReviewResult) {
+      return `${this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount)} if finalized`;
+    }
     if (withholdCount > acceptCount) return 'Likely withheld after review result';
     if (acceptCount > withholdCount) return proposal.emergency ? 'Accepted if finalized' : 'Voting if finalized';
     return 'Waiting for committee review';
@@ -4109,7 +5071,7 @@ class ProposalInfoModal {
     this.updateSubmitButtons();
   }
 
-  renderReviewResultAction({ capabilities, reviewWindow }) {
+  renderReviewResultAction({ capabilities, reviewWindow, proposal, acceptCount, withholdCount }) {
     if (!this.reviewResultSection) return;
     if (!capabilities.canFinalizeReviewResult) {
       this.hideReviewResultAction();
@@ -4119,7 +5081,8 @@ class ProposalInfoModal {
     this.canSubmitReviewResult = true;
     this.reviewResultSection.classList.remove('hidden');
     if (this.reviewResultHelp) {
-      this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to its next state.`;
+      const nextState = this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount);
+      this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to ${nextState}.`;
     }
     this.updateSubmitButtons();
   }
@@ -4128,6 +5091,311 @@ class ProposalInfoModal {
     this.canSubmitReviewResult = false;
     this.reviewResultSection?.classList.add('hidden');
     this.updateSubmitButtons();
+  }
+
+  renderLifecycleActions(actions) {
+    this.currentLifecycleActions = actions;
+    if (!this.lifecycleActionSection || this.currentLifecycleActions.length === 0) {
+      this.hideLifecycleAction();
+      return;
+    }
+
+    this.lifecycleActionSection.innerHTML = this.currentLifecycleActions
+      .map((action, index) => `
+        <div class="proposal-lifecycle-action">
+          <div class="proposal-committee-actions-header">
+            <h3>${escapeHtml(action.title)}</h3>
+            <p>${escapeHtml(action.help)}</p>
+          </div>
+          <button
+            type="button"
+            class="btn btn--primary btn--pill btn--full"
+            data-lifecycle-action-index="${index}"
+          >${escapeHtml(action.buttonLabel)}</button>
+        </div>
+      `)
+      .join('');
+    this.lifecycleActionSection.classList.remove('hidden');
+    this.updateSubmitButtons();
+  }
+
+  hideLifecycleAction() {
+    this.currentLifecycleActions = [];
+    this.submittingLifecycleAction = null;
+    if (this.lifecycleActionSection) {
+      this.lifecycleActionSection.innerHTML = '';
+      this.lifecycleActionSection.classList.add('hidden');
+    }
+    this.updateSubmitButtons();
+  }
+
+  resetVoteState(proposal) {
+    const options = getDaoProposalOptions(proposal);
+    this.voteWeights = options.map(() => 0);
+    this.voteSpendLib = '';
+    if (this.voteSpendInput) this.voteSpendInput.value = '';
+  }
+
+  renderVoteActions(proposal, state) {
+    if (!this.voteActionSection) return;
+    if (state !== 'voting') {
+      this.hideVoteActions();
+      return;
+    }
+
+    const votingWindow = getDaoProposalVotingWindow(proposal);
+    if (votingWindow.end && Date.now() > votingWindow.end) {
+      this.hideVoteActions();
+      return;
+    }
+
+    const options = getDaoProposalOptions(proposal);
+    if (this.voteWeights.length !== options.length) {
+      this.voteWeights = options.map(() => 0);
+    }
+
+    this.voteActionSection.classList.remove('hidden');
+    if (this.voteActionHelp) {
+      this.voteActionHelp.textContent = 'Allocate options and spend LIB to preview voting power.';
+    }
+    if (this.voteSubmitButton) {
+      this.voteSubmitButton.textContent = this.voteSubmitButtonLabel;
+    }
+    if (this.voteSpendInput) {
+      this.voteSpendInput.value = this.voteSpendLib;
+    }
+    if (this.voteOptions) {
+      this.voteOptions.innerHTML = `
+        <div class="proposal-vote-options-header">
+          <span>Option</span>
+          <span>Allocation</span>
+        </div>
+        ${options.map((option, index) => this.renderVoteOption(option, index)).join('')}
+        <div class="proposal-vote-options-help">Allocation is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.</div>
+      `;
+    }
+
+    this.updateVotePreview(proposal);
+  }
+
+  hideVoteActions() {
+    this.canSubmitVote = false;
+    this.voteActionSection?.classList.add('hidden');
+    this.updateSubmitButtons();
+  }
+
+  renderVoteOption(option, index) {
+    const weight = this.voteWeights[index] || 0;
+    return `
+      <label class="proposal-vote-option">
+        <span>${escapeHtml(option)}</span>
+        <input
+          type="number"
+          class="form-control"
+          min="0"
+          max="${DAO_VOTE_WEIGHT_MAX}"
+          step="1"
+          inputmode="numeric"
+          placeholder="0"
+          aria-label="${escapeDaoFormAttribute(`${option} allocation`)}"
+          data-vote-option-index="${index}"
+          value="${escapeDaoFormAttribute(String(weight))}"
+        >
+      </label>
+    `;
+  }
+
+  handleVoteWeightInput(event) {
+    const input = event.target?.closest?.('input[data-vote-option-index]');
+    if (!input) return;
+    const index = Number(input.dataset.voteOptionIndex);
+    if (!Number.isInteger(index) || index < 0 || index >= this.voteWeights.length) return;
+    this.voteWeights[index] = this.normalizeVoteWeight(input.value);
+    input.value = String(this.voteWeights[index]);
+    this.updateVotePreview(this.getCurrentProposal());
+  }
+
+  handleVoteSpendInput() {
+    this.voteSpendLib = String(this.voteSpendInput?.value || '');
+    this.updateVotePreview(this.getCurrentProposal());
+  }
+
+  normalizeVoteWeight(value) {
+    const n = Number(value);
+    if (!Number.isSafeInteger(n) || n < 0) return 0;
+    return Math.min(n, DAO_VOTE_WEIGHT_MAX);
+  }
+
+  updateVotePreview(proposal) {
+    if (!this.votePreview || !proposal) {
+      this.canSubmitVote = false;
+      this.updateSubmitButtons();
+      return;
+    }
+
+    const submission = this.getVoteSubmission(proposal);
+    if (!submission.ok) {
+      this.canSubmitVote = false;
+      this.updateSubmitButtons();
+      this.votePreview.classList.add('proposal-vote-preview--message');
+      this.votePreview.innerHTML = this.renderVotePreviewMessage(submission.message, submission.tone);
+      return;
+    }
+
+    this.canSubmitVote = true;
+    this.updateSubmitButtons();
+
+    const estimate = this.getVoteWeightEstimate(proposal, submission.spendWei, submission.totalWeight, submission.timestamp);
+    if (!estimate.ok) {
+      this.votePreview.classList.add('proposal-vote-preview--message');
+      this.votePreview.innerHTML = this.renderVotePreviewMessage(`${estimate.message} You can still submit; final weight is calculated by the network.`, 'muted');
+      return;
+    }
+    this.votePreview.classList.remove('proposal-vote-preview--message');
+
+    const optionRows = getDaoProposalOptions(proposal)
+      .map((option, index) => {
+        const weight = this.voteWeights[index] || 0;
+        const share = weight / submission.totalWeight;
+        const applied = estimate.optionAppliedWeights[index] ?? 0n;
+        return `
+          <div class="proposal-vote-preview-row">
+            <span>${escapeHtml(formatDaoPercent(share))}</span>
+            <span>${escapeHtml(option)}</span>
+            <strong>${escapeHtml(formatDaoEstimatedVotingPower(applied))}</strong>
+          </div>
+        `;
+      })
+      .join('');
+
+    this.votePreview.innerHTML = `
+      <div class="proposal-vote-preview-total">
+        <span>Estimated voting power</span>
+        <strong>${escapeHtml(formatDaoEstimatedVotingPower(estimate.totalAppliedWeight))}</strong>
+      </div>
+      <details class="proposal-vote-power-help">
+        <summary>What is voting power?</summary>
+        <p>Voting power is the normalized weight from your LIB spend and timing. Final weight can shift slightly if the transaction lands later or network pricing changes before validation.</p>
+      </details>
+      <div class="proposal-vote-preview-meter">
+        <span style="width: ${Math.min(100, Math.max(4, estimate.timeMultiplier * 100))}%"></span>
+      </div>
+      <div class="proposal-vote-preview-note">
+        Timing weight: ${escapeHtml(formatDaoPercent(estimate.timeMultiplier))} of full power
+      </div>
+      <div class="proposal-vote-preview-options">${optionRows}</div>
+    `;
+  }
+
+  getVoteSubmission(proposal) {
+    const timestamp = getTransactionTimestamp();
+    const validation = this.getVotePreviewValidation(proposal, timestamp);
+    if (!validation.ok) {
+      return { ok: false, message: validation.message, tone: 'warning' };
+    }
+
+    return {
+      ok: true,
+      spendWei: validation.spendWei,
+      totalWeight: validation.totalWeight,
+      timestamp,
+    };
+  }
+
+  getVotePreviewValidation(proposal, timestamp) {
+    if (getEffectiveDaoState(proposal) !== 'voting') {
+      return { ok: false, message: 'Voting is only available while the proposal is in voting status.' };
+    }
+    if (!myAccount?.keys?.address) {
+      return { ok: false, message: 'Sign in with a wallet to preview vote eligibility.' };
+    }
+
+    const totalWeight = this.voteWeights.reduce((sum, weight) => sum + weight, 0);
+    if (totalWeight <= 0) {
+      return { ok: false, message: 'Enter at least one positive option weight.' };
+    }
+
+    const spendWei = parseDaoPositiveLibAmount(this.voteSpendLib);
+    if (spendWei === null) {
+      return { ok: false, message: 'Enter a positive LIB spend amount.' };
+    }
+
+    const votingWindow = getDaoProposalVotingWindow(proposal, timestamp);
+    if (!votingWindow.canPreviewVote) {
+      return { ok: false, message: votingWindow.label };
+    }
+
+    const balanceWei = getLibBalanceWei();
+    const feeWei = getTransactionFeeWei({ allowNull: true }) || 0n;
+    if (balanceWei < spendWei + feeWei) {
+      return { ok: false, message: `Balance is below spend plus fee. Available: ${formatDaoLibWei(balanceWei)}.` };
+    }
+
+    const thresholdUsd = Number(proposal.voteThresholdUsdStr || 0);
+    if (thresholdUsd > 0) {
+      const thresholdWei = getDaoUsdAsLibWei(proposal.voteThresholdUsdStr);
+      if (thresholdWei === null) {
+        return { ok: false, message: 'Vote threshold is unavailable until network pricing is loaded.' };
+      }
+      if (balanceWei < thresholdWei) {
+        return { ok: false, message: `Wallet balance must be at least ${formatDaoLibWei(thresholdWei)} to vote. Current balance: ${formatDaoLibWei(balanceWei)}.` };
+      }
+    }
+
+    return { ok: true, spendWei, totalWeight };
+  }
+
+  getVoteWeightEstimate(proposal, spendWei, totalWeight, timestamp) {
+    const minimumSpendWei = getDaoUsdAsLibWei(proposal.minimumSpendUsdStr);
+    const voteExponent = Number(proposal.voteExponent);
+    const votingWindow = getDaoProposalVotingWindow(proposal, timestamp);
+    if (
+      minimumSpendWei === null ||
+      minimumSpendWei <= 0n ||
+      !Number.isFinite(voteExponent) ||
+      votingWindow.timeMultiplier === null
+    ) {
+      return { ok: false, message: 'Applied-weight estimate is unavailable until proposal voting parameters are loaded.' };
+    }
+
+    if (spendWei < minimumSpendWei) {
+      return { ok: false, message: `Spend must be at least ${formatDaoLibWei(minimumSpendWei)}.` };
+    }
+    if (totalWeight <= 0) {
+      return { ok: false, message: 'Applied-weight estimate is unavailable for these inputs.' };
+    }
+
+    const spendLib = Number(EthNum.toStr(spendWei));
+    const minimumSpendLib = Number(EthNum.toStr(minimumSpendWei));
+    const spendBoost = Math.pow(spendLib / minimumSpendLib, voteExponent);
+    const baseAppliedWeight = spendLib * spendBoost * votingWindow.timeMultiplier * DAO_VOTE_WEIGHT_PRECISION / totalWeight;
+    if (!Number.isFinite(baseAppliedWeight) || baseAppliedWeight <= 0) {
+      return { ok: false, message: 'Applied-weight estimate is unavailable for these inputs.' };
+    }
+
+    const optionAppliedWeights = this.voteWeights.map((weight) => {
+      if (weight <= 0) return 0n;
+      return floorDaoVoteWeightEstimate(baseAppliedWeight * weight);
+    });
+    if (optionAppliedWeights.some((weight) => weight === null)) {
+      return { ok: false, message: 'Applied-weight estimate is unavailable for these inputs.' };
+    }
+
+    const totalAppliedWeight = optionAppliedWeights.reduce((sum, weight) => sum + weight, 0n);
+    if (totalAppliedWeight <= 0n) {
+      return { ok: false, message: 'Applied-weight estimate is too small to affect vote totals.' };
+    }
+
+    return {
+      ok: true,
+      totalAppliedWeight,
+      optionAppliedWeights,
+      timeMultiplier: votingWindow.timeMultiplier,
+    };
+  }
+
+  renderVotePreviewMessage(message, tone) {
+    return `<div class="proposal-vote-preview-message proposal-vote-preview-message--${tone}">${escapeHtml(message)}</div>`;
   }
 
   setSubmitting(isSubmitting) {
@@ -4140,6 +5408,7 @@ class ProposalInfoModal {
     const disableCommittee = this.isSubmitting || !this.canSubmitCommitteeReview;
     const isSameVote = Boolean(this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote);
     const disableResult = this.isSubmitting || !this.canSubmitReviewResult;
+    const disableVote = this.isSubmitting || !this.canSubmitVote;
 
     if (this.acceptButton) this.acceptButton.disabled = disableCommittee || this.currentCommitteeVote === 'accept';
     if (this.withholdButton) this.withholdButton.disabled = disableCommittee || this.currentCommitteeVote === 'withhold';
@@ -4152,6 +5421,23 @@ class ProposalInfoModal {
     if (this.reviewResultButton) {
       this.reviewResultButton.disabled = disableResult;
       this.reviewResultButton.textContent = this.isSubmitting && this.canSubmitReviewResult ? 'Finalizing...' : this.reviewResultButtonLabel;
+    }
+    for (const button of this.lifecycleActionSection?.querySelectorAll('button[data-lifecycle-action-index]') || []) {
+      const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
+      const isSubmittingAction = this.isSubmitting && action === this.submittingLifecycleAction;
+      const canSubmitLifecycle = action?.canSubmit !== false;
+      button.disabled = this.isSubmitting || !action || !canSubmitLifecycle;
+      button.textContent = isSubmittingAction ? action.loadingLabel : action?.buttonLabel || '';
+    }
+    if (this.voteSubmitButton) {
+      this.voteSubmitButton.disabled = disableVote;
+      this.voteSubmitButton.textContent = this.isSubmitting && this.canSubmitVote ? 'Submitting...' : this.voteSubmitButtonLabel;
+    }
+    if (this.voteSpendInput) this.voteSpendInput.disabled = this.isSubmitting;
+    if (this.voteOptions) {
+      for (const input of this.voteOptions.querySelectorAll('input[data-vote-option-index]')) {
+        input.disabled = this.isSubmitting;
+      }
     }
   }
 
@@ -4233,28 +5519,25 @@ class ProposalInfoModal {
     return injectTx(transaction, txid);
   }
 
-  async refreshCurrentProposal() {
-    await daoRepo.refresh({ force: true });
-    if (daoModal?.isActive?.()) daoModal.render();
-
-    this.renderCurrentProposal();
-  }
-
-  async refreshAfterDaoAction(warningMessage) {
+  async refreshAfterDaoAction(warningMessage, { refreshNetworkParams = false } = {}) {
     try {
-      await this.refreshCurrentProposal();
+      await daoRepo.refresh({ force: true });
+      if (daoModal?.isActive?.()) daoModal.render();
+
+      const proposal = this.getCurrentProposal();
+      if (proposal) {
+        this.renderProposal(proposal);
+      } else {
+        this.renderNotFound();
+      }
+
+      if (refreshNetworkParams) {
+        const refreshed = await getNetworkParams(true);
+        if (!refreshed) throw new Error('Network parameter refresh failed');
+      }
     } catch (error) {
       console.warn('Failed to refresh proposal after DAO action:', error);
       showToast(warningMessage, 4000, 'warning');
-    }
-  }
-
-  renderCurrentProposal() {
-    const proposal = this.getCurrentProposal();
-    if (proposal) {
-      this.renderProposal(proposal);
-    } else {
-      this.renderNotFound();
     }
   }
 
@@ -4359,15 +5642,130 @@ class ProposalInfoModal {
     }
   }
 
+  handleLifecycleActionClick(event) {
+    const button = event.target?.closest?.('button[data-lifecycle-action-index]');
+    if (!button || !this.lifecycleActionSection?.contains(button)) return;
+
+    const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
+    this.handleLifecycleActionSubmit(action);
+  }
+
+  async handleLifecycleActionSubmit(action) {
+    if (this.isSubmitting || !action || action.canSubmit === false) return;
+
+    const proposal = this.getCurrentProposal();
+    if (!proposal) {
+      showToast('Proposal data is unavailable', 2500, 'warning');
+      return;
+    }
+    if (!myAccount?.keys?.address) {
+      showToast('Wallet keys unavailable', 2500, 'warning');
+      return;
+    }
+
+    this.submittingLifecycleAction = action;
+    this.setSubmitting(true);
+    const loadingToastId = showToast(action.loadingLabel, 0, 'loading');
+
+    try {
+      const request = {
+        from: getDaoCurrentAccountAddress(),
+        proposal,
+        timestamp: getTransactionTimestamp(),
+        networkId: network?.netid || '',
+        submitTransaction: (transaction) => this.submitDaoTransaction(transaction),
+      };
+      let result;
+      switch (action.kind) {
+        case 'vote_result':
+          result = await daoRepo.finalizeVoteResult(request);
+          break;
+        case 'claim_reward':
+          result = await daoRepo.claimReward(request);
+          break;
+        case 'burn_reward':
+          result = await daoRepo.burnReward(request);
+          break;
+        case 'apply_parameters':
+          result = await daoRepo.applyParameters(request);
+          break;
+        default:
+          throw new Error(`Unknown DAO lifecycle action: ${action.kind}`);
+      }
+
+      if (!result.ok) {
+        showToast(result.error || `${action.title} failed`, 3000, 'warning');
+        return;
+      }
+
+      showToast(action.successMessage, 3000, 'success');
+      await this.refreshAfterDaoAction(action.refreshWarning, { refreshNetworkParams: action.refreshNetworkParams });
+    } catch (error) {
+      console.warn('Failed to submit DAO lifecycle action:', error);
+      showToast(error?.message || `${action.title} failed`, 3000, 'warning');
+    } finally {
+      if (loadingToastId) hideToast(loadingToastId);
+      this.submittingLifecycleAction = null;
+      this.setSubmitting(false);
+    }
+  }
+
+  async handleVoteSubmit() {
+    if (this.isSubmitting || !this.canSubmitVote) return;
+
+    const proposal = this.getCurrentProposal();
+    if (!proposal) {
+      showToast('Proposal data is unavailable', 2500, 'warning');
+      return;
+    }
+    if (!myAccount?.keys?.address) {
+      showToast('Wallet keys unavailable', 2500, 'warning');
+      return;
+    }
+
+    const submission = this.getVoteSubmission(proposal);
+    if (!submission.ok) {
+      showToast(submission.message, 3000, 'warning');
+      this.updateVotePreview(proposal);
+      return;
+    }
+
+    this.setSubmitting(true);
+    const loadingToastId = showToast('Submitting vote...', 0, 'loading');
+
+    try {
+      const result = await daoRepo.castVote({
+        from: getDaoCurrentAccountAddress(),
+        proposal,
+        weights: this.voteWeights.slice(),
+        spend: submission.spendWei,
+        timestamp: submission.timestamp,
+        networkId: network?.netid || '',
+        submitTransaction: (transaction) => this.submitDaoTransaction(transaction),
+      });
+
+      if (!result.ok) {
+        showToast(result.error || 'Vote submission failed', 3000, 'warning');
+        return;
+      }
+
+      showToast('Vote submitted', 3000, 'success');
+      await this.refreshAfterDaoAction('Vote submitted, but proposal refresh failed');
+    } catch (error) {
+      console.warn('Failed to submit vote:', error);
+      showToast(error?.message || 'Vote submission failed', 3000, 'warning');
+    } finally {
+      if (loadingToastId) hideToast(loadingToastId);
+      this.setSubmitting(false);
+    }
+  }
+
   close() {
     if (this.isSubmitting) return;
     this.modal.classList.remove('active');
     enterFullscreen();
   }
 
-  isActive() {
-    return this.modal.classList.contains('active');
-  }
 }
 
 const proposalInfoModal = new ProposalInfoModal();

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -243,6 +243,87 @@ export function buildDaoProposalCreateTransaction({
   return transaction;
 }
 
+function getDaoProposalTransactionId(proposal) {
+  return requireDaoDraftString(proposal?.accountId || proposal?.proposalId || proposal?.id, 'DAO proposal account ID');
+}
+
+export function buildDaoCommitteeVoteTransaction({
+  from,
+  proposal,
+  vote,
+  withheldReason,
+  timestamp,
+  networkId,
+} = {}) {
+  const safeVote = requireDaoDraftString(vote, 'Committee review vote');
+  if (safeVote !== 'accept' && safeVote !== 'withhold') {
+    throw new Error('Committee review vote must be accept or withhold');
+  }
+  const txTimestamp = requireDaoNonNegativeNumber(timestamp, 'Committee review timestamp');
+  if (txTimestamp <= 0) throw new Error('Committee review timestamp is required');
+
+  const transaction = {
+    type: 'dao_committee_vote',
+    timestamp: txTimestamp,
+    networkId: requireDaoDraftString(networkId, 'Network ID'),
+    from: requireDaoDraftString(from, 'Committee review sender'),
+    proposalId: getDaoProposalTransactionId(proposal),
+    vote: safeVote,
+  };
+
+  if (safeVote === 'withhold') {
+    const reason = requireDaoDraftString(withheldReason, 'Withhold reason');
+    if (reason.length > 1000) throw new Error('Withhold reason must be 1000 characters or less');
+    transaction.withheldReason = reason;
+  }
+
+  return transaction;
+}
+
+export function buildDaoCommitteeResultTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  const txTimestamp = requireDaoNonNegativeNumber(timestamp, 'Review result timestamp');
+  if (txTimestamp <= 0) throw new Error('Review result timestamp is required');
+
+  return {
+    type: 'dao_committee_result',
+    timestamp: txTimestamp,
+    networkId: requireDaoDraftString(networkId, 'Network ID'),
+    from: requireDaoDraftString(from, 'Review result sender'),
+    proposalId: getDaoProposalTransactionId(proposal),
+  };
+}
+
+async function submitDaoTransaction({ transaction, submitTransaction, errorMessage }) {
+  try {
+    if (typeof submitTransaction !== 'function') {
+      throw new Error('DAO submit handler is required');
+    }
+
+    const response = await submitTransaction(transaction);
+    if (!response?.result?.success) {
+      return {
+        ok: false,
+        error: response?.result?.reason || errorMessage,
+        response,
+        transaction,
+      };
+    }
+
+    return { ok: true, response, transaction };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error?.message || errorMessage,
+      transaction,
+    };
+  }
+}
+
 // In-memory DAO repository.
 // Goal: UI uses this API while backend data loading stays behind this boundary.
 
@@ -517,6 +598,7 @@ function storeToUiList(store, groupKey) {
       return {
         id,
         number: p.number,
+        accountId: p.accountId,
         nonce: p.nonce,
         title: p.title,
         summary: description,
@@ -656,5 +738,43 @@ export const daoRepo = {
 
   async castVote() {
     return { ok: false, error: 'Voting is not connected yet' };
+  },
+
+  async submitCommitteeVote({ from, proposal, vote, withheldReason, timestamp, networkId, submitTransaction } = {}) {
+    try {
+      const transaction = buildDaoCommitteeVoteTransaction({
+        from,
+        proposal,
+        vote,
+        withheldReason,
+        timestamp,
+        networkId,
+      });
+      return submitDaoTransaction({
+        transaction,
+        submitTransaction,
+        errorMessage: 'Committee review submission failed',
+      });
+    } catch (error) {
+      return { ok: false, error: error?.message || 'Committee review submission failed', transaction: null };
+    }
+  },
+
+  async finalizeCommitteeResult({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    try {
+      const transaction = buildDaoCommitteeResultTransaction({
+        from,
+        proposal,
+        timestamp,
+        networkId,
+      });
+      return submitDaoTransaction({
+        transaction,
+        submitTransaction,
+        errorMessage: 'Review result finalization failed',
+      });
+    } catch (error) {
+      return { ok: false, error: error?.message || 'Review result finalization failed', transaction: null };
+    }
   },
 };

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -18,9 +18,12 @@ export const DAO_CONFIG_CHANGE_OPTIONS = {
   governance: [
     { key: 'claimDuration', path: 'current.dao.claimDuration', label: 'Claim Duration', valueType: 'integer' },
     { key: 'graceDuration', path: 'current.dao.graceDuration', label: 'Grace Duration', valueType: 'integer' },
+    { key: 'minimumSpendUsdStr', path: 'current.dao.minimumSpendUsdStr', label: 'Minimum Vote Spend', valueType: 'float' },
     { key: 'pctBurned', path: 'current.dao.pctBurned', label: 'Percent Burned', valueType: 'integer' },
+    { key: 'proposalFeeUsdStr', path: 'current.dao.proposalFeeUsdStr', label: 'Proposal Fee', valueType: 'float' },
     { key: 'reviewDuration', path: 'current.dao.reviewDuration', label: 'Review Duration', valueType: 'integer' },
     { key: 'voteExponent', path: 'current.dao.voteExponent', label: 'Vote Exponent', valueType: 'float' },
+    { key: 'voteThresholdUsdStr', path: 'current.dao.voteThresholdUsdStr', label: 'Vote Threshold', valueType: 'float' },
     { key: 'votingDuration', path: 'current.dao.votingDuration', label: 'Voting Duration', valueType: 'integer' },
   ],
   economic: [
@@ -74,6 +77,7 @@ export const DAO_STATES = [
 const DAO_PROPOSAL_DAY_MS = 24 * 60 * 60 * 1000;
 const DAO_AFFIRMATIVE_OPTION_STRINGS = ['yes', 'accept', 'approve'];
 const DAO_PROPOSALS_META_ID_STRING = 'dao proposals meta';
+export const DAO_PROPOSAL_TITLE_MAX_LENGTH = 100;
 
 export function getDaoTypeLabel(typeKey) {
   return DAO_TYPE_OPTIONS.find((t) => t.key === typeKey)?.label || typeKey || '';
@@ -84,15 +88,17 @@ export function getDaoStateLabel(key) {
 }
 
 export function getEffectiveDaoState(proposal) {
-  const state = proposal?.status || proposal?.state || 'review';
-  return state === 'discussion' ? 'review' : state;
+  return proposal?.status || proposal?.state || 'review';
 }
 
 const DAO_PROPOSAL_QUERY_BATCH_SIZE = 10;
 
-function requireDaoDraftString(value, label) {
+function requireDaoDraftString(value, label, maxLength) {
   const text = String(value ?? '').trim();
   if (!text) throw new Error(`${label} is required`);
+  if (Number.isSafeInteger(maxLength) && text.length > maxLength) {
+    throw new Error(`${label} must be ${maxLength} characters or less`);
+  }
   return text;
 }
 
@@ -188,7 +194,7 @@ export function buildDaoProposalCreateDraft({
     from: requireDaoDraftString(from, 'DAO proposal sender'),
     emergency: isEmergency,
     proposalType: safeProposalType,
-    // TODO: Add title here when DaoProposalCreate supports a server title field.
+    title: requireDaoDraftString(displayTitle, 'DAO proposal title', DAO_PROPOSAL_TITLE_MAX_LENGTH),
     description: requireDaoDraftString(description, 'DAO proposal description'),
     options: safeOptions,
     [safeProposalType]: { changes: safeChanges },
@@ -197,7 +203,7 @@ export function buildDaoProposalCreateDraft({
   transaction.gracePeriod = safeGracePeriodMs;
 
   return {
-    displayTitle: requireDaoDraftString(displayTitle, 'DAO proposal title'),
+    displayTitle: transaction.title,
     proposalFeeUsdStr: feeUsdStr,
     startDelayMs,
     transaction,
@@ -244,7 +250,28 @@ export function buildDaoProposalCreateTransaction({
 }
 
 function getDaoProposalTransactionId(proposal) {
-  return requireDaoDraftString(proposal?.accountId || proposal?.proposalId || proposal?.id, 'DAO proposal account ID');
+  return requireDaoDraftString(proposal?.accountId, 'DAO proposal account ID');
+}
+
+function buildDaoProposalActionTransaction({
+  type,
+  from,
+  proposal,
+  timestamp,
+  networkId,
+  timestampLabel,
+  fromLabel,
+} = {}) {
+  const txTimestamp = requireDaoNonNegativeNumber(timestamp, timestampLabel);
+  if (txTimestamp <= 0) throw new Error(`${timestampLabel} is required`);
+
+  return {
+    type: requireDaoDraftString(type, 'DAO transaction type'),
+    timestamp: txTimestamp,
+    networkId: requireDaoDraftString(networkId, 'Network ID'),
+    from: requireDaoDraftString(from, fromLabel),
+    proposalId: getDaoProposalTransactionId(proposal),
+  };
 }
 
 export function buildDaoCommitteeVoteTransaction({
@@ -286,16 +313,127 @@ export function buildDaoCommitteeResultTransaction({
   timestamp,
   networkId,
 } = {}) {
-  const txTimestamp = requireDaoNonNegativeNumber(timestamp, 'Review result timestamp');
-  if (txTimestamp <= 0) throw new Error('Review result timestamp is required');
+  return buildDaoProposalActionTransaction({
+    type: 'dao_committee_result',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Review result timestamp',
+    fromLabel: 'Review result sender',
+  });
+}
+
+export function buildDaoVoteTransaction({
+  from,
+  proposal,
+  weights,
+  spend,
+  timestamp,
+  networkId,
+} = {}) {
+  const txTimestamp = requireDaoNonNegativeNumber(timestamp, 'Vote timestamp');
+  if (txTimestamp <= 0) throw new Error('Vote timestamp is required');
+
+  const options = Array.isArray(proposal?.options) ? proposal.options : [];
+  if (options.length < 2 || options.length > 10) {
+    throw new Error('DAO vote proposal options are required');
+  }
+  if (!Array.isArray(weights) || weights.length !== options.length) {
+    throw new Error('Vote weights must match proposal options');
+  }
+
+  let totalWeight = 0;
+  for (const weight of weights) {
+    if (!Number.isSafeInteger(weight) || weight < 0) {
+      throw new Error('Vote weights must be non-negative whole numbers');
+    }
+    totalWeight += weight;
+  }
+  if (!Number.isSafeInteger(totalWeight) || totalWeight <= 0) {
+    throw new Error('Vote weights must include at least one positive weight');
+  }
+  if (typeof spend !== 'bigint' || spend <= 0n) {
+    throw new Error('Vote spend must be a positive LIB amount');
+  }
 
   return {
-    type: 'dao_committee_result',
+    type: 'dao_vote',
     timestamp: txTimestamp,
     networkId: requireDaoDraftString(networkId, 'Network ID'),
-    from: requireDaoDraftString(from, 'Review result sender'),
+    from: requireDaoDraftString(from, 'Vote sender'),
     proposalId: getDaoProposalTransactionId(proposal),
+    weights: weights.slice(),
+    spend,
   };
+}
+
+export function buildDaoVoteResultTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_vote_result',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Vote result timestamp',
+    fromLabel: 'Vote result sender',
+  });
+}
+
+export function buildDaoClaimRewardTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_claim_reward',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Reward claim timestamp',
+    fromLabel: 'Reward claim sender',
+  });
+}
+
+export function buildDaoBurnRewardTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_burn_reward',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Reward burn timestamp',
+    fromLabel: 'Reward burn sender',
+  });
+}
+
+export function buildDaoApplyParametersTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_apply_parameters',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Apply parameters timestamp',
+    fromLabel: 'Apply parameters sender',
+  });
 }
 
 async function submitDaoTransaction({ transaction, submitTransaction, errorMessage }) {
@@ -321,6 +459,32 @@ async function submitDaoTransaction({ transaction, submitTransaction, errorMessa
       error: error?.message || errorMessage,
       transaction,
     };
+  }
+}
+
+async function submitDaoProposalAction({
+  buildTransaction,
+  from,
+  proposal,
+  timestamp,
+  networkId,
+  submitTransaction,
+  errorMessage,
+} = {}) {
+  try {
+    const transaction = buildTransaction({
+      from,
+      proposal,
+      timestamp,
+      networkId,
+    });
+    return submitDaoTransaction({
+      transaction,
+      submitTransaction,
+      errorMessage,
+    });
+  } catch (error) {
+    return { ok: false, error: error?.message || errorMessage, transaction: null };
   }
 }
 
@@ -350,65 +514,36 @@ function normalizeDaoTimestamp(value) {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
-function normalizeDaoVoteNumber(value) {
-  if (typeof value === 'bigint') return Number(value);
-  const n = Number(value || 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function getDaoProposalDescription(proposal) {
-  return String(proposal?.description || proposal?.summary || '').trim();
-}
-
-function getDaoProposalFields(proposal) {
-  const fields = proposal?.fields && typeof proposal.fields === 'object' ? { ...proposal.fields } : {};
-  if (proposal?.governance) fields.governance = proposal.governance;
-  if (proposal?.economic) fields.economic = proposal.economic;
-  if (proposal?.protocol) fields.protocol = proposal.protocol;
-  return fields;
-}
-
-function getDaoProposalVotes(proposal) {
-  if (proposal?.votes && typeof proposal.votes === 'object') return proposal.votes;
-
-  const totals = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
-  return {
-    yes: normalizeDaoVoteNumber(totals[0]),
-    no: normalizeDaoVoteNumber(totals[1]),
-    by: {},
-  };
-}
-
 function mapBackendProposalToStoreProposal(proposal) {
   if (!proposal || typeof proposal !== 'object') return null;
 
   const number = normalizeDaoPositiveInteger(proposal.number);
   if (!number) return null;
 
-  const nonce = String(proposal.id || proposal.nonce || number);
-  const type = proposal.proposalType || proposal.type || '';
+  const accountId = String(proposal.id || '').trim();
+  if (!accountId) return null;
+
+  const nonce = accountId;
+  const proposalType = String(proposal.proposalType || '').trim();
+  if (!proposalType) return null;
+
   const state = getEffectiveDaoState(proposal);
-  const created = normalizeDaoTimestamp(proposal.creationTime || proposal.created || proposal.timestamp);
-  const stateChanged = normalizeDaoTimestamp(proposal.timestamp || proposal.state_changed || created);
-  const description = getDaoProposalDescription(proposal);
+  const created = normalizeDaoTimestamp(proposal.creationTime);
+  const stateChanged = normalizeDaoTimestamp(proposal.timestamp);
+  const title = String(proposal.title || proposal.description || '').trim();
 
   return {
     ...proposal,
-    accountId: proposal.id,
+    accountId,
     number,
     nonce,
-    title: String(proposal.title || '').trim(),
-    summary: description,
-    description,
-    type,
-    proposalType: type,
+    title,
+    description: String(proposal.description || '').trim(),
+    proposalType,
     state,
     status: state,
     state_changed: stateChanged,
     created,
-    createdBy: proposal.createdBy || proposal.creator || proposal.from || '',
-    fields: getDaoProposalFields(proposal),
-    votes: getDaoProposalVotes(proposal),
   };
 }
 
@@ -419,7 +554,6 @@ function getDaoStoreMeta(proposal) {
     state: proposal.state,
     status: proposal.status,
     state_changed: proposal.state_changed,
-    type: proposal.type,
     proposalType: proposal.proposalType,
     nonce: proposal.nonce,
   };
@@ -452,23 +586,19 @@ async function fetchBackendProposal(queryDaoApi, proposalNumber) {
   const body = await queryDaoApi(`/dao/proposals/${proposalNumber}`);
   if (!body) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: no response`);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   if (body.error || !body.proposal) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: proposal unavailable`, body.error || body);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   return body.proposal;
 }
 
-export function createDaoBackendFetcher(queryDaoApi, { batchSize = DAO_PROPOSAL_QUERY_BATCH_SIZE } = {}) {
+export function createDaoBackendFetcher(queryDaoApi) {
   if (typeof queryDaoApi !== 'function') {
     return async () => createEmptyDaoStore();
   }
-
-  const safeBatchSize = normalizeDaoPositiveInteger(batchSize) || DAO_PROPOSAL_QUERY_BATCH_SIZE;
 
   return async () => {
     const body = await queryDaoApi('/dao/proposals/meta');
@@ -484,8 +614,8 @@ export function createDaoBackendFetcher(queryDaoApi, { batchSize = DAO_PROPOSAL_
     if (!count) return buildStoreFromBackendProposals(meta, []);
 
     const proposals = [];
-    for (let start = 1; start <= count; start += safeBatchSize) {
-      const end = Math.min(start + safeBatchSize - 1, count);
+    for (let start = 1; start <= count; start += DAO_PROPOSAL_QUERY_BATCH_SIZE) {
+      const end = Math.min(start + DAO_PROPOSAL_QUERY_BATCH_SIZE - 1, count);
       const batch = await Promise.all(
         Array.from({ length: end - start + 1 }, (_, index) => fetchBackendProposal(queryDaoApi, start + index))
       );
@@ -522,13 +652,6 @@ function normalizeDaoStore(store) {
     const full = safe.proposals[id];
     if (!full) continue;
 
-    // Migration: older versions wrote a synthetic `state: 'archived'`.
-    // We cannot reliably recover the original state; map to a server-supported final state.
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-
     const state = getEffectiveDaoState({ status: full.status || meta.status, state: full.state || meta.state });
     const enteredAt = Number(full.state_changed || meta.state_changed || full.created || 0);
     const isArchivable = DAO_ARCHIVABLE_STATE_KEYS.includes(state);
@@ -543,7 +666,7 @@ function normalizeDaoStore(store) {
           title: meta.title,
           state,
           state_changed: enteredAt,
-          type: meta.type,
+          proposalType: meta.proposalType,
           nonce: meta.nonce,
         });
         archivedIds.add(id);
@@ -561,17 +684,6 @@ function normalizeDaoStore(store) {
     const id = daoProposalId(m.number, m.nonce);
     return Boolean(safe.proposals[id]);
   });
-
-  // Migration: older versions stored `state: 'archived'` for archived items.
-  for (const meta of safe.archivedProposals) {
-    const id = daoProposalId(meta.number, meta.nonce);
-    const full = safe.proposals[id];
-    if (!full) continue;
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-  }
 
   safe.meta.active = safe.activeProposals.length;
   safe.meta.archived = safe.archivedProposals.length;
@@ -592,38 +704,36 @@ function storeToUiList(store, groupKey) {
       const id = daoProposalId(m.number, m.nonce);
       const p = safe.proposals?.[id];
       if (!p) return null;
-      const description = p.description || p.summary;
       const state = getEffectiveDaoState({ status: p.status || m.status, state: p.state || m.state });
-      const type = p.proposalType || p.type;
       return {
         id,
         number: p.number,
         accountId: p.accountId,
         nonce: p.nonce,
         title: p.title,
-        summary: description,
-        description,
-        type,
-        proposalType: type,
+        description: p.description,
+        proposalType: p.proposalType,
+        emergency: Boolean(p.emergency),
         createdAt: p.created,
         state,
         status: state,
         stateEnteredAt: p.state_changed,
-        createdBy: p.createdBy,
-        fields: p.fields || {},
-        options: Array.isArray(p.options) ? p.options : ['yes', 'no'],
-        totalVote: Array.isArray(p.totalVote) ? p.totalVote : undefined,
-        committeeVotes: Array.isArray(p.committeeVotes) ? p.committeeVotes : [],
-        committeeAddresses: Array.isArray(p.committeeAddresses) ? p.committeeAddresses : [],
+        options: p.options,
+        totalVote: p.totalVote,
+        committeeVotes: p.committeeVotes,
+        committeeAddresses: p.committeeAddresses,
         voterRewardPool: p.voterRewardPool,
         claimedReward: p.claimedReward,
         initialBurnedReward: p.initialBurnedReward,
         finalBurnedReward: p.finalBurnedReward,
+        voterList: p.voterList,
+        claimList: p.claimList,
         startTime: p.startTime,
         reviewDuration: p.reviewDuration,
         votingDuration: p.votingDuration,
         claimDuration: p.claimDuration,
-        votes: p.votes || { yes: 0, no: 0, by: {} },
+        gracePeriod: p.gracePeriod,
+        applyEligibleAt: p.applyEligibleAt,
         archivedAt: p.archivedAt || 0,
       };
     })
@@ -641,7 +751,7 @@ export function setDaoBackendFetcher(fetcher) {
   _backendFetcher = typeof fetcher === 'function' ? fetcher : null;
 }
 
-async function refreshInternal({ force } = {}) {
+async function refreshInternal({ force }) {
   if (_loadingPromise && !force) return _loadingPromise;
   if (_store && !force) return _store;
 
@@ -683,7 +793,7 @@ export const daoRepo = {
   },
 
   getProposalsForUi(groupKey) {
-    return storeToUiList(_store, groupKey || 'active');
+    return storeToUiList(_store, groupKey);
   },
 
   async createProposal({ draft, timestamp, networkId, submitTransaction } = {}) {
@@ -736,8 +846,24 @@ export const daoRepo = {
     }
   },
 
-  async castVote() {
-    return { ok: false, error: 'Voting is not connected yet' };
+  async castVote({ from, proposal, weights, spend, timestamp, networkId, submitTransaction } = {}) {
+    try {
+      const transaction = buildDaoVoteTransaction({
+        from,
+        proposal,
+        weights,
+        spend,
+        timestamp,
+        networkId,
+      });
+      return submitDaoTransaction({
+        transaction,
+        submitTransaction,
+        errorMessage: 'Vote submission failed',
+      });
+    } catch (error) {
+      return { ok: false, error: error?.message || 'Vote submission failed', transaction: null };
+    }
   },
 
   async submitCommitteeVote({ from, proposal, vote, withheldReason, timestamp, networkId, submitTransaction } = {}) {
@@ -761,20 +887,62 @@ export const daoRepo = {
   },
 
   async finalizeCommitteeResult({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
-    try {
-      const transaction = buildDaoCommitteeResultTransaction({
-        from,
-        proposal,
-        timestamp,
-        networkId,
-      });
-      return submitDaoTransaction({
-        transaction,
-        submitTransaction,
-        errorMessage: 'Review result finalization failed',
-      });
-    } catch (error) {
-      return { ok: false, error: error?.message || 'Review result finalization failed', transaction: null };
-    }
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoCommitteeResultTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Review result finalization failed',
+    });
+  },
+
+  async finalizeVoteResult({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoVoteResultTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Vote result finalization failed',
+    });
+  },
+
+  async claimReward({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoClaimRewardTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Reward claim failed',
+    });
+  },
+
+  async burnReward({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoBurnRewardTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Reward burn failed',
+    });
+  },
+
+  async applyParameters({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoApplyParametersTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Apply parameters failed',
+    });
   },
 };

--- a/index.html
+++ b/index.html
@@ -480,6 +480,13 @@
               </div>
               <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalCommitteeSubmit">Submit review</button>
             </section>
+            <section class="proposal-review-result-actions hidden" id="proposalReviewResultSection" aria-label="Review result action">
+              <div class="proposal-committee-actions-header">
+                <h3>Review result</h3>
+                <p id="proposalReviewResultHelp"></p>
+              </div>
+              <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalReviewResultSubmit">Finalize review result</button>
+            </section>
           </div>
         </div>
         <a class="last-item" href="#"> </a>

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
           <!-- Contact items will be inserted here -->
         </ul>
       </div>
-      <button class="floating-button" id="newChatButton">+</button>
+      <button class="floating-button" id="newChatButton" aria-label="New chat"><span class="plus-glyph" aria-hidden="true">+</span></button>
 
       <div class="app-screen" id="walletScreen">
         <div class="wallet-balance">
@@ -315,7 +315,7 @@
               <div>Proposal data appears here when available</div>
             </div>
           </ul>
-          <button class="floating-button" id="daoAddProposalButton" aria-label="Add proposal">+</button>
+          <button class="floating-button" id="daoAddProposalButton" aria-label="Add proposal"><span class="plus-glyph" aria-hidden="true">+</span></button>
         </div>
         <a class="last-item" href="#"> </a>
       </div>
@@ -374,7 +374,7 @@
               </div>
               <div class="form-group">
                 <label for="addProposalTitle">Title</label>
-                <input id="addProposalTitle" class="form-control" type="text" maxlength="120" placeholder="Proposal title" required />
+                <input id="addProposalTitle" class="form-control" type="text" maxlength="100" placeholder="Proposal title" required />
               </div>
               <div class="form-group">
                 <label for="addProposalType">Proposal Type</label>
@@ -394,14 +394,20 @@
                   <label>Parameter Changes</label>
                 </div>
                 <div class="dao-form-list" id="addProposalChangesList"></div>
-                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalChangeButton">Add parameter change</button>
+                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalChangeButton">
+                  <span class="dao-form-add-icon" aria-hidden="true"><span class="plus-glyph">+</span></span>
+                  <span>Add parameter change</span>
+                </button>
               </div>
               <div class="form-group dao-form-section">
                 <div class="dao-form-section-header">
                   <label>Options</label>
                 </div>
                 <div class="dao-form-list" id="addProposalOptionsList"></div>
-                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalOptionButton">Add option</button>
+                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalOptionButton">
+                  <span class="dao-form-add-icon" aria-hidden="true"><span class="plus-glyph">+</span></span>
+                  <span>Add option</span>
+                </button>
                 <div class="dao-form-help">2 to 10 options. The first option must be yes, accept, or approve.</div>
               </div>
               <div class="form-group dao-form-section">
@@ -487,6 +493,24 @@
               </div>
               <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalReviewResultSubmit">Finalize review result</button>
             </section>
+            <section class="proposal-lifecycle-actions hidden" id="proposalLifecycleActionSection" aria-label="Proposal lifecycle action"></section>
+            <section class="proposal-vote-actions hidden" id="proposalVoteActionSection" aria-label="Proposal voting actions">
+              <div class="proposal-committee-actions-header">
+                <h3>Vote preview</h3>
+                <p id="proposalVoteActionHelp"></p>
+              </div>
+              <div class="proposal-vote-options" id="proposalVoteOptions"></div>
+              <div class="proposal-vote-spend-row">
+                <div class="form-group">
+                  <label for="proposalVoteSpend">Spend amount</label>
+                  <input type="number" id="proposalVoteSpend" class="form-control" min="0" step="0.000001" inputmode="decimal" placeholder="0.000000">
+                </div>
+                <span>LIB</span>
+              </div>
+              <div class="proposal-vote-preview" id="proposalVotePreview"></div>
+              <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalVoteSubmit" disabled>Submit vote</button>
+            </section>
+            <div class="proposal-details" id="proposalDetailsContent"></div>
           </div>
         </div>
         <a class="last-item" href="#"> </a>
@@ -1523,7 +1547,7 @@
           <button class="message-context-reaction-button" type="button" data-emoji="😂" data-default-emoji="😂" data-default-aria-label="React with tears of joy" aria-label="React with tears of joy">😂</button>
           <button class="message-context-reaction-button" type="button" data-emoji="😮" data-default-emoji="😮" data-default-aria-label="React with surprised face" aria-label="React with surprised face">😮</button>
           <button class="message-context-reaction-button" type="button" data-emoji="👎" data-default-emoji="👎" data-default-aria-label="React with thumbs down" aria-label="React with thumbs down">👎</button>
-          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction">+</button>
+          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction"><span class="plus-glyph" aria-hidden="true">+</span></button>
         </div>
         <!-- Voice message specific action: Save -->
         <div class="context-menu-option" data-action="save" data-icon="download" style="display: none;">
@@ -1577,7 +1601,7 @@
           <button class="message-context-reaction-button" type="button" data-emoji="😂" data-default-emoji="😂" data-default-aria-label="React with tears of joy" aria-label="React with tears of joy">😂</button>
           <button class="message-context-reaction-button" type="button" data-emoji="😮" data-default-emoji="😮" data-default-aria-label="React with surprised face" aria-label="React with surprised face">😮</button>
           <button class="message-context-reaction-button" type="button" data-emoji="👎" data-default-emoji="👎" data-default-aria-label="React with thumbs down" aria-label="React with thumbs down">👎</button>
-          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction">+</button>
+          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction"><span class="plus-glyph" aria-hidden="true">+</span></button>
         </div>
         <div class="context-menu-option" data-action="import-contacts" data-icon="contacts" style="display: none;">
           <span class="context-menu-icon"></span>

--- a/styles.css
+++ b/styles.css
@@ -1920,22 +1920,46 @@ input[type='file'].form-control::file-selector-button {
   width: 100%;
 }
 
-#addProposalModal .dao-form-add-button::before {
+.plus-glyph {
+  background-color: currentColor;
+  display: inline-block;
+  flex: 0 0 auto;
+  height: 0.68em;
+  line-height: 1;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 2.5h2V7h4.5v2H9v4.5H7V9H2.5V7H7z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 2.5h2V7h4.5v2H9v4.5H7V9H2.5V7H7z'/%3E%3C/svg%3E") center / contain no-repeat;
+  overflow: hidden;
+  text-indent: 100%;
+  transform: none;
+  white-space: nowrap;
+  width: 0.68em;
+}
+
+#addProposalModal .dao-form-add-icon {
   align-items: center;
   background-color: var(--primary-tint-60);
   border-radius: 999px;
   border: none;
+  box-sizing: border-box;
   box-shadow: var(--shadow-primary);
   color: var(--text-color);
-  content: "+";
   display: inline-flex;
+  flex: 0 0 22px;
   font-size: 16px;
   font-weight: 400;
   height: 22px;
   justify-content: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
   line-height: 1;
   padding: 0;
+  text-align: center;
   width: 22px;
+}
+
+.message-context-reaction-button-more .plus-glyph {
+  position: relative;
+  z-index: 1;
 }
 
 #addProposalModal .dao-form-remove-button {
@@ -2059,24 +2083,46 @@ input[type='file'].form-control::file-selector-button {
 #confirmProposalModal .dao-confirm,
 #proposalInfoModal .proposal-info,
 #proposalInfoModal .proposal-committee-actions,
-#proposalInfoModal .proposal-review-result-actions {
+#proposalInfoModal .proposal-review-result-actions,
+#proposalInfoModal .proposal-lifecycle-actions,
+#proposalInfoModal .proposal-vote-actions {
   display: grid;
-  gap: 18px;
+  gap: 14px;
   margin: 0 auto;
   max-width: 720px;
   width: 100%;
 }
 
+#proposalInfoModal .proposal-info-heading {
+  display: grid;
+  gap: 4px;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-info-title {
+  margin-bottom: 0;
+}
+
+#proposalInfoModal .proposal-info-description {
+  color: var(--secondary-text-color);
+  font-size: 14px;
+  line-height: 1.35;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 #confirmProposalModal .dao-confirm-section,
 #proposalInfoModal .proposal-info-section {
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 #confirmProposalModal .dao-confirm-section h3,
 #proposalInfoModal .proposal-info-section h3,
 #proposalInfoModal .proposal-committee-actions h3,
-#proposalInfoModal .proposal-review-result-actions h3 {
+#proposalInfoModal .proposal-review-result-actions h3,
+#proposalInfoModal .proposal-lifecycle-actions h3,
+#proposalInfoModal .proposal-vote-actions h3 {
   color: var(--text-color);
   font-size: 16px;
   font-weight: var(--font-weight-semibold);
@@ -2088,9 +2134,10 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm-grid,
 #proposalInfoModal .proposal-info-grid {
-  display: grid;
-  gap: 10px;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
 }
 
 #confirmProposalModal .dao-confirm-row,
@@ -2098,29 +2145,24 @@ input[type='file'].form-control::file-selector-button {
   background: var(--input-background);
   border-radius: 8px;
   display: grid;
+  flex: 0 1 calc((100% - 16px) / 3);
   gap: 8px;
-  grid-column: span 2;
   grid-template-rows: auto minmax(0, 1fr);
-  min-height: 76px;
-  padding: 10px;
+  min-width: 0;
+  min-height: 68px;
+  padding: 8px;
   text-align: center;
 }
 
-#confirmProposalModal .dao-confirm-grid--two .dao-confirm-row:first-child {
-  grid-column: 2 / span 2;
-}
-
-#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) {
-  grid-column: 2 / span 2;
-}
-
-#proposalInfoModal .proposal-info-row--center-pair {
-  grid-column: 2 / span 2;
+#proposalInfoModal .proposal-info-row {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
 }
 
 #confirmProposalModal .dao-confirm-row--full,
 #proposalInfoModal .proposal-info-row--full {
-  grid-column: 1 / -1;
+  flex-basis: 100%;
 }
 
 #proposalInfoModal .proposal-info-row--accept {
@@ -2135,7 +2177,7 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm-label,
 #confirmProposalModal .dao-confirm-change-title,
-#proposalInfoModal .proposal-info-row span,
+#proposalInfoModal .proposal-info-row > span:not(.proposal-info-value),
 #proposalInfoModal .proposal-change-row span {
   color: var(--secondary-text-color);
   font-size: 12px;
@@ -2156,7 +2198,6 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm-value,
 #confirmProposalModal .dao-confirm-change-values strong,
-#proposalInfoModal .proposal-info-row strong,
 #proposalInfoModal .proposal-change-row strong {
   color: var(--text-color);
   font-size: 13px;
@@ -2168,24 +2209,215 @@ input[type='file'].form-control::file-selector-button {
   white-space: pre-wrap;
 }
 
-#proposalInfoModal .proposal-info-row--accept strong {
+#proposalInfoModal .proposal-info-value {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-normal);
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-align: center;
+  white-space: pre-wrap;
+}
+
+#proposalInfoModal .proposal-info-row--accept .proposal-info-value {
   color: #0f5f27;
 }
 
-#proposalInfoModal .proposal-info-row--withhold strong {
+#proposalInfoModal .proposal-info-row--withhold .proposal-info-value {
   color: #8f1d16;
 }
 
 #confirmProposalModal .dao-confirm-label,
-#proposalInfoModal .proposal-info-row span {
+#proposalInfoModal .proposal-info-row > span:not(.proposal-info-value) {
   align-self: start;
   justify-self: center;
 }
 
 #confirmProposalModal .dao-confirm-value,
-#proposalInfoModal .proposal-info-row strong {
+#proposalInfoModal .proposal-info-value {
   align-self: center;
   justify-self: center;
+}
+
+#proposalInfoModal .proposal-result-card span,
+#proposalInfoModal .proposal-result-meter-label small {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-result-overview {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+#proposalInfoModal .proposal-result-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 0 solid var(--border-color);
+  border-radius: 0 0 8px 8px;
+  border-width: 0 1px 1px;
+  box-shadow: 0 2px 2px rgba(28, 28, 33, 0.04);
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-value {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-normal);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-meter {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-result-meter-labels,
+#proposalInfoModal .proposal-result-meter-track {
+  align-items: center;
+  display: flex;
+  min-width: 0;
+  width: 100%;
+}
+
+#proposalInfoModal .proposal-result-meter-label {
+  display: grid;
+  flex: var(--result-segment-units) 1 0;
+  gap: 2px;
+  min-width: 0;
+  padding: 0 4px;
+}
+
+#proposalInfoModal .proposal-result-meter-labels--balanced .proposal-result-meter-label {
+  flex: 1 1 0;
+}
+
+#proposalInfoModal .proposal-result-meter-label--start {
+  justify-items: start;
+  text-align: left;
+}
+
+#proposalInfoModal .proposal-result-meter-label--center {
+  justify-items: center;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-meter-label--end {
+  justify-items: end;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-result-meter-label > span {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-result-meter-label > span,
+#proposalInfoModal .proposal-result-meter-label > small {
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-meter-label--winner > span {
+  color: var(--text-color);
+}
+
+#proposalInfoModal .proposal-result-meter-label--accept.proposal-result-meter-label--winner > span {
+  color: #0f5f27;
+}
+
+#proposalInfoModal .proposal-result-meter-label--withhold.proposal-result-meter-label--winner > span {
+  color: #8f1d16;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-0 > span {
+  color: #3d3dce;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-1 > span {
+  color: #65676b;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-2 > span {
+  color: #6f68e8;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-3 > span {
+  color: #838a93;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-4 > span {
+  color: #2f2fa8;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-5 > span {
+  color: #4e555f;
+}
+
+#proposalInfoModal .proposal-result-meter-track {
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  height: 16px;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-result-meter-segment {
+  align-self: stretch;
+  background: rgba(101, 103, 107, 0.34);
+  border-left: 1px solid rgba(255, 255, 255, 0.72);
+  flex: var(--result-segment-units) 1 0;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-result-meter-segment:first-child {
+  border-left: 0;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-0 {
+  background: #3d3dce;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-1 {
+  background: #aeb3ba;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-2 {
+  background: #6f68e8;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-3 {
+  background: #c4c8ce;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-4 {
+  background: #2f2fa8;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-5 {
+  background: #8d949e;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--accept {
+  background: #1e7e34;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--withhold {
+  background: #c42d2d;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--empty {
+  background: rgba(101, 103, 107, 0.18);
 }
 
 #confirmProposalModal .dao-confirm-change,
@@ -2193,16 +2425,49 @@ input[type='file'].form-control::file-selector-button {
   background: var(--input-background);
   border-radius: 8px;
   display: grid;
-  gap: 8px;
-  padding: 10px;
+  gap: 6px;
+  justify-items: stretch;
+  min-inline-size: 0;
+  padding: 8px;
+  width: 100%;
+}
+
+#proposalInfoModal .proposal-change-row {
+  flex: 0 1 calc(50% - 4px);
+  min-width: min(100%, 180px);
+}
+
+#proposalInfoModal .proposal-change-row--single {
+  background: rgba(255, 255, 255, 0.92);
+  border: 0 solid var(--border-color);
+  border-radius: 0 0 8px 8px;
+  border-width: 0 1px 1px;
+  box-shadow: 0 2px 2px rgba(28, 28, 33, 0.04);
+  flex-basis: calc(66.666% - 4px);
+}
+
+#proposalInfoModal .proposal-change-row--wide {
+  flex-basis: 100%;
+}
+
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values {
+  grid-template-columns: minmax(0, 1fr) 12px minmax(0, 1fr);
+  justify-content: center;
+}
+
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values small,
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 #confirmProposalModal .dao-confirm-change-values,
 #proposalInfoModal .proposal-change-values {
   align-items: center;
   display: grid;
-  column-gap: 10px;
+  column-gap: 8px;
   grid-template-columns: minmax(0, 1fr) 16px minmax(0, 1fr);
+  min-width: 0;
   width: 100%;
 }
 
@@ -2217,13 +2482,40 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #confirmProposalModal .dao-confirm-change-values small,
-#proposalInfoModal .proposal-change-values small {
-  text-align: right;
+#proposalInfoModal .proposal-change-values small,
+#proposalInfoModal .proposal-change-values strong {
+  display: grid;
+  gap: 2px;
+  justify-items: center;
+  min-width: 0;
+  text-align: center;
 }
 
-#confirmProposalModal .dao-confirm-change-values strong,
-#proposalInfoModal .proposal-change-values strong {
-  text-align: left;
+#confirmProposalModal .dao-confirm-change-values small > span,
+#confirmProposalModal .dao-confirm-change-values small > strong,
+#proposalInfoModal .proposal-change-values small > span,
+#proposalInfoModal .proposal-change-values small > strong,
+#proposalInfoModal .proposal-change-values strong > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+#confirmProposalModal .dao-confirm-change-values small > span,
+#proposalInfoModal .proposal-change-values small > span,
+#proposalInfoModal .proposal-change-values strong > span:first-child {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+}
+
+#confirmProposalModal .dao-confirm-change-values small > strong,
+#proposalInfoModal .proposal-change-values small > strong,
+#proposalInfoModal .proposal-change-values strong > span:last-child {
+  color: var(--text-color);
+  font-size: 13px;
+}
+
+#confirmProposalModal .dao-confirm-change-values strong {
+  text-align: center;
 }
 
 #confirmProposalModal .dao-confirm-change-arrow,
@@ -2240,6 +2532,8 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-info-muted,
 #proposalInfoModal .proposal-committee-actions p,
 #proposalInfoModal .proposal-review-result-actions p,
+#proposalInfoModal .proposal-lifecycle-actions p,
+#proposalInfoModal .proposal-vote-actions p,
 #proposalInfoModal .proposal-change-row small {
   color: var(--secondary-text-color);
   font-size: 12px;
@@ -2259,47 +2553,130 @@ input[type='file'].form-control::file-selector-button {
 @media (max-width: 420px) {
   #confirmProposalModal .dao-confirm-row,
   #proposalInfoModal .proposal-info-row {
-    grid-column: span 3;
-  }
-
-  #proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) {
-    grid-column: span 3;
-  }
-
-  #proposalInfoModal .proposal-info-row--center-pair {
-    grid-column: span 3;
+    flex-basis: calc((100% - 8px) / 2);
   }
 
   #confirmProposalModal .dao-confirm-row--full,
   #proposalInfoModal .proposal-info-row--full {
-    grid-column: 1 / -1;
+    flex-basis: 100%;
   }
 }
 
 #proposalInfoModal .proposal-info + .proposal-committee-actions,
-#proposalInfoModal .proposal-info + .proposal-review-result-actions,
-#proposalInfoModal .proposal-committee-actions + .proposal-review-result-actions {
-  margin-top: 12px;
+#proposalInfoModal .proposal-committee-actions + .proposal-review-result-actions,
+#proposalInfoModal .proposal-review-result-actions + .proposal-lifecycle-actions,
+#proposalInfoModal .proposal-lifecycle-actions + .proposal-vote-actions {
+  margin-top: 10px;
 }
 
 #proposalInfoModal .proposal-committee-actions,
-#proposalInfoModal .proposal-review-result-actions {
+#proposalInfoModal .proposal-review-result-actions,
+#proposalInfoModal .proposal-lifecycle-actions,
+#proposalInfoModal .proposal-vote-actions {
   border: 1px solid var(--border-color);
   border-radius: 8px;
   display: grid;
-  gap: 10px;
-  padding: 12px;
+  gap: 8px;
+  padding: 10px;
+}
+
+#proposalInfoModal .proposal-lifecycle-action {
+  display: grid;
+  gap: 8px;
+}
+
+#proposalInfoModal .proposal-lifecycle-actions .proposal-committee-actions-header,
+#proposalInfoModal .proposal-vote-actions .proposal-committee-actions-header {
+  display: grid;
+  gap: 2px;
+}
+
+#proposalInfoModal .proposal-details {
+  display: grid;
+  margin: 10px auto 0;
+  max-width: 720px;
+  width: 100%;
+}
+
+#proposalInfoModal .proposal-details:empty {
+  display: none;
+}
+
+#proposalInfoModal .proposal-more {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  display: grid;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-more summary {
+  align-items: center;
+  cursor: pointer;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: minmax(0, 1fr) 18px;
+  list-style: none;
+  padding: 10px;
+}
+
+#proposalInfoModal .proposal-more summary::-webkit-details-marker {
+  display: none;
+}
+
+#proposalInfoModal .proposal-more summary::after {
+  align-self: center;
+  border-bottom: 2px solid var(--secondary-text-color);
+  border-right: 2px solid var(--secondary-text-color);
+  content: "";
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  height: 8px;
+  justify-self: center;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  width: 8px;
+}
+
+#proposalInfoModal .proposal-more[open] summary {
+  border-bottom: 1px solid var(--border-color);
+}
+
+#proposalInfoModal .proposal-more[open] summary::after {
+  transform: rotate(225deg);
+}
+
+#proposalInfoModal .proposal-more-title {
+  color: var(--text-color);
+  font-size: 14px;
+  font-weight: var(--font-weight-semibold);
+  grid-column: 1;
+  line-height: 1.25;
+}
+
+#proposalInfoModal .proposal-more-note {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  grid-column: 1;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-more-content {
+  display: grid;
+  gap: 14px;
+  padding: 10px;
 }
 
 #proposalInfoModal .proposal-payload {
-  display: grid;
-  gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
 }
 
 #proposalInfoModal .proposal-payload-title {
   color: var(--text-color);
+  flex: 0 0 100%;
   font-size: 13px;
-  font-weight: var(--font-weight-semibold);
   line-height: 1.3;
   text-align: center;
 }
@@ -2349,27 +2726,37 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-committee-actions .btn,
-#proposalInfoModal .proposal-review-result-actions .btn {
+#proposalInfoModal .proposal-review-result-actions .btn,
+#proposalInfoModal .proposal-lifecycle-actions .btn,
+#proposalInfoModal .proposal-vote-actions .btn {
   font-size: 14px;
   height: 40px;
   padding: 8px 14px;
 }
 
 #proposalInfoModal .proposal-committee-actions .btn--pill.btn--full,
-#proposalInfoModal .proposal-review-result-actions .btn--pill.btn--full {
+#proposalInfoModal .proposal-review-result-actions .btn--pill.btn--full,
+#proposalInfoModal .proposal-lifecycle-actions .btn--pill.btn--full,
+#proposalInfoModal .proposal-vote-actions .btn--pill.btn--full {
   margin: 0;
   width: 100%;
 }
 
-#proposalInfoModal .proposal-committee-actions .form-group {
+#proposalInfoModal .proposal-committee-actions .form-group,
+#proposalInfoModal .proposal-vote-actions .form-group {
   margin-bottom: 0;
 }
 
-#proposalInfoModal .proposal-committee-actions .form-control {
+#proposalInfoModal .proposal-committee-actions .form-control,
+#proposalInfoModal .proposal-vote-actions .form-control {
   border-radius: 8px;
   font-size: 14px;
   height: 44px;
   padding: 10px 12px;
+}
+
+#proposalInfoModal .proposal-vote-actions .form-control {
+  height: 40px;
 }
 
 #proposalInfoModal .proposal-committee-actions select.form-control {
@@ -2384,6 +2771,317 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-withhold-fields {
   display: grid;
   gap: 10px;
+}
+
+#proposalInfoModal .proposal-vote-status-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+#proposalInfoModal .proposal-vote-current-meter {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-vote-current-labels,
+#proposalInfoModal .proposal-vote-current-track {
+  align-items: center;
+  display: flex;
+  min-width: 0;
+  width: 100%;
+}
+
+#proposalInfoModal .proposal-vote-current-label {
+  display: grid;
+  flex: var(--vote-total-segment-units) 1 0;
+  gap: 4px;
+  min-width: 0;
+  padding: 0 4px;
+}
+
+#proposalInfoModal .proposal-vote-current-labels--balanced .proposal-vote-current-label {
+  flex: 1 1 0;
+}
+
+#proposalInfoModal .proposal-vote-current-label--start {
+  justify-items: start;
+  text-align: left;
+}
+
+#proposalInfoModal .proposal-vote-current-label--center {
+  justify-items: center;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-vote-current-label--end {
+  justify-items: end;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-vote-current-label > span,
+#proposalInfoModal .proposal-vote-current-label > small {
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-vote-current-label > span {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-vote-current-label > small {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-vote-current-label--winner > span {
+  color: var(--primary-color);
+}
+
+#proposalInfoModal .proposal-vote-current-track {
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  height: 16px;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-vote-current-segment {
+  align-self: stretch;
+  background: rgba(101, 103, 107, 0.34);
+  border-left: 1px solid rgba(255, 255, 255, 0.72);
+  flex: var(--vote-total-segment-units) 1 0;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-vote-current-segment:first-child {
+  border-left: 0;
+}
+
+#proposalInfoModal .proposal-vote-current-segment--winner {
+  background: var(--primary-color);
+}
+
+#proposalInfoModal .proposal-vote-current-segment--empty {
+  background: rgba(101, 103, 107, 0.18);
+}
+
+#proposalInfoModal .proposal-vote-status-card,
+#proposalInfoModal .proposal-vote-preview {
+  background: var(--input-background);
+  border-radius: 8px;
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+}
+
+#proposalInfoModal .proposal-vote-preview {
+  padding: 8px;
+}
+
+#proposalInfoModal .proposal-vote-preview--message {
+  background: transparent;
+  padding: 0;
+}
+
+#proposalInfoModal .proposal-vote-status-card {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 8px 10px;
+}
+
+#proposalInfoModal .proposal-vote-status-card strong {
+  min-width: 0;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-vote-status-card--deadline {
+  justify-self: end;
+  max-width: 100%;
+  width: fit-content;
+}
+
+#proposalInfoModal .proposal-vote-status-card span,
+#proposalInfoModal .proposal-vote-option span,
+#proposalInfoModal .proposal-vote-preview-total span,
+#proposalInfoModal .proposal-vote-preview-row span,
+#proposalInfoModal .proposal-vote-preview-note {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-vote-status-card strong,
+#proposalInfoModal .proposal-vote-preview-total strong,
+#proposalInfoModal .proposal-vote-preview-row strong {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+#proposalInfoModal .proposal-vote-options {
+  display: grid;
+  gap: 8px;
+}
+
+#proposalInfoModal .proposal-vote-options-help,
+#proposalInfoModal .proposal-vote-options-header {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-vote-options-header {
+  display: grid;
+  font-weight: var(--font-weight-semibold);
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 92px;
+}
+
+#proposalInfoModal .proposal-vote-options-header span:last-child {
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-vote-option,
+#proposalInfoModal .proposal-vote-spend-row {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 92px;
+}
+
+#proposalInfoModal .proposal-vote-spend-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+#proposalInfoModal .proposal-vote-spend-row .form-group {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+#proposalInfoModal .proposal-vote-spend-row label {
+  margin: 0;
+  white-space: nowrap;
+}
+
+#proposalInfoModal .proposal-vote-spend-row > span {
+  color: var(--secondary-text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 40px;
+}
+
+#proposalInfoModal .proposal-vote-preview-total,
+#proposalInfoModal .proposal-vote-preview-row {
+  align-items: center;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+#proposalInfoModal .proposal-vote-preview-row {
+  grid-template-columns: 52px minmax(72px, 1fr) minmax(96px, auto);
+}
+
+#proposalInfoModal .proposal-vote-preview-row > span:nth-child(2) {
+  justify-self: center;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-vote-preview-row > strong {
+  justify-self: end;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-vote-power-help {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-vote-power-help summary {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 6px;
+  list-style: none;
+}
+
+#proposalInfoModal .proposal-vote-power-help summary::-webkit-details-marker {
+  display: none;
+}
+
+#proposalInfoModal .proposal-vote-power-help summary::before {
+  background-image: var(--icon-info);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 16px 16px;
+  content: "";
+  height: 16px;
+  width: 16px;
+}
+
+#proposalInfoModal .proposal-vote-power-help p {
+  margin: 6px 0 0;
+}
+
+#proposalInfoModal .proposal-vote-preview-meter {
+  background: var(--border-color);
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-vote-preview-meter span {
+  background: var(--primary-color);
+  display: block;
+  height: 100%;
+}
+
+#proposalInfoModal .proposal-vote-preview-options {
+  display: grid;
+  gap: 6px;
+}
+
+#proposalInfoModal .proposal-vote-preview-message {
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+  padding: 8px 10px;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-vote-preview-message--warning {
+  background: rgba(196, 45, 45, 0.12);
+  color: #8f1d16;
+}
+
+#proposalInfoModal .proposal-vote-preview-message--muted {
+  background: var(--input-background);
+  color: var(--secondary-text-color);
+}
+
+@media (max-width: 520px) {
+  #proposalInfoModal .proposal-result-overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  #proposalInfoModal .proposal-vote-option {
+    grid-template-columns: minmax(0, 1fr) 92px;
+  }
 }
 
 #proposalInfoModal .hidden {
@@ -7252,6 +7950,7 @@ small {
   min-width: 0;
   overflow: visible;
   overflow-wrap: anywhere;
+  text-align: left;
   text-overflow: clip;
   white-space: normal;
 }
@@ -7260,7 +7959,7 @@ small {
   align-items: center;
   color: var(--secondary-text-color);
   display: flex;
-  gap: 18px;
+  gap: 10px;
   min-width: 0;
   width: 100%;
 }
@@ -7273,37 +7972,55 @@ small {
 }
 
 #daoModal .dao-row-meta-item--type {
-  flex: 1 1 auto;
-}
-
-#daoModal .dao-row-meta-item--updated {
   flex: 0 0 auto;
-  margin-left: auto;
-  white-space: nowrap;
-}
-
-#daoModal .dao-row-meta-label {
-  flex: 0 0 auto;
-  font-family: var(--font-primary);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: var(--font-weight-medium);
   line-height: 1.2;
-}
-
-#daoModal .dao-row-meta-value {
-  color: var(--text-color);
-  display: block;
-  font-family: var(--font-primary);
-  font-size: 12px;
-  font-weight: var(--font-weight-semibold);
-  line-height: 1.2;
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-#daoModal .dao-row-meta-item--updated .dao-row-meta-value {
-  overflow-wrap: normal;
+  max-width: 34%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+#daoModal .dao-row-previews {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  gap: 4px;
+  justify-content: flex-end;
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+#daoModal .dao-row-preview {
+  align-items: center;
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-color);
+  display: inline-flex;
+  flex: 0 1 auto;
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  padding: 4px 6px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#daoModal .dao-row-preview--accepted,
+#daoModal .dao-row-preview--accept {
+  background: rgba(30, 126, 52, 0.12);
+  border-color: rgba(30, 126, 52, 0.3);
+}
+
+#daoModal .dao-row-preview--rejected {
+  background: rgba(196, 45, 45, 0.1);
+  border-color: rgba(196, 45, 45, 0.28);
 }
 
 #daoStatusContextMenu {

--- a/styles.css
+++ b/styles.css
@@ -2058,7 +2058,8 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm,
 #proposalInfoModal .proposal-info,
-#proposalInfoModal .proposal-committee-actions {
+#proposalInfoModal .proposal-committee-actions,
+#proposalInfoModal .proposal-review-result-actions {
   display: grid;
   gap: 18px;
   margin: 0 auto;
@@ -2074,7 +2075,8 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm-section h3,
 #proposalInfoModal .proposal-info-section h3,
-#proposalInfoModal .proposal-committee-actions h3 {
+#proposalInfoModal .proposal-committee-actions h3,
+#proposalInfoModal .proposal-review-result-actions h3 {
   color: var(--text-color);
   font-size: 16px;
   font-weight: var(--font-weight-semibold);
@@ -2112,9 +2114,23 @@ input[type='file'].form-control::file-selector-button {
   grid-column: 2 / span 2;
 }
 
+#proposalInfoModal .proposal-info-row--center-pair {
+  grid-column: 2 / span 2;
+}
+
 #confirmProposalModal .dao-confirm-row--full,
 #proposalInfoModal .proposal-info-row--full {
   grid-column: 1 / -1;
+}
+
+#proposalInfoModal .proposal-info-row--accept {
+  background: rgba(30, 126, 52, 0.16);
+  border: 1px solid rgba(30, 126, 52, 0.34);
+}
+
+#proposalInfoModal .proposal-info-row--withhold {
+  background: rgba(196, 45, 45, 0.14);
+  border: 1px solid rgba(196, 45, 45, 0.32);
 }
 
 #confirmProposalModal .dao-confirm-label,
@@ -2130,6 +2146,14 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
+#proposalInfoModal .proposal-info-row--accept span {
+  color: #1e7e34;
+}
+
+#proposalInfoModal .proposal-info-row--withhold span {
+  color: #b42318;
+}
+
 #confirmProposalModal .dao-confirm-value,
 #confirmProposalModal .dao-confirm-change-values strong,
 #proposalInfoModal .proposal-info-row strong,
@@ -2142,6 +2166,14 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
   text-align: center;
   white-space: pre-wrap;
+}
+
+#proposalInfoModal .proposal-info-row--accept strong {
+  color: #0f5f27;
+}
+
+#proposalInfoModal .proposal-info-row--withhold strong {
+  color: #8f1d16;
 }
 
 #confirmProposalModal .dao-confirm-label,
@@ -2207,6 +2239,7 @@ input[type='file'].form-control::file-selector-button {
 #confirmProposalModal .dao-confirm-help,
 #proposalInfoModal .proposal-info-muted,
 #proposalInfoModal .proposal-committee-actions p,
+#proposalInfoModal .proposal-review-result-actions p,
 #proposalInfoModal .proposal-change-row small {
   color: var(--secondary-text-color);
   font-size: 12px;
@@ -2233,17 +2266,24 @@ input[type='file'].form-control::file-selector-button {
     grid-column: span 3;
   }
 
+  #proposalInfoModal .proposal-info-row--center-pair {
+    grid-column: span 3;
+  }
+
   #confirmProposalModal .dao-confirm-row--full,
   #proposalInfoModal .proposal-info-row--full {
     grid-column: 1 / -1;
   }
 }
 
-#proposalInfoModal .proposal-info + .proposal-committee-actions {
+#proposalInfoModal .proposal-info + .proposal-committee-actions,
+#proposalInfoModal .proposal-info + .proposal-review-result-actions,
+#proposalInfoModal .proposal-committee-actions + .proposal-review-result-actions {
   margin-top: 12px;
 }
 
-#proposalInfoModal .proposal-committee-actions {
+#proposalInfoModal .proposal-committee-actions,
+#proposalInfoModal .proposal-review-result-actions {
   border: 1px solid var(--border-color);
   border-radius: 8px;
   display: grid;
@@ -2308,13 +2348,15 @@ input[type='file'].form-control::file-selector-button {
   color: var(--background-color);
 }
 
-#proposalInfoModal .proposal-committee-actions .btn {
+#proposalInfoModal .proposal-committee-actions .btn,
+#proposalInfoModal .proposal-review-result-actions .btn {
   font-size: 14px;
   height: 40px;
   padding: 8px 14px;
 }
 
-#proposalInfoModal .proposal-committee-actions .btn--pill.btn--full {
+#proposalInfoModal .proposal-committee-actions .btn--pill.btn--full,
+#proposalInfoModal .proposal-review-result-actions .btn--pill.btn--full {
   margin: 0;
   width: 100%;
 }


### PR DESCRIPTION
## What Changed

This PR connects the Phase 4.B committee review UI to real DAO backend transactions and adds the separate review-result finalization path.

- `dao.repo.js` now builds `dao_committee_vote` transactions with `buildDaoCommitteeVoteTransaction(...)`, including Accept/Withhold validation and optional `withheldReason`.
- `dao.repo.js` now builds `dao_committee_result` transactions with `buildDaoCommitteeResultTransaction(...)` so the review result can be finalized after the review window.
- `daoRepo.submitCommitteeVote(...)` and `daoRepo.finalizeCommitteeResult(...)` wrap those builders with shared `submitDaoTransaction(...)` success/error handling.
- Backend proposal account ids are preserved through `accountId: proposal.id`, and transaction builders resolve `proposal.accountId || proposal.proposalId || proposal.id` into the submitted `proposalId`.
- `ProposalInfoModal` now derives review permissions with `getReviewCapabilities(...)`, using backend booleans such as `isCommitteeMemberForProposal`, `canCommitteeVote`, and `canFinalizeReviewResult` when available, with local committee/timing fallback otherwise.
- Committee review actions are hidden when review finalization is available, and a separate `#proposalReviewResultSection` shows the `Finalize review result` action instead.
- Existing committee votes now preselect the opposite choice so changing Accept/Withhold is the default path, while same-vote resubmission is disabled.
- `handleCommitteeSubmit()` validates proposal data, wallet keys, withhold reason presence, and the 1000-character withhold reason limit before signing.
- `handleReviewResultSubmit()` submits the review-result transaction through the same signing/injection path.
- Successful committee/review-result actions force-refresh DAO data, re-render the DAO list if open, and refresh the current proposal detail modal.

## Added Flow And Code References

1. User opens a proposal from the DAO list; the existing row path calls `proposalInfoModal.open(proposal.id)`.
2. `ProposalInfoModal.load()` wires the original committee controls plus the new review-result controls: `#proposalReviewResultSection`, `#proposalReviewResultHelp`, and `#proposalReviewResultSubmit`.
3. `ProposalInfoModal._open(proposalId)` opens the modal, runs `await daoRepo.ensureLoaded()`, loads the proposal with `daoRepo.getProposalById(proposalId)`, resets submit state with `this.setSubmitting(false)`, and renders the proposal.
4. `renderProposal(proposal)` computes committee state from `proposal.committeeVotes`, `proposal.committeeAddresses`, `acceptCount`, `withholdCount`, and the current account vote.
5. `getDaoProposalReviewWindow(proposal)` now returns `canFinalizeReviewResult: true` when the review window has ended and `canCommitteeVote: false`.
6. `getReviewCapabilities(...)` uses backend capability syntax like `getDaoBooleanCapability(proposal, 'canCommitteeVote')`; if the backend field is missing, it falls back to `state === 'review' && reviewWindow.canCommitteeVote && isCommitteeMember`.
7. `renderCommitteeActions(...)` hides committee voting once finalization is possible with `if (!capabilities.isCommitteeMember || capabilities.canFinalizeReviewResult) { this.hideCommitteeActions(); return; }`.
8. `getDefaultCommitteeChoice(currentVote)` returns `withhold` after an existing Accept vote and `accept` otherwise, so the UI is set up to change the prior review decision.
9. `renderReviewResultAction(...)` shows `#proposalReviewResultSection` only when `capabilities.canFinalizeReviewResult` is true and sets help text from `reviewWindow.label`.
10. `updateSubmitButtons()` disables same-vote resubmission, locks both action paths while `this.isSubmitting`, and changes button text to `Submitting...` or `Finalizing...`.
11. `handleCommitteeSubmit()` validates current proposal data and `myAccount.keys.address`, then validates withhold details before calling `daoRepo.submitCommitteeVote(...)`.
12. The committee submit call passes the real transaction context: `from: getDaoCurrentAccountAddress()`, `proposal`, `vote: this.committeeChoice`, `withheldReason`, `timestamp: getTransactionTimestamp()`, `networkId: network?.netid || ''`, and `submitTransaction: (transaction) => this.submitDaoTransaction(transaction)`.
13. `buildDaoCommitteeVoteTransaction(...)` creates the backend payload with `type: 'dao_committee_vote'`, `from`, `proposalId`, `vote`, `timestamp`, and `networkId`; withhold votes also attach `transaction.withheldReason = reason`.
14. `ProposalInfoModal.submitDaoTransaction(transaction)` signs with `signObj(transaction, myAccount.keys)` and injects with `injectTx(transaction, txid)`.
15. Successful committee review submission shows `Committee review submitted` and calls `refreshAfterDaoAction(...)`, which refreshes DAO data and re-renders the current proposal.
16. `handleReviewResultSubmit()` follows the same guarded/loading path but calls `daoRepo.finalizeCommitteeResult(...)`.
17. `buildDaoCommitteeResultTransaction(...)` creates the finalization payload with `type: 'dao_committee_result'`, `from`, `proposalId`, `timestamp`, and `networkId`.
18. `index.html` adds `#proposalReviewResultSection` after the committee action section, and `styles.css` extends the same compact proposal action styling to `.proposal-review-result-actions`.

## Why

Phase 4.A created the review/status UI but intentionally left committee review submission disconnected. This branch moves committee Accept/Withhold and review-result finalization onto real DAO transactions while preserving the existing separation: `dao.repo.js` owns transaction construction and response normalization, and `app.js` owns wallet signing, transaction injection, modal state, and refresh behavior.

## Validation

- `git show issue-1421-committee-review-backend-integration:app.js | node --check --input-type=module -`
- `git show issue-1421-committee-review-backend-integration:dao.repo.js | node --check --input-type=module -`
- `git diff --check issue-1420-proposal-status-committee-review-ui..issue-1421-committee-review-backend-integration`

Closes #1421
Parent: #1413
Builds on #1420
Next phase: #1422