### PR TITLE
Mark timed-out pending messages as failed

### DIFF
--- a/app.js
+++ b/app.js
@@ -30114,6 +30114,11 @@ async function checkPendingTransactions() {
           }
           chatModal.refreshCurrentView(txid);
         }
+        if (type === 'message') {
+          updateTransactionStatus(txid, pendingTxInfo.to, 'failed', type);
+          chatModal.refreshCurrentView(txid);
+          await chatsScreen.updateChatList();
+        }
         // remove the pending tx from the pending array
         myData.pending.splice(i, 1);
         didMutatePendingState = true;


### PR DESCRIPTION
## Summary
- Mark pending message transactions as failed when receipt lookup times out
- Refresh the visible chat and chat list after timeout status changes
- Keep the existing pending removal/save flow intact

Fixes #1443

## Testing
- node --check app.js