### PR TITLE
Show failed chat preview indicator

### DIFF
--- a/app.js
+++ b/app.js
@@ -1723,6 +1723,7 @@ class ChatsScreen {
       const isShowingReactionPreview = !!reactionPreview && reactionPreview.timestamp > latestActivity.timestamp;
       const latestItemTimestamp = isShowingReactionPreview ? reactionPreview.timestamp : latestActivity.timestamp;
       const unreadCount = contact.unread;
+      const isFailedOutgoingActivity = !isShowingReactionPreview && latestActivity.my && latestActivity.status === 'failed';
 
       let previewHTML = '';
       if (isShowingReactionPreview) {
@@ -1811,6 +1812,9 @@ class ChatsScreen {
           : `📎 ${attachmentCount} attachments`;
         displayPrefix = '< ';
       }
+      const failedIndicatorHTML = isFailedOutgoingActivity
+        ? '<span class="chat-failed-indicator" title="Not sent" aria-label="Not sent">!</span>'
+        : '';
       // Create the list item element
       const li = document.createElement('li');
       li.classList.add('chat-item');
@@ -1823,7 +1827,7 @@ class ChatsScreen {
                   <div class="chat-time">${timeDisplay}</div>
               </div>
               <div class="chat-message">
-                ${unreadCount ? `<span class="chat-unread">${unreadCount}</span>` : ((contact.draft || contact.draftReplyTxid || hasDraftAttachment) ? `<span class="chat-draft" title="Draft"></span>` : '')}
+                ${failedIndicatorHTML}${unreadCount ? `<span class="chat-unread">${unreadCount}</span>` : ((contact.draft || contact.draftReplyTxid || hasDraftAttachment) ? `<span class="chat-draft" title="Draft"></span>` : '')}
                 ${displayPrefix}${displayPreview}
               </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -1012,6 +1012,22 @@ body {
   text-align: left;
 }
 
+.chat-failed-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background-color: var(--danger-color);
+  color: var(--background-color);
+  font-size: 11px;
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+  vertical-align: text-bottom;
+}
+
 .chat-unread {
   background-color: var(--primary-color);
   color: var(--background-color);


### PR DESCRIPTION
## What Changed

This PR shows a failed-message indicator in the chat list preview when the latest outgoing chat activity timed out or failed.

- `ChatsScreen.updateChatList` now detects failed outgoing latest activity and prepends a small `!` indicator to the preview row.
- Draft indicators and draft preview text can still render alongside the failed icon, so users can see both that they have a draft and that the last sent message failed.
- `styles.css` adds the minimal failed-preview indicator styling used by the chat list.

## Fixed Flow

1. A user sends a chat message.
2. The pending transaction times out and the existing pending transaction flow marks the message as `failed`.
3. The chat list renders that chat row.
4. The row now includes a visible `Not sent` indicator, even if the user has started drafting a follow-up message.

## Why

This branch should be used instead of `origin/issue-1444-failed-chat-preview` because it keeps issue #1444 scoped to the chat-list rendering behavior. The older branch also changes broader chat-list update mechanics, including the `upsertSortedChatListEntry` helper, address normalization in multiple pending/send flows, and render sequencing. Those changes are not needed for showing the failed preview icon now that the timeout/failure marking behavior is already on `main`.

This PR only adds the UI signal for failed previews and avoids changing chat ordering, pending transaction settlement, or send/update data flow.

## Validation

- `node --check app.js`

Closes #1444