### PR TITLE
DAO proposal results and rewards UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -4583,7 +4583,7 @@ class ProposalInfoModal {
         return `
           <div class="proposal-result-row${isWinner ? ' proposal-result-row--winner' : ''}">
             <span>${escapeHtml(row.option)}</span>
-            <strong>${escapeHtml(formatDaoVotingPower(row.total))}</strong>
+            <span class="proposal-result-value">${escapeHtml(formatDaoVotingPower(row.total))}</span>
             <small>${escapeHtml(formatDaoBigIntPercent(row.total, result.totalWeight))}</small>
           </div>
         `;
@@ -4596,11 +4596,11 @@ class ProposalInfoModal {
         <div class="proposal-result-overview">
           <div class="proposal-result-card">
             <span>Winner</span>
-            <strong>${escapeHtml(winnerLabel)}</strong>
+            <span class="proposal-result-value">${escapeHtml(winnerLabel)}</span>
           </div>
           <div class="proposal-result-card">
             <span>Total voting power</span>
-            <strong>${escapeHtml(totalLabel)}</strong>
+            <span class="proposal-result-value">${escapeHtml(totalLabel)}</span>
           </div>
         </div>
         <div class="proposal-result-list">${rows}</div>
@@ -4705,7 +4705,7 @@ class ProposalInfoModal {
       .map((row) => `
         <div class="${row.classes.join(' ')}">
           <span>${escapeHtml(row.label)}</span>
-          <strong>${escapeHtml(row.value)}</strong>
+          <span class="proposal-info-value">${escapeHtml(row.value)}</span>
         </div>
       `)
       .join('');
@@ -4793,36 +4793,66 @@ class ProposalInfoModal {
     `;
   }
 
+  getParameterChangeRowClass(parts, { isSingleRow = false } = {}) {
+    const normalizedParts = parts.map((part) => String(part ?? '').trim());
+    const shouldUseWideRow = normalizedParts.some((part) => part.length > 22)
+      || normalizedParts.join(' ').length > 52;
+    return [
+      'proposal-change-row',
+      shouldUseWideRow ? 'proposal-change-row--wide' : '',
+      !shouldUseWideRow && isSingleRow ? 'proposal-change-row--single' : '',
+    ].filter(Boolean).join(' ');
+  }
+
   renderPayloadRows(payload, payloadTitle = '') {
     const titleHtml = payloadTitle
       ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
       : '';
 
     if (Array.isArray(payload?.changes)) {
-      return payload.changes
-        .map((change) => `
-          <div class="proposal-change-row">
+      const changes = payload.changes;
+      return changes
+        .map((change, index) => {
+          const key = change?.key || 'Unknown key';
+          const current = formatDaoDetailValue(change?.current);
+          const next = formatDaoDetailValue(change?.value);
+          const rowClass = this.getParameterChangeRowClass(
+            [key, `Current: ${current}`, `New: ${next}`],
+            { isSingleRow: index === changes.length - 1 && changes.length % 2 === 1 },
+          );
+          return `
+          <div class="${rowClass}">
             ${titleHtml}
-            <span>${escapeHtml(change?.key || 'Unknown key')}</span>
+            <span>${escapeHtml(key)}</span>
             <div class="proposal-change-values">
-              <small><span>Current:</span><strong>${escapeHtml(formatDaoDetailValue(change?.current))}</strong></small>
+              <small><span>Current:</span><strong>${escapeHtml(current)}</strong></small>
               <span class="proposal-change-arrow" aria-hidden="true">&rarr;</span>
-              <strong><span>New:</span><span>${escapeHtml(formatDaoDetailValue(change?.value))}</span></strong>
+              <strong><span>New:</span><span>${escapeHtml(next)}</span></strong>
             </div>
           </div>
-        `)
+        `;
+        })
         .join('');
     }
 
-    return Object.entries(payload)
-      .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0)
-      .map(([key, value]) => `
-        <div class="proposal-change-row">
+    const entries = Object.entries(payload)
+      .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0);
+
+    return entries
+      .map(([key, value], index) => {
+        const displayValue = formatDaoDetailValue(value);
+        const rowClass = this.getParameterChangeRowClass(
+          [key, displayValue],
+          { isSingleRow: index === entries.length - 1 && entries.length % 2 === 1 },
+        );
+        return `
+        <div class="${rowClass}">
           ${titleHtml}
           <span>${escapeHtml(key)}</span>
-          <strong>${escapeHtml(formatDaoDetailValue(value))}</strong>
+          <strong>${escapeHtml(displayValue)}</strong>
         </div>
-      `)
+      `;
+      })
       .join('');
   }
 

--- a/app.js
+++ b/app.js
@@ -3983,11 +3983,14 @@ function getDaoCommitteeReviewResultSummary(proposal) {
   const outcome = getDaoFinalOutcome(proposal);
 
   return {
+    acceptCount,
+    committeeSize: committeeAddresses.length,
     detail: `Committee review: ${acceptCount} accept, ${withholdCount} withhold.`,
     headline: outcome.label,
     label: 'Final result',
     source: 'committee',
     tone: outcome.tone,
+    withholdCount,
     rows: [
       ['Decision source', 'Committee review'],
       ['Outcome', outcome.label, outcome.tone === 'accepted' ? 'accept' : 'withhold'],
@@ -4560,32 +4563,55 @@ class ProposalInfoModal {
 
   renderProposalResultSummary(result) {
     if (!result) return '';
-    return `
-      <section class="proposal-result-banner proposal-result-banner--${escapeDaoFormAttribute(result.tone)}">
-        <span>${escapeHtml(result.label)}</span>
-        <strong>${escapeHtml(result.headline)}</strong>
-        <small>${escapeHtml(result.detail)}</small>
-      </section>
-    `;
+    return this.renderProposalResults(result);
   }
 
   renderProposalResults(result) {
     if (!result) return '';
     if (result.source === 'committee') {
-      return this.renderSection('Results', result.rows);
+      return this.renderCommitteeResults(result);
     }
 
     const winnerLabel = result.winner ? `${result.winner.option} (${result.outcome})` : 'Unavailable';
     const totalLabel = result.totalWeight > 0n ? formatDaoVotingPower(result.totalWeight) : 'No votes yet';
-    const rows = result.totals
+    const labelLayout = result.totals.length === 2 ? 'balanced' : 'segmented';
+    const segments = result.totals
+      .map((row, rowPosition) => {
+        const isWinner = result.winner?.index === row.index;
+        const units = this.getResultSegmentUnits(row.total, result.totalWeight);
+        const power = formatDaoVotingPower(row.total);
+        const displayPower = power.endsWith(' power') ? power.slice(0, -6) : power;
+        const percent = formatDaoBigIntPercent(row.total, result.totalWeight);
+        const position = rowPosition === 0
+          ? 'start'
+          : rowPosition === result.totals.length - 1
+            ? 'end'
+            : 'center';
+        const style = `--result-segment-units: ${units};`;
+        const label = `${row.option}: ${power}, ${percent}`;
+        return `
+          <div
+            class="proposal-result-meter-label proposal-result-meter-label--${position}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
+            style="${escapeDaoFormAttribute(style)}"
+            title="${escapeDaoFormAttribute(label)}"
+            aria-label="${escapeDaoFormAttribute(label)}"
+          >
+            <span>${escapeHtml(row.option)}</span>
+            <small>${escapeHtml(displayPower)} / ${escapeHtml(percent)}</small>
+          </div>
+        `;
+      })
+      .join('');
+    const bars = result.totals
       .map((row) => {
         const isWinner = result.winner?.index === row.index;
+        const units = this.getResultSegmentUnits(row.total, result.totalWeight);
+        const style = `--result-segment-units: ${units};`;
         return `
-          <div class="proposal-result-row${isWinner ? ' proposal-result-row--winner' : ''}">
-            <span>${escapeHtml(row.option)}</span>
-            <span class="proposal-result-value">${escapeHtml(formatDaoVotingPower(row.total))}</span>
-            <small>${escapeHtml(formatDaoBigIntPercent(row.total, result.totalWeight))}</small>
-          </div>
+          <span
+            class="proposal-result-meter-segment${isWinner ? ' proposal-result-meter-segment--winner' : ''}${row.total === 0n ? ' proposal-result-meter-segment--empty' : ''}"
+            style="${escapeDaoFormAttribute(style)}"
+          ></span>
         `;
       })
       .join('');
@@ -4603,9 +4629,93 @@ class ProposalInfoModal {
             <span class="proposal-result-value">${escapeHtml(totalLabel)}</span>
           </div>
         </div>
-        <div class="proposal-result-list">${rows}</div>
+        <div class="proposal-result-meter" aria-label="Vote result breakdown">
+          <div class="proposal-result-meter-labels proposal-result-meter-labels--${labelLayout}">${segments}</div>
+          <div class="proposal-result-meter-track" aria-hidden="true">${bars}</div>
+        </div>
       </section>
     `;
+  }
+
+  renderCommitteeResults(result) {
+    const acceptCount = Number(result.acceptCount || 0);
+    const withholdCount = Number(result.withholdCount || 0);
+    const submittedCount = acceptCount + withholdCount;
+    const committeeSize = Number(result.committeeSize || 0);
+    const committeeSizeLabel = committeeSize > 0 ? String(committeeSize) : 'Unavailable';
+    const acceptPercent = this.formatCountPercent(acceptCount, submittedCount);
+    const withholdPercent = this.formatCountPercent(withholdCount, submittedCount);
+    const acceptUnits = this.getCountResultSegmentUnits(acceptCount, submittedCount);
+    const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
+    const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
+    const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
+    const acceptSegmentWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-segment--winner' : '';
+    const withholdSegmentWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-segment--winner' : '';
+
+    return `
+      <section class="proposal-info-section">
+        <h3>Results</h3>
+        <div class="proposal-result-overview">
+          <div class="proposal-result-card">
+            <span>Outcome</span>
+            <span class="proposal-result-value">${escapeHtml(result.headline || 'Unavailable')}</span>
+          </div>
+          <div class="proposal-result-card">
+            <span>Committee size</span>
+            <span class="proposal-result-value">${escapeHtml(committeeSizeLabel)}</span>
+          </div>
+        </div>
+        <div class="proposal-result-meter" aria-label="Committee result breakdown">
+          <div class="proposal-result-meter-labels proposal-result-meter-labels--balanced">
+            <div
+              class="proposal-result-meter-label proposal-result-meter-label--start proposal-result-meter-label--accept${acceptWinnerClass}"
+              style="--result-segment-units: ${acceptUnits};"
+              title="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
+              aria-label="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
+            >
+              <span>Accept</span>
+              <small>${escapeHtml(`${acceptCount} / ${acceptPercent}`)}</small>
+            </div>
+            <div
+              class="proposal-result-meter-label proposal-result-meter-label--end proposal-result-meter-label--withhold${withholdWinnerClass}"
+              style="--result-segment-units: ${withholdUnits};"
+              title="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
+              aria-label="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
+            >
+              <span>Withhold</span>
+              <small>${escapeHtml(`${withholdCount} / ${withholdPercent}`)}</small>
+            </div>
+          </div>
+          <div class="proposal-result-meter-track" aria-hidden="true">
+            <span
+              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptSegmentWinnerClass}${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              style="--result-segment-units: ${acceptUnits};"
+            ></span>
+            <span
+              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdSegmentWinnerClass}${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              style="--result-segment-units: ${withholdUnits};"
+            ></span>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  getResultSegmentUnits(part, total) {
+    if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return 1;
+    const units = Number((part * 1000n + total / 2n) / total);
+    return Math.max(1, units);
+  }
+
+  getCountResultSegmentUnits(part, total) {
+    if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return 1;
+    if (part <= 0) return 0;
+    return Math.max(1, Math.round((part / total) * 1000));
+  }
+
+  formatCountPercent(part, total) {
+    if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return '0%';
+    return formatDaoPercent(part / total);
   }
 
   renderProposalRewards(reward) {
@@ -4656,7 +4766,6 @@ class ProposalInfoModal {
       ]),
       state === 'voting' ? this.renderVotingDetails(proposal) : '',
       this.renderProposalBody(proposal),
-      this.renderProposalResults(resultSummary),
       this.renderProposalRewards(rewardSummary),
     ].filter(Boolean);
 
@@ -4676,7 +4785,6 @@ class ProposalInfoModal {
   getProposalDetailsSummary(state, resultSummary, rewardSummary) {
     const parts = ['Overview', 'review timeline', 'proposal body'];
     if (state === 'voting') parts.push('voting totals');
-    if (resultSummary) parts.push('result breakdown');
     if (rewardSummary) parts.push('reward accounting');
     return parts.join(', ');
   }

--- a/app.js
+++ b/app.js
@@ -2742,6 +2742,7 @@ class DaoModal {
       const title = escapeHtml(titleText);
       const updatedLabel = escapeHtml(formatDaoRowTimestampLabel(p.stateEnteredAt || p.createdAt));
       const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
+      const previewHtml = this.renderProposalRowPreview(p);
 
       li.tabIndex = 0;
       li.setAttribute('role', 'button');
@@ -2759,6 +2760,7 @@ class DaoModal {
               <strong class="dao-row-meta-value">${updatedLabel}</strong>
             </span>
           </div>
+          ${previewHtml}
         </div>
       `;
       li.onclick = () => this.openProposal(p);
@@ -2774,6 +2776,39 @@ class DaoModal {
     if (this.addButton) {
       this.addButton.classList.toggle('visible', this.isActive());
     }
+  }
+
+  renderProposalRowPreview(proposal) {
+    const chips = [];
+    const result = getDaoProposalResultSummary(proposal);
+    const reward = getDaoProposalRewardSummary(proposal);
+
+    if (result) {
+      chips.push({
+        label: 'Result',
+        value: result.headline,
+        tone: result.tone,
+      });
+    }
+    if (reward) {
+      chips.push({
+        label: 'Reward',
+        value: reward.previewLabel,
+        tone: reward.statusTone,
+      });
+    }
+
+    if (chips.length === 0) return '';
+    return `
+      <div class="dao-row-previews">
+        ${chips.map((chip) => `
+          <span class="dao-row-preview dao-row-preview--${escapeDaoFormAttribute(chip.tone || 'neutral')}">
+            <span>${escapeHtml(chip.label)}</span>
+            <strong>${escapeHtml(chip.value)}</strong>
+          </span>
+        `).join('')}
+      </div>
+    `;
   }
 
   openProposal(proposal) {
@@ -3707,6 +3742,7 @@ const DAO_WITHHOLD_REASON_MAX_LENGTH = 1000;
 const DAO_VOTE_WEIGHT_MAX = 1_000_000;
 const DAO_VOTE_WEIGHT_PRECISION = 1_000_000_000_000;
 const DAO_VOTE_WEIGHT_PRECISION_BIGINT = 1_000_000_000_000n;
+const DAO_CLAIM_REWARD_PRECISION = 10n ** 18n;
 
 function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
@@ -3868,6 +3904,300 @@ function formatDaoLibWei(value) {
   }
 }
 
+function parseDaoUnsignedBigInt(value) {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value === 'bigint') return value >= 0n ? value : null;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) return null;
+    return BigInt(Math.trunc(value));
+  }
+
+  const text = String(value).trim();
+  if (!text) return null;
+  try {
+    const parsed = BigInt(text);
+    return parsed >= 0n ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatDaoRewardAmount(value) {
+  return value === null ? 'Unavailable' : formatDaoLibWei(value);
+}
+
+function formatDaoBigIntPercent(part, total) {
+  if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return '0%';
+  const tenths = (part * 1000n + total / 2n) / total;
+  const whole = tenths / 10n;
+  const fraction = tenths % 10n;
+  return fraction === 0n ? `${whole}%` : `${whole}.${fraction}%`;
+}
+
+function getDaoProposalOptions(proposal) {
+  if (!Array.isArray(proposal?.options) || proposal.options.length === 0) return ['Yes', 'No'];
+  return proposal.options.map((option, index) => String(option || `Option ${index + 1}`));
+}
+
+function getDaoVoteTotals(proposal) {
+  const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+  if (totalVote.length === 0) return [];
+
+  const options = getDaoProposalOptions(proposal);
+  const rowCount = Math.max(options.length, totalVote.length);
+  return Array.from({ length: rowCount }, (_, index) => ({
+    index,
+    option: options[index] || `Option ${index + 1}`,
+    total: parseDaoUnsignedBigInt(totalVote[index]) ?? 0n,
+  }));
+}
+
+function getDaoVoteWinner(totals) {
+  const totalWeight = totals.reduce((sum, row) => sum + row.total, 0n);
+  if (totalWeight <= 0n) return { totalWeight, winner: null };
+
+  const winner = totals.reduce((current, row) => (row.total > current.total ? row : current), totals[0]);
+  return { totalWeight, winner };
+}
+
+function isDaoFinalResultState(state) {
+  return state === 'accepted' || state === 'rejected' || state === 'applied';
+}
+
+function getDaoFinalOutcome(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  const label = getDaoStateLabel(state) || state || 'Unavailable';
+  const tone = state === 'withheld' || state === 'rejected' ? 'rejected' : 'accepted';
+  return { label, tone };
+}
+
+function getDaoCommitteeReviewResultSummary(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  if (state !== 'withheld' && !(proposal?.emergency && isDaoFinalResultState(state))) return null;
+
+  const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
+  const committeeAddresses = Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : [];
+  const committeeAddressSet = new Set(committeeAddresses);
+  const acceptCount = committeeVotes.filter((vote) => vote?.vote === 'accept' && committeeAddressSet.has(vote.memberAddress)).length;
+  const withholdCount = committeeVotes.filter((vote) => vote?.vote === 'withhold' && committeeAddressSet.has(vote.memberAddress)).length;
+  const outcome = getDaoFinalOutcome(proposal);
+
+  return {
+    detail: `Committee review: ${acceptCount} accept, ${withholdCount} withhold.`,
+    headline: outcome.label,
+    label: 'Final result',
+    source: 'committee',
+    tone: outcome.tone,
+    rows: [
+      ['Decision source', 'Committee review'],
+      ['Outcome', outcome.label, outcome.tone === 'accepted' ? 'accept' : 'withhold'],
+      ['Accept votes', String(acceptCount), 'accept'],
+      ['Withhold votes', String(withholdCount), withholdCount > 0 ? 'withhold' : ''],
+      ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
+    ],
+  };
+}
+
+function getDaoVoteResultSummary(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  if (!isDaoFinalResultState(state)) return null;
+
+  const totals = getDaoVoteTotals(proposal);
+  if (totals.length === 0) return null;
+
+  const { totalWeight, winner } = getDaoVoteWinner(totals);
+  if (totalWeight <= 0n) return null;
+
+  const outcome = winner
+    ? winner.index === 0 ? 'Accepted' : 'Rejected'
+    : 'No votes yet';
+  const label = 'Final result';
+  const headline = winner
+    ? outcome
+    : 'No votes yet';
+  const detail = winner
+    ? `${winner.option} has ${formatDaoVotingPower(winner.total)} (${formatDaoBigIntPercent(winner.total, totalWeight)}).`
+    : 'No weighted votes are recorded yet.';
+  const tone = winner
+    ? winner.index === 0 ? 'accepted' : 'rejected'
+    : 'pending';
+
+  return { detail, headline, label, outcome, source: 'vote', tone, totalWeight, totals, winner };
+}
+
+function getDaoProposalResultSummary(proposal) {
+  return getDaoCommitteeReviewResultSummary(proposal) || getDaoVoteResultSummary(proposal);
+}
+
+function normalizeDaoAddress(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function getDaoVoterEntries(proposal) {
+  if (!Array.isArray(proposal?.voterList)) return [];
+  return proposal.voterList
+    .map((entry) => ({
+      address: normalizeDaoAddress(entry?.address),
+      timestamp: Number(entry?.timestamp || 0),
+    }))
+    .filter((entry) => entry.address && Number.isFinite(entry.timestamp) && entry.timestamp > 0);
+}
+
+function getDaoClaimList(proposal) {
+  if (!Array.isArray(proposal?.claimList)) return [];
+  return proposal.claimList.map(normalizeDaoAddress).filter(Boolean);
+}
+
+function getDaoProposalClaimWindow(proposal) {
+  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewDuration = Number(proposal?.reviewDuration);
+  const votingDuration = Number(proposal?.votingDuration);
+  const claimDuration = Number(proposal?.claimDuration);
+  if (
+    !Number.isFinite(reviewStart) ||
+    !Number.isFinite(reviewDuration) ||
+    !Number.isFinite(votingDuration) ||
+    !Number.isFinite(claimDuration)
+  ) {
+    return { start: null, end: null, votingStart: null, votingDuration: null };
+  }
+
+  const votingStart = reviewStart + reviewDuration;
+  const votingEnd = proposal?.emergency ? votingStart : votingStart + votingDuration;
+  return {
+    start: votingEnd,
+    end: votingEnd + claimDuration,
+    votingStart,
+    votingDuration,
+  };
+}
+
+function formatDaoClaimWindowLabel(claimWindow, now) {
+  if (!claimWindow.start || !claimWindow.end) return 'Unavailable';
+  const start = formatDaoTimestamp(claimWindow.start) || 'Unavailable';
+  const end = formatDaoTimestamp(claimWindow.end) || 'Unavailable';
+  if (now < claimWindow.start) return `Opens ${start}\nEnds ${end}`;
+  if (now <= claimWindow.end) return `Open until ${end}`;
+  return `Ended ${end}`;
+}
+
+function getDaoClaimRewardEstimate({ pool, claimed, voterEntries, voterIndex, votingStart, votingDuration }) {
+  if (pool <= 0n || claimed >= pool || voterIndex < 0 || voterEntries.length === 0) return null;
+  if (!Number.isFinite(votingStart) || !Number.isFinite(votingDuration) || votingDuration <= 0) return null;
+
+  const voter = voterEntries[voterIndex];
+  const previousTimestamp = voterIndex === 0 ? votingStart : voterEntries[voterIndex - 1]?.timestamp;
+  if (!Number.isFinite(voter?.timestamp) || !Number.isFinite(previousTimestamp)) return null;
+
+  const timeDelta = BigInt(Math.max(0, Math.trunc(voter.timestamp - previousTimestamp)));
+  const duration = BigInt(Math.trunc(votingDuration));
+  const voterCount = BigInt(voterEntries.length);
+  const timePart = (timeDelta * DAO_CLAIM_REWARD_PRECISION) / duration;
+  const equalPart = DAO_CLAIM_REWARD_PRECISION / voterCount;
+  let reward = (pool * (timePart + equalPart)) / (2n * DAO_CLAIM_REWARD_PRECISION);
+  const remaining = pool > claimed ? pool - claimed : 0n;
+  if (reward > remaining) reward = remaining;
+  return reward;
+}
+
+function getDaoRewardClaimStatus({ state, currentAddress, voterIndex, hasClaimed, pool, claimed, claimWindow, now }) {
+  if (!currentAddress) return 'Sign in to check rewards';
+  if (state === 'withheld') return 'Reward pool burned';
+  if (voterIndex < 0) return 'Not eligible';
+  if (hasClaimed) return 'Already claimed';
+  if (pool <= 0n) return 'Reward pool empty';
+  if (claimed >= pool) return 'Reward pool fully claimed';
+  if (!claimWindow.end) return 'Claim timing unavailable';
+  if (now > claimWindow.end) return 'Claim window ended';
+  if (now < claimWindow.start) return 'Claim window not open';
+  return 'Claimable';
+}
+
+function getDaoRewardPreviewLabel(summary) {
+  if (summary.claimStatus === 'Claimable' && summary.claimEstimate !== null) {
+    return `${formatDaoLibWei(summary.claimEstimate)} claimable`;
+  }
+  if (summary.claimStatus === 'Already claimed') return 'Reward claimed';
+  if (summary.initialBurned !== null && summary.initialBurned > 0n) {
+    return `${formatDaoLibWei(summary.initialBurned)} burned`;
+  }
+  if (summary.finalBurned !== null && summary.finalBurned > 0n) {
+    return `${formatDaoLibWei(summary.finalBurned)} burned`;
+  }
+  if (summary.unclaimed !== null && summary.unclaimed > 0n) {
+    return `${formatDaoLibWei(summary.unclaimed)} unclaimed`;
+  }
+  return summary.claimStatus;
+}
+
+function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+  const state = getEffectiveDaoState(proposal);
+  const isRewardState = state === 'accepted' || state === 'rejected' || state === 'applied' || state === 'withheld';
+  if (!isRewardState) return null;
+
+  const pool = parseDaoUnsignedBigInt(proposal?.voterRewardPool);
+  const claimed = parseDaoUnsignedBigInt(proposal?.claimedReward);
+  const initialBurned = parseDaoUnsignedBigInt(proposal?.initialBurnedReward);
+  const finalBurned = parseDaoUnsignedBigInt(proposal?.finalBurnedReward);
+  const voterEntries = getDaoVoterEntries(proposal);
+  const claimList = getDaoClaimList(proposal);
+  const hasRewardData = (
+    pool !== null ||
+    claimed !== null ||
+    initialBurned !== null ||
+    finalBurned !== null ||
+    voterEntries.length > 0 ||
+    claimList.length > 0
+  );
+  if (!hasRewardData) return null;
+
+  const safePool = pool ?? 0n;
+  const safeClaimed = claimed ?? 0n;
+  const claimWindow = getDaoProposalClaimWindow(proposal);
+  const normalizedAddress = normalizeDaoAddress(currentAddress);
+  const voterIndex = normalizedAddress ? voterEntries.findIndex((entry) => entry.address === normalizedAddress) : -1;
+  const hasClaimed = normalizedAddress ? claimList.includes(normalizedAddress) : false;
+  const claimStatus = getDaoRewardClaimStatus({
+    state,
+    currentAddress: normalizedAddress,
+    voterIndex,
+    hasClaimed,
+    pool: safePool,
+    claimed: safeClaimed,
+    claimWindow,
+    now,
+  });
+  const claimEstimate = hasClaimed
+    ? null
+    : getDaoClaimRewardEstimate({
+        pool: safePool,
+        claimed: safeClaimed,
+        voterEntries,
+        voterIndex,
+        votingStart: claimWindow.votingStart,
+        votingDuration: claimWindow.votingDuration,
+      });
+  const unclaimed = pool !== null && claimed !== null
+    ? safePool > safeClaimed ? safePool - safeClaimed : 0n
+    : null;
+
+  const summary = {
+    claimEstimate,
+    claimStatus,
+    claimWindowLabel: formatDaoClaimWindowLabel(claimWindow, now),
+    claimed,
+    finalBurned,
+    initialBurned,
+    pool,
+    unclaimed,
+  };
+  return {
+    ...summary,
+    previewLabel: getDaoRewardPreviewLabel(summary),
+    statusTone: claimStatus === 'Claimable' ? 'accept' : '',
+  };
+}
+
 function formatDaoDetailValue(value) {
   if (value === undefined || value === null || value === '') return 'Unavailable';
   if (typeof value === 'bigint') return value.toString();
@@ -4027,12 +4357,28 @@ class ProposalInfoModal {
       committeeAddressSet,
     });
     const proposalType = proposal.proposalType || proposal.type;
+    const resultSummary = getDaoProposalResultSummary(proposal);
+    const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
+    const committeeReviewSection = state === 'review'
+      ? this.renderSection('Committee Review', [
+        ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
+        ['Accept votes', String(acceptCount)],
+        ['Withhold votes', String(withholdCount)],
+        [
+          'Your vote',
+          currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
+          this.getCommitteeVoteTone(currentVote),
+        ],
+        ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount)],
+      ])
+      : '';
 
     if (this.content) {
       this.content.innerHTML = [
         this.renderProposalTitle(proposal),
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
+        this.renderProposalResultSummary(resultSummary),
         this.renderSection('Overview', [
           ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
           ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
@@ -4047,18 +4393,10 @@ class ProposalInfoModal {
           ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
         ]),
         this.renderProposalBody(proposal),
-        this.renderSection('Committee Review', [
-          ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
-          ['Accept votes', String(acceptCount)],
-          ['Withhold votes', String(withholdCount)],
-          [
-            'Your vote',
-            currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
-            this.getCommitteeVoteTone(currentVote),
-          ],
-          ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount)],
-        ]),
-      ].join('');
+        committeeReviewSection,
+        this.renderProposalResults(resultSummary),
+        this.renderProposalRewards(rewardSummary),
+      ].filter(Boolean).join('');
     }
 
     if (state === 'review') {
@@ -4220,6 +4558,70 @@ class ProposalInfoModal {
 
   getProposalTitle(proposal) {
     return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
+  }
+
+  renderProposalResultSummary(result) {
+    if (!result) return '';
+    return `
+      <section class="proposal-result-banner proposal-result-banner--${escapeDaoFormAttribute(result.tone)}">
+        <span>${escapeHtml(result.label)}</span>
+        <strong>${escapeHtml(result.headline)}</strong>
+        <small>${escapeHtml(result.detail)}</small>
+      </section>
+    `;
+  }
+
+  renderProposalResults(result) {
+    if (!result) return '';
+    if (result.source === 'committee') {
+      return this.renderSection('Results', result.rows);
+    }
+
+    const winnerLabel = result.winner ? `${result.winner.option} (${result.outcome})` : 'Unavailable';
+    const totalLabel = result.totalWeight > 0n ? formatDaoVotingPower(result.totalWeight) : 'No votes yet';
+    const rows = result.totals
+      .map((row) => {
+        const isWinner = result.winner?.index === row.index;
+        return `
+          <div class="proposal-result-row${isWinner ? ' proposal-result-row--winner' : ''}">
+            <span>${escapeHtml(row.option)}</span>
+            <strong>${escapeHtml(formatDaoVotingPower(row.total))}</strong>
+            <small>${escapeHtml(formatDaoBigIntPercent(row.total, result.totalWeight))}</small>
+          </div>
+        `;
+      })
+      .join('');
+
+    return `
+      <section class="proposal-info-section">
+        <h3>Results</h3>
+        <div class="proposal-result-overview">
+          <div class="proposal-result-card">
+            <span>Winner</span>
+            <strong>${escapeHtml(winnerLabel)}</strong>
+          </div>
+          <div class="proposal-result-card">
+            <span>Total voting power</span>
+            <strong>${escapeHtml(totalLabel)}</strong>
+          </div>
+        </div>
+        <div class="proposal-result-list">${rows}</div>
+      </section>
+    `;
+  }
+
+  renderProposalRewards(reward) {
+    if (!reward) return '';
+    return this.renderSection('Rewards', [
+      ['Claim status', reward.claimStatus, reward.statusTone],
+      ['Claim estimate', reward.claimEstimate === null ? 'Unavailable' : formatDaoLibWei(reward.claimEstimate), reward.statusTone],
+      ['Claim window', reward.claimWindowLabel],
+      ['Reward pool', formatDaoRewardAmount(reward.pool)],
+      ['Claimed', formatDaoRewardAmount(reward.claimed)],
+      ['Unclaimed pool', formatDaoRewardAmount(reward.unclaimed)],
+      ['Initial burn', formatDaoRewardAmount(reward.initialBurned)],
+      ['Final burn', formatDaoRewardAmount(reward.finalBurned)],
+    ]);
   }
 
   setTitle(title) {
@@ -4436,9 +4838,7 @@ class ProposalInfoModal {
   }
 
   getVoteOptions(proposal) {
-    return Array.isArray(proposal?.options) && proposal.options.length
-      ? proposal.options.map((option) => String(option))
-      : ['Yes', 'No'];
+    return getDaoProposalOptions(proposal);
   }
 
   renderVoteActions({ proposal, state }) {

--- a/app.js
+++ b/app.js
@@ -4249,6 +4249,7 @@ class ProposalInfoModal {
     this.closeButton = document.getElementById('closeProposalInfoModal');
     this.title = document.getElementById('proposalInfoModalTitle');
     this.content = document.getElementById('proposalInfoContent');
+    this.detailsContent = document.getElementById('proposalDetailsContent');
     this.committeeActionSection = document.getElementById('proposalCommitteeActionSection');
     this.committeeActionHelp = document.getElementById('proposalCommitteeActionHelp');
     this.acceptButton = document.getElementById('proposalCommitteeAccept');
@@ -4333,6 +4334,9 @@ class ProposalInfoModal {
     if (this.content) {
       this.content.innerHTML = '<section class="proposal-info-section"><h3>Proposal not found</h3><p class="proposal-info-muted">The proposal data is unavailable.</p></section>';
     }
+    if (this.detailsContent) {
+      this.detailsContent.innerHTML = '';
+    }
     this.hideCommitteeActions();
     this.hideReviewResultAction();
     this.hideVoteActions();
@@ -4379,23 +4383,18 @@ class ProposalInfoModal {
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResultSummary(resultSummary),
-        this.renderSection('Overview', [
-          ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
-          ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
-          ['Status', getDaoStateLabel(state) || state],
-          ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
-          ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
-        ]),
-        this.renderSection('Review Timeline', [
-          ['Window state', reviewWindow.label],
-          ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
-          ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
-        ]),
-        this.renderProposalBody(proposal),
         committeeReviewSection,
-        this.renderProposalResults(resultSummary),
-        this.renderProposalRewards(rewardSummary),
       ].filter(Boolean).join('');
+    }
+    if (this.detailsContent) {
+      this.detailsContent.innerHTML = this.renderProposalDetails({
+        proposal,
+        proposalType,
+        state,
+        reviewWindow,
+        resultSummary,
+        rewardSummary,
+      });
     }
 
     if (state === 'review') {
@@ -4621,6 +4620,65 @@ class ProposalInfoModal {
       ['Initial burn', formatDaoRewardAmount(reward.initialBurned)],
       ['Final burn', formatDaoRewardAmount(reward.finalBurned)],
     ]);
+  }
+
+  getVoteStatusData(proposal) {
+    const votingWindow = getDaoProposalVotingWindow(proposal);
+    const totalVote = Array.isArray(proposal.totalVote) ? proposal.totalVote : [];
+    const options = this.getVoteOptions(proposal);
+    const totalVoteText = totalVote.length
+      ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
+      : 'No votes yet';
+    return { votingWindow, totalVoteText };
+  }
+
+  renderVotingDetails(proposal) {
+    const { votingWindow, totalVoteText } = this.getVoteStatusData(proposal);
+    return this.renderSection('Voting Details', [
+      ['Voting state', votingWindow.label],
+      ['Current totals', totalVoteText],
+    ]);
+  }
+
+  renderProposalDetails({ proposal, proposalType, state, reviewWindow, resultSummary, rewardSummary }) {
+    const sections = [
+      this.renderSection('Overview', [
+        ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
+        ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
+        ['Status', getDaoStateLabel(state) || state],
+        ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
+        ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
+      ]),
+      this.renderSection('Review Timeline', [
+        ['Window state', reviewWindow.label],
+        ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
+        ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
+      ]),
+      state === 'voting' ? this.renderVotingDetails(proposal) : '',
+      this.renderProposalBody(proposal),
+      this.renderProposalResults(resultSummary),
+      this.renderProposalRewards(rewardSummary),
+    ].filter(Boolean);
+
+    if (sections.length === 0) return '';
+
+    return `
+      <details class="proposal-more">
+        <summary>
+          <span class="proposal-more-title">Show proposal details</span>
+          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, resultSummary, rewardSummary))}</span>
+        </summary>
+        <div class="proposal-more-content">${sections.join('')}</div>
+      </details>
+    `;
+  }
+
+  getProposalDetailsSummary(state, resultSummary, rewardSummary) {
+    const parts = ['Overview', 'review timeline', 'proposal body'];
+    if (state === 'voting') parts.push('voting totals');
+    if (resultSummary) parts.push('result breakdown');
+    if (rewardSummary) parts.push('reward accounting');
+    return parts.join(', ');
   }
 
   setTitle(title) {

--- a/app.js
+++ b/app.js
@@ -4383,7 +4383,6 @@ class ProposalInfoModal {
           ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
           ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
           ['Status', getDaoStateLabel(state) || state],
-          ['Creator', proposal.createdBy || proposal.from || 'Unavailable'],
           ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
           ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
         ]),

--- a/app.js
+++ b/app.js
@@ -2466,19 +2466,6 @@ function formatDaoTimestamp(ts) {
   }
 }
 
-function formatDaoRowTimestampLabel(ts) {
-  const n = Number(ts || 0);
-  if (!n) return '—';
-  const date = new Date(n);
-  try {
-    const dateLabel = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-    const timeLabel = date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-    return `${dateLabel} ${timeLabel}`;
-  } catch {
-    return '—';
-  }
-}
-
 function getDaoUiStateLabel(key) {
   if (key === 'discussion') return 'Review';
   return getDaoStateLabel(key);
@@ -2740,7 +2727,6 @@ class DaoModal {
 
       const titleText = p.title || (p.number ? `Proposal #${p.number}` : 'Proposal');
       const title = escapeHtml(titleText);
-      const updatedLabel = escapeHtml(formatDaoRowTimestampLabel(p.stateEnteredAt || p.createdAt));
       const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
       const previewHtml = this.renderProposalRowPreview(p);
 
@@ -2755,12 +2741,8 @@ class DaoModal {
               <span class="dao-row-meta-label">Type</span>
               <strong class="dao-row-meta-value">${typeLabel}</strong>
             </span>
-            <span class="dao-row-meta-item dao-row-meta-item--updated">
-              <span class="dao-row-meta-label">Updated</span>
-              <strong class="dao-row-meta-value">${updatedLabel}</strong>
-            </span>
+            ${previewHtml}
           </div>
-          ${previewHtml}
         </div>
       `;
       li.onclick = () => this.openProposal(p);

--- a/app.js
+++ b/app.js
@@ -3967,19 +3967,10 @@ function getDaoCommitteeReviewResultSummary(proposal) {
   return {
     acceptCount,
     committeeSize: committeeAddresses.length,
-    detail: `Committee review: ${acceptCount} accept, ${withholdCount} withhold.`,
     headline: outcome.label,
-    label: 'Final result',
     source: 'committee',
     tone: outcome.tone,
     withholdCount,
-    rows: [
-      ['Decision source', 'Committee review'],
-      ['Outcome', outcome.label, outcome.tone === 'accepted' ? 'accept' : 'withhold'],
-      ['Accept votes', String(acceptCount), 'accept'],
-      ['Withhold votes', String(withholdCount), withholdCount > 0 ? 'withhold' : ''],
-      ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
-    ],
   };
 }
 
@@ -3993,21 +3984,10 @@ function getDaoVoteResultSummary(proposal) {
   const { totalWeight, winner } = getDaoVoteWinner(totals);
   if (totalWeight <= 0n) return null;
 
-  const outcome = winner
-    ? winner.index === 0 ? 'Accepted' : 'Rejected'
-    : 'No votes yet';
-  const label = 'Final result';
-  const headline = winner
-    ? outcome
-    : 'No votes yet';
-  const detail = winner
-    ? `${winner.option} has ${formatDaoVotingPower(winner.total)} (${formatDaoBigIntPercent(winner.total, totalWeight)}).`
-    : 'No weighted votes are recorded yet.';
-  const tone = winner
-    ? winner.index === 0 ? 'accepted' : 'rejected'
-    : 'pending';
+  const outcome = winner.index === 0 ? 'Accepted' : 'Rejected';
+  const tone = winner.index === 0 ? 'accepted' : 'rejected';
 
-  return { detail, headline, label, outcome, source: 'vote', tone, totalWeight, totals, winner };
+  return { headline: outcome, outcome, source: 'vote', tone, totalWeight, totals, winner };
 }
 
 function getDaoProposalResultSummary(proposal) {
@@ -4367,7 +4347,7 @@ class ProposalInfoModal {
         this.renderProposalTitle(proposal),
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
-        this.renderProposalResultSummary(resultSummary),
+        this.renderProposalResults(resultSummary),
         committeeReviewSection,
       ].filter(Boolean).join('');
     }
@@ -4541,11 +4521,6 @@ class ProposalInfoModal {
 
   getProposalTitle(proposal) {
     return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
-  }
-
-  renderProposalResultSummary(result) {
-    if (!result) return '';
-    return this.renderProposalResults(result);
   }
 
   renderProposalResults(result) {

--- a/app.js
+++ b/app.js
@@ -4560,6 +4560,9 @@ class ProposalInfoModal {
     const segments = result.totals
       .map((row, rowPosition) => {
         const isWinner = result.winner?.index === row.index;
+        const paletteClass = result.totals.length > 1
+          ? ` proposal-result-meter-label--palette-${rowPosition % 6}`
+          : '';
         const units = this.getResultSegmentUnits(row.total, result.totalWeight);
         const power = formatDaoVotingPower(row.total);
         const displayPower = power.endsWith(' power') ? power.slice(0, -6) : power;
@@ -4573,7 +4576,7 @@ class ProposalInfoModal {
         const label = `${row.option}: ${power}, ${percent}`;
         return `
           <div
-            class="proposal-result-meter-label proposal-result-meter-label--${position}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
+            class="proposal-result-meter-label proposal-result-meter-label--${position}${paletteClass}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
             style="${escapeDaoFormAttribute(style)}"
             title="${escapeDaoFormAttribute(label)}"
             aria-label="${escapeDaoFormAttribute(label)}"
@@ -4585,13 +4588,15 @@ class ProposalInfoModal {
       })
       .join('');
     const bars = result.totals
-      .map((row) => {
-        const isWinner = result.winner?.index === row.index;
+      .map((row, rowPosition) => {
+        const paletteClass = result.totals.length > 1
+          ? ` proposal-result-meter-segment--palette-${rowPosition % 6}`
+          : ' proposal-result-meter-segment--palette-0';
         const units = this.getResultSegmentUnits(row.total, result.totalWeight);
         const style = `--result-segment-units: ${units};`;
         return `
           <span
-            class="proposal-result-meter-segment${isWinner ? ' proposal-result-meter-segment--winner' : ''}${row.total === 0n ? ' proposal-result-meter-segment--empty' : ''}"
+            class="proposal-result-meter-segment${paletteClass}${row.total === 0n ? ' proposal-result-meter-segment--empty' : ''}"
             style="${escapeDaoFormAttribute(style)}"
           ></span>
         `;

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -670,6 +670,8 @@ function storeToUiList(store, groupKey) {
         claimedReward: p.claimedReward,
         initialBurnedReward: p.initialBurnedReward,
         finalBurnedReward: p.finalBurnedReward,
+        voterList: Array.isArray(p.voterList) ? p.voterList : [],
+        claimList: Array.isArray(p.claimList) ? p.claimList : [],
         startTime: p.startTime,
         reviewDuration: p.reviewDuration,
         votingDuration: p.votingDuration,

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -513,12 +513,10 @@ async function fetchBackendProposal(queryDaoApi, proposalNumber) {
   return body.proposal;
 }
 
-export function createDaoBackendFetcher(queryDaoApi, { batchSize = DAO_PROPOSAL_QUERY_BATCH_SIZE } = {}) {
+export function createDaoBackendFetcher(queryDaoApi) {
   if (typeof queryDaoApi !== 'function') {
     return async () => createEmptyDaoStore();
   }
-
-  const safeBatchSize = normalizeDaoPositiveInteger(batchSize) || DAO_PROPOSAL_QUERY_BATCH_SIZE;
 
   return async () => {
     const body = await queryDaoApi('/dao/proposals/meta');
@@ -534,8 +532,8 @@ export function createDaoBackendFetcher(queryDaoApi, { batchSize = DAO_PROPOSAL_
     if (!count) return buildStoreFromBackendProposals(meta, []);
 
     const proposals = [];
-    for (let start = 1; start <= count; start += safeBatchSize) {
-      const end = Math.min(start + safeBatchSize - 1, count);
+    for (let start = 1; start <= count; start += DAO_PROPOSAL_QUERY_BATCH_SIZE) {
+      const end = Math.min(start + DAO_PROPOSAL_QUERY_BATCH_SIZE - 1, count);
       const batch = await Promise.all(
         Array.from({ length: end - start + 1 }, (_, index) => fetchBackendProposal(queryDaoApi, start + index))
       );
@@ -655,6 +653,7 @@ function storeToUiList(store, groupKey) {
         description,
         type,
         proposalType: type,
+        emergency: Boolean(p.emergency),
         createdAt: p.created,
         state,
         status: state,

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -457,7 +457,6 @@ function mapBackendProposalToStoreProposal(proposal) {
     status: state,
     state_changed: stateChanged,
     created,
-    createdBy: proposal.createdBy || proposal.creator || proposal.from || '',
     fields: getDaoProposalFields(proposal),
     votes: getDaoProposalVotes(proposal),
   };
@@ -660,7 +659,6 @@ function storeToUiList(store, groupKey) {
         state,
         status: state,
         stateEnteredAt: p.state_changed,
-        createdBy: p.createdBy,
         fields: p.fields || {},
         options: Array.isArray(p.options) ? p.options : ['yes', 'no'],
         totalVote: Array.isArray(p.totalVote) ? p.totalVote : undefined,

--- a/index.html
+++ b/index.html
@@ -504,6 +504,7 @@
               <div class="proposal-vote-preview" id="proposalVotePreview"></div>
               <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalVoteSubmit" disabled>Submit vote</button>
             </section>
+            <div class="proposal-details" id="proposalDetailsContent"></div>
           </div>
         </div>
         <a class="last-item" href="#"> </a>

--- a/styles.css
+++ b/styles.css
@@ -2245,9 +2245,6 @@ input[type='file'].form-control::file-selector-button {
   display: grid;
   gap: 6px;
   padding: 10px;
-}
-
-#proposalInfoModal .proposal-result-card {
   text-align: center;
 }
 
@@ -2875,10 +2872,6 @@ input[type='file'].form-control::file-selector-button {
   background: rgba(101, 103, 107, 0.18);
 }
 
-#proposalInfoModal .proposal-vote-status-card--full {
-  grid-column: 1 / -1;
-}
-
 #proposalInfoModal .proposal-vote-status-card,
 #proposalInfoModal .proposal-vote-preview {
   background: var(--input-background);
@@ -2903,20 +2896,8 @@ input[type='file'].form-control::file-selector-button {
   padding: 8px 10px;
 }
 
-#proposalInfoModal .proposal-vote-status-card--full {
-  justify-self: center;
-  justify-items: center;
-  width: calc(66.666% - 4px);
-  grid-template-columns: minmax(0, 1fr);
-  text-align: center;
-}
-
 #proposalInfoModal .proposal-vote-status-card strong {
   text-align: right;
-}
-
-#proposalInfoModal .proposal-vote-status-card--full strong {
-  text-align: center;
 }
 
 #proposalInfoModal .proposal-vote-status-card span,

--- a/styles.css
+++ b/styles.css
@@ -2326,6 +2326,30 @@ input[type='file'].form-control::file-selector-button {
   color: #8f1d16;
 }
 
+#proposalInfoModal .proposal-result-meter-label--palette-0 > span {
+  color: #3d3dce;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-1 > span {
+  color: #65676b;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-2 > span {
+  color: #6f68e8;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-3 > span {
+  color: #838a93;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-4 > span {
+  color: #2f2fa8;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-5 > span {
+  color: #4e555f;
+}
+
 #proposalInfoModal .proposal-result-meter-track {
   background: var(--input-background);
   border: 1px solid var(--border-color);
@@ -2348,6 +2372,30 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-meter-segment--winner {
   background: var(--primary-color);
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-0 {
+  background: #3d3dce;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-1 {
+  background: #aeb3ba;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-2 {
+  background: #6f68e8;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-3 {
+  background: #c4c8ce;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-4 {
+  background: #2f2fa8;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-5 {
+  background: #8d949e;
 }
 
 #proposalInfoModal .proposal-result-meter-segment--accept {

--- a/styles.css
+++ b/styles.css
@@ -2471,6 +2471,81 @@ input[type='file'].form-control::file-selector-button {
   gap: 2px;
 }
 
+#proposalInfoModal .proposal-details {
+  display: grid;
+  margin: 12px auto 0;
+  max-width: 720px;
+  width: 100%;
+}
+
+#proposalInfoModal .proposal-details:empty {
+  display: none;
+}
+
+#proposalInfoModal .proposal-more {
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  display: grid;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-more summary {
+  align-items: center;
+  cursor: pointer;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: minmax(0, 1fr) 18px;
+  list-style: none;
+  padding: 12px;
+}
+
+#proposalInfoModal .proposal-more summary::-webkit-details-marker {
+  display: none;
+}
+
+#proposalInfoModal .proposal-more summary::after {
+  align-self: center;
+  border-bottom: 2px solid var(--secondary-text-color);
+  border-right: 2px solid var(--secondary-text-color);
+  content: "";
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  height: 8px;
+  justify-self: center;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  width: 8px;
+}
+
+#proposalInfoModal .proposal-more[open] summary {
+  border-bottom: 1px solid var(--border-color);
+}
+
+#proposalInfoModal .proposal-more[open] summary::after {
+  transform: rotate(225deg);
+}
+
+#proposalInfoModal .proposal-more-title {
+  color: var(--text-color);
+  font-size: 14px;
+  font-weight: var(--font-weight-semibold);
+  grid-column: 1;
+  line-height: 1.25;
+}
+
+#proposalInfoModal .proposal-more-note {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  grid-column: 1;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-more-content {
+  display: grid;
+  gap: 18px;
+  padding: 12px;
+}
+
 #proposalInfoModal .proposal-payload {
   display: grid;
   gap: 8px;
@@ -2675,6 +2750,10 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-vote-current-segment--empty {
   background: rgba(101, 103, 107, 0.18);
+}
+
+#proposalInfoModal .proposal-vote-status-card--full {
+  grid-column: 1 / -1;
 }
 
 #proposalInfoModal .proposal-vote-status-card,

--- a/styles.css
+++ b/styles.css
@@ -2128,7 +2128,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row {
   background: rgba(255, 255, 255, 0.92);
-  border: 2px solid var(--border-color);
+  border: 1px solid var(--border-color);
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
 }
 
@@ -2150,17 +2150,17 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row--accept {
   background: rgba(30, 126, 52, 0.16);
-  border: 2px solid rgba(30, 126, 52, 0.34);
+  border: 1px solid rgba(30, 126, 52, 0.34);
 }
 
 #proposalInfoModal .proposal-info-row--withhold {
   background: rgba(196, 45, 45, 0.14);
-  border: 2px solid rgba(196, 45, 45, 0.32);
+  border: 1px solid rgba(196, 45, 45, 0.32);
 }
 
 #confirmProposalModal .dao-confirm-label,
 #confirmProposalModal .dao-confirm-change-title,
-#proposalInfoModal .proposal-info-row span,
+#proposalInfoModal .proposal-info-row > span:not(.proposal-info-value),
 #proposalInfoModal .proposal-change-row span {
   color: var(--secondary-text-color);
   font-size: 12px;
@@ -2181,7 +2181,6 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm-value,
 #confirmProposalModal .dao-confirm-change-values strong,
-#proposalInfoModal .proposal-info-row strong,
 #proposalInfoModal .proposal-change-row strong {
   color: var(--text-color);
   font-size: 13px;
@@ -2193,22 +2192,33 @@ input[type='file'].form-control::file-selector-button {
   white-space: pre-wrap;
 }
 
-#proposalInfoModal .proposal-info-row--accept strong {
+#proposalInfoModal .proposal-info-value {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-normal);
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-align: center;
+  white-space: pre-wrap;
+}
+
+#proposalInfoModal .proposal-info-row--accept .proposal-info-value {
   color: #0f5f27;
 }
 
-#proposalInfoModal .proposal-info-row--withhold strong {
+#proposalInfoModal .proposal-info-row--withhold .proposal-info-value {
   color: #8f1d16;
 }
 
 #confirmProposalModal .dao-confirm-label,
-#proposalInfoModal .proposal-info-row span {
+#proposalInfoModal .proposal-info-row > span:not(.proposal-info-value) {
   align-self: start;
   justify-self: center;
 }
 
 #confirmProposalModal .dao-confirm-value,
-#proposalInfoModal .proposal-info-row strong {
+#proposalInfoModal .proposal-info-value {
   align-self: center;
   justify-self: center;
 }
@@ -2270,11 +2280,10 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#proposalInfoModal .proposal-result-card strong,
-#proposalInfoModal .proposal-result-row strong {
+#proposalInfoModal .proposal-result-value {
   color: var(--text-color);
   font-size: 13px;
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-normal);
   line-height: 1.35;
   overflow-wrap: anywhere;
 }
@@ -2298,7 +2307,7 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
-#proposalInfoModal .proposal-result-row > strong,
+#proposalInfoModal .proposal-result-row > .proposal-result-value,
 #proposalInfoModal .proposal-result-row > small {
   justify-self: end;
   text-align: right;
@@ -2327,6 +2336,34 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
   overflow-wrap: anywhere;
   white-space: normal;
+}
+
+#proposalInfoModal .proposal-change-row {
+  flex: 0 1 calc(50% - 5px);
+  min-width: min(100%, 180px);
+}
+
+#proposalInfoModal .proposal-change-row--single {
+  background: rgba(255, 255, 255, 0.92);
+  border: 0 solid var(--border-color);
+  border-radius: 0 0 8px 8px;
+  border-width: 0 1px 1px;
+  box-shadow: 0 2px 2px rgba(28, 28, 33, 0.04);
+  flex-basis: calc(66.666% - 4px);
+}
+
+#proposalInfoModal .proposal-change-row--wide {
+  flex-basis: 100%;
+}
+
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values {
+  grid-template-columns: max-content 16px max-content;
+  justify-content: center;
+}
+
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values small,
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
+  white-space: nowrap;
 }
 
 #confirmProposalModal .dao-confirm-change-values,
@@ -2455,7 +2492,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
 #proposalInfoModal .proposal-vote-actions {
-  border: 2px solid var(--border-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   display: grid;
   gap: 8px;
@@ -2483,7 +2520,7 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-more {
-  border: 2px solid var(--border-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   display: grid;
   overflow: hidden;
@@ -2547,14 +2584,16 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-payload {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  justify-content: center;
 }
 
 #proposalInfoModal .proposal-payload-title {
   color: var(--text-color);
+  flex: 0 0 100%;
   font-size: 13px;
-  font-weight: var(--font-weight-semibold);
   line-height: 1.3;
   text-align: center;
 }
@@ -2780,8 +2819,20 @@ input[type='file'].form-control::file-selector-button {
   padding: 8px 10px;
 }
 
+#proposalInfoModal .proposal-vote-status-card--full {
+  justify-self: center;
+  justify-items: center;
+  width: calc(66.666% - 4px);
+  grid-template-columns: minmax(0, 1fr);
+  text-align: center;
+}
+
 #proposalInfoModal .proposal-vote-status-card strong {
   text-align: right;
+}
+
+#proposalInfoModal .proposal-vote-status-card--full strong {
+  text-align: center;
 }
 
 #proposalInfoModal .proposal-vote-status-card span,
@@ -2961,7 +3012,7 @@ input[type='file'].form-control::file-selector-button {
     grid-template-columns: minmax(0, 1fr) 92px;
   }
 
-  #proposalInfoModal .proposal-result-row > strong,
+  #proposalInfoModal .proposal-result-row > .proposal-result-value,
   #proposalInfoModal .proposal-result-row > small {
     justify-self: start;
     text-align: left;

--- a/styles.css
+++ b/styles.css
@@ -2372,20 +2372,10 @@ input[type='file'].form-control::file-selector-button {
   padding: 8px;
 }
 
-#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values {
-  grid-template-columns: minmax(0, 1fr) 12px minmax(0, 1fr);
-  justify-content: center;
-}
-
-#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values small,
-#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
-  overflow-wrap: anywhere;
-  white-space: normal;
-}
-
 #proposalInfoModal .proposal-change-row {
-  flex: 0 1 calc(50% - 5px);
+  flex: 0 1 calc(50% - 4px);
   min-width: min(100%, 180px);
+  min-inline-size: 0;
 }
 
 #proposalInfoModal .proposal-change-row--single {
@@ -2402,13 +2392,14 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values {
-  grid-template-columns: max-content 16px max-content;
+  grid-template-columns: minmax(0, 1fr) 12px minmax(0, 1fr);
   justify-content: center;
 }
 
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values small,
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 #confirmProposalModal .dao-confirm-change-values,
@@ -2555,7 +2546,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-details {
   display: grid;
-  margin: 12px auto 0;
+  margin: 10px auto 0;
   max-width: 720px;
   width: 100%;
 }
@@ -2578,7 +2569,7 @@ input[type='file'].form-control::file-selector-button {
   gap: 4px;
   grid-template-columns: minmax(0, 1fr) 18px;
   list-style: none;
-  padding: 12px;
+  padding: 10px;
 }
 
 #proposalInfoModal .proposal-more summary::-webkit-details-marker {
@@ -2624,8 +2615,8 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-more-content {
   display: grid;
-  gap: 18px;
-  padding: 12px;
+  gap: 14px;
+  padding: 10px;
 }
 
 #proposalInfoModal .proposal-payload {

--- a/styles.css
+++ b/styles.css
@@ -7931,7 +7931,7 @@ small {
   align-items: center;
   color: var(--secondary-text-color);
   display: flex;
-  gap: 18px;
+  gap: 10px;
   min-width: 0;
   width: 100%;
 }
@@ -7944,13 +7944,8 @@ small {
 }
 
 #daoModal .dao-row-meta-item--type {
-  flex: 1 1 auto;
-}
-
-#daoModal .dao-row-meta-item--updated {
   flex: 0 0 auto;
-  margin-left: auto;
-  white-space: nowrap;
+  max-width: 34%;
 }
 
 #daoModal .dao-row-meta-label {
@@ -7969,18 +7964,18 @@ small {
   font-weight: var(--font-weight-semibold);
   line-height: 1.2;
   min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-#daoModal .dao-row-meta-item--updated .dao-row-meta-value {
-  overflow-wrap: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 #daoModal .dao-row-previews {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  gap: 4px;
+  justify-content: flex-end;
+  margin-left: auto;
   min-width: 0;
 }
 
@@ -7990,9 +7985,11 @@ small {
   border: 1px solid var(--border-color);
   border-radius: 8px;
   display: inline-flex;
-  gap: 5px;
+  flex: 0 1 auto;
+  gap: 4px;
   max-width: 100%;
-  padding: 5px 7px;
+  min-width: 0;
+  padding: 4px 6px;
 }
 
 #daoModal .dao-row-preview--accepted,
@@ -8012,6 +8009,7 @@ small {
   font-size: 11px;
   font-weight: var(--font-weight-medium);
   line-height: 1.2;
+  white-space: nowrap;
 }
 
 #daoModal .dao-row-preview strong {
@@ -8020,7 +8018,9 @@ small {
   font-weight: var(--font-weight-semibold);
   line-height: 1.2;
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 #daoStatusContextMenu {

--- a/styles.css
+++ b/styles.css
@@ -2238,8 +2238,10 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-card {
   background: rgba(255, 255, 255, 0.92);
-  border-radius: 8px;
-  box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
+  border: 0 solid var(--border-color);
+  border-radius: 0 0 8px 8px;
+  border-width: 0 1px 1px;
+  box-shadow: 0 2px 2px rgba(28, 28, 33, 0.04);
   display: grid;
   gap: 6px;
   padding: 10px;
@@ -2281,6 +2283,11 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-meter-labels--balanced .proposal-result-meter-label {
   flex: 1 1 0;
+}
+
+#proposalInfoModal .proposal-result-meter-label--start {
+  justify-items: start;
+  text-align: left;
 }
 
 #proposalInfoModal .proposal-result-meter-label--center {

--- a/styles.css
+++ b/styles.css
@@ -2223,41 +2223,11 @@ input[type='file'].form-control::file-selector-button {
   justify-self: center;
 }
 
-#proposalInfoModal .proposal-result-banner {
-  background: var(--input-background);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  display: grid;
-  gap: 6px;
-  padding: 12px;
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-result-banner--accepted {
-  background: rgba(30, 126, 52, 0.14);
-  border-color: rgba(30, 126, 52, 0.34);
-}
-
-#proposalInfoModal .proposal-result-banner--rejected {
-  background: rgba(196, 45, 45, 0.12);
-  border-color: rgba(196, 45, 45, 0.3);
-}
-
-#proposalInfoModal .proposal-result-banner span,
-#proposalInfoModal .proposal-result-banner small,
 #proposalInfoModal .proposal-result-card span,
-#proposalInfoModal .proposal-result-row small {
+#proposalInfoModal .proposal-result-meter-label small {
   color: var(--secondary-text-color);
   font-size: 12px;
   line-height: 1.35;
-}
-
-#proposalInfoModal .proposal-result-banner strong {
-  color: var(--text-color);
-  font-size: 16px;
-  font-weight: var(--font-weight-semibold);
-  line-height: 1.25;
-  overflow-wrap: anywhere;
 }
 
 #proposalInfoModal .proposal-result-overview {
@@ -2266,8 +2236,7 @@ input[type='file'].form-control::file-selector-button {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-#proposalInfoModal .proposal-result-card,
-#proposalInfoModal .proposal-result-row {
+#proposalInfoModal .proposal-result-card {
   background: rgba(255, 255, 255, 0.92);
   border-radius: 8px;
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
@@ -2288,33 +2257,102 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
-#proposalInfoModal .proposal-result-list {
+#proposalInfoModal .proposal-result-meter {
   display: grid;
   gap: 8px;
+  min-width: 0;
 }
 
-#proposalInfoModal .proposal-result-row {
+#proposalInfoModal .proposal-result-meter-labels,
+#proposalInfoModal .proposal-result-meter-track {
   align-items: center;
-  grid-template-columns: minmax(0, 1fr) minmax(96px, auto) 52px;
+  display: flex;
+  min-width: 0;
+  width: 100%;
 }
 
-#proposalInfoModal .proposal-result-row > span {
+#proposalInfoModal .proposal-result-meter-label {
+  display: grid;
+  flex: var(--result-segment-units) 1 0;
+  gap: 2px;
+  min-width: 0;
+  padding: 0 4px;
+}
+
+#proposalInfoModal .proposal-result-meter-labels--balanced .proposal-result-meter-label {
+  flex: 1 1 0;
+}
+
+#proposalInfoModal .proposal-result-meter-label--center {
+  justify-items: center;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-meter-label--end {
+  justify-items: end;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-result-meter-label > span {
   color: var(--secondary-text-color);
   font-size: 12px;
   font-weight: var(--font-weight-medium);
   line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-result-meter-label > span,
+#proposalInfoModal .proposal-result-meter-label > small {
+  max-width: 100%;
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
-#proposalInfoModal .proposal-result-row > .proposal-result-value,
-#proposalInfoModal .proposal-result-row > small {
-  justify-self: end;
-  text-align: right;
+#proposalInfoModal .proposal-result-meter-label--winner > span {
+  color: var(--text-color);
 }
 
-#proposalInfoModal .proposal-result-row--winner {
-  border: 1px solid var(--primary-tint-40);
+#proposalInfoModal .proposal-result-meter-label--accept.proposal-result-meter-label--winner > span {
+  color: #0f5f27;
+}
+
+#proposalInfoModal .proposal-result-meter-label--withhold.proposal-result-meter-label--winner > span {
+  color: #8f1d16;
+}
+
+#proposalInfoModal .proposal-result-meter-track {
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  height: 16px;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-result-meter-segment {
+  align-self: stretch;
+  background: rgba(101, 103, 107, 0.34);
+  border-left: 1px solid rgba(255, 255, 255, 0.72);
+  flex: var(--result-segment-units) 1 0;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-result-meter-segment:first-child {
+  border-left: 0;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--winner {
+  background: var(--primary-color);
+}
+
+#proposalInfoModal .proposal-result-meter-segment--accept {
+  background: #1e7e34;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--withhold {
+  background: #c42d2d;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--empty {
+  background: rgba(101, 103, 107, 0.18);
 }
 
 #confirmProposalModal .dao-confirm-change,
@@ -3003,19 +3041,12 @@ input[type='file'].form-control::file-selector-button {
 }
 
 @media (max-width: 520px) {
-  #proposalInfoModal .proposal-result-overview,
-  #proposalInfoModal .proposal-result-row {
+  #proposalInfoModal .proposal-result-overview {
     grid-template-columns: minmax(0, 1fr);
   }
 
   #proposalInfoModal .proposal-vote-option {
     grid-template-columns: minmax(0, 1fr) 92px;
-  }
-
-  #proposalInfoModal .proposal-result-row > .proposal-result-value,
-  #proposalInfoModal .proposal-result-row > small {
-    justify-self: start;
-    text-align: left;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -2213,6 +2213,101 @@ input[type='file'].form-control::file-selector-button {
   justify-self: center;
 }
 
+#proposalInfoModal .proposal-result-banner {
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-banner--accepted {
+  background: rgba(30, 126, 52, 0.14);
+  border-color: rgba(30, 126, 52, 0.34);
+}
+
+#proposalInfoModal .proposal-result-banner--rejected {
+  background: rgba(196, 45, 45, 0.12);
+  border-color: rgba(196, 45, 45, 0.3);
+}
+
+#proposalInfoModal .proposal-result-banner span,
+#proposalInfoModal .proposal-result-banner small,
+#proposalInfoModal .proposal-result-card span,
+#proposalInfoModal .proposal-result-row small {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-result-banner strong {
+  color: var(--text-color);
+  font-size: 16px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-overview {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+#proposalInfoModal .proposal-result-card,
+#proposalInfoModal .proposal-result-row {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+}
+
+#proposalInfoModal .proposal-result-card {
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-card strong,
+#proposalInfoModal .proposal-result-row strong {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-list {
+  display: grid;
+  gap: 8px;
+}
+
+#proposalInfoModal .proposal-result-row {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) minmax(96px, auto) 52px;
+}
+
+#proposalInfoModal .proposal-result-row > span {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-row > strong,
+#proposalInfoModal .proposal-result-row > small {
+  justify-self: end;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-result-row--winner {
+  border: 1px solid var(--primary-tint-40);
+}
+
 #confirmProposalModal .dao-confirm-change,
 #proposalInfoModal .proposal-change-row {
   background: var(--input-background);
@@ -2778,8 +2873,19 @@ input[type='file'].form-control::file-selector-button {
 }
 
 @media (max-width: 520px) {
+  #proposalInfoModal .proposal-result-overview,
+  #proposalInfoModal .proposal-result-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   #proposalInfoModal .proposal-vote-option {
     grid-template-columns: minmax(0, 1fr) 92px;
+  }
+
+  #proposalInfoModal .proposal-result-row > strong,
+  #proposalInfoModal .proposal-result-row > small {
+    justify-self: start;
+    text-align: left;
   }
 }
 
@@ -7701,6 +7807,52 @@ small {
 #daoModal .dao-row-meta-item--updated .dao-row-meta-value {
   overflow-wrap: normal;
   white-space: nowrap;
+}
+
+#daoModal .dao-row-previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+#daoModal .dao-row-preview {
+  align-items: baseline;
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  display: inline-flex;
+  gap: 5px;
+  max-width: 100%;
+  padding: 5px 7px;
+}
+
+#daoModal .dao-row-preview--accepted,
+#daoModal .dao-row-preview--accept {
+  background: rgba(30, 126, 52, 0.12);
+  border-color: rgba(30, 126, 52, 0.3);
+}
+
+#daoModal .dao-row-preview--rejected {
+  background: rgba(196, 45, 45, 0.1);
+  border-color: rgba(196, 45, 45, 0.28);
+}
+
+#daoModal .dao-row-preview span {
+  color: var(--secondary-text-color);
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
+}
+
+#daoModal .dao-row-preview strong {
+  color: var(--text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.2;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 #daoStatusContextMenu {

--- a/styles.css
+++ b/styles.css
@@ -2128,6 +2128,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row {
   background: rgba(255, 255, 255, 0.92);
+  border: 2px solid var(--border-color);
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
 }
 
@@ -2135,12 +2136,11 @@ input[type='file'].form-control::file-selector-button {
   grid-column: 2 / span 2;
 }
 
-#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) {
-  grid-column: 2 / span 2;
-}
-
-#proposalInfoModal .proposal-info-row--center-pair {
-  grid-column: 2 / span 2;
+#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1),
+#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) + .proposal-info-row,
+#proposalInfoModal .proposal-info-row--center-pair,
+#proposalInfoModal .proposal-info-row--center-pair + .proposal-info-row {
+  grid-column: span 3;
 }
 
 #confirmProposalModal .dao-confirm-row--full,
@@ -2150,12 +2150,12 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row--accept {
   background: rgba(30, 126, 52, 0.16);
-  border: 1px solid rgba(30, 126, 52, 0.34);
+  border: 2px solid rgba(30, 126, 52, 0.34);
 }
 
 #proposalInfoModal .proposal-info-row--withhold {
   background: rgba(196, 45, 45, 0.14);
-  border: 1px solid rgba(196, 45, 45, 0.32);
+  border: 2px solid rgba(196, 45, 45, 0.32);
 }
 
 #confirmProposalModal .dao-confirm-label,
@@ -2455,7 +2455,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
 #proposalInfoModal .proposal-vote-actions {
-  border: 1px solid var(--border-color);
+  border: 2px solid var(--border-color);
   border-radius: 8px;
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## Superseded

This split PR has been folded into #1449, which is now retargeted to `issue-1423-voting-flow-transaction-integration` and represents the combined Phase 6.A results/rewards UI work.

The original detailed summary is preserved below.

## What Changed

This PR adds the Phase 6.A DAO proposal results and rewards presentation layer.

- DAO proposal rows now show compact Result and Reward preview chips through `renderProposalRowPreview(proposal)`.
- `dao.repo.js` now carries final-state fields into UI records, including `emergency`, reward pool fields, `voterList`, `claimList`, and DAO timing durations.
- `index.html` adds `#proposalDetailsContent`, and `ProposalInfoModal` now renders longer detail/accounting content into a collapsible proposal details drawer.
- `getDaoProposalResultSummary(proposal)` now summarizes committee outcomes for withheld/emergency final proposals and vote outcomes for final vote states.
- `renderProposalResults(result)` renders final vote results with winner/total cards and a segmented meter, while `renderCommitteeResults(result)` renders accept/withhold committee outcomes.
- `getDaoProposalRewardSummary(proposal, currentAddress, now)` computes reward status, claim window, claim estimate, claimed/unclaimed pool, and burn accounting from server-shaped proposal data.
- `renderProposalRewards(reward)` adds reward accounting rows inside the details drawer.
- `styles.css` adds compact row-preview chips, result-meter palettes, and the collapsible proposal details layout.
- `createDaoBackendFetcher(queryDaoApi)` now always uses the shared internal `DAO_PROPOSAL_QUERY_BATCH_SIZE`.

## Validation

- `git show issue-1424-results-rewards-ui:app.js | node --check --input-type=module -`
- `git show issue-1424-results-rewards-ui:dao.repo.js | node --check --input-type=module -`
- `git diff --check issue-1423-voting-flow-transaction-integration..issue-1424-results-rewards-ui`