### PR TITLE
Phase 6.A: Results And Rewards UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -4583,7 +4583,7 @@ class ProposalInfoModal {
         return `
           <div class="proposal-result-row${isWinner ? ' proposal-result-row--winner' : ''}">
             <span>${escapeHtml(row.option)}</span>
-            <strong>${escapeHtml(formatDaoVotingPower(row.total))}</strong>
+            <span class="proposal-result-value">${escapeHtml(formatDaoVotingPower(row.total))}</span>
             <small>${escapeHtml(formatDaoBigIntPercent(row.total, result.totalWeight))}</small>
           </div>
         `;
@@ -4596,11 +4596,11 @@ class ProposalInfoModal {
         <div class="proposal-result-overview">
           <div class="proposal-result-card">
             <span>Winner</span>
-            <strong>${escapeHtml(winnerLabel)}</strong>
+            <span class="proposal-result-value">${escapeHtml(winnerLabel)}</span>
           </div>
           <div class="proposal-result-card">
             <span>Total voting power</span>
-            <strong>${escapeHtml(totalLabel)}</strong>
+            <span class="proposal-result-value">${escapeHtml(totalLabel)}</span>
           </div>
         </div>
         <div class="proposal-result-list">${rows}</div>
@@ -4705,7 +4705,7 @@ class ProposalInfoModal {
       .map((row) => `
         <div class="${row.classes.join(' ')}">
           <span>${escapeHtml(row.label)}</span>
-          <strong>${escapeHtml(row.value)}</strong>
+          <span class="proposal-info-value">${escapeHtml(row.value)}</span>
         </div>
       `)
       .join('');
@@ -4793,36 +4793,66 @@ class ProposalInfoModal {
     `;
   }
 
+  getParameterChangeRowClass(parts, { isSingleRow = false } = {}) {
+    const normalizedParts = parts.map((part) => String(part ?? '').trim());
+    const shouldUseWideRow = normalizedParts.some((part) => part.length > 22)
+      || normalizedParts.join(' ').length > 52;
+    return [
+      'proposal-change-row',
+      shouldUseWideRow ? 'proposal-change-row--wide' : '',
+      !shouldUseWideRow && isSingleRow ? 'proposal-change-row--single' : '',
+    ].filter(Boolean).join(' ');
+  }
+
   renderPayloadRows(payload, payloadTitle = '') {
     const titleHtml = payloadTitle
       ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
       : '';
 
     if (Array.isArray(payload?.changes)) {
-      return payload.changes
-        .map((change) => `
-          <div class="proposal-change-row">
+      const changes = payload.changes;
+      return changes
+        .map((change, index) => {
+          const key = change?.key || 'Unknown key';
+          const current = formatDaoDetailValue(change?.current);
+          const next = formatDaoDetailValue(change?.value);
+          const rowClass = this.getParameterChangeRowClass(
+            [key, `Current: ${current}`, `New: ${next}`],
+            { isSingleRow: index === changes.length - 1 && changes.length % 2 === 1 },
+          );
+          return `
+          <div class="${rowClass}">
             ${titleHtml}
-            <span>${escapeHtml(change?.key || 'Unknown key')}</span>
+            <span>${escapeHtml(key)}</span>
             <div class="proposal-change-values">
-              <small><span>Current:</span><strong>${escapeHtml(formatDaoDetailValue(change?.current))}</strong></small>
+              <small><span>Current:</span><strong>${escapeHtml(current)}</strong></small>
               <span class="proposal-change-arrow" aria-hidden="true">&rarr;</span>
-              <strong><span>New:</span><span>${escapeHtml(formatDaoDetailValue(change?.value))}</span></strong>
+              <strong><span>New:</span><span>${escapeHtml(next)}</span></strong>
             </div>
           </div>
-        `)
+        `;
+        })
         .join('');
     }
 
-    return Object.entries(payload)
-      .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0)
-      .map(([key, value]) => `
-        <div class="proposal-change-row">
+    const entries = Object.entries(payload)
+      .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0);
+
+    return entries
+      .map(([key, value], index) => {
+        const displayValue = formatDaoDetailValue(value);
+        const rowClass = this.getParameterChangeRowClass(
+          [key, displayValue],
+          { isSingleRow: index === entries.length - 1 && entries.length % 2 === 1 },
+        );
+        return `
+        <div class="${rowClass}">
           ${titleHtml}
           <span>${escapeHtml(key)}</span>
-          <strong>${escapeHtml(formatDaoDetailValue(value))}</strong>
+          <strong>${escapeHtml(displayValue)}</strong>
         </div>
-      `)
+      `;
+      })
       .join('');
   }
 

--- a/app.js
+++ b/app.js
@@ -3983,11 +3983,14 @@ function getDaoCommitteeReviewResultSummary(proposal) {
   const outcome = getDaoFinalOutcome(proposal);
 
   return {
+    acceptCount,
+    committeeSize: committeeAddresses.length,
     detail: `Committee review: ${acceptCount} accept, ${withholdCount} withhold.`,
     headline: outcome.label,
     label: 'Final result',
     source: 'committee',
     tone: outcome.tone,
+    withholdCount,
     rows: [
       ['Decision source', 'Committee review'],
       ['Outcome', outcome.label, outcome.tone === 'accepted' ? 'accept' : 'withhold'],
@@ -4560,32 +4563,55 @@ class ProposalInfoModal {
 
   renderProposalResultSummary(result) {
     if (!result) return '';
-    return `
-      <section class="proposal-result-banner proposal-result-banner--${escapeDaoFormAttribute(result.tone)}">
-        <span>${escapeHtml(result.label)}</span>
-        <strong>${escapeHtml(result.headline)}</strong>
-        <small>${escapeHtml(result.detail)}</small>
-      </section>
-    `;
+    return this.renderProposalResults(result);
   }
 
   renderProposalResults(result) {
     if (!result) return '';
     if (result.source === 'committee') {
-      return this.renderSection('Results', result.rows);
+      return this.renderCommitteeResults(result);
     }
 
     const winnerLabel = result.winner ? `${result.winner.option} (${result.outcome})` : 'Unavailable';
     const totalLabel = result.totalWeight > 0n ? formatDaoVotingPower(result.totalWeight) : 'No votes yet';
-    const rows = result.totals
+    const labelLayout = result.totals.length === 2 ? 'balanced' : 'segmented';
+    const segments = result.totals
+      .map((row, rowPosition) => {
+        const isWinner = result.winner?.index === row.index;
+        const units = this.getResultSegmentUnits(row.total, result.totalWeight);
+        const power = formatDaoVotingPower(row.total);
+        const displayPower = power.endsWith(' power') ? power.slice(0, -6) : power;
+        const percent = formatDaoBigIntPercent(row.total, result.totalWeight);
+        const position = rowPosition === 0
+          ? 'start'
+          : rowPosition === result.totals.length - 1
+            ? 'end'
+            : 'center';
+        const style = `--result-segment-units: ${units};`;
+        const label = `${row.option}: ${power}, ${percent}`;
+        return `
+          <div
+            class="proposal-result-meter-label proposal-result-meter-label--${position}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
+            style="${escapeDaoFormAttribute(style)}"
+            title="${escapeDaoFormAttribute(label)}"
+            aria-label="${escapeDaoFormAttribute(label)}"
+          >
+            <span>${escapeHtml(row.option)}</span>
+            <small>${escapeHtml(displayPower)} / ${escapeHtml(percent)}</small>
+          </div>
+        `;
+      })
+      .join('');
+    const bars = result.totals
       .map((row) => {
         const isWinner = result.winner?.index === row.index;
+        const units = this.getResultSegmentUnits(row.total, result.totalWeight);
+        const style = `--result-segment-units: ${units};`;
         return `
-          <div class="proposal-result-row${isWinner ? ' proposal-result-row--winner' : ''}">
-            <span>${escapeHtml(row.option)}</span>
-            <span class="proposal-result-value">${escapeHtml(formatDaoVotingPower(row.total))}</span>
-            <small>${escapeHtml(formatDaoBigIntPercent(row.total, result.totalWeight))}</small>
-          </div>
+          <span
+            class="proposal-result-meter-segment${isWinner ? ' proposal-result-meter-segment--winner' : ''}${row.total === 0n ? ' proposal-result-meter-segment--empty' : ''}"
+            style="${escapeDaoFormAttribute(style)}"
+          ></span>
         `;
       })
       .join('');
@@ -4603,9 +4629,93 @@ class ProposalInfoModal {
             <span class="proposal-result-value">${escapeHtml(totalLabel)}</span>
           </div>
         </div>
-        <div class="proposal-result-list">${rows}</div>
+        <div class="proposal-result-meter" aria-label="Vote result breakdown">
+          <div class="proposal-result-meter-labels proposal-result-meter-labels--${labelLayout}">${segments}</div>
+          <div class="proposal-result-meter-track" aria-hidden="true">${bars}</div>
+        </div>
       </section>
     `;
+  }
+
+  renderCommitteeResults(result) {
+    const acceptCount = Number(result.acceptCount || 0);
+    const withholdCount = Number(result.withholdCount || 0);
+    const submittedCount = acceptCount + withholdCount;
+    const committeeSize = Number(result.committeeSize || 0);
+    const committeeSizeLabel = committeeSize > 0 ? String(committeeSize) : 'Unavailable';
+    const acceptPercent = this.formatCountPercent(acceptCount, submittedCount);
+    const withholdPercent = this.formatCountPercent(withholdCount, submittedCount);
+    const acceptUnits = this.getCountResultSegmentUnits(acceptCount, submittedCount);
+    const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
+    const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
+    const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
+    const acceptSegmentWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-segment--winner' : '';
+    const withholdSegmentWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-segment--winner' : '';
+
+    return `
+      <section class="proposal-info-section">
+        <h3>Results</h3>
+        <div class="proposal-result-overview">
+          <div class="proposal-result-card">
+            <span>Outcome</span>
+            <span class="proposal-result-value">${escapeHtml(result.headline || 'Unavailable')}</span>
+          </div>
+          <div class="proposal-result-card">
+            <span>Committee size</span>
+            <span class="proposal-result-value">${escapeHtml(committeeSizeLabel)}</span>
+          </div>
+        </div>
+        <div class="proposal-result-meter" aria-label="Committee result breakdown">
+          <div class="proposal-result-meter-labels proposal-result-meter-labels--balanced">
+            <div
+              class="proposal-result-meter-label proposal-result-meter-label--start proposal-result-meter-label--accept${acceptWinnerClass}"
+              style="--result-segment-units: ${acceptUnits};"
+              title="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
+              aria-label="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
+            >
+              <span>Accept</span>
+              <small>${escapeHtml(`${acceptCount} / ${acceptPercent}`)}</small>
+            </div>
+            <div
+              class="proposal-result-meter-label proposal-result-meter-label--end proposal-result-meter-label--withhold${withholdWinnerClass}"
+              style="--result-segment-units: ${withholdUnits};"
+              title="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
+              aria-label="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
+            >
+              <span>Withhold</span>
+              <small>${escapeHtml(`${withholdCount} / ${withholdPercent}`)}</small>
+            </div>
+          </div>
+          <div class="proposal-result-meter-track" aria-hidden="true">
+            <span
+              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptSegmentWinnerClass}${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              style="--result-segment-units: ${acceptUnits};"
+            ></span>
+            <span
+              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdSegmentWinnerClass}${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              style="--result-segment-units: ${withholdUnits};"
+            ></span>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  getResultSegmentUnits(part, total) {
+    if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return 1;
+    const units = Number((part * 1000n + total / 2n) / total);
+    return Math.max(1, units);
+  }
+
+  getCountResultSegmentUnits(part, total) {
+    if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return 1;
+    if (part <= 0) return 0;
+    return Math.max(1, Math.round((part / total) * 1000));
+  }
+
+  formatCountPercent(part, total) {
+    if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return '0%';
+    return formatDaoPercent(part / total);
   }
 
   renderProposalRewards(reward) {
@@ -4656,7 +4766,6 @@ class ProposalInfoModal {
       ]),
       state === 'voting' ? this.renderVotingDetails(proposal) : '',
       this.renderProposalBody(proposal),
-      this.renderProposalResults(resultSummary),
       this.renderProposalRewards(rewardSummary),
     ].filter(Boolean);
 
@@ -4676,7 +4785,6 @@ class ProposalInfoModal {
   getProposalDetailsSummary(state, resultSummary, rewardSummary) {
     const parts = ['Overview', 'review timeline', 'proposal body'];
     if (state === 'voting') parts.push('voting totals');
-    if (resultSummary) parts.push('result breakdown');
     if (rewardSummary) parts.push('reward accounting');
     return parts.join(', ');
   }

--- a/app.js
+++ b/app.js
@@ -3698,9 +3698,9 @@ class ConfirmProposalModal {
           <div class="dao-confirm-change">
             <div class="dao-confirm-change-title">Change ${index + 1}: ${escapeHtml(change.key)}</div>
             <div class="dao-confirm-change-values">
-              <small>Current: ${escapeHtml(formatDaoConfirmValue(change.current))}</small>
+              <small><span>Current:</span><strong>${escapeHtml(formatDaoConfirmValue(change.current))}</strong></small>
               <span class="dao-confirm-change-arrow" aria-hidden="true">&rarr;</span>
-              <strong>New: ${escapeHtml(formatDaoConfirmValue(change.value))}</strong>
+              <small><span>New:</span><strong>${escapeHtml(formatDaoConfirmValue(change.value))}</strong></small>
             </div>
           </div>
         `).join('')
@@ -4767,28 +4767,22 @@ class ProposalInfoModal {
   }
 
   renderSection(title, rows) {
-    const renderedRows = rows.map(([label, value, tone]) => {
-      const displayValue = formatDaoDetailValue(value);
-      const rowClass = this.getSectionRowClass(label, displayValue);
-      return {
-        label,
-        value: displayValue,
-        classes: [
+    const rowHtml = rows
+      .map(([label, value, tone]) => {
+        const displayValue = formatDaoDetailValue(value);
+        const rowClass = this.getSectionRowClass(label, displayValue);
+        const classes = [
           rowClass,
           tone ? `proposal-info-row--${tone}` : '',
-        ].filter(Boolean),
-        isFull: rowClass.includes('proposal-info-row--full'),
-      };
-    });
-    this.centerTwoCardRows(renderedRows);
+        ].filter(Boolean);
 
-    const rowHtml = renderedRows
-      .map((row) => `
-        <div class="${row.classes.join(' ')}">
-          <span>${escapeHtml(row.label)}</span>
-          <span class="proposal-info-value">${escapeHtml(row.value)}</span>
+        return `
+        <div class="${classes.join(' ')}">
+          <span>${escapeHtml(label)}</span>
+          <span class="proposal-info-value">${escapeHtml(displayValue)}</span>
         </div>
-      `)
+      `;
+      })
       .join('');
 
     return `
@@ -4797,24 +4791,6 @@ class ProposalInfoModal {
         <div class="proposal-info-grid">${rowHtml}</div>
       </section>
     `;
-  }
-
-  centerTwoCardRows(renderedRows) {
-    let row = [];
-    const flush = () => {
-      if (row.length === 2) row[0].classes.push('proposal-info-row--center-pair');
-      row = [];
-    };
-
-    for (const renderedRow of renderedRows) {
-      if (renderedRow.isFull) {
-        flush();
-        continue;
-      }
-      row.push(renderedRow);
-      if (row.length === 3) flush();
-    }
-    flush();
   }
 
   getSectionRowClass(label, value) {

--- a/app.js
+++ b/app.js
@@ -4357,6 +4357,7 @@ class ProposalInfoModal {
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResults(resultSummary),
+        state === 'review' ? this.renderProposalBody(proposal) : '',
         committeeReviewSection,
       ].filter(Boolean).join('');
     }
@@ -4736,7 +4737,7 @@ class ProposalInfoModal {
         ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
       ]),
       state === 'voting' ? this.renderVotingDetails(proposal) : '',
-      this.renderProposalBody(proposal),
+      state === 'review' ? '' : this.renderProposalBody(proposal),
       this.renderProposalRewards(rewardSummary),
     ].filter(Boolean);
 
@@ -4754,7 +4755,8 @@ class ProposalInfoModal {
   }
 
   getProposalDetailsSummary(state, resultSummary, rewardSummary) {
-    const parts = ['Overview', 'review timeline', 'proposal body'];
+    const parts = ['Overview', 'review timeline'];
+    if (state !== 'review') parts.push('proposal body');
     if (state === 'voting') parts.push('voting totals');
     if (rewardSummary) parts.push('reward accounting');
     return parts.join(', ');

--- a/app.js
+++ b/app.js
@@ -2466,9 +2466,14 @@ function formatDaoTimestamp(ts) {
   }
 }
 
-function getDaoUiStateLabel(key) {
-  if (key === 'discussion') return 'Review';
-  return getDaoStateLabel(key);
+function formatDaoDate(ts) {
+  const n = Number(ts || 0);
+  if (!n) return '';
+  try {
+    return new Date(n).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch {
+    return '';
+  }
 }
 
 class DaoModal {
@@ -2632,10 +2637,6 @@ class DaoModal {
     this.render();
   }
 
-  getProposals() {
-    return daoRepo.getProposalsForUi(this.selectedGroupKey);
-  }
-
   render() {
     const proposalsActive = daoRepo.getProposalsForUi('active');
     const proposalsArchived = daoRepo.getProposalsForUi('archived');
@@ -2651,7 +2652,7 @@ class DaoModal {
 
     // Update header title
     const groupLabel = this.selectedGroupKey === 'archived' ? 'Archived' : 'Active';
-    const label = getDaoUiStateLabel(this.selectedStateKey);
+    const label = getDaoStateLabel(this.selectedStateKey);
     if (this.titleEl) this.titleEl.textContent = `DAO - ${groupLabel} - ${label}`;
 
     // Update group toggle labels + selection
@@ -2671,7 +2672,7 @@ class DaoModal {
       const labelEl = document.getElementById(`daoStatusOption${s.label.replace(/\s+/g, '')}`);
       const countEl = option?.querySelector('.dao-status-count');
       const count = counts[s.key] || 0;
-      const displayLabel = getDaoUiStateLabel(s.key);
+      const displayLabel = getDaoStateLabel(s.key);
 
       if (labelEl) labelEl.textContent = displayLabel;
       if (countEl) {
@@ -2725,21 +2726,21 @@ class DaoModal {
       const li = document.createElement('li');
       li.classList.add('chat-item', 'dao-proposal-row');
 
-      const titleText = p.title || (p.number ? `Proposal #${p.number}` : 'Proposal');
-      const title = escapeHtml(titleText);
-      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
+      const titleText = String(p.title || '').trim() || 'Proposal';
+      const rowTitleText = p.number ? `#${p.number}: ${titleText}` : titleText;
+      const title = escapeHtml(rowTitleText);
+      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType) || 'Proposal');
       const previewHtml = this.renderProposalRowPreview(p);
 
       li.tabIndex = 0;
       li.setAttribute('role', 'button');
-      li.setAttribute('aria-label', `Open ${titleText}`);
+      li.setAttribute('aria-label', `Open ${rowTitleText}`);
       li.innerHTML = `
         <div class="dao-row-content">
           <div class="dao-row-title">${title}</div>
           <div class="dao-row-meta">
             <span class="dao-row-meta-item dao-row-meta-item--type">
-              <span class="dao-row-meta-label">Type</span>
-              <strong class="dao-row-meta-value">${typeLabel}</strong>
+              ${typeLabel}
             </span>
             ${previewHtml}
           </div>
@@ -2766,26 +2767,59 @@ class DaoModal {
     const result = getDaoProposalResultSummary(proposal);
     const reward = getDaoProposalRewardSummary(proposal);
 
-    if (result) {
-      chips.push({
-        label: 'Result',
-        value: result.headline,
-        tone: result.tone,
-      });
-    }
     if (state === 'review') {
       const reviewWindow = getDaoProposalReviewWindow(proposal);
 
       chips.push({
-        label: 'Review',
         value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,
         tone: 'neutral',
       });
-    } else if (reward) {
+    } else if (state === 'voting') {
+      const now = Date.now();
+      const votingWindow = getDaoProposalVotingWindow(proposal, now);
+      const endDate = formatDaoDate(votingWindow.end);
+      const votingEnded = Boolean(votingWindow.end && now > votingWindow.end);
+
+      if (endDate && !votingEnded) {
+        chips.push({
+          value: `Ends ${endDate}`,
+          tone: 'neutral',
+        });
+      }
+      if (votingEnded) {
+        chips.push({
+          value: 'Ready to finalize',
+          tone: 'neutral',
+        });
+      }
+    } else {
+      const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward);
+      const claimAction = lifecycleActions.find((action) => action.kind === 'claim_reward');
+      const applyAction = lifecycleActions.find((action) => action.kind === 'apply_parameters');
+
+      if (claimAction) {
+        chips.push({
+          value: 'Ready to claim',
+          tone: reward?.statusTone,
+        });
+      }
+      if (lifecycleActions.some((action) => action.kind === 'burn_reward')) {
+        chips.push({
+          value: 'Ready to burn',
+          tone: 'neutral',
+        });
+      }
+      if (applyAction?.rowPreviewLabel) {
+        chips.push({
+          value: applyAction.rowPreviewLabel,
+          tone: 'neutral',
+        });
+      }
+    }
+    if (result) {
       chips.push({
-        label: 'Reward',
-        value: reward.previewLabel,
-        tone: reward.statusTone,
+        value: result.headline,
+        tone: result.tone,
       });
     }
 
@@ -2794,8 +2828,7 @@ class DaoModal {
       <div class="dao-row-previews">
         ${chips.map((chip) => `
           <span class="dao-row-preview dao-row-preview--${escapeDaoFormAttribute(chip.tone || 'neutral')}">
-            <span>${escapeHtml(chip.label)}</span>
-            <strong>${escapeHtml(chip.value)}</strong>
+            ${escapeHtml(chip.value)}
           </span>
         `).join('')}
       </div>
@@ -2893,10 +2926,8 @@ class AddProposalModal {
     if (this.startDelayInput) this.startDelayInput.value = '0';
     if (this.gracePeriodInput) this.gracePeriodInput.value = '';
     this.renderOptions(['yes', 'no']);
-    this.renderProposalFee();
     this.renderGracePeriodDefaultHint();
     this.refreshProposalFee();
-    this.renderConfigLoadingState();
     this.refreshSelectedConfigOptions();
     setTimeout(() => {
       this.titleInput?.focus();
@@ -3209,12 +3240,11 @@ class AddProposalModal {
     return this.getConfigOptions().find((option) => option.key === key) || null;
   }
 
-  renderParameterChanges(rows = null) {
+  renderParameterChanges(rows) {
     if (!this.changesList) return;
 
     const options = this.getConfigOptions();
-    const sourceRows = rows || this.getParameterChanges();
-    const validRows = sourceRows
+    const validRows = rows
       .filter((row) => options.some((option) => option.key === row.key))
       .map((row) => ({ key: row.key, value: row.value }));
 
@@ -3448,7 +3478,6 @@ class AddProposalModal {
       confirmProposalModal.open(draft);
     } catch (e) {
       this.showValidationError(e);
-      return;
     }
   }
 }
@@ -3629,6 +3658,9 @@ class ConfirmProposalModal {
     const proposalType = tx.proposalType;
     const changes = Array.isArray(tx[proposalType]?.changes) ? tx[proposalType].changes : [];
     const gracePeriodSummary = formatDaoDurationSummary(tx.gracePeriod);
+    const formattedOptions = tx.options
+      .map((option, index) => `${index + 1}. ${option}`)
+      .join('\n');
 
     this.setTitle('Review Proposal');
     this.content.innerHTML = [
@@ -3641,7 +3673,7 @@ class ConfirmProposalModal {
         ['Type', getDaoTypeLabel(proposalType)],
         ['Emergency', tx.emergency ? 'Yes' : 'No'],
         ['Description', tx.description],
-        ['Options', this.formatProposalOptions(tx.options)],
+        ['Options', formattedOptions],
         ['Review starts', formatDaoDurationSummary(draft.startDelayMs)],
         ['Grace period', gracePeriodSummary],
       ]),
@@ -3651,7 +3683,6 @@ class ConfirmProposalModal {
   }
 
   renderSection(title, rows) {
-    const gridClass = rows.length === 2 ? 'dao-confirm-grid dao-confirm-grid--two' : 'dao-confirm-grid';
     const rowHtml = rows
       .map(([label, value]) => {
         const displayValue = formatDaoConfirmValue(value);
@@ -3668,13 +3699,13 @@ class ConfirmProposalModal {
     return `
       <section class="dao-confirm-section">
         <h3>${escapeHtml(title)}</h3>
-        <div class="${gridClass}">${rowHtml}</div>
+        <div class="dao-confirm-grid">${rowHtml}</div>
       </section>
     `;
   }
 
   getSectionRowClass(label, value) {
-    const fullWidthLabels = ['Description', 'Options', 'from', 'description', 'options'];
+    const fullWidthLabels = ['Description', 'Options'];
     if (!fullWidthLabels.includes(label)) return 'dao-confirm-row';
 
     const text = String(value);
@@ -3684,12 +3715,6 @@ class ConfirmProposalModal {
       return 'dao-confirm-row dao-confirm-row--full';
     }
     return 'dao-confirm-row';
-  }
-
-  formatProposalOptions(options) {
-    return Array.isArray(options) && options.length
-      ? options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : options;
   }
 
   renderChanges(changes) {
@@ -3740,7 +3765,7 @@ function getDaoCurrentAccountAddress() {
 }
 
 function getDaoProposalReviewWindow(proposal) {
-  const start = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const start = Number(proposal?.startTime || 0);
   const duration = Number(proposal?.reviewDuration);
   if (!start || !Number.isFinite(duration) || duration < 0) {
     return {
@@ -3782,7 +3807,7 @@ function getDaoProposalReviewWindow(proposal) {
 }
 
 function getDaoProposalVotingWindow(proposal, now = Date.now()) {
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   if (
@@ -3863,14 +3888,10 @@ function formatDaoScaledBigInt(value, scale, decimals = 3) {
 }
 
 function formatDaoVoteWeightUnits(value, suffix) {
-  if (typeof value === 'bigint') {
-    const formatted = formatDaoScaledBigInt(value, DAO_VOTE_WEIGHT_PRECISION_BIGINT, 3);
-    return formatted === null ? 'Unavailable' : `${formatted} ${suffix}`;
-  }
-
-  const n = Number(value);
-  if (!Number.isFinite(n)) return 'Unavailable';
-  return `${formatDaoShortNumber(n / DAO_VOTE_WEIGHT_PRECISION, 3)} ${suffix}`;
+  const bigintValue = parseDaoUnsignedBigInt(value);
+  if (bigintValue === null) return 'Unavailable';
+  const formatted = formatDaoScaledBigInt(bigintValue, DAO_VOTE_WEIGHT_PRECISION_BIGINT, 3);
+  return formatted === null ? 'Unavailable' : `${formatted} ${suffix}`;
 }
 
 function formatDaoVotingPower(value) {
@@ -3887,12 +3908,9 @@ function formatDaoPercent(value) {
 }
 
 function formatDaoLibWei(value) {
-  try {
-    const weiValue = typeof value === 'bigint' ? value : BigInt(value || 0);
-    return `${formatDaoShortNumber(EthNum.toStr(weiValue))} LIB`;
-  } catch {
-    return 'Unavailable';
-  }
+  const weiValue = parseDaoUnsignedBigInt(value);
+  if (weiValue === null) return 'Unavailable';
+  return `${formatDaoShortNumber(EthNum.toStr(weiValue))} LIB`;
 }
 
 function parseDaoUnsignedBigInt(value) {
@@ -3901,6 +3919,16 @@ function parseDaoUnsignedBigInt(value) {
   if (typeof value === 'number') {
     if (!Number.isFinite(value) || value < 0) return null;
     return BigInt(Math.trunc(value));
+  }
+  if (typeof value === 'object') {
+    if (value.dataType !== 'bi') return null;
+    const hexText = String(value.value ?? '').trim();
+    if (!/^[0-9a-f]+$/i.test(hexText)) return null;
+    try {
+      return BigInt(`0x${hexText}`);
+    } catch {
+      return null;
+    }
   }
 
   const text = String(value).trim();
@@ -3926,12 +3954,11 @@ function formatDaoBigIntPercent(part, total) {
 }
 
 function getDaoProposalOptions(proposal) {
-  if (!Array.isArray(proposal?.options) || proposal.options.length === 0) return ['Yes', 'No'];
-  return proposal.options.map((option, index) => String(option || `Option ${index + 1}`));
+  return proposal.options.map((option) => String(option));
 }
 
 function getDaoVoteTotals(proposal) {
-  const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+  const totalVote = proposal.totalVote;
   if (totalVote.length === 0) return [];
 
   const options = getDaoProposalOptions(proposal);
@@ -4004,7 +4031,9 @@ function getDaoProposalResultSummary(proposal) {
 }
 
 function normalizeDaoAddress(value) {
-  return String(value || '').trim().toLowerCase();
+  const text = String(value || '').trim();
+  if (!text) return '';
+  return normalizeAddress(text);
 }
 
 function getDaoVoterEntries(proposal) {
@@ -4023,7 +4052,7 @@ function getDaoClaimList(proposal) {
 }
 
 function getDaoProposalClaimWindow(proposal) {
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   const claimDuration = Number(proposal?.claimDuration);
@@ -4044,6 +4073,95 @@ function getDaoProposalClaimWindow(proposal) {
     votingStart,
     votingDuration,
   };
+}
+
+function getDaoProposalApplyWindow(proposal, now = Date.now()) {
+  if (proposal?.emergency) {
+    return { eligibleAt: null, isReady: true };
+  }
+
+  const backendEligibleAt = Number(proposal?.applyEligibleAt);
+  if (Number.isFinite(backendEligibleAt) && backendEligibleAt > 0) {
+    return { eligibleAt: backendEligibleAt, isReady: now >= backendEligibleAt };
+  }
+
+  const reviewStart = Number(proposal?.startTime || 0);
+  const reviewDuration = Number(proposal?.reviewDuration);
+  const votingDuration = Number(proposal?.votingDuration);
+  const gracePeriod = Number(proposal?.gracePeriod);
+  if (
+    !Number.isFinite(reviewStart) ||
+    !Number.isFinite(reviewDuration) ||
+    !Number.isFinite(votingDuration) ||
+    !Number.isFinite(gracePeriod)
+  ) {
+    return { eligibleAt: null, isReady: false };
+  }
+
+  const eligibleAt = reviewStart + reviewDuration + votingDuration + gracePeriod;
+  return { eligibleAt, isReady: now >= eligibleAt };
+}
+
+function isDaoParameterProposalType(proposal) {
+  const type = String(proposal?.proposalType || '').toLowerCase();
+  return type === 'governance' || type === 'economic' || type === 'protocol';
+}
+
+function isDaoProposalCommitteeMember(proposal, currentAddress) {
+  const normalizedAddress = normalizeDaoAddress(currentAddress);
+  if (!normalizedAddress || !Array.isArray(proposal?.committeeAddresses)) return false;
+  return proposal.committeeAddresses.some((address) => normalizeDaoAddress(address) === normalizedAddress);
+}
+
+function getDaoApplyParametersLifecycleAction(help, canSubmit, rowPreviewLabel = '') {
+  const action = {
+    kind: 'apply_parameters',
+    title: 'Apply parameters',
+    help,
+    buttonLabel: 'Apply parameters',
+    loadingLabel: 'Applying parameters...',
+    successMessage: 'Parameters applied',
+    refreshWarning: 'Parameters applied, but proposal or parameter refresh failed',
+    refreshNetworkParams: true,
+    canSubmit,
+  };
+  if (rowPreviewLabel) action.rowPreviewLabel = rowPreviewLabel;
+  return action;
+}
+
+function getDaoProposalApplyLifecycleAction(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+  if (getEffectiveDaoState(proposal) !== 'accepted') return null;
+
+  if (!isDaoParameterProposalType(proposal)) {
+    return getDaoApplyParametersLifecycleAction(
+      'This proposal type does not support parameter application.',
+      false,
+    );
+  }
+
+  if (proposal?.emergency && !isDaoProposalCommitteeMember(proposal, currentAddress)) {
+    return getDaoApplyParametersLifecycleAction(
+      'Emergency proposal parameters can only be applied by a proposal committee member.',
+      false,
+    );
+  }
+
+  const applyWindow = getDaoProposalApplyWindow(proposal, now);
+  if (!applyWindow.isReady) {
+    const eligibleAt = applyWindow.eligibleAt ? formatDaoTimestamp(applyWindow.eligibleAt) : '';
+    return getDaoApplyParametersLifecycleAction(
+      eligibleAt
+        ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
+        : 'Apply timing is unavailable until the proposal includes grace-period timing.',
+      false,
+    );
+  }
+
+  return getDaoApplyParametersLifecycleAction(
+    'This proposal is ready to apply. Submit the transaction to apply the accepted parameter changes.',
+    true,
+    'Ready to apply',
+  );
 }
 
 function formatDaoClaimWindowLabel(claimWindow, now) {
@@ -4085,23 +4203,6 @@ function getDaoRewardClaimStatus({ state, currentAddress, voterIndex, hasClaimed
   if (now > claimWindow.end) return 'Claim window ended';
   if (now < claimWindow.start) return 'Claim window not open';
   return 'Claimable';
-}
-
-function getDaoRewardPreviewLabel(summary) {
-  if (summary.claimStatus === 'Claimable' && summary.claimEstimate !== null) {
-    return `${formatDaoLibWei(summary.claimEstimate)} claimable`;
-  }
-  if (summary.claimStatus === 'Already claimed') return 'Reward claimed';
-  if (summary.initialBurned !== null && summary.initialBurned > 0n) {
-    return `${formatDaoLibWei(summary.initialBurned)} burned`;
-  }
-  if (summary.finalBurned !== null && summary.finalBurned > 0n) {
-    return `${formatDaoLibWei(summary.finalBurned)} burned`;
-  }
-  if (summary.unclaimed !== null && summary.unclaimed > 0n) {
-    return `${formatDaoLibWei(summary.unclaimed)} unclaimed`;
-  }
-  return summary.claimStatus;
 }
 
 function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
@@ -4155,7 +4256,7 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
     ? safePool > safeClaimed ? safePool - safeClaimed : 0n
     : null;
 
-  const summary = {
+  return {
     claimEstimate,
     claimStatus,
     claimWindowLabel: formatDaoClaimWindowLabel(claimWindow, now),
@@ -4164,12 +4265,74 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
     initialBurned,
     pool,
     unclaimed,
-  };
-  return {
-    ...summary,
-    previewLabel: getDaoRewardPreviewLabel(summary),
     statusTone: claimStatus === 'Claimable' ? 'accept' : '',
   };
+}
+
+function getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+  const state = getEffectiveDaoState(proposal);
+
+  if (state === 'voting') {
+    const votingWindow = getDaoProposalVotingWindow(proposal, now);
+    if (votingWindow.end && now > votingWindow.end) {
+      return [{
+        kind: 'vote_result',
+        title: 'Vote result',
+        help: 'Voting has ended. Finalize the vote result to move this proposal to accepted or rejected.',
+        buttonLabel: 'Finalize vote result',
+        loadingLabel: 'Finalizing vote result...',
+        successMessage: 'Vote result finalized',
+        refreshWarning: 'Vote result finalized, but proposal refresh failed',
+      }];
+    }
+    return [];
+  }
+
+  if (!isDaoFinalResultState(state)) return [];
+
+  const actions = [];
+  const claimWindow = getDaoProposalClaimWindow(proposal);
+  const pool = parseDaoUnsignedBigInt(proposal?.voterRewardPool) ?? 0n;
+  const claimed = parseDaoUnsignedBigInt(proposal?.claimedReward) ?? 0n;
+  const unclaimed = pool > claimed ? pool - claimed : 0n;
+
+  if (claimWindow.end && now > claimWindow.end && unclaimed > 0n) {
+    actions.push({
+      kind: 'burn_reward',
+      title: 'Reward burn',
+      help: 'The claim window has ended. Burn the unclaimed reward pool so the proposal accounting is finalized.',
+      buttonLabel: 'Burn unclaimed reward',
+      loadingLabel: 'Burning reward...',
+      successMessage: 'Unclaimed reward burned',
+      refreshWarning: 'Reward burned, but proposal refresh failed',
+    });
+  }
+
+  if (
+    claimWindow.start &&
+    claimWindow.end &&
+    now >= claimWindow.start &&
+    now <= claimWindow.end &&
+    unclaimed > 0n &&
+    currentAddress &&
+    rewardSummary?.claimStatus === 'Claimable'
+  ) {
+    actions.push({
+      kind: 'claim_reward',
+      title: 'Reward claim',
+      help: rewardSummary.claimEstimate === null
+        ? 'Your reward is claimable. Submit the claim and refresh proposal accounting.'
+        : `Your estimated claim is ${formatDaoLibWei(rewardSummary.claimEstimate)}. Submit the claim and refresh proposal accounting.`,
+      buttonLabel: 'Claim reward',
+      loadingLabel: 'Claiming reward...',
+      successMessage: 'Reward claimed',
+      refreshWarning: 'Reward claimed, but proposal refresh failed',
+    });
+  }
+
+  const applyAction = getDaoProposalApplyLifecycleAction(proposal, currentAddress, now);
+  if (applyAction) actions.push(applyAction);
+  return actions;
 }
 
 function formatDaoDetailValue(value) {
@@ -4178,10 +4341,6 @@ function formatDaoDetailValue(value) {
   if (Array.isArray(value)) return value.map(formatDaoDetailValue).join(', ');
   if (typeof value === 'object') return stringify(value);
   return String(value);
-}
-
-function getDaoBooleanCapability(proposal, key) {
-  return typeof proposal?.[key] === 'boolean' ? proposal[key] : null;
 }
 
 function parseDaoPositiveLibAmount(value) {
@@ -4236,9 +4395,9 @@ class ProposalInfoModal {
     this.reviewResultSection = document.getElementById('proposalReviewResultSection');
     this.reviewResultHelp = document.getElementById('proposalReviewResultHelp');
     this.reviewResultButton = document.getElementById('proposalReviewResultSubmit');
+    this.lifecycleActionSection = document.getElementById('proposalLifecycleActionSection');
     this.voteActionSection = document.getElementById('proposalVoteActionSection');
     this.voteActionHelp = document.getElementById('proposalVoteActionHelp');
-    this.voteStatusGrid = document.getElementById('proposalVoteStatusGrid');
     this.voteOptions = document.getElementById('proposalVoteOptions');
     this.voteSpendInput = document.getElementById('proposalVoteSpend');
     this.votePreview = document.getElementById('proposalVotePreview');
@@ -4252,6 +4411,8 @@ class ProposalInfoModal {
     this.isSubmitting = false;
     this.canSubmitCommitteeReview = false;
     this.canSubmitReviewResult = false;
+    this.currentLifecycleActions = [];
+    this.submittingLifecycleAction = null;
     this.canSubmitVote = false;
     this.submitButtonLabel = this.submitButton?.textContent || 'Submit review';
     this.reviewResultButtonLabel = this.reviewResultButton?.textContent || 'Finalize review result';
@@ -4263,6 +4424,7 @@ class ProposalInfoModal {
     if (this.withholdReasonSelect) this.withholdReasonSelect.addEventListener('change', () => this.handleWithholdReasonChange());
     if (this.submitButton) this.submitButton.addEventListener('click', () => this.handleCommitteeSubmit());
     if (this.reviewResultButton) this.reviewResultButton.addEventListener('click', () => this.handleReviewResultSubmit());
+    if (this.lifecycleActionSection) this.lifecycleActionSection.addEventListener('click', (event) => this.handleLifecycleActionClick(event));
     if (this.voteSpendInput) this.voteSpendInput.addEventListener('input', () => this.handleVoteSpendInput());
     if (this.voteOptions) this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
     if (this.voteSubmitButton) this.voteSubmitButton.addEventListener('click', () => this.handleVoteSubmit());
@@ -4313,6 +4475,7 @@ class ProposalInfoModal {
     }
     this.hideCommitteeActions();
     this.hideReviewResultAction();
+    this.hideLifecycleAction();
     this.hideVoteActions();
   }
 
@@ -4328,15 +4491,14 @@ class ProposalInfoModal {
     const currentAddress = getDaoCurrentAccountAddress();
     const currentVote = committeeVotes.find((vote) => vote?.memberAddress === currentAddress) || null;
     const capabilities = this.getReviewCapabilities({
-      proposal,
       state,
       reviewWindow,
       currentAddress,
       committeeAddressSet,
     });
-    const proposalType = proposal.proposalType || proposal.type;
     const resultSummary = getDaoProposalResultSummary(proposal);
     const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
+    const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
     const committeeReviewSection = state === 'review'
       ? this.renderSection('Committee Review', [
         ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
@@ -4364,10 +4526,8 @@ class ProposalInfoModal {
     if (this.detailsContent) {
       this.detailsContent.innerHTML = this.renderProposalDetails({
         proposal,
-        proposalType,
         state,
         reviewWindow,
-        resultSummary,
         rewardSummary,
       });
     }
@@ -4379,24 +4539,14 @@ class ProposalInfoModal {
       this.hideCommitteeActions();
       this.hideReviewResultAction();
     }
-    this.renderVoteActions({ proposal, state });
+    this.renderLifecycleActions(lifecycleActions);
+    this.renderVoteActions(proposal, state);
   }
 
-  getReviewCapabilities({ proposal, state, reviewWindow, currentAddress, committeeAddressSet }) {
-    const backendCommitteeMember = getDaoBooleanCapability(proposal, 'isCommitteeMemberForProposal');
-    const isCommitteeMember = backendCommitteeMember ?? Boolean(currentAddress && committeeAddressSet.has(currentAddress));
-
-    const backendCanCommitteeVote = getDaoBooleanCapability(proposal, 'canCommitteeVote');
-    const canCommitteeVote = backendCanCommitteeVote ?? (
-      state === 'review' &&
-      reviewWindow.canCommitteeVote &&
-      isCommitteeMember
-    );
-
-    const backendCanFinalizeReviewResult = getDaoBooleanCapability(proposal, 'canFinalizeReviewResult');
-    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && (
-      backendCanFinalizeReviewResult ?? reviewWindow.canFinalizeReviewResult
-    );
+  getReviewCapabilities({ state, reviewWindow, currentAddress, committeeAddressSet }) {
+    const isCommitteeMember = Boolean(currentAddress && committeeAddressSet.has(currentAddress));
+    const canCommitteeVote = state === 'review' && reviewWindow.canCommitteeVote && isCommitteeMember;
+    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && reviewWindow.canFinalizeReviewResult;
 
     return { isCommitteeMember, canCommitteeVote, canFinalizeReviewResult };
   }
@@ -4408,14 +4558,15 @@ class ProposalInfoModal {
   }
 
   renderProposalTitle(proposal) {
-    const description = proposal.description || proposal.summary || '';
+    const description = proposal.description || '';
+    const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
     const descriptionHtml = description
       ? `<p class="proposal-info-description">${escapeHtml(description)}</p>`
       : '';
 
     return `
       <div class="proposal-info-heading">
-        <h2 class="proposal-info-title">${escapeHtml(this.getProposalTitle(proposal))}</h2>
+        <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
         ${descriptionHtml}
       </div>
     `;
@@ -4438,7 +4589,7 @@ class ProposalInfoModal {
         const isWinner = index === winnerIndex;
         const units = this.getCurrentVoteSegmentUnits(row.total, totalWeight);
         const power = formatDaoVotingPower(row.total);
-        const percent = this.formatCurrentVotePercent(row.total, totalWeight);
+        const percent = formatDaoBigIntPercent(row.total, totalWeight);
         const valueLabel = totalWeight > 0n ? `${power} / ${percent}` : power;
         const title = totalWeight > 0n
           ? `${row.option}: ${power}, ${percent}`
@@ -4489,29 +4640,12 @@ class ProposalInfoModal {
   }
 
   getCurrentVoteTotalRows(proposal) {
-    const options = this.getVoteOptions(proposal);
-    const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+    const options = getDaoProposalOptions(proposal);
+    const totalVote = proposal.totalVote;
     return options.map((option, index) => ({
       option,
-      total: this.parseCurrentVoteTotal(totalVote[index]),
+      total: parseDaoUnsignedBigInt(totalVote[index]) ?? 0n,
     }));
-  }
-
-  parseCurrentVoteTotal(value) {
-    if (typeof value === 'bigint') return value >= 0n ? value : 0n;
-    if (typeof value === 'number') {
-      if (!Number.isFinite(value) || value <= 0) return 0n;
-      return BigInt(Math.trunc(value));
-    }
-
-    const text = String(value ?? '').trim();
-    if (!text) return 0n;
-    try {
-      const parsed = BigInt(text);
-      return parsed >= 0n ? parsed : 0n;
-    } catch {
-      return 0n;
-    }
   }
 
   getCurrentVoteSegmentUnits(part, total) {
@@ -4519,18 +4653,6 @@ class ProposalInfoModal {
     if (part <= 0n) return 0;
     const units = Number((part * 1000n) / total);
     return Math.max(1, units);
-  }
-
-  formatCurrentVotePercent(part, total) {
-    if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return '0%';
-    const tenths = (part * 1000n + total / 2n) / total;
-    const whole = tenths / 10n;
-    const fraction = tenths % 10n;
-    return fraction === 0n ? `${whole}%` : `${whole}.${fraction}%`;
-  }
-
-  getProposalTitle(proposal) {
-    return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
   }
 
   renderProposalResults(result) {
@@ -4621,8 +4743,6 @@ class ProposalInfoModal {
     const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
     const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
     const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
-    const acceptSegmentWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-segment--winner' : '';
-    const withholdSegmentWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-segment--winner' : '';
 
     return `
       <section class="proposal-info-section">
@@ -4660,11 +4780,11 @@ class ProposalInfoModal {
           </div>
           <div class="proposal-result-meter-track" aria-hidden="true">
             <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptSegmentWinnerClass}${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
               style="--result-segment-units: ${acceptUnits};"
             ></span>
             <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdSegmentWinnerClass}${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
               style="--result-segment-units: ${withholdUnits};"
             ></span>
           </div>
@@ -4704,32 +4824,27 @@ class ProposalInfoModal {
     ]);
   }
 
-  getVoteStatusData(proposal) {
+  renderVotingDetails(proposal) {
     const votingWindow = getDaoProposalVotingWindow(proposal);
     const totalVote = Array.isArray(proposal.totalVote) ? proposal.totalVote : [];
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     const totalVoteText = totalVote.length
       ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
       : 'No votes yet';
-    return { votingWindow, totalVoteText };
-  }
-
-  renderVotingDetails(proposal) {
-    const { votingWindow, totalVoteText } = this.getVoteStatusData(proposal);
     return this.renderSection('Voting Details', [
       ['Voting state', votingWindow.label],
       ['Current totals', totalVoteText],
     ]);
   }
 
-  renderProposalDetails({ proposal, proposalType, state, reviewWindow, resultSummary, rewardSummary }) {
+  renderProposalDetails({ proposal, state, reviewWindow, rewardSummary }) {
     const sections = [
       this.renderSection('Overview', [
         ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
-        ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
+        ['Type', getDaoTypeLabel(proposal.proposalType) || 'Unavailable'],
         ['Status', getDaoStateLabel(state) || state],
-        ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
-        ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
+        ['Created', formatDaoDetailTimestamp(proposal.created)],
+        ['Updated', formatDaoDetailTimestamp(proposal.state_changed)],
       ]),
       this.renderSection('Review Timeline', [
         ['Window state', reviewWindow.label],
@@ -4741,20 +4856,18 @@ class ProposalInfoModal {
       this.renderProposalRewards(rewardSummary),
     ].filter(Boolean);
 
-    if (sections.length === 0) return '';
-
     return `
       <details class="proposal-more">
         <summary>
           <span class="proposal-more-title">Show proposal details</span>
-          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, resultSummary, rewardSummary))}</span>
+          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, rewardSummary))}</span>
         </summary>
         <div class="proposal-more-content">${sections.join('')}</div>
       </details>
     `;
   }
 
-  getProposalDetailsSummary(state, resultSummary, rewardSummary) {
+  getProposalDetailsSummary(state, rewardSummary) {
     const parts = ['Overview', 'review timeline'];
     if (state !== 'review') parts.push('proposal body');
     if (state === 'voting') parts.push('voting totals');
@@ -4811,9 +4924,7 @@ class ProposalInfoModal {
   }
 
   renderProposalBody(proposal) {
-    const options = Array.isArray(proposal.options) && proposal.options.length
-      ? proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : 'Unavailable';
+    const options = proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n');
 
     return this.renderSection('Proposal Body', [
       ['Emergency', proposal.emergency ? 'Yes' : 'No'],
@@ -4822,9 +4933,8 @@ class ProposalInfoModal {
   }
 
   renderParameterChanges(proposal) {
-    const fields = proposal.fields && typeof proposal.fields === 'object' ? proposal.fields : {};
     const payloads = ['governance', 'economic', 'protocol']
-      .map((key) => [key, proposal[key] || fields[key]])
+      .map((key) => [key, proposal[key]])
       .filter(([, payload]) => payload && typeof payload === 'object');
 
     if (payloads.length === 0) {
@@ -4850,7 +4960,7 @@ class ProposalInfoModal {
     `;
   }
 
-  getParameterChangeRowClass(parts, { isSingleRow = false } = {}) {
+  getParameterChangeRowClass(parts, isSingleRow) {
     const normalizedParts = parts.map((part) => String(part ?? '').trim());
     const shouldUseWideRow = normalizedParts.some((part) => part.length > 22)
       || normalizedParts.join(' ').length > 52;
@@ -4861,7 +4971,7 @@ class ProposalInfoModal {
     ].filter(Boolean).join(' ');
   }
 
-  renderPayloadRows(payload, payloadTitle = '') {
+  renderPayloadRows(payload, payloadTitle) {
     const titleHtml = payloadTitle
       ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
       : '';
@@ -4875,7 +4985,7 @@ class ProposalInfoModal {
           const next = formatDaoDetailValue(change?.value);
           const rowClass = this.getParameterChangeRowClass(
             [key, `Current: ${current}`, `New: ${next}`],
-            { isSingleRow: index === changes.length - 1 && changes.length % 2 === 1 },
+            index === changes.length - 1 && changes.length % 2 === 1,
           );
           return `
           <div class="${rowClass}">
@@ -4900,7 +5010,7 @@ class ProposalInfoModal {
         const displayValue = formatDaoDetailValue(value);
         const rowClass = this.getParameterChangeRowClass(
           [key, displayValue],
-          { isSingleRow: index === entries.length - 1 && entries.length % 2 === 1 },
+          index === entries.length - 1 && entries.length % 2 === 1,
         );
         return `
         <div class="${rowClass}">
@@ -4983,25 +5093,63 @@ class ProposalInfoModal {
     this.updateSubmitButtons();
   }
 
+  renderLifecycleActions(actions) {
+    this.currentLifecycleActions = actions;
+    if (!this.lifecycleActionSection || this.currentLifecycleActions.length === 0) {
+      this.hideLifecycleAction();
+      return;
+    }
+
+    this.lifecycleActionSection.innerHTML = this.currentLifecycleActions
+      .map((action, index) => `
+        <div class="proposal-lifecycle-action">
+          <div class="proposal-committee-actions-header">
+            <h3>${escapeHtml(action.title)}</h3>
+            <p>${escapeHtml(action.help)}</p>
+          </div>
+          <button
+            type="button"
+            class="btn btn--primary btn--pill btn--full"
+            data-lifecycle-action-index="${index}"
+          >${escapeHtml(action.buttonLabel)}</button>
+        </div>
+      `)
+      .join('');
+    this.lifecycleActionSection.classList.remove('hidden');
+    this.updateSubmitButtons();
+  }
+
+  hideLifecycleAction() {
+    this.currentLifecycleActions = [];
+    this.submittingLifecycleAction = null;
+    if (this.lifecycleActionSection) {
+      this.lifecycleActionSection.innerHTML = '';
+      this.lifecycleActionSection.classList.add('hidden');
+    }
+    this.updateSubmitButtons();
+  }
+
   resetVoteState(proposal) {
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     this.voteWeights = options.map(() => 0);
     this.voteSpendLib = '';
     if (this.voteSpendInput) this.voteSpendInput.value = '';
   }
 
-  getVoteOptions(proposal) {
-    return getDaoProposalOptions(proposal);
-  }
-
-  renderVoteActions({ proposal, state }) {
+  renderVoteActions(proposal, state) {
     if (!this.voteActionSection) return;
     if (state !== 'voting') {
       this.hideVoteActions();
       return;
     }
 
-    const options = this.getVoteOptions(proposal);
+    const votingWindow = getDaoProposalVotingWindow(proposal);
+    if (votingWindow.end && Date.now() > votingWindow.end) {
+      this.hideVoteActions();
+      return;
+    }
+
+    const options = getDaoProposalOptions(proposal);
     if (this.voteWeights.length !== options.length) {
       this.voteWeights = options.map(() => 0);
     }
@@ -5027,7 +5175,6 @@ class ProposalInfoModal {
       `;
     }
 
-    this.renderVoteStatus(proposal);
     this.updateVotePreview(proposal);
   }
 
@@ -5056,11 +5203,6 @@ class ProposalInfoModal {
         >
       </label>
     `;
-  }
-
-  renderVoteStatus(proposal) {
-    if (!this.voteStatusGrid) return;
-    this.voteStatusGrid.innerHTML = '';
   }
 
   handleVoteWeightInput(event) {
@@ -5111,7 +5253,7 @@ class ProposalInfoModal {
     }
     this.votePreview.classList.remove('proposal-vote-preview--message');
 
-    const optionRows = this.getVoteOptions(proposal)
+    const optionRows = getDaoProposalOptions(proposal)
       .map((option, index) => {
         const weight = this.voteWeights[index] || 0;
         const share = weight / submission.totalWeight;
@@ -5145,7 +5287,8 @@ class ProposalInfoModal {
     `;
   }
 
-  getVoteSubmission(proposal, timestamp = getTransactionTimestamp()) {
+  getVoteSubmission(proposal) {
+    const timestamp = getTransactionTimestamp();
     const validation = this.getVotePreviewValidation(proposal, timestamp);
     if (!validation.ok) {
       return { ok: false, message: validation.message, tone: 'warning' };
@@ -5279,6 +5422,13 @@ class ProposalInfoModal {
       this.reviewResultButton.disabled = disableResult;
       this.reviewResultButton.textContent = this.isSubmitting && this.canSubmitReviewResult ? 'Finalizing...' : this.reviewResultButtonLabel;
     }
+    for (const button of this.lifecycleActionSection?.querySelectorAll('button[data-lifecycle-action-index]') || []) {
+      const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
+      const isSubmittingAction = this.isSubmitting && action === this.submittingLifecycleAction;
+      const canSubmitLifecycle = action?.canSubmit !== false;
+      button.disabled = this.isSubmitting || !action || !canSubmitLifecycle;
+      button.textContent = isSubmittingAction ? action.loadingLabel : action?.buttonLabel || '';
+    }
     if (this.voteSubmitButton) {
       this.voteSubmitButton.disabled = disableVote;
       this.voteSubmitButton.textContent = this.isSubmitting && this.canSubmitVote ? 'Submitting...' : this.voteSubmitButtonLabel;
@@ -5369,28 +5519,25 @@ class ProposalInfoModal {
     return injectTx(transaction, txid);
   }
 
-  async refreshCurrentProposal() {
-    await daoRepo.refresh({ force: true });
-    if (daoModal?.isActive?.()) daoModal.render();
-
-    this.renderCurrentProposal();
-  }
-
-  async refreshAfterDaoAction(warningMessage) {
+  async refreshAfterDaoAction(warningMessage, { refreshNetworkParams = false } = {}) {
     try {
-      await this.refreshCurrentProposal();
+      await daoRepo.refresh({ force: true });
+      if (daoModal?.isActive?.()) daoModal.render();
+
+      const proposal = this.getCurrentProposal();
+      if (proposal) {
+        this.renderProposal(proposal);
+      } else {
+        this.renderNotFound();
+      }
+
+      if (refreshNetworkParams) {
+        const refreshed = await getNetworkParams(true);
+        if (!refreshed) throw new Error('Network parameter refresh failed');
+      }
     } catch (error) {
       console.warn('Failed to refresh proposal after DAO action:', error);
       showToast(warningMessage, 4000, 'warning');
-    }
-  }
-
-  renderCurrentProposal() {
-    const proposal = this.getCurrentProposal();
-    if (proposal) {
-      this.renderProposal(proposal);
-    } else {
-      this.renderNotFound();
     }
   }
 
@@ -5495,6 +5642,74 @@ class ProposalInfoModal {
     }
   }
 
+  handleLifecycleActionClick(event) {
+    const button = event.target?.closest?.('button[data-lifecycle-action-index]');
+    if (!button || !this.lifecycleActionSection?.contains(button)) return;
+
+    const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
+    this.handleLifecycleActionSubmit(action);
+  }
+
+  async handleLifecycleActionSubmit(action) {
+    if (this.isSubmitting || !action || action.canSubmit === false) return;
+
+    const proposal = this.getCurrentProposal();
+    if (!proposal) {
+      showToast('Proposal data is unavailable', 2500, 'warning');
+      return;
+    }
+    if (!myAccount?.keys?.address) {
+      showToast('Wallet keys unavailable', 2500, 'warning');
+      return;
+    }
+
+    this.submittingLifecycleAction = action;
+    this.setSubmitting(true);
+    const loadingToastId = showToast(action.loadingLabel, 0, 'loading');
+
+    try {
+      const request = {
+        from: getDaoCurrentAccountAddress(),
+        proposal,
+        timestamp: getTransactionTimestamp(),
+        networkId: network?.netid || '',
+        submitTransaction: (transaction) => this.submitDaoTransaction(transaction),
+      };
+      let result;
+      switch (action.kind) {
+        case 'vote_result':
+          result = await daoRepo.finalizeVoteResult(request);
+          break;
+        case 'claim_reward':
+          result = await daoRepo.claimReward(request);
+          break;
+        case 'burn_reward':
+          result = await daoRepo.burnReward(request);
+          break;
+        case 'apply_parameters':
+          result = await daoRepo.applyParameters(request);
+          break;
+        default:
+          throw new Error(`Unknown DAO lifecycle action: ${action.kind}`);
+      }
+
+      if (!result.ok) {
+        showToast(result.error || `${action.title} failed`, 3000, 'warning');
+        return;
+      }
+
+      showToast(action.successMessage, 3000, 'success');
+      await this.refreshAfterDaoAction(action.refreshWarning, { refreshNetworkParams: action.refreshNetworkParams });
+    } catch (error) {
+      console.warn('Failed to submit DAO lifecycle action:', error);
+      showToast(error?.message || `${action.title} failed`, 3000, 'warning');
+    } finally {
+      if (loadingToastId) hideToast(loadingToastId);
+      this.submittingLifecycleAction = null;
+      this.setSubmitting(false);
+    }
+  }
+
   async handleVoteSubmit() {
     if (this.isSubmitting || !this.canSubmitVote) return;
 
@@ -5551,9 +5766,6 @@ class ProposalInfoModal {
     enterFullscreen();
   }
 
-  isActive() {
-    return this.modal.classList.contains('active');
-  }
 }
 
 const proposalInfoModal = new ProposalInfoModal();

--- a/app.js
+++ b/app.js
@@ -3842,21 +3842,6 @@ function formatDaoDetailTimestamp(ts) {
   return formatted ? formatted.replace(', ', '\n') : 'Unavailable';
 }
 
-function renderDaoVotingEndsTimestamp(ts) {
-  const formatted = formatDaoTimestamp(ts);
-  if (!formatted) return 'Unavailable';
-
-  const [datePart, ...timeParts] = formatted.split(', ');
-  if (timeParts.length === 0) {
-    return escapeHtml(formatted);
-  }
-
-  return [
-    `<span>${escapeHtml(datePart)}</span>`,
-    `<span>${escapeHtml(timeParts.join(', '))}</span>`,
-  ].join(' ');
-}
-
 function formatDaoShortNumber(value, decimals = 6) {
   const n = Number(value);
   if (!Number.isFinite(n)) return 'Unavailable';
@@ -4496,7 +4481,7 @@ class ProposalInfoModal {
         <div class="proposal-vote-status-grid proposal-vote-status-grid--current">
           <div class="proposal-vote-status-card proposal-vote-status-card--deadline">
             <span>Voting ends</span>
-            <strong class="proposal-vote-deadline">${renderDaoVotingEndsTimestamp(votingWindow.end)}</strong>
+            <strong>${escapeHtml(formatDaoDetailTimestamp(votingWindow.end))}</strong>
           </div>
         </div>
       </section>
@@ -4964,7 +4949,7 @@ class ProposalInfoModal {
 
   getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow) {
     if (proposal.status && proposal.status !== 'review') return getDaoStateLabel(proposal.status) || proposal.status;
-    if (reviewWindow?.canFinalizeReviewResult) {
+    if (reviewWindow.canFinalizeReviewResult) {
       return `${this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount)} if finalized`;
     }
     if (withholdCount > acceptCount) return 'Likely withheld after review result';
@@ -5010,9 +4995,7 @@ class ProposalInfoModal {
     this.canSubmitReviewResult = true;
     this.reviewResultSection.classList.remove('hidden');
     if (this.reviewResultHelp) {
-      const nextState = proposal
-        ? this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount)
-        : 'its next state';
+      const nextState = this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount);
       this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to ${nextState}.`;
     }
     this.updateSubmitButtons();

--- a/app.js
+++ b/app.js
@@ -2762,6 +2762,7 @@ class DaoModal {
 
   renderProposalRowPreview(proposal) {
     const chips = [];
+    const state = getEffectiveDaoState(proposal);
     const result = getDaoProposalResultSummary(proposal);
     const reward = getDaoProposalRewardSummary(proposal);
 
@@ -2772,7 +2773,15 @@ class DaoModal {
         tone: result.tone,
       });
     }
-    if (reward) {
+    if (state === 'review') {
+      const reviewWindow = getDaoProposalReviewWindow(proposal);
+
+      chips.push({
+        label: 'Review',
+        value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,
+        tone: 'neutral',
+      });
+    } else if (reward) {
       chips.push({
         label: 'Reward',
         value: reward.previewLabel,
@@ -4338,7 +4347,7 @@ class ProposalInfoModal {
           currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
           this.getCommitteeVoteTone(currentVote),
         ],
-        ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount)],
+        ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
       ])
       : '';
 
@@ -4364,7 +4373,7 @@ class ProposalInfoModal {
 
     if (state === 'review') {
       this.renderCommitteeActions({ capabilities, reviewWindow, currentVote, state });
-      this.renderReviewResultAction({ capabilities, reviewWindow });
+      this.renderReviewResultAction({ capabilities, reviewWindow, proposal, acceptCount, withholdCount });
     } else {
       this.hideCommitteeActions();
       this.hideReviewResultAction();
@@ -4931,8 +4940,16 @@ class ProposalInfoModal {
     return vote.withheldReason ? `Withhold - ${vote.withheldReason}` : 'Withhold';
   }
 
-  getNextStateHint(proposal, acceptCount, withholdCount) {
+  getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount) {
+    if (withholdCount > acceptCount) return 'Withheld';
+    return proposal.emergency ? 'Accepted' : 'Voting';
+  }
+
+  getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow) {
     if (proposal.status && proposal.status !== 'review') return getDaoStateLabel(proposal.status) || proposal.status;
+    if (reviewWindow?.canFinalizeReviewResult) {
+      return `${this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount)} if finalized`;
+    }
     if (withholdCount > acceptCount) return 'Likely withheld after review result';
     if (acceptCount > withholdCount) return proposal.emergency ? 'Accepted if finalized' : 'Voting if finalized';
     return 'Waiting for committee review';
@@ -4966,7 +4983,7 @@ class ProposalInfoModal {
     this.updateSubmitButtons();
   }
 
-  renderReviewResultAction({ capabilities, reviewWindow }) {
+  renderReviewResultAction({ capabilities, reviewWindow, proposal, acceptCount, withholdCount }) {
     if (!this.reviewResultSection) return;
     if (!capabilities.canFinalizeReviewResult) {
       this.hideReviewResultAction();
@@ -4976,7 +4993,10 @@ class ProposalInfoModal {
     this.canSubmitReviewResult = true;
     this.reviewResultSection.classList.remove('hidden');
     if (this.reviewResultHelp) {
-      this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to its next state.`;
+      const nextState = proposal
+        ? this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount)
+        : 'its next state';
+      this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to ${nextState}.`;
     }
     this.updateSubmitButtons();
   }

--- a/app.js
+++ b/app.js
@@ -2742,6 +2742,7 @@ class DaoModal {
       const title = escapeHtml(titleText);
       const updatedLabel = escapeHtml(formatDaoRowTimestampLabel(p.stateEnteredAt || p.createdAt));
       const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
+      const previewHtml = this.renderProposalRowPreview(p);
 
       li.tabIndex = 0;
       li.setAttribute('role', 'button');
@@ -2759,6 +2760,7 @@ class DaoModal {
               <strong class="dao-row-meta-value">${updatedLabel}</strong>
             </span>
           </div>
+          ${previewHtml}
         </div>
       `;
       li.onclick = () => this.openProposal(p);
@@ -2774,6 +2776,39 @@ class DaoModal {
     if (this.addButton) {
       this.addButton.classList.toggle('visible', this.isActive());
     }
+  }
+
+  renderProposalRowPreview(proposal) {
+    const chips = [];
+    const result = getDaoProposalResultSummary(proposal);
+    const reward = getDaoProposalRewardSummary(proposal);
+
+    if (result) {
+      chips.push({
+        label: 'Result',
+        value: result.headline,
+        tone: result.tone,
+      });
+    }
+    if (reward) {
+      chips.push({
+        label: 'Reward',
+        value: reward.previewLabel,
+        tone: reward.statusTone,
+      });
+    }
+
+    if (chips.length === 0) return '';
+    return `
+      <div class="dao-row-previews">
+        ${chips.map((chip) => `
+          <span class="dao-row-preview dao-row-preview--${escapeDaoFormAttribute(chip.tone || 'neutral')}">
+            <span>${escapeHtml(chip.label)}</span>
+            <strong>${escapeHtml(chip.value)}</strong>
+          </span>
+        `).join('')}
+      </div>
+    `;
   }
 
   openProposal(proposal) {
@@ -3707,6 +3742,7 @@ const DAO_WITHHOLD_REASON_MAX_LENGTH = 1000;
 const DAO_VOTE_WEIGHT_MAX = 1_000_000;
 const DAO_VOTE_WEIGHT_PRECISION = 1_000_000_000_000;
 const DAO_VOTE_WEIGHT_PRECISION_BIGINT = 1_000_000_000_000n;
+const DAO_CLAIM_REWARD_PRECISION = 10n ** 18n;
 
 function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
@@ -3868,6 +3904,300 @@ function formatDaoLibWei(value) {
   }
 }
 
+function parseDaoUnsignedBigInt(value) {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value === 'bigint') return value >= 0n ? value : null;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) return null;
+    return BigInt(Math.trunc(value));
+  }
+
+  const text = String(value).trim();
+  if (!text) return null;
+  try {
+    const parsed = BigInt(text);
+    return parsed >= 0n ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatDaoRewardAmount(value) {
+  return value === null ? 'Unavailable' : formatDaoLibWei(value);
+}
+
+function formatDaoBigIntPercent(part, total) {
+  if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return '0%';
+  const tenths = (part * 1000n + total / 2n) / total;
+  const whole = tenths / 10n;
+  const fraction = tenths % 10n;
+  return fraction === 0n ? `${whole}%` : `${whole}.${fraction}%`;
+}
+
+function getDaoProposalOptions(proposal) {
+  if (!Array.isArray(proposal?.options) || proposal.options.length === 0) return ['Yes', 'No'];
+  return proposal.options.map((option, index) => String(option || `Option ${index + 1}`));
+}
+
+function getDaoVoteTotals(proposal) {
+  const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+  if (totalVote.length === 0) return [];
+
+  const options = getDaoProposalOptions(proposal);
+  const rowCount = Math.max(options.length, totalVote.length);
+  return Array.from({ length: rowCount }, (_, index) => ({
+    index,
+    option: options[index] || `Option ${index + 1}`,
+    total: parseDaoUnsignedBigInt(totalVote[index]) ?? 0n,
+  }));
+}
+
+function getDaoVoteWinner(totals) {
+  const totalWeight = totals.reduce((sum, row) => sum + row.total, 0n);
+  if (totalWeight <= 0n) return { totalWeight, winner: null };
+
+  const winner = totals.reduce((current, row) => (row.total > current.total ? row : current), totals[0]);
+  return { totalWeight, winner };
+}
+
+function isDaoFinalResultState(state) {
+  return state === 'accepted' || state === 'rejected' || state === 'applied';
+}
+
+function getDaoFinalOutcome(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  const label = getDaoStateLabel(state) || state || 'Unavailable';
+  const tone = state === 'withheld' || state === 'rejected' ? 'rejected' : 'accepted';
+  return { label, tone };
+}
+
+function getDaoCommitteeReviewResultSummary(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  if (state !== 'withheld' && !(proposal?.emergency && isDaoFinalResultState(state))) return null;
+
+  const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
+  const committeeAddresses = Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : [];
+  const committeeAddressSet = new Set(committeeAddresses);
+  const acceptCount = committeeVotes.filter((vote) => vote?.vote === 'accept' && committeeAddressSet.has(vote.memberAddress)).length;
+  const withholdCount = committeeVotes.filter((vote) => vote?.vote === 'withhold' && committeeAddressSet.has(vote.memberAddress)).length;
+  const outcome = getDaoFinalOutcome(proposal);
+
+  return {
+    detail: `Committee review: ${acceptCount} accept, ${withholdCount} withhold.`,
+    headline: outcome.label,
+    label: 'Final result',
+    source: 'committee',
+    tone: outcome.tone,
+    rows: [
+      ['Decision source', 'Committee review'],
+      ['Outcome', outcome.label, outcome.tone === 'accepted' ? 'accept' : 'withhold'],
+      ['Accept votes', String(acceptCount), 'accept'],
+      ['Withhold votes', String(withholdCount), withholdCount > 0 ? 'withhold' : ''],
+      ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
+    ],
+  };
+}
+
+function getDaoVoteResultSummary(proposal) {
+  const state = getEffectiveDaoState(proposal);
+  if (!isDaoFinalResultState(state)) return null;
+
+  const totals = getDaoVoteTotals(proposal);
+  if (totals.length === 0) return null;
+
+  const { totalWeight, winner } = getDaoVoteWinner(totals);
+  if (totalWeight <= 0n) return null;
+
+  const outcome = winner
+    ? winner.index === 0 ? 'Accepted' : 'Rejected'
+    : 'No votes yet';
+  const label = 'Final result';
+  const headline = winner
+    ? outcome
+    : 'No votes yet';
+  const detail = winner
+    ? `${winner.option} has ${formatDaoVotingPower(winner.total)} (${formatDaoBigIntPercent(winner.total, totalWeight)}).`
+    : 'No weighted votes are recorded yet.';
+  const tone = winner
+    ? winner.index === 0 ? 'accepted' : 'rejected'
+    : 'pending';
+
+  return { detail, headline, label, outcome, source: 'vote', tone, totalWeight, totals, winner };
+}
+
+function getDaoProposalResultSummary(proposal) {
+  return getDaoCommitteeReviewResultSummary(proposal) || getDaoVoteResultSummary(proposal);
+}
+
+function normalizeDaoAddress(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function getDaoVoterEntries(proposal) {
+  if (!Array.isArray(proposal?.voterList)) return [];
+  return proposal.voterList
+    .map((entry) => ({
+      address: normalizeDaoAddress(entry?.address),
+      timestamp: Number(entry?.timestamp || 0),
+    }))
+    .filter((entry) => entry.address && Number.isFinite(entry.timestamp) && entry.timestamp > 0);
+}
+
+function getDaoClaimList(proposal) {
+  if (!Array.isArray(proposal?.claimList)) return [];
+  return proposal.claimList.map(normalizeDaoAddress).filter(Boolean);
+}
+
+function getDaoProposalClaimWindow(proposal) {
+  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewDuration = Number(proposal?.reviewDuration);
+  const votingDuration = Number(proposal?.votingDuration);
+  const claimDuration = Number(proposal?.claimDuration);
+  if (
+    !Number.isFinite(reviewStart) ||
+    !Number.isFinite(reviewDuration) ||
+    !Number.isFinite(votingDuration) ||
+    !Number.isFinite(claimDuration)
+  ) {
+    return { start: null, end: null, votingStart: null, votingDuration: null };
+  }
+
+  const votingStart = reviewStart + reviewDuration;
+  const votingEnd = proposal?.emergency ? votingStart : votingStart + votingDuration;
+  return {
+    start: votingEnd,
+    end: votingEnd + claimDuration,
+    votingStart,
+    votingDuration,
+  };
+}
+
+function formatDaoClaimWindowLabel(claimWindow, now) {
+  if (!claimWindow.start || !claimWindow.end) return 'Unavailable';
+  const start = formatDaoTimestamp(claimWindow.start) || 'Unavailable';
+  const end = formatDaoTimestamp(claimWindow.end) || 'Unavailable';
+  if (now < claimWindow.start) return `Opens ${start}\nEnds ${end}`;
+  if (now <= claimWindow.end) return `Open until ${end}`;
+  return `Ended ${end}`;
+}
+
+function getDaoClaimRewardEstimate({ pool, claimed, voterEntries, voterIndex, votingStart, votingDuration }) {
+  if (pool <= 0n || claimed >= pool || voterIndex < 0 || voterEntries.length === 0) return null;
+  if (!Number.isFinite(votingStart) || !Number.isFinite(votingDuration) || votingDuration <= 0) return null;
+
+  const voter = voterEntries[voterIndex];
+  const previousTimestamp = voterIndex === 0 ? votingStart : voterEntries[voterIndex - 1]?.timestamp;
+  if (!Number.isFinite(voter?.timestamp) || !Number.isFinite(previousTimestamp)) return null;
+
+  const timeDelta = BigInt(Math.max(0, Math.trunc(voter.timestamp - previousTimestamp)));
+  const duration = BigInt(Math.trunc(votingDuration));
+  const voterCount = BigInt(voterEntries.length);
+  const timePart = (timeDelta * DAO_CLAIM_REWARD_PRECISION) / duration;
+  const equalPart = DAO_CLAIM_REWARD_PRECISION / voterCount;
+  let reward = (pool * (timePart + equalPart)) / (2n * DAO_CLAIM_REWARD_PRECISION);
+  const remaining = pool > claimed ? pool - claimed : 0n;
+  if (reward > remaining) reward = remaining;
+  return reward;
+}
+
+function getDaoRewardClaimStatus({ state, currentAddress, voterIndex, hasClaimed, pool, claimed, claimWindow, now }) {
+  if (!currentAddress) return 'Sign in to check rewards';
+  if (state === 'withheld') return 'Reward pool burned';
+  if (voterIndex < 0) return 'Not eligible';
+  if (hasClaimed) return 'Already claimed';
+  if (pool <= 0n) return 'Reward pool empty';
+  if (claimed >= pool) return 'Reward pool fully claimed';
+  if (!claimWindow.end) return 'Claim timing unavailable';
+  if (now > claimWindow.end) return 'Claim window ended';
+  if (now < claimWindow.start) return 'Claim window not open';
+  return 'Claimable';
+}
+
+function getDaoRewardPreviewLabel(summary) {
+  if (summary.claimStatus === 'Claimable' && summary.claimEstimate !== null) {
+    return `${formatDaoLibWei(summary.claimEstimate)} claimable`;
+  }
+  if (summary.claimStatus === 'Already claimed') return 'Reward claimed';
+  if (summary.initialBurned !== null && summary.initialBurned > 0n) {
+    return `${formatDaoLibWei(summary.initialBurned)} burned`;
+  }
+  if (summary.finalBurned !== null && summary.finalBurned > 0n) {
+    return `${formatDaoLibWei(summary.finalBurned)} burned`;
+  }
+  if (summary.unclaimed !== null && summary.unclaimed > 0n) {
+    return `${formatDaoLibWei(summary.unclaimed)} unclaimed`;
+  }
+  return summary.claimStatus;
+}
+
+function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+  const state = getEffectiveDaoState(proposal);
+  const isRewardState = state === 'accepted' || state === 'rejected' || state === 'applied' || state === 'withheld';
+  if (!isRewardState) return null;
+
+  const pool = parseDaoUnsignedBigInt(proposal?.voterRewardPool);
+  const claimed = parseDaoUnsignedBigInt(proposal?.claimedReward);
+  const initialBurned = parseDaoUnsignedBigInt(proposal?.initialBurnedReward);
+  const finalBurned = parseDaoUnsignedBigInt(proposal?.finalBurnedReward);
+  const voterEntries = getDaoVoterEntries(proposal);
+  const claimList = getDaoClaimList(proposal);
+  const hasRewardData = (
+    pool !== null ||
+    claimed !== null ||
+    initialBurned !== null ||
+    finalBurned !== null ||
+    voterEntries.length > 0 ||
+    claimList.length > 0
+  );
+  if (!hasRewardData) return null;
+
+  const safePool = pool ?? 0n;
+  const safeClaimed = claimed ?? 0n;
+  const claimWindow = getDaoProposalClaimWindow(proposal);
+  const normalizedAddress = normalizeDaoAddress(currentAddress);
+  const voterIndex = normalizedAddress ? voterEntries.findIndex((entry) => entry.address === normalizedAddress) : -1;
+  const hasClaimed = normalizedAddress ? claimList.includes(normalizedAddress) : false;
+  const claimStatus = getDaoRewardClaimStatus({
+    state,
+    currentAddress: normalizedAddress,
+    voterIndex,
+    hasClaimed,
+    pool: safePool,
+    claimed: safeClaimed,
+    claimWindow,
+    now,
+  });
+  const claimEstimate = hasClaimed
+    ? null
+    : getDaoClaimRewardEstimate({
+        pool: safePool,
+        claimed: safeClaimed,
+        voterEntries,
+        voterIndex,
+        votingStart: claimWindow.votingStart,
+        votingDuration: claimWindow.votingDuration,
+      });
+  const unclaimed = pool !== null && claimed !== null
+    ? safePool > safeClaimed ? safePool - safeClaimed : 0n
+    : null;
+
+  const summary = {
+    claimEstimate,
+    claimStatus,
+    claimWindowLabel: formatDaoClaimWindowLabel(claimWindow, now),
+    claimed,
+    finalBurned,
+    initialBurned,
+    pool,
+    unclaimed,
+  };
+  return {
+    ...summary,
+    previewLabel: getDaoRewardPreviewLabel(summary),
+    statusTone: claimStatus === 'Claimable' ? 'accept' : '',
+  };
+}
+
 function formatDaoDetailValue(value) {
   if (value === undefined || value === null || value === '') return 'Unavailable';
   if (typeof value === 'bigint') return value.toString();
@@ -4027,12 +4357,28 @@ class ProposalInfoModal {
       committeeAddressSet,
     });
     const proposalType = proposal.proposalType || proposal.type;
+    const resultSummary = getDaoProposalResultSummary(proposal);
+    const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
+    const committeeReviewSection = state === 'review'
+      ? this.renderSection('Committee Review', [
+        ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
+        ['Accept votes', String(acceptCount)],
+        ['Withhold votes', String(withholdCount)],
+        [
+          'Your vote',
+          currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
+          this.getCommitteeVoteTone(currentVote),
+        ],
+        ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount)],
+      ])
+      : '';
 
     if (this.content) {
       this.content.innerHTML = [
         this.renderProposalTitle(proposal),
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
+        this.renderProposalResultSummary(resultSummary),
         this.renderSection('Overview', [
           ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
           ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
@@ -4047,18 +4393,10 @@ class ProposalInfoModal {
           ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
         ]),
         this.renderProposalBody(proposal),
-        this.renderSection('Committee Review', [
-          ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
-          ['Accept votes', String(acceptCount)],
-          ['Withhold votes', String(withholdCount)],
-          [
-            'Your vote',
-            currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
-            this.getCommitteeVoteTone(currentVote),
-          ],
-          ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount)],
-        ]),
-      ].join('');
+        committeeReviewSection,
+        this.renderProposalResults(resultSummary),
+        this.renderProposalRewards(rewardSummary),
+      ].filter(Boolean).join('');
     }
 
     if (state === 'review') {
@@ -4220,6 +4558,70 @@ class ProposalInfoModal {
 
   getProposalTitle(proposal) {
     return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
+  }
+
+  renderProposalResultSummary(result) {
+    if (!result) return '';
+    return `
+      <section class="proposal-result-banner proposal-result-banner--${escapeDaoFormAttribute(result.tone)}">
+        <span>${escapeHtml(result.label)}</span>
+        <strong>${escapeHtml(result.headline)}</strong>
+        <small>${escapeHtml(result.detail)}</small>
+      </section>
+    `;
+  }
+
+  renderProposalResults(result) {
+    if (!result) return '';
+    if (result.source === 'committee') {
+      return this.renderSection('Results', result.rows);
+    }
+
+    const winnerLabel = result.winner ? `${result.winner.option} (${result.outcome})` : 'Unavailable';
+    const totalLabel = result.totalWeight > 0n ? formatDaoVotingPower(result.totalWeight) : 'No votes yet';
+    const rows = result.totals
+      .map((row) => {
+        const isWinner = result.winner?.index === row.index;
+        return `
+          <div class="proposal-result-row${isWinner ? ' proposal-result-row--winner' : ''}">
+            <span>${escapeHtml(row.option)}</span>
+            <strong>${escapeHtml(formatDaoVotingPower(row.total))}</strong>
+            <small>${escapeHtml(formatDaoBigIntPercent(row.total, result.totalWeight))}</small>
+          </div>
+        `;
+      })
+      .join('');
+
+    return `
+      <section class="proposal-info-section">
+        <h3>Results</h3>
+        <div class="proposal-result-overview">
+          <div class="proposal-result-card">
+            <span>Winner</span>
+            <strong>${escapeHtml(winnerLabel)}</strong>
+          </div>
+          <div class="proposal-result-card">
+            <span>Total voting power</span>
+            <strong>${escapeHtml(totalLabel)}</strong>
+          </div>
+        </div>
+        <div class="proposal-result-list">${rows}</div>
+      </section>
+    `;
+  }
+
+  renderProposalRewards(reward) {
+    if (!reward) return '';
+    return this.renderSection('Rewards', [
+      ['Claim status', reward.claimStatus, reward.statusTone],
+      ['Claim estimate', reward.claimEstimate === null ? 'Unavailable' : formatDaoLibWei(reward.claimEstimate), reward.statusTone],
+      ['Claim window', reward.claimWindowLabel],
+      ['Reward pool', formatDaoRewardAmount(reward.pool)],
+      ['Claimed', formatDaoRewardAmount(reward.claimed)],
+      ['Unclaimed pool', formatDaoRewardAmount(reward.unclaimed)],
+      ['Initial burn', formatDaoRewardAmount(reward.initialBurned)],
+      ['Final burn', formatDaoRewardAmount(reward.finalBurned)],
+    ]);
   }
 
   setTitle(title) {
@@ -4436,9 +4838,7 @@ class ProposalInfoModal {
   }
 
   getVoteOptions(proposal) {
-    return Array.isArray(proposal?.options) && proposal.options.length
-      ? proposal.options.map((option) => String(option))
-      : ['Yes', 'No'];
+    return getDaoProposalOptions(proposal);
   }
 
   renderVoteActions({ proposal, state }) {

--- a/app.js
+++ b/app.js
@@ -4249,6 +4249,7 @@ class ProposalInfoModal {
     this.closeButton = document.getElementById('closeProposalInfoModal');
     this.title = document.getElementById('proposalInfoModalTitle');
     this.content = document.getElementById('proposalInfoContent');
+    this.detailsContent = document.getElementById('proposalDetailsContent');
     this.committeeActionSection = document.getElementById('proposalCommitteeActionSection');
     this.committeeActionHelp = document.getElementById('proposalCommitteeActionHelp');
     this.acceptButton = document.getElementById('proposalCommitteeAccept');
@@ -4333,6 +4334,9 @@ class ProposalInfoModal {
     if (this.content) {
       this.content.innerHTML = '<section class="proposal-info-section"><h3>Proposal not found</h3><p class="proposal-info-muted">The proposal data is unavailable.</p></section>';
     }
+    if (this.detailsContent) {
+      this.detailsContent.innerHTML = '';
+    }
     this.hideCommitteeActions();
     this.hideReviewResultAction();
     this.hideVoteActions();
@@ -4379,23 +4383,18 @@ class ProposalInfoModal {
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResultSummary(resultSummary),
-        this.renderSection('Overview', [
-          ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
-          ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
-          ['Status', getDaoStateLabel(state) || state],
-          ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
-          ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
-        ]),
-        this.renderSection('Review Timeline', [
-          ['Window state', reviewWindow.label],
-          ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
-          ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
-        ]),
-        this.renderProposalBody(proposal),
         committeeReviewSection,
-        this.renderProposalResults(resultSummary),
-        this.renderProposalRewards(rewardSummary),
       ].filter(Boolean).join('');
+    }
+    if (this.detailsContent) {
+      this.detailsContent.innerHTML = this.renderProposalDetails({
+        proposal,
+        proposalType,
+        state,
+        reviewWindow,
+        resultSummary,
+        rewardSummary,
+      });
     }
 
     if (state === 'review') {
@@ -4621,6 +4620,65 @@ class ProposalInfoModal {
       ['Initial burn', formatDaoRewardAmount(reward.initialBurned)],
       ['Final burn', formatDaoRewardAmount(reward.finalBurned)],
     ]);
+  }
+
+  getVoteStatusData(proposal) {
+    const votingWindow = getDaoProposalVotingWindow(proposal);
+    const totalVote = Array.isArray(proposal.totalVote) ? proposal.totalVote : [];
+    const options = this.getVoteOptions(proposal);
+    const totalVoteText = totalVote.length
+      ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
+      : 'No votes yet';
+    return { votingWindow, totalVoteText };
+  }
+
+  renderVotingDetails(proposal) {
+    const { votingWindow, totalVoteText } = this.getVoteStatusData(proposal);
+    return this.renderSection('Voting Details', [
+      ['Voting state', votingWindow.label],
+      ['Current totals', totalVoteText],
+    ]);
+  }
+
+  renderProposalDetails({ proposal, proposalType, state, reviewWindow, resultSummary, rewardSummary }) {
+    const sections = [
+      this.renderSection('Overview', [
+        ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
+        ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
+        ['Status', getDaoStateLabel(state) || state],
+        ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
+        ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
+      ]),
+      this.renderSection('Review Timeline', [
+        ['Window state', reviewWindow.label],
+        ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
+        ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
+      ]),
+      state === 'voting' ? this.renderVotingDetails(proposal) : '',
+      this.renderProposalBody(proposal),
+      this.renderProposalResults(resultSummary),
+      this.renderProposalRewards(rewardSummary),
+    ].filter(Boolean);
+
+    if (sections.length === 0) return '';
+
+    return `
+      <details class="proposal-more">
+        <summary>
+          <span class="proposal-more-title">Show proposal details</span>
+          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, resultSummary, rewardSummary))}</span>
+        </summary>
+        <div class="proposal-more-content">${sections.join('')}</div>
+      </details>
+    `;
+  }
+
+  getProposalDetailsSummary(state, resultSummary, rewardSummary) {
+    const parts = ['Overview', 'review timeline', 'proposal body'];
+    if (state === 'voting') parts.push('voting totals');
+    if (resultSummary) parts.push('result breakdown');
+    if (rewardSummary) parts.push('reward accounting');
+    return parts.join(', ');
   }
 
   setTitle(title) {

--- a/app.js
+++ b/app.js
@@ -4383,7 +4383,6 @@ class ProposalInfoModal {
           ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
           ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
           ['Status', getDaoStateLabel(state) || state],
-          ['Creator', proposal.createdBy || proposal.from || 'Unavailable'],
           ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
           ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
         ]),

--- a/app.js
+++ b/app.js
@@ -2466,19 +2466,6 @@ function formatDaoTimestamp(ts) {
   }
 }
 
-function formatDaoRowTimestampLabel(ts) {
-  const n = Number(ts || 0);
-  if (!n) return '—';
-  const date = new Date(n);
-  try {
-    const dateLabel = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-    const timeLabel = date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-    return `${dateLabel} ${timeLabel}`;
-  } catch {
-    return '—';
-  }
-}
-
 function getDaoUiStateLabel(key) {
   if (key === 'discussion') return 'Review';
   return getDaoStateLabel(key);
@@ -2740,7 +2727,6 @@ class DaoModal {
 
       const titleText = p.title || (p.number ? `Proposal #${p.number}` : 'Proposal');
       const title = escapeHtml(titleText);
-      const updatedLabel = escapeHtml(formatDaoRowTimestampLabel(p.stateEnteredAt || p.createdAt));
       const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
       const previewHtml = this.renderProposalRowPreview(p);
 
@@ -2755,12 +2741,8 @@ class DaoModal {
               <span class="dao-row-meta-label">Type</span>
               <strong class="dao-row-meta-value">${typeLabel}</strong>
             </span>
-            <span class="dao-row-meta-item dao-row-meta-item--updated">
-              <span class="dao-row-meta-label">Updated</span>
-              <strong class="dao-row-meta-value">${updatedLabel}</strong>
-            </span>
+            ${previewHtml}
           </div>
-          ${previewHtml}
         </div>
       `;
       li.onclick = () => this.openProposal(p);

--- a/app.js
+++ b/app.js
@@ -3842,6 +3842,21 @@ function formatDaoDetailTimestamp(ts) {
   return formatted ? formatted.replace(', ', '\n') : 'Unavailable';
 }
 
+function renderDaoVotingEndsTimestamp(ts) {
+  const formatted = formatDaoTimestamp(ts);
+  if (!formatted) return 'Unavailable';
+
+  const [datePart, ...timeParts] = formatted.split(', ');
+  if (timeParts.length === 0) {
+    return escapeHtml(formatted);
+  }
+
+  return [
+    `<span>${escapeHtml(datePart)}</span>`,
+    `<span>${escapeHtml(timeParts.join(', '))}</span>`,
+  ].join(' ');
+}
+
 function formatDaoShortNumber(value, decimals = 6) {
   const n = Number(value);
   if (!Number.isFinite(n)) return 'Unavailable';
@@ -4479,9 +4494,9 @@ class ProposalInfoModal {
           <div class="proposal-vote-current-track" aria-hidden="true">${segments}</div>
         </div>
         <div class="proposal-vote-status-grid proposal-vote-status-grid--current">
-          <div class="proposal-vote-status-card">
+          <div class="proposal-vote-status-card proposal-vote-status-card--deadline">
             <span>Voting ends</span>
-            <strong>${escapeHtml(formatDaoDetailTimestamp(votingWindow.end))}</strong>
+            <strong class="proposal-vote-deadline">${renderDaoVotingEndsTimestamp(votingWindow.end)}</strong>
           </div>
         </div>
       </section>
@@ -4908,7 +4923,7 @@ class ProposalInfoModal {
             <div class="proposal-change-values">
               <small><span>Current:</span><strong>${escapeHtml(current)}</strong></small>
               <span class="proposal-change-arrow" aria-hidden="true">&rarr;</span>
-              <strong><span>New:</span><span>${escapeHtml(next)}</span></strong>
+              <small><span>New:</span><strong>${escapeHtml(next)}</strong></small>
             </div>
           </div>
         `;

--- a/app.js
+++ b/app.js
@@ -3967,19 +3967,10 @@ function getDaoCommitteeReviewResultSummary(proposal) {
   return {
     acceptCount,
     committeeSize: committeeAddresses.length,
-    detail: `Committee review: ${acceptCount} accept, ${withholdCount} withhold.`,
     headline: outcome.label,
-    label: 'Final result',
     source: 'committee',
     tone: outcome.tone,
     withholdCount,
-    rows: [
-      ['Decision source', 'Committee review'],
-      ['Outcome', outcome.label, outcome.tone === 'accepted' ? 'accept' : 'withhold'],
-      ['Accept votes', String(acceptCount), 'accept'],
-      ['Withhold votes', String(withholdCount), withholdCount > 0 ? 'withhold' : ''],
-      ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
-    ],
   };
 }
 
@@ -3993,21 +3984,10 @@ function getDaoVoteResultSummary(proposal) {
   const { totalWeight, winner } = getDaoVoteWinner(totals);
   if (totalWeight <= 0n) return null;
 
-  const outcome = winner
-    ? winner.index === 0 ? 'Accepted' : 'Rejected'
-    : 'No votes yet';
-  const label = 'Final result';
-  const headline = winner
-    ? outcome
-    : 'No votes yet';
-  const detail = winner
-    ? `${winner.option} has ${formatDaoVotingPower(winner.total)} (${formatDaoBigIntPercent(winner.total, totalWeight)}).`
-    : 'No weighted votes are recorded yet.';
-  const tone = winner
-    ? winner.index === 0 ? 'accepted' : 'rejected'
-    : 'pending';
+  const outcome = winner.index === 0 ? 'Accepted' : 'Rejected';
+  const tone = winner.index === 0 ? 'accepted' : 'rejected';
 
-  return { detail, headline, label, outcome, source: 'vote', tone, totalWeight, totals, winner };
+  return { headline: outcome, outcome, source: 'vote', tone, totalWeight, totals, winner };
 }
 
 function getDaoProposalResultSummary(proposal) {
@@ -4367,7 +4347,7 @@ class ProposalInfoModal {
         this.renderProposalTitle(proposal),
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
-        this.renderProposalResultSummary(resultSummary),
+        this.renderProposalResults(resultSummary),
         committeeReviewSection,
       ].filter(Boolean).join('');
     }
@@ -4541,11 +4521,6 @@ class ProposalInfoModal {
 
   getProposalTitle(proposal) {
     return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
-  }
-
-  renderProposalResultSummary(result) {
-    if (!result) return '';
-    return this.renderProposalResults(result);
   }
 
   renderProposalResults(result) {

--- a/app.js
+++ b/app.js
@@ -4560,6 +4560,9 @@ class ProposalInfoModal {
     const segments = result.totals
       .map((row, rowPosition) => {
         const isWinner = result.winner?.index === row.index;
+        const paletteClass = result.totals.length > 1
+          ? ` proposal-result-meter-label--palette-${rowPosition % 6}`
+          : '';
         const units = this.getResultSegmentUnits(row.total, result.totalWeight);
         const power = formatDaoVotingPower(row.total);
         const displayPower = power.endsWith(' power') ? power.slice(0, -6) : power;
@@ -4573,7 +4576,7 @@ class ProposalInfoModal {
         const label = `${row.option}: ${power}, ${percent}`;
         return `
           <div
-            class="proposal-result-meter-label proposal-result-meter-label--${position}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
+            class="proposal-result-meter-label proposal-result-meter-label--${position}${paletteClass}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
             style="${escapeDaoFormAttribute(style)}"
             title="${escapeDaoFormAttribute(label)}"
             aria-label="${escapeDaoFormAttribute(label)}"
@@ -4585,13 +4588,15 @@ class ProposalInfoModal {
       })
       .join('');
     const bars = result.totals
-      .map((row) => {
-        const isWinner = result.winner?.index === row.index;
+      .map((row, rowPosition) => {
+        const paletteClass = result.totals.length > 1
+          ? ` proposal-result-meter-segment--palette-${rowPosition % 6}`
+          : ' proposal-result-meter-segment--palette-0';
         const units = this.getResultSegmentUnits(row.total, result.totalWeight);
         const style = `--result-segment-units: ${units};`;
         return `
           <span
-            class="proposal-result-meter-segment${isWinner ? ' proposal-result-meter-segment--winner' : ''}${row.total === 0n ? ' proposal-result-meter-segment--empty' : ''}"
+            class="proposal-result-meter-segment${paletteClass}${row.total === 0n ? ' proposal-result-meter-segment--empty' : ''}"
             style="${escapeDaoFormAttribute(style)}"
           ></span>
         `;

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -670,6 +670,8 @@ function storeToUiList(store, groupKey) {
         claimedReward: p.claimedReward,
         initialBurnedReward: p.initialBurnedReward,
         finalBurnedReward: p.finalBurnedReward,
+        voterList: Array.isArray(p.voterList) ? p.voterList : [],
+        claimList: Array.isArray(p.claimList) ? p.claimList : [],
         startTime: p.startTime,
         reviewDuration: p.reviewDuration,
         votingDuration: p.votingDuration,

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -513,12 +513,10 @@ async function fetchBackendProposal(queryDaoApi, proposalNumber) {
   return body.proposal;
 }
 
-export function createDaoBackendFetcher(queryDaoApi, { batchSize = DAO_PROPOSAL_QUERY_BATCH_SIZE } = {}) {
+export function createDaoBackendFetcher(queryDaoApi) {
   if (typeof queryDaoApi !== 'function') {
     return async () => createEmptyDaoStore();
   }
-
-  const safeBatchSize = normalizeDaoPositiveInteger(batchSize) || DAO_PROPOSAL_QUERY_BATCH_SIZE;
 
   return async () => {
     const body = await queryDaoApi('/dao/proposals/meta');
@@ -534,8 +532,8 @@ export function createDaoBackendFetcher(queryDaoApi, { batchSize = DAO_PROPOSAL_
     if (!count) return buildStoreFromBackendProposals(meta, []);
 
     const proposals = [];
-    for (let start = 1; start <= count; start += safeBatchSize) {
-      const end = Math.min(start + safeBatchSize - 1, count);
+    for (let start = 1; start <= count; start += DAO_PROPOSAL_QUERY_BATCH_SIZE) {
+      const end = Math.min(start + DAO_PROPOSAL_QUERY_BATCH_SIZE - 1, count);
       const batch = await Promise.all(
         Array.from({ length: end - start + 1 }, (_, index) => fetchBackendProposal(queryDaoApi, start + index))
       );
@@ -655,6 +653,7 @@ function storeToUiList(store, groupKey) {
         description,
         type,
         proposalType: type,
+        emergency: Boolean(p.emergency),
         createdAt: p.created,
         state,
         status: state,

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -88,8 +88,7 @@ export function getDaoStateLabel(key) {
 }
 
 export function getEffectiveDaoState(proposal) {
-  const state = proposal?.status || proposal?.state || 'review';
-  return state === 'discussion' ? 'review' : state;
+  return proposal?.status || proposal?.state || 'review';
 }
 
 const DAO_PROPOSAL_QUERY_BATCH_SIZE = 10;
@@ -251,7 +250,28 @@ export function buildDaoProposalCreateTransaction({
 }
 
 function getDaoProposalTransactionId(proposal) {
-  return requireDaoDraftString(proposal?.accountId || proposal?.proposalId || proposal?.id, 'DAO proposal account ID');
+  return requireDaoDraftString(proposal?.accountId, 'DAO proposal account ID');
+}
+
+function buildDaoProposalActionTransaction({
+  type,
+  from,
+  proposal,
+  timestamp,
+  networkId,
+  timestampLabel,
+  fromLabel,
+} = {}) {
+  const txTimestamp = requireDaoNonNegativeNumber(timestamp, timestampLabel);
+  if (txTimestamp <= 0) throw new Error(`${timestampLabel} is required`);
+
+  return {
+    type: requireDaoDraftString(type, 'DAO transaction type'),
+    timestamp: txTimestamp,
+    networkId: requireDaoDraftString(networkId, 'Network ID'),
+    from: requireDaoDraftString(from, fromLabel),
+    proposalId: getDaoProposalTransactionId(proposal),
+  };
 }
 
 export function buildDaoCommitteeVoteTransaction({
@@ -293,16 +313,15 @@ export function buildDaoCommitteeResultTransaction({
   timestamp,
   networkId,
 } = {}) {
-  const txTimestamp = requireDaoNonNegativeNumber(timestamp, 'Review result timestamp');
-  if (txTimestamp <= 0) throw new Error('Review result timestamp is required');
-
-  return {
+  return buildDaoProposalActionTransaction({
     type: 'dao_committee_result',
-    timestamp: txTimestamp,
-    networkId: requireDaoDraftString(networkId, 'Network ID'),
-    from: requireDaoDraftString(from, 'Review result sender'),
-    proposalId: getDaoProposalTransactionId(proposal),
-  };
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Review result timestamp',
+    fromLabel: 'Review result sender',
+  });
 }
 
 export function buildDaoVoteTransaction({
@@ -349,6 +368,74 @@ export function buildDaoVoteTransaction({
   };
 }
 
+export function buildDaoVoteResultTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_vote_result',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Vote result timestamp',
+    fromLabel: 'Vote result sender',
+  });
+}
+
+export function buildDaoClaimRewardTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_claim_reward',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Reward claim timestamp',
+    fromLabel: 'Reward claim sender',
+  });
+}
+
+export function buildDaoBurnRewardTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_burn_reward',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Reward burn timestamp',
+    fromLabel: 'Reward burn sender',
+  });
+}
+
+export function buildDaoApplyParametersTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_apply_parameters',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Apply parameters timestamp',
+    fromLabel: 'Apply parameters sender',
+  });
+}
+
 async function submitDaoTransaction({ transaction, submitTransaction, errorMessage }) {
   try {
     if (typeof submitTransaction !== 'function') {
@@ -372,6 +459,32 @@ async function submitDaoTransaction({ transaction, submitTransaction, errorMessa
       error: error?.message || errorMessage,
       transaction,
     };
+  }
+}
+
+async function submitDaoProposalAction({
+  buildTransaction,
+  from,
+  proposal,
+  timestamp,
+  networkId,
+  submitTransaction,
+  errorMessage,
+} = {}) {
+  try {
+    const transaction = buildTransaction({
+      from,
+      proposal,
+      timestamp,
+      networkId,
+    });
+    return submitDaoTransaction({
+      transaction,
+      submitTransaction,
+      errorMessage,
+    });
+  } catch (error) {
+    return { ok: false, error: error?.message || errorMessage, transaction: null };
   }
 }
 
@@ -401,64 +514,36 @@ function normalizeDaoTimestamp(value) {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
-function normalizeDaoVoteNumber(value) {
-  if (typeof value === 'bigint') return Number(value);
-  const n = Number(value || 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function getDaoProposalDescription(proposal) {
-  return String(proposal?.description || proposal?.summary || '').trim();
-}
-
-function getDaoProposalFields(proposal) {
-  const fields = proposal?.fields && typeof proposal.fields === 'object' ? { ...proposal.fields } : {};
-  if (proposal?.governance) fields.governance = proposal.governance;
-  if (proposal?.economic) fields.economic = proposal.economic;
-  if (proposal?.protocol) fields.protocol = proposal.protocol;
-  return fields;
-}
-
-function getDaoProposalVotes(proposal) {
-  if (proposal?.votes && typeof proposal.votes === 'object') return proposal.votes;
-
-  const totals = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
-  return {
-    yes: normalizeDaoVoteNumber(totals[0]),
-    no: normalizeDaoVoteNumber(totals[1]),
-    by: {},
-  };
-}
-
 function mapBackendProposalToStoreProposal(proposal) {
   if (!proposal || typeof proposal !== 'object') return null;
 
   const number = normalizeDaoPositiveInteger(proposal.number);
   if (!number) return null;
 
-  const nonce = String(proposal.id || proposal.nonce || number);
-  const type = proposal.proposalType || proposal.type || '';
+  const accountId = String(proposal.id || '').trim();
+  if (!accountId) return null;
+
+  const nonce = accountId;
+  const proposalType = String(proposal.proposalType || '').trim();
+  if (!proposalType) return null;
+
   const state = getEffectiveDaoState(proposal);
-  const created = normalizeDaoTimestamp(proposal.creationTime || proposal.created || proposal.timestamp);
-  const stateChanged = normalizeDaoTimestamp(proposal.timestamp || proposal.state_changed || created);
-  const description = getDaoProposalDescription(proposal);
+  const created = normalizeDaoTimestamp(proposal.creationTime);
+  const stateChanged = normalizeDaoTimestamp(proposal.timestamp);
+  const title = String(proposal.title || proposal.description || '').trim();
 
   return {
     ...proposal,
-    accountId: proposal.id,
+    accountId,
     number,
     nonce,
-    title: String(proposal.title || '').trim(),
-    summary: description,
-    description,
-    type,
-    proposalType: type,
+    title,
+    description: String(proposal.description || '').trim(),
+    proposalType,
     state,
     status: state,
     state_changed: stateChanged,
     created,
-    fields: getDaoProposalFields(proposal),
-    votes: getDaoProposalVotes(proposal),
   };
 }
 
@@ -469,7 +554,6 @@ function getDaoStoreMeta(proposal) {
     state: proposal.state,
     status: proposal.status,
     state_changed: proposal.state_changed,
-    type: proposal.type,
     proposalType: proposal.proposalType,
     nonce: proposal.nonce,
   };
@@ -502,12 +586,10 @@ async function fetchBackendProposal(queryDaoApi, proposalNumber) {
   const body = await queryDaoApi(`/dao/proposals/${proposalNumber}`);
   if (!body) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: no response`);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   if (body.error || !body.proposal) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: proposal unavailable`, body.error || body);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   return body.proposal;
@@ -570,13 +652,6 @@ function normalizeDaoStore(store) {
     const full = safe.proposals[id];
     if (!full) continue;
 
-    // Migration: older versions wrote a synthetic `state: 'archived'`.
-    // We cannot reliably recover the original state; map to a server-supported final state.
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-
     const state = getEffectiveDaoState({ status: full.status || meta.status, state: full.state || meta.state });
     const enteredAt = Number(full.state_changed || meta.state_changed || full.created || 0);
     const isArchivable = DAO_ARCHIVABLE_STATE_KEYS.includes(state);
@@ -591,7 +666,7 @@ function normalizeDaoStore(store) {
           title: meta.title,
           state,
           state_changed: enteredAt,
-          type: meta.type,
+          proposalType: meta.proposalType,
           nonce: meta.nonce,
         });
         archivedIds.add(id);
@@ -609,17 +684,6 @@ function normalizeDaoStore(store) {
     const id = daoProposalId(m.number, m.nonce);
     return Boolean(safe.proposals[id]);
   });
-
-  // Migration: older versions stored `state: 'archived'` for archived items.
-  for (const meta of safe.archivedProposals) {
-    const id = daoProposalId(meta.number, meta.nonce);
-    const full = safe.proposals[id];
-    if (!full) continue;
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-  }
 
   safe.meta.active = safe.activeProposals.length;
   safe.meta.archived = safe.archivedProposals.length;
@@ -640,40 +704,36 @@ function storeToUiList(store, groupKey) {
       const id = daoProposalId(m.number, m.nonce);
       const p = safe.proposals?.[id];
       if (!p) return null;
-      const description = p.description || p.summary;
       const state = getEffectiveDaoState({ status: p.status || m.status, state: p.state || m.state });
-      const type = p.proposalType || p.type;
       return {
         id,
         number: p.number,
         accountId: p.accountId,
         nonce: p.nonce,
         title: p.title,
-        summary: description,
-        description,
-        type,
-        proposalType: type,
+        description: p.description,
+        proposalType: p.proposalType,
         emergency: Boolean(p.emergency),
         createdAt: p.created,
         state,
         status: state,
         stateEnteredAt: p.state_changed,
-        fields: p.fields || {},
-        options: Array.isArray(p.options) ? p.options : ['yes', 'no'],
-        totalVote: Array.isArray(p.totalVote) ? p.totalVote : undefined,
-        committeeVotes: Array.isArray(p.committeeVotes) ? p.committeeVotes : [],
-        committeeAddresses: Array.isArray(p.committeeAddresses) ? p.committeeAddresses : [],
+        options: p.options,
+        totalVote: p.totalVote,
+        committeeVotes: p.committeeVotes,
+        committeeAddresses: p.committeeAddresses,
         voterRewardPool: p.voterRewardPool,
         claimedReward: p.claimedReward,
         initialBurnedReward: p.initialBurnedReward,
         finalBurnedReward: p.finalBurnedReward,
-        voterList: Array.isArray(p.voterList) ? p.voterList : [],
-        claimList: Array.isArray(p.claimList) ? p.claimList : [],
+        voterList: p.voterList,
+        claimList: p.claimList,
         startTime: p.startTime,
         reviewDuration: p.reviewDuration,
         votingDuration: p.votingDuration,
         claimDuration: p.claimDuration,
-        votes: p.votes || { yes: 0, no: 0, by: {} },
+        gracePeriod: p.gracePeriod,
+        applyEligibleAt: p.applyEligibleAt,
         archivedAt: p.archivedAt || 0,
       };
     })
@@ -691,7 +751,7 @@ export function setDaoBackendFetcher(fetcher) {
   _backendFetcher = typeof fetcher === 'function' ? fetcher : null;
 }
 
-async function refreshInternal({ force } = {}) {
+async function refreshInternal({ force }) {
   if (_loadingPromise && !force) return _loadingPromise;
   if (_store && !force) return _store;
 
@@ -733,7 +793,7 @@ export const daoRepo = {
   },
 
   getProposalsForUi(groupKey) {
-    return storeToUiList(_store, groupKey || 'active');
+    return storeToUiList(_store, groupKey);
   },
 
   async createProposal({ draft, timestamp, networkId, submitTransaction } = {}) {
@@ -827,20 +887,62 @@ export const daoRepo = {
   },
 
   async finalizeCommitteeResult({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
-    try {
-      const transaction = buildDaoCommitteeResultTransaction({
-        from,
-        proposal,
-        timestamp,
-        networkId,
-      });
-      return submitDaoTransaction({
-        transaction,
-        submitTransaction,
-        errorMessage: 'Review result finalization failed',
-      });
-    } catch (error) {
-      return { ok: false, error: error?.message || 'Review result finalization failed', transaction: null };
-    }
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoCommitteeResultTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Review result finalization failed',
+    });
+  },
+
+  async finalizeVoteResult({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoVoteResultTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Vote result finalization failed',
+    });
+  },
+
+  async claimReward({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoClaimRewardTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Reward claim failed',
+    });
+  },
+
+  async burnReward({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoBurnRewardTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Reward burn failed',
+    });
+  },
+
+  async applyParameters({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoApplyParametersTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Apply parameters failed',
+    });
   },
 };

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -457,7 +457,6 @@ function mapBackendProposalToStoreProposal(proposal) {
     status: state,
     state_changed: stateChanged,
     created,
-    createdBy: proposal.createdBy || proposal.creator || proposal.from || '',
     fields: getDaoProposalFields(proposal),
     votes: getDaoProposalVotes(proposal),
   };
@@ -660,7 +659,6 @@ function storeToUiList(store, groupKey) {
         state,
         status: state,
         stateEnteredAt: p.state_changed,
-        createdBy: p.createdBy,
         fields: p.fields || {},
         options: Array.isArray(p.options) ? p.options : ['yes', 'no'],
         totalVote: Array.isArray(p.totalVote) ? p.totalVote : undefined,

--- a/index.html
+++ b/index.html
@@ -504,6 +504,7 @@
               <div class="proposal-vote-preview" id="proposalVotePreview"></div>
               <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalVoteSubmit" disabled>Submit vote</button>
             </section>
+            <div class="proposal-details" id="proposalDetailsContent"></div>
           </div>
         </div>
         <a class="last-item" href="#"> </a>

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
           <!-- Contact items will be inserted here -->
         </ul>
       </div>
-      <button class="floating-button" id="newChatButton">+</button>
+      <button class="floating-button" id="newChatButton" aria-label="New chat"><span class="plus-glyph" aria-hidden="true">+</span></button>
 
       <div class="app-screen" id="walletScreen">
         <div class="wallet-balance">
@@ -315,7 +315,7 @@
               <div>Proposal data appears here when available</div>
             </div>
           </ul>
-          <button class="floating-button" id="daoAddProposalButton" aria-label="Add proposal">+</button>
+          <button class="floating-button" id="daoAddProposalButton" aria-label="Add proposal"><span class="plus-glyph" aria-hidden="true">+</span></button>
         </div>
         <a class="last-item" href="#"> </a>
       </div>
@@ -394,14 +394,20 @@
                   <label>Parameter Changes</label>
                 </div>
                 <div class="dao-form-list" id="addProposalChangesList"></div>
-                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalChangeButton">Add parameter change</button>
+                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalChangeButton">
+                  <span class="dao-form-add-icon" aria-hidden="true"><span class="plus-glyph">+</span></span>
+                  <span>Add parameter change</span>
+                </button>
               </div>
               <div class="form-group dao-form-section">
                 <div class="dao-form-section-header">
                   <label>Options</label>
                 </div>
                 <div class="dao-form-list" id="addProposalOptionsList"></div>
-                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalOptionButton">Add option</button>
+                <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalOptionButton">
+                  <span class="dao-form-add-icon" aria-hidden="true"><span class="plus-glyph">+</span></span>
+                  <span>Add option</span>
+                </button>
                 <div class="dao-form-help">2 to 10 options. The first option must be yes, accept, or approve.</div>
               </div>
               <div class="form-group dao-form-section">
@@ -1541,7 +1547,7 @@
           <button class="message-context-reaction-button" type="button" data-emoji="😂" data-default-emoji="😂" data-default-aria-label="React with tears of joy" aria-label="React with tears of joy">😂</button>
           <button class="message-context-reaction-button" type="button" data-emoji="😮" data-default-emoji="😮" data-default-aria-label="React with surprised face" aria-label="React with surprised face">😮</button>
           <button class="message-context-reaction-button" type="button" data-emoji="👎" data-default-emoji="👎" data-default-aria-label="React with thumbs down" aria-label="React with thumbs down">👎</button>
-          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction">+</button>
+          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction"><span class="plus-glyph" aria-hidden="true">+</span></button>
         </div>
         <!-- Voice message specific action: Save -->
         <div class="context-menu-option" data-action="save" data-icon="download" style="display: none;">
@@ -1595,7 +1601,7 @@
           <button class="message-context-reaction-button" type="button" data-emoji="😂" data-default-emoji="😂" data-default-aria-label="React with tears of joy" aria-label="React with tears of joy">😂</button>
           <button class="message-context-reaction-button" type="button" data-emoji="😮" data-default-emoji="😮" data-default-aria-label="React with surprised face" aria-label="React with surprised face">😮</button>
           <button class="message-context-reaction-button" type="button" data-emoji="👎" data-default-emoji="👎" data-default-aria-label="React with thumbs down" aria-label="React with thumbs down">👎</button>
-          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction">+</button>
+          <button class="message-context-reaction-button message-context-reaction-button-more" type="button" data-reaction-picker-trigger="true" aria-label="Add reaction"><span class="plus-glyph" aria-hidden="true">+</span></button>
         </div>
         <div class="context-menu-option" data-action="import-contacts" data-icon="contacts" style="display: none;">
           <span class="context-menu-icon"></span>

--- a/index.html
+++ b/index.html
@@ -493,12 +493,12 @@
               </div>
               <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalReviewResultSubmit">Finalize review result</button>
             </section>
+            <section class="proposal-lifecycle-actions hidden" id="proposalLifecycleActionSection" aria-label="Proposal lifecycle action"></section>
             <section class="proposal-vote-actions hidden" id="proposalVoteActionSection" aria-label="Proposal voting actions">
               <div class="proposal-committee-actions-header">
                 <h3>Vote preview</h3>
                 <p id="proposalVoteActionHelp"></p>
               </div>
-              <div class="proposal-vote-status-grid" id="proposalVoteStatusGrid"></div>
               <div class="proposal-vote-options" id="proposalVoteOptions"></div>
               <div class="proposal-vote-spend-row">
                 <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -2084,6 +2084,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-info,
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
+#proposalInfoModal .proposal-lifecycle-actions,
 #proposalInfoModal .proposal-vote-actions {
   display: grid;
   gap: 14px;
@@ -2120,6 +2121,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-info-section h3,
 #proposalInfoModal .proposal-committee-actions h3,
 #proposalInfoModal .proposal-review-result-actions h3,
+#proposalInfoModal .proposal-lifecycle-actions h3,
 #proposalInfoModal .proposal-vote-actions h3 {
   color: var(--text-color);
   font-size: 16px;
@@ -2382,10 +2384,6 @@ input[type='file'].form-control::file-selector-button {
   border-left: 0;
 }
 
-#proposalInfoModal .proposal-result-meter-segment--winner {
-  background: var(--primary-color);
-}
-
 #proposalInfoModal .proposal-result-meter-segment--palette-0 {
   background: #3d3dce;
 }
@@ -2437,7 +2435,6 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-change-row {
   flex: 0 1 calc(50% - 4px);
   min-width: min(100%, 180px);
-  min-inline-size: 0;
 }
 
 #proposalInfoModal .proposal-change-row--single {
@@ -2517,19 +2514,7 @@ input[type='file'].form-control::file-selector-button {
   font-size: 13px;
 }
 
-#confirmProposalModal .dao-confirm-change-values small {
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-change-values small {
-  text-align: center;
-}
-
 #confirmProposalModal .dao-confirm-change-values strong {
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-change-values strong {
   text-align: center;
 }
 
@@ -2547,6 +2532,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-info-muted,
 #proposalInfoModal .proposal-committee-actions p,
 #proposalInfoModal .proposal-review-result-actions p,
+#proposalInfoModal .proposal-lifecycle-actions p,
 #proposalInfoModal .proposal-vote-actions p,
 #proposalInfoModal .proposal-change-row small {
   color: var(--secondary-text-color);
@@ -2577,15 +2563,15 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-info + .proposal-committee-actions,
-#proposalInfoModal .proposal-info + .proposal-review-result-actions,
-#proposalInfoModal .proposal-info + .proposal-vote-actions,
 #proposalInfoModal .proposal-committee-actions + .proposal-review-result-actions,
-#proposalInfoModal .proposal-review-result-actions + .proposal-vote-actions {
+#proposalInfoModal .proposal-review-result-actions + .proposal-lifecycle-actions,
+#proposalInfoModal .proposal-lifecycle-actions + .proposal-vote-actions {
   margin-top: 10px;
 }
 
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
+#proposalInfoModal .proposal-lifecycle-actions,
 #proposalInfoModal .proposal-vote-actions {
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -2594,10 +2580,12 @@ input[type='file'].form-control::file-selector-button {
   padding: 10px;
 }
 
-#proposalInfoModal .proposal-vote-actions {
+#proposalInfoModal .proposal-lifecycle-action {
+  display: grid;
   gap: 8px;
 }
 
+#proposalInfoModal .proposal-lifecycle-actions .proposal-committee-actions-header,
 #proposalInfoModal .proposal-vote-actions .proposal-committee-actions-header {
   display: grid;
   gap: 2px;
@@ -2739,6 +2727,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-committee-actions .btn,
 #proposalInfoModal .proposal-review-result-actions .btn,
+#proposalInfoModal .proposal-lifecycle-actions .btn,
 #proposalInfoModal .proposal-vote-actions .btn {
   font-size: 14px;
   height: 40px;
@@ -2747,6 +2736,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-committee-actions .btn--pill.btn--full,
 #proposalInfoModal .proposal-review-result-actions .btn--pill.btn--full,
+#proposalInfoModal .proposal-lifecycle-actions .btn--pill.btn--full,
 #proposalInfoModal .proposal-vote-actions .btn--pill.btn--full {
   margin: 0;
   width: 100%;
@@ -2787,10 +2777,6 @@ input[type='file'].form-control::file-selector-button {
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(0, 1fr);
-}
-
-#proposalInfoModal .proposal-vote-status-grid:empty {
-  display: none;
 }
 
 #proposalInfoModal .proposal-vote-current-meter {
@@ -7964,6 +7950,7 @@ small {
   min-width: 0;
   overflow: visible;
   overflow-wrap: anywhere;
+  text-align: left;
   text-overflow: clip;
   white-space: normal;
 }
@@ -7986,25 +7973,10 @@ small {
 
 #daoModal .dao-row-meta-item--type {
   flex: 0 0 auto;
-  max-width: 34%;
-}
-
-#daoModal .dao-row-meta-label {
-  flex: 0 0 auto;
-  font-family: var(--font-primary);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: var(--font-weight-medium);
   line-height: 1.2;
-}
-
-#daoModal .dao-row-meta-value {
-  color: var(--text-color);
-  display: block;
-  font-family: var(--font-primary);
-  font-size: 12px;
-  font-weight: var(--font-weight-semibold);
-  line-height: 1.2;
-  min-width: 0;
+  max-width: 34%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -8018,19 +7990,26 @@ small {
   justify-content: flex-end;
   margin-left: auto;
   min-width: 0;
+  overflow: hidden;
 }
 
 #daoModal .dao-row-preview {
-  align-items: baseline;
+  align-items: center;
   background: var(--input-background);
   border: 1px solid var(--border-color);
   border-radius: 8px;
+  color: var(--text-color);
   display: inline-flex;
   flex: 0 1 auto;
-  gap: 4px;
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
   max-width: 100%;
   min-width: 0;
+  overflow: hidden;
   padding: 4px 6px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 #daoModal .dao-row-preview--accepted,
@@ -8042,26 +8021,6 @@ small {
 #daoModal .dao-row-preview--rejected {
   background: rgba(196, 45, 45, 0.1);
   border-color: rgba(196, 45, 45, 0.28);
-}
-
-#daoModal .dao-row-preview span {
-  color: var(--secondary-text-color);
-  flex: 0 0 auto;
-  font-size: 11px;
-  font-weight: var(--font-weight-medium);
-  line-height: 1.2;
-  white-space: nowrap;
-}
-
-#daoModal .dao-row-preview strong {
-  color: var(--text-color);
-  font-size: 12px;
-  font-weight: var(--font-weight-semibold);
-  line-height: 1.2;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 #daoStatusContextMenu {

--- a/styles.css
+++ b/styles.css
@@ -1920,23 +1920,46 @@ input[type='file'].form-control::file-selector-button {
   width: 100%;
 }
 
-#addProposalModal .dao-form-add-button::before {
+.plus-glyph {
+  background-color: currentColor;
+  display: inline-block;
+  flex: 0 0 auto;
+  height: 0.68em;
+  line-height: 1;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 2.5h2V7h4.5v2H9v4.5H7V9H2.5V7H7z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 2.5h2V7h4.5v2H9v4.5H7V9H2.5V7H7z'/%3E%3C/svg%3E") center / contain no-repeat;
+  overflow: hidden;
+  text-indent: 100%;
+  transform: none;
+  white-space: nowrap;
+  width: 0.68em;
+}
+
+#addProposalModal .dao-form-add-icon {
   align-items: center;
   background-color: var(--primary-tint-60);
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 3.5V12.5M3.5 8H12.5' stroke='%231c1c21' stroke-width='2.25' stroke-linecap='round'/%3E%3C/svg%3E");
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 14px 14px;
   border-radius: 999px;
   border: none;
+  box-sizing: border-box;
   box-shadow: var(--shadow-primary);
-  content: "";
+  color: var(--text-color);
   display: inline-flex;
   flex: 0 0 22px;
+  font-size: 16px;
+  font-weight: 400;
   height: 22px;
   justify-content: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  line-height: 1;
   padding: 0;
+  text-align: center;
   width: 22px;
+}
+
+.message-context-reaction-button-more .plus-glyph {
+  position: relative;
+  z-index: 1;
 }
 
 #addProposalModal .dao-form-remove-button {

--- a/styles.css
+++ b/styles.css
@@ -2245,9 +2245,6 @@ input[type='file'].form-control::file-selector-button {
   display: grid;
   gap: 6px;
   padding: 10px;
-}
-
-#proposalInfoModal .proposal-result-card {
   text-align: center;
 }
 
@@ -2875,10 +2872,6 @@ input[type='file'].form-control::file-selector-button {
   background: rgba(101, 103, 107, 0.18);
 }
 
-#proposalInfoModal .proposal-vote-status-card--full {
-  grid-column: 1 / -1;
-}
-
 #proposalInfoModal .proposal-vote-status-card,
 #proposalInfoModal .proposal-vote-preview {
   background: var(--input-background);
@@ -2903,20 +2896,8 @@ input[type='file'].form-control::file-selector-button {
   padding: 8px 10px;
 }
 
-#proposalInfoModal .proposal-vote-status-card--full {
-  justify-self: center;
-  justify-items: center;
-  width: calc(66.666% - 4px);
-  grid-template-columns: minmax(0, 1fr);
-  text-align: center;
-}
-
 #proposalInfoModal .proposal-vote-status-card strong {
   text-align: right;
-}
-
-#proposalInfoModal .proposal-vote-status-card--full strong {
-  text-align: center;
 }
 
 #proposalInfoModal .proposal-vote-status-card span,

--- a/styles.css
+++ b/styles.css
@@ -1923,17 +1923,18 @@ input[type='file'].form-control::file-selector-button {
 #addProposalModal .dao-form-add-button::before {
   align-items: center;
   background-color: var(--primary-tint-60);
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 3.5V12.5M3.5 8H12.5' stroke='%231c1c21' stroke-width='2.25' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 14px 14px;
   border-radius: 999px;
   border: none;
   box-shadow: var(--shadow-primary);
-  color: var(--text-color);
-  content: "+";
+  content: "";
   display: inline-flex;
-  font-size: 16px;
-  font-weight: 400;
+  flex: 0 0 22px;
   height: 22px;
   justify-content: center;
-  line-height: 1;
   padding: 0;
   width: 22px;
 }
@@ -2108,9 +2109,10 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm-grid,
 #proposalInfoModal .proposal-info-grid {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  justify-content: center;
 }
 
 #confirmProposalModal .dao-confirm-row,
@@ -2118,9 +2120,10 @@ input[type='file'].form-control::file-selector-button {
   background: var(--input-background);
   border-radius: 8px;
   display: grid;
+  flex: 0 1 calc((100% - 16px) / 3);
   gap: 8px;
-  grid-column: span 2;
   grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
   min-height: 68px;
   padding: 8px;
   text-align: center;
@@ -2132,20 +2135,9 @@ input[type='file'].form-control::file-selector-button {
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
 }
 
-#confirmProposalModal .dao-confirm-grid--two .dao-confirm-row:first-child {
-  grid-column: 2 / span 2;
-}
-
-#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1),
-#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) + .proposal-info-row,
-#proposalInfoModal .proposal-info-row--center-pair,
-#proposalInfoModal .proposal-info-row--center-pair + .proposal-info-row {
-  grid-column: span 3;
-}
-
 #confirmProposalModal .dao-confirm-row--full,
 #proposalInfoModal .proposal-info-row--full {
-  grid-column: 1 / -1;
+  flex-basis: 100%;
 }
 
 #proposalInfoModal .proposal-info-row--accept {
@@ -2413,8 +2405,10 @@ input[type='file'].form-control::file-selector-button {
   border-radius: 8px;
   display: grid;
   gap: 6px;
+  justify-items: stretch;
   min-inline-size: 0;
   padding: 8px;
+  width: 100%;
 }
 
 #proposalInfoModal .proposal-change-row {
@@ -2467,6 +2461,7 @@ input[type='file'].form-control::file-selector-button {
   line-height: 1.35;
 }
 
+#confirmProposalModal .dao-confirm-change-values small,
 #proposalInfoModal .proposal-change-values small,
 #proposalInfoModal .proposal-change-values strong {
   display: grid;
@@ -2476,6 +2471,8 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
+#confirmProposalModal .dao-confirm-change-values small > span,
+#confirmProposalModal .dao-confirm-change-values small > strong,
 #proposalInfoModal .proposal-change-values small > span,
 #proposalInfoModal .proposal-change-values small > strong,
 #proposalInfoModal .proposal-change-values strong > span {
@@ -2483,12 +2480,14 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
+#confirmProposalModal .dao-confirm-change-values small > span,
 #proposalInfoModal .proposal-change-values small > span,
 #proposalInfoModal .proposal-change-values strong > span:first-child {
   color: var(--secondary-text-color);
   font-size: 12px;
 }
 
+#confirmProposalModal .dao-confirm-change-values small > strong,
 #proposalInfoModal .proposal-change-values small > strong,
 #proposalInfoModal .proposal-change-values strong > span:last-child {
   color: var(--text-color);
@@ -2496,7 +2495,7 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #confirmProposalModal .dao-confirm-change-values small {
-  text-align: right;
+  text-align: center;
 }
 
 #proposalInfoModal .proposal-change-values small {
@@ -2504,7 +2503,7 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #confirmProposalModal .dao-confirm-change-values strong {
-  text-align: left;
+  text-align: center;
 }
 
 #proposalInfoModal .proposal-change-values strong {
@@ -2545,20 +2544,12 @@ input[type='file'].form-control::file-selector-button {
 @media (max-width: 420px) {
   #confirmProposalModal .dao-confirm-row,
   #proposalInfoModal .proposal-info-row {
-    grid-column: span 3;
-  }
-
-  #proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) {
-    grid-column: span 3;
-  }
-
-  #proposalInfoModal .proposal-info-row--center-pair {
-    grid-column: span 3;
+    flex-basis: calc((100% - 8px) / 2);
   }
 
   #confirmProposalModal .dao-confirm-row--full,
   #proposalInfoModal .proposal-info-row--full {
-    grid-column: 1 / -1;
+    flex-basis: 100%;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -2326,6 +2326,30 @@ input[type='file'].form-control::file-selector-button {
   color: #8f1d16;
 }
 
+#proposalInfoModal .proposal-result-meter-label--palette-0 > span {
+  color: #3d3dce;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-1 > span {
+  color: #65676b;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-2 > span {
+  color: #6f68e8;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-3 > span {
+  color: #838a93;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-4 > span {
+  color: #2f2fa8;
+}
+
+#proposalInfoModal .proposal-result-meter-label--palette-5 > span {
+  color: #4e555f;
+}
+
 #proposalInfoModal .proposal-result-meter-track {
   background: var(--input-background);
   border: 1px solid var(--border-color);
@@ -2348,6 +2372,30 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-meter-segment--winner {
   background: var(--primary-color);
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-0 {
+  background: #3d3dce;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-1 {
+  background: #aeb3ba;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-2 {
+  background: #6f68e8;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-3 {
+  background: #c4c8ce;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-4 {
+  background: #2f2fa8;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--palette-5 {
+  background: #8d949e;
 }
 
 #proposalInfoModal .proposal-result-meter-segment--accept {

--- a/styles.css
+++ b/styles.css
@@ -2902,29 +2902,9 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-vote-status-card--deadline {
-  display: flex;
   justify-self: end;
   max-width: 100%;
   width: fit-content;
-}
-
-#proposalInfoModal .proposal-vote-status-card--deadline > span {
-  flex: 0 0 auto;
-  white-space: nowrap;
-}
-
-#proposalInfoModal .proposal-vote-deadline {
-  display: flex;
-  flex: 1 1 auto;
-  flex-wrap: wrap;
-  gap: 0 4px;
-  justify-content: flex-end;
-  min-width: 0;
-}
-
-#proposalInfoModal .proposal-vote-deadline span {
-  color: inherit;
-  white-space: nowrap;
 }
 
 #proposalInfoModal .proposal-vote-status-card span,

--- a/styles.css
+++ b/styles.css
@@ -2471,6 +2471,81 @@ input[type='file'].form-control::file-selector-button {
   gap: 2px;
 }
 
+#proposalInfoModal .proposal-details {
+  display: grid;
+  margin: 12px auto 0;
+  max-width: 720px;
+  width: 100%;
+}
+
+#proposalInfoModal .proposal-details:empty {
+  display: none;
+}
+
+#proposalInfoModal .proposal-more {
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  display: grid;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-more summary {
+  align-items: center;
+  cursor: pointer;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: minmax(0, 1fr) 18px;
+  list-style: none;
+  padding: 12px;
+}
+
+#proposalInfoModal .proposal-more summary::-webkit-details-marker {
+  display: none;
+}
+
+#proposalInfoModal .proposal-more summary::after {
+  align-self: center;
+  border-bottom: 2px solid var(--secondary-text-color);
+  border-right: 2px solid var(--secondary-text-color);
+  content: "";
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  height: 8px;
+  justify-self: center;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  width: 8px;
+}
+
+#proposalInfoModal .proposal-more[open] summary {
+  border-bottom: 1px solid var(--border-color);
+}
+
+#proposalInfoModal .proposal-more[open] summary::after {
+  transform: rotate(225deg);
+}
+
+#proposalInfoModal .proposal-more-title {
+  color: var(--text-color);
+  font-size: 14px;
+  font-weight: var(--font-weight-semibold);
+  grid-column: 1;
+  line-height: 1.25;
+}
+
+#proposalInfoModal .proposal-more-note {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  grid-column: 1;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-more-content {
+  display: grid;
+  gap: 18px;
+  padding: 12px;
+}
+
 #proposalInfoModal .proposal-payload {
   display: grid;
   gap: 8px;
@@ -2675,6 +2750,10 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-vote-current-segment--empty {
   background: rgba(101, 103, 107, 0.18);
+}
+
+#proposalInfoModal .proposal-vote-status-card--full {
+  grid-column: 1 / -1;
 }
 
 #proposalInfoModal .proposal-vote-status-card,

--- a/styles.css
+++ b/styles.css
@@ -2128,7 +2128,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row {
   background: rgba(255, 255, 255, 0.92);
-  border: 2px solid var(--border-color);
+  border: 1px solid var(--border-color);
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
 }
 
@@ -2150,17 +2150,17 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row--accept {
   background: rgba(30, 126, 52, 0.16);
-  border: 2px solid rgba(30, 126, 52, 0.34);
+  border: 1px solid rgba(30, 126, 52, 0.34);
 }
 
 #proposalInfoModal .proposal-info-row--withhold {
   background: rgba(196, 45, 45, 0.14);
-  border: 2px solid rgba(196, 45, 45, 0.32);
+  border: 1px solid rgba(196, 45, 45, 0.32);
 }
 
 #confirmProposalModal .dao-confirm-label,
 #confirmProposalModal .dao-confirm-change-title,
-#proposalInfoModal .proposal-info-row span,
+#proposalInfoModal .proposal-info-row > span:not(.proposal-info-value),
 #proposalInfoModal .proposal-change-row span {
   color: var(--secondary-text-color);
   font-size: 12px;
@@ -2181,7 +2181,6 @@ input[type='file'].form-control::file-selector-button {
 
 #confirmProposalModal .dao-confirm-value,
 #confirmProposalModal .dao-confirm-change-values strong,
-#proposalInfoModal .proposal-info-row strong,
 #proposalInfoModal .proposal-change-row strong {
   color: var(--text-color);
   font-size: 13px;
@@ -2193,22 +2192,33 @@ input[type='file'].form-control::file-selector-button {
   white-space: pre-wrap;
 }
 
-#proposalInfoModal .proposal-info-row--accept strong {
+#proposalInfoModal .proposal-info-value {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-normal);
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-align: center;
+  white-space: pre-wrap;
+}
+
+#proposalInfoModal .proposal-info-row--accept .proposal-info-value {
   color: #0f5f27;
 }
 
-#proposalInfoModal .proposal-info-row--withhold strong {
+#proposalInfoModal .proposal-info-row--withhold .proposal-info-value {
   color: #8f1d16;
 }
 
 #confirmProposalModal .dao-confirm-label,
-#proposalInfoModal .proposal-info-row span {
+#proposalInfoModal .proposal-info-row > span:not(.proposal-info-value) {
   align-self: start;
   justify-self: center;
 }
 
 #confirmProposalModal .dao-confirm-value,
-#proposalInfoModal .proposal-info-row strong {
+#proposalInfoModal .proposal-info-value {
   align-self: center;
   justify-self: center;
 }
@@ -2270,11 +2280,10 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#proposalInfoModal .proposal-result-card strong,
-#proposalInfoModal .proposal-result-row strong {
+#proposalInfoModal .proposal-result-value {
   color: var(--text-color);
   font-size: 13px;
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-normal);
   line-height: 1.35;
   overflow-wrap: anywhere;
 }
@@ -2298,7 +2307,7 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
-#proposalInfoModal .proposal-result-row > strong,
+#proposalInfoModal .proposal-result-row > .proposal-result-value,
 #proposalInfoModal .proposal-result-row > small {
   justify-self: end;
   text-align: right;
@@ -2327,6 +2336,34 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
   overflow-wrap: anywhere;
   white-space: normal;
+}
+
+#proposalInfoModal .proposal-change-row {
+  flex: 0 1 calc(50% - 5px);
+  min-width: min(100%, 180px);
+}
+
+#proposalInfoModal .proposal-change-row--single {
+  background: rgba(255, 255, 255, 0.92);
+  border: 0 solid var(--border-color);
+  border-radius: 0 0 8px 8px;
+  border-width: 0 1px 1px;
+  box-shadow: 0 2px 2px rgba(28, 28, 33, 0.04);
+  flex-basis: calc(66.666% - 4px);
+}
+
+#proposalInfoModal .proposal-change-row--wide {
+  flex-basis: 100%;
+}
+
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values {
+  grid-template-columns: max-content 16px max-content;
+  justify-content: center;
+}
+
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values small,
+#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
+  white-space: nowrap;
 }
 
 #confirmProposalModal .dao-confirm-change-values,
@@ -2455,7 +2492,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
 #proposalInfoModal .proposal-vote-actions {
-  border: 2px solid var(--border-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   display: grid;
   gap: 8px;
@@ -2483,7 +2520,7 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-more {
-  border: 2px solid var(--border-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   display: grid;
   overflow: hidden;
@@ -2547,14 +2584,16 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-payload {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  justify-content: center;
 }
 
 #proposalInfoModal .proposal-payload-title {
   color: var(--text-color);
+  flex: 0 0 100%;
   font-size: 13px;
-  font-weight: var(--font-weight-semibold);
   line-height: 1.3;
   text-align: center;
 }
@@ -2780,8 +2819,20 @@ input[type='file'].form-control::file-selector-button {
   padding: 8px 10px;
 }
 
+#proposalInfoModal .proposal-vote-status-card--full {
+  justify-self: center;
+  justify-items: center;
+  width: calc(66.666% - 4px);
+  grid-template-columns: minmax(0, 1fr);
+  text-align: center;
+}
+
 #proposalInfoModal .proposal-vote-status-card strong {
   text-align: right;
+}
+
+#proposalInfoModal .proposal-vote-status-card--full strong {
+  text-align: center;
 }
 
 #proposalInfoModal .proposal-vote-status-card span,
@@ -2961,7 +3012,7 @@ input[type='file'].form-control::file-selector-button {
     grid-template-columns: minmax(0, 1fr) 92px;
   }
 
-  #proposalInfoModal .proposal-result-row > strong,
+  #proposalInfoModal .proposal-result-row > .proposal-result-value,
   #proposalInfoModal .proposal-result-row > small {
     justify-self: start;
     text-align: left;

--- a/styles.css
+++ b/styles.css
@@ -2372,20 +2372,10 @@ input[type='file'].form-control::file-selector-button {
   padding: 8px;
 }
 
-#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values {
-  grid-template-columns: minmax(0, 1fr) 12px minmax(0, 1fr);
-  justify-content: center;
-}
-
-#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values small,
-#proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
-  overflow-wrap: anywhere;
-  white-space: normal;
-}
-
 #proposalInfoModal .proposal-change-row {
-  flex: 0 1 calc(50% - 5px);
+  flex: 0 1 calc(50% - 4px);
   min-width: min(100%, 180px);
+  min-inline-size: 0;
 }
 
 #proposalInfoModal .proposal-change-row--single {
@@ -2402,13 +2392,14 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values {
-  grid-template-columns: max-content 16px max-content;
+  grid-template-columns: minmax(0, 1fr) 12px minmax(0, 1fr);
   justify-content: center;
 }
 
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values small,
 #proposalInfoModal .proposal-change-row:not(.proposal-change-row--wide) .proposal-change-values strong {
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 #confirmProposalModal .dao-confirm-change-values,
@@ -2555,7 +2546,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-details {
   display: grid;
-  margin: 12px auto 0;
+  margin: 10px auto 0;
   max-width: 720px;
   width: 100%;
 }
@@ -2578,7 +2569,7 @@ input[type='file'].form-control::file-selector-button {
   gap: 4px;
   grid-template-columns: minmax(0, 1fr) 18px;
   list-style: none;
-  padding: 12px;
+  padding: 10px;
 }
 
 #proposalInfoModal .proposal-more summary::-webkit-details-marker {
@@ -2624,8 +2615,8 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-more-content {
   display: grid;
-  gap: 18px;
-  padding: 12px;
+  gap: 14px;
+  padding: 10px;
 }
 
 #proposalInfoModal .proposal-payload {

--- a/styles.css
+++ b/styles.css
@@ -7931,7 +7931,7 @@ small {
   align-items: center;
   color: var(--secondary-text-color);
   display: flex;
-  gap: 18px;
+  gap: 10px;
   min-width: 0;
   width: 100%;
 }
@@ -7944,13 +7944,8 @@ small {
 }
 
 #daoModal .dao-row-meta-item--type {
-  flex: 1 1 auto;
-}
-
-#daoModal .dao-row-meta-item--updated {
   flex: 0 0 auto;
-  margin-left: auto;
-  white-space: nowrap;
+  max-width: 34%;
 }
 
 #daoModal .dao-row-meta-label {
@@ -7969,18 +7964,18 @@ small {
   font-weight: var(--font-weight-semibold);
   line-height: 1.2;
   min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-#daoModal .dao-row-meta-item--updated .dao-row-meta-value {
-  overflow-wrap: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 #daoModal .dao-row-previews {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  gap: 4px;
+  justify-content: flex-end;
+  margin-left: auto;
   min-width: 0;
 }
 
@@ -7990,9 +7985,11 @@ small {
   border: 1px solid var(--border-color);
   border-radius: 8px;
   display: inline-flex;
-  gap: 5px;
+  flex: 0 1 auto;
+  gap: 4px;
   max-width: 100%;
-  padding: 5px 7px;
+  min-width: 0;
+  padding: 4px 6px;
 }
 
 #daoModal .dao-row-preview--accepted,
@@ -8012,6 +8009,7 @@ small {
   font-size: 11px;
   font-weight: var(--font-weight-medium);
   line-height: 1.2;
+  white-space: nowrap;
 }
 
 #daoModal .dao-row-preview strong {
@@ -8020,7 +8018,9 @@ small {
   font-weight: var(--font-weight-semibold);
   line-height: 1.2;
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 #daoStatusContextMenu {

--- a/styles.css
+++ b/styles.css
@@ -2238,8 +2238,10 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-card {
   background: rgba(255, 255, 255, 0.92);
-  border-radius: 8px;
-  box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
+  border: 0 solid var(--border-color);
+  border-radius: 0 0 8px 8px;
+  border-width: 0 1px 1px;
+  box-shadow: 0 2px 2px rgba(28, 28, 33, 0.04);
   display: grid;
   gap: 6px;
   padding: 10px;
@@ -2281,6 +2283,11 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-meter-labels--balanced .proposal-result-meter-label {
   flex: 1 1 0;
+}
+
+#proposalInfoModal .proposal-result-meter-label--start {
+  justify-items: start;
+  text-align: left;
 }
 
 #proposalInfoModal .proposal-result-meter-label--center {

--- a/styles.css
+++ b/styles.css
@@ -2897,7 +2897,34 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-vote-status-card strong {
+  min-width: 0;
   text-align: right;
+}
+
+#proposalInfoModal .proposal-vote-status-card--deadline {
+  display: flex;
+  justify-self: end;
+  max-width: 100%;
+  width: fit-content;
+}
+
+#proposalInfoModal .proposal-vote-status-card--deadline > span {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+#proposalInfoModal .proposal-vote-deadline {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 0 4px;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-vote-deadline span {
+  color: inherit;
+  white-space: nowrap;
 }
 
 #proposalInfoModal .proposal-vote-status-card span,

--- a/styles.css
+++ b/styles.css
@@ -2223,41 +2223,11 @@ input[type='file'].form-control::file-selector-button {
   justify-self: center;
 }
 
-#proposalInfoModal .proposal-result-banner {
-  background: var(--input-background);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  display: grid;
-  gap: 6px;
-  padding: 12px;
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-result-banner--accepted {
-  background: rgba(30, 126, 52, 0.14);
-  border-color: rgba(30, 126, 52, 0.34);
-}
-
-#proposalInfoModal .proposal-result-banner--rejected {
-  background: rgba(196, 45, 45, 0.12);
-  border-color: rgba(196, 45, 45, 0.3);
-}
-
-#proposalInfoModal .proposal-result-banner span,
-#proposalInfoModal .proposal-result-banner small,
 #proposalInfoModal .proposal-result-card span,
-#proposalInfoModal .proposal-result-row small {
+#proposalInfoModal .proposal-result-meter-label small {
   color: var(--secondary-text-color);
   font-size: 12px;
   line-height: 1.35;
-}
-
-#proposalInfoModal .proposal-result-banner strong {
-  color: var(--text-color);
-  font-size: 16px;
-  font-weight: var(--font-weight-semibold);
-  line-height: 1.25;
-  overflow-wrap: anywhere;
 }
 
 #proposalInfoModal .proposal-result-overview {
@@ -2266,8 +2236,7 @@ input[type='file'].form-control::file-selector-button {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-#proposalInfoModal .proposal-result-card,
-#proposalInfoModal .proposal-result-row {
+#proposalInfoModal .proposal-result-card {
   background: rgba(255, 255, 255, 0.92);
   border-radius: 8px;
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
@@ -2288,33 +2257,102 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
-#proposalInfoModal .proposal-result-list {
+#proposalInfoModal .proposal-result-meter {
   display: grid;
   gap: 8px;
+  min-width: 0;
 }
 
-#proposalInfoModal .proposal-result-row {
+#proposalInfoModal .proposal-result-meter-labels,
+#proposalInfoModal .proposal-result-meter-track {
   align-items: center;
-  grid-template-columns: minmax(0, 1fr) minmax(96px, auto) 52px;
+  display: flex;
+  min-width: 0;
+  width: 100%;
 }
 
-#proposalInfoModal .proposal-result-row > span {
+#proposalInfoModal .proposal-result-meter-label {
+  display: grid;
+  flex: var(--result-segment-units) 1 0;
+  gap: 2px;
+  min-width: 0;
+  padding: 0 4px;
+}
+
+#proposalInfoModal .proposal-result-meter-labels--balanced .proposal-result-meter-label {
+  flex: 1 1 0;
+}
+
+#proposalInfoModal .proposal-result-meter-label--center {
+  justify-items: center;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-meter-label--end {
+  justify-items: end;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-result-meter-label > span {
   color: var(--secondary-text-color);
   font-size: 12px;
   font-weight: var(--font-weight-medium);
   line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-result-meter-label > span,
+#proposalInfoModal .proposal-result-meter-label > small {
+  max-width: 100%;
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
-#proposalInfoModal .proposal-result-row > .proposal-result-value,
-#proposalInfoModal .proposal-result-row > small {
-  justify-self: end;
-  text-align: right;
+#proposalInfoModal .proposal-result-meter-label--winner > span {
+  color: var(--text-color);
 }
 
-#proposalInfoModal .proposal-result-row--winner {
-  border: 1px solid var(--primary-tint-40);
+#proposalInfoModal .proposal-result-meter-label--accept.proposal-result-meter-label--winner > span {
+  color: #0f5f27;
+}
+
+#proposalInfoModal .proposal-result-meter-label--withhold.proposal-result-meter-label--winner > span {
+  color: #8f1d16;
+}
+
+#proposalInfoModal .proposal-result-meter-track {
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  height: 16px;
+  overflow: hidden;
+}
+
+#proposalInfoModal .proposal-result-meter-segment {
+  align-self: stretch;
+  background: rgba(101, 103, 107, 0.34);
+  border-left: 1px solid rgba(255, 255, 255, 0.72);
+  flex: var(--result-segment-units) 1 0;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-result-meter-segment:first-child {
+  border-left: 0;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--winner {
+  background: var(--primary-color);
+}
+
+#proposalInfoModal .proposal-result-meter-segment--accept {
+  background: #1e7e34;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--withhold {
+  background: #c42d2d;
+}
+
+#proposalInfoModal .proposal-result-meter-segment--empty {
+  background: rgba(101, 103, 107, 0.18);
 }
 
 #confirmProposalModal .dao-confirm-change,
@@ -3003,19 +3041,12 @@ input[type='file'].form-control::file-selector-button {
 }
 
 @media (max-width: 520px) {
-  #proposalInfoModal .proposal-result-overview,
-  #proposalInfoModal .proposal-result-row {
+  #proposalInfoModal .proposal-result-overview {
     grid-template-columns: minmax(0, 1fr);
   }
 
   #proposalInfoModal .proposal-vote-option {
     grid-template-columns: minmax(0, 1fr) 92px;
-  }
-
-  #proposalInfoModal .proposal-result-row > .proposal-result-value,
-  #proposalInfoModal .proposal-result-row > small {
-    justify-self: start;
-    text-align: left;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -2213,6 +2213,101 @@ input[type='file'].form-control::file-selector-button {
   justify-self: center;
 }
 
+#proposalInfoModal .proposal-result-banner {
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-banner--accepted {
+  background: rgba(30, 126, 52, 0.14);
+  border-color: rgba(30, 126, 52, 0.34);
+}
+
+#proposalInfoModal .proposal-result-banner--rejected {
+  background: rgba(196, 45, 45, 0.12);
+  border-color: rgba(196, 45, 45, 0.3);
+}
+
+#proposalInfoModal .proposal-result-banner span,
+#proposalInfoModal .proposal-result-banner small,
+#proposalInfoModal .proposal-result-card span,
+#proposalInfoModal .proposal-result-row small {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-result-banner strong {
+  color: var(--text-color);
+  font-size: 16px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-overview {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+#proposalInfoModal .proposal-result-card,
+#proposalInfoModal .proposal-result-row {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+}
+
+#proposalInfoModal .proposal-result-card {
+  text-align: center;
+}
+
+#proposalInfoModal .proposal-result-card strong,
+#proposalInfoModal .proposal-result-row strong {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-list {
+  display: grid;
+  gap: 8px;
+}
+
+#proposalInfoModal .proposal-result-row {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) minmax(96px, auto) 52px;
+}
+
+#proposalInfoModal .proposal-result-row > span {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+#proposalInfoModal .proposal-result-row > strong,
+#proposalInfoModal .proposal-result-row > small {
+  justify-self: end;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-result-row--winner {
+  border: 1px solid var(--primary-tint-40);
+}
+
 #confirmProposalModal .dao-confirm-change,
 #proposalInfoModal .proposal-change-row {
   background: var(--input-background);
@@ -2778,8 +2873,19 @@ input[type='file'].form-control::file-selector-button {
 }
 
 @media (max-width: 520px) {
+  #proposalInfoModal .proposal-result-overview,
+  #proposalInfoModal .proposal-result-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   #proposalInfoModal .proposal-vote-option {
     grid-template-columns: minmax(0, 1fr) 92px;
+  }
+
+  #proposalInfoModal .proposal-result-row > strong,
+  #proposalInfoModal .proposal-result-row > small {
+    justify-self: start;
+    text-align: left;
   }
 }
 
@@ -7701,6 +7807,52 @@ small {
 #daoModal .dao-row-meta-item--updated .dao-row-meta-value {
   overflow-wrap: normal;
   white-space: nowrap;
+}
+
+#daoModal .dao-row-previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+#daoModal .dao-row-preview {
+  align-items: baseline;
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  display: inline-flex;
+  gap: 5px;
+  max-width: 100%;
+  padding: 5px 7px;
+}
+
+#daoModal .dao-row-preview--accepted,
+#daoModal .dao-row-preview--accept {
+  background: rgba(30, 126, 52, 0.12);
+  border-color: rgba(30, 126, 52, 0.3);
+}
+
+#daoModal .dao-row-preview--rejected {
+  background: rgba(196, 45, 45, 0.1);
+  border-color: rgba(196, 45, 45, 0.28);
+}
+
+#daoModal .dao-row-preview span {
+  color: var(--secondary-text-color);
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
+}
+
+#daoModal .dao-row-preview strong {
+  color: var(--text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.2;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 #daoStatusContextMenu {

--- a/styles.css
+++ b/styles.css
@@ -2128,6 +2128,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row {
   background: rgba(255, 255, 255, 0.92);
+  border: 2px solid var(--border-color);
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
 }
 
@@ -2135,12 +2136,11 @@ input[type='file'].form-control::file-selector-button {
   grid-column: 2 / span 2;
 }
 
-#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) {
-  grid-column: 2 / span 2;
-}
-
-#proposalInfoModal .proposal-info-row--center-pair {
-  grid-column: 2 / span 2;
+#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1),
+#proposalInfoModal .proposal-info-row:nth-last-child(2):nth-child(3n+1) + .proposal-info-row,
+#proposalInfoModal .proposal-info-row--center-pair,
+#proposalInfoModal .proposal-info-row--center-pair + .proposal-info-row {
+  grid-column: span 3;
 }
 
 #confirmProposalModal .dao-confirm-row--full,
@@ -2150,12 +2150,12 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row--accept {
   background: rgba(30, 126, 52, 0.16);
-  border: 1px solid rgba(30, 126, 52, 0.34);
+  border: 2px solid rgba(30, 126, 52, 0.34);
 }
 
 #proposalInfoModal .proposal-info-row--withhold {
   background: rgba(196, 45, 45, 0.14);
-  border: 1px solid rgba(196, 45, 45, 0.32);
+  border: 2px solid rgba(196, 45, 45, 0.32);
 }
 
 #confirmProposalModal .dao-confirm-label,
@@ -2455,7 +2455,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
 #proposalInfoModal .proposal-vote-actions {
-  border: 1px solid var(--border-color);
+  border: 2px solid var(--border-color);
   border-radius: 8px;
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## What Changed

This PR combines the Phase 6.A DAO results/rewards UI work with the small review-finalize UX follow-up that was previously stacked above it.

- DAO proposal rows now show compact result/reward preview chips through `renderProposalRowPreview(proposal)`.
- Review-state rows show a Review chip, including `Ready to finalize` when the review window has ended.
- `dao.repo.js` carries final-state fields into UI records, including `emergency`, reward pool fields, `voterList`, `claimList`, and DAO timing durations.
- `index.html` adds `#proposalDetailsContent`, and `ProposalInfoModal` renders longer detail/accounting content into a collapsible proposal details drawer.
- `getDaoProposalResultSummary(proposal)` summarizes committee outcomes for withheld/emergency final proposals and vote outcomes for final vote states.
- `renderProposalResults(result)` renders final vote results with winner/total cards and a segmented meter, while `renderCommitteeResults(result)` renders accept/withhold committee outcomes.
- `getDaoProposalRewardSummary(proposal, currentAddress, now)` computes reward status, claim window, claim estimate, claimed/unclaimed pool, and burn accounting.
- Review proposals now show Proposal Body in the primary modal flow before Committee Review, and the details drawer omits that duplicated body while in review state.
- `getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount)` centralizes the destination state shown for review finalization: `Withheld`, `Accepted`, or `Voting`.
- Committee review action controls are hidden when `capabilities.canFinalizeReviewResult` is true, leaving Finalize review result as the active path.
- The Voting ends card uses `proposal-vote-status-card--deadline` with fit-content sizing so it does not stretch awkwardly.
- Parameter-change `Current` and `New` markup now share the same label/value structure.
- `createDaoBackendFetcher(queryDaoApi)` now always uses the shared internal `DAO_PROPOSAL_QUERY_BATCH_SIZE`.

## Added Flow And Code References

1. Backend proposal data enters the UI through `storeToUiList(...)`, which now preserves fields like `emergency: Boolean(p.emergency)`, `voterList: Array.isArray(p.voterList) ? p.voterList : []`, and `claimList: Array.isArray(p.claimList) ? p.claimList : []`.
2. `DaoModal.render()` calls `const previewHtml = this.renderProposalRowPreview(p)` and inserts `${previewHtml}` beside the Type metadata for each proposal row.
3. `renderProposalRowPreview(proposal)` reads `const state = getEffectiveDaoState(proposal)`, emits a Review chip for review proposals, and otherwise emits Result/Reward chips from `getDaoProposalResultSummary(proposal)` and `getDaoProposalRewardSummary(proposal)`.
4. `ProposalInfoModal.load()` stores `this.detailsContent = document.getElementById('proposalDetailsContent')`, matching the new `<div class="proposal-details" id="proposalDetailsContent"></div>` added after the modal action sections.
5. `ProposalInfoModal.renderProposal(proposal)` computes `resultSummary` and `rewardSummary`, then renders title, parameter changes, current voting totals, result summary, review-state proposal body, and committee review context in the primary modal content.
6. `getDaoProposalResultSummary(proposal)` returns `getDaoCommitteeReviewResultSummary(proposal) || getDaoVoteResultSummary(proposal)`.
7. `getDaoVoteResultSummary(...)` uses `getDaoVoteWinner(totals)` and maps `winner.index === 0` to `Accepted`; other winning options become `Rejected`.
8. `renderProposalResults(result)` renders vote results with result cards and meter segments using `--result-segment-units`; committee summaries are routed to `renderCommitteeResults(result)`.
9. `getDaoProposalRewardSummary(...)` only returns for final states and reads reward pool, claimed amount, burn fields, voter list, claim list, and claim timing.
10. `getDaoRewardClaimStatus(...)` produces the visible claim state, while `getDaoClaimRewardEstimate(...)` estimates claimable LIB with `(pool * (timePart + equalPart)) / (2n * DAO_CLAIM_REWARD_PRECISION)`.
11. `renderProposalDetails(...)` writes a `<details class="proposal-more">` drawer containing Overview, Review Timeline, optional Voting Details, Proposal Body outside review state, and Rewards.
12. `renderProposalRewards(reward)` displays Claim status, Claim estimate, Claim window, Reward pool, Claimed, Unclaimed pool, Initial burn, and Final burn.
13. `getReviewFinalizedStateLabel(...)` returns `Withheld` when `withholdCount > acceptCount`; otherwise it returns `Accepted` for emergency proposals and `Voting` for regular proposals.
14. `getNextStateHint(...)` returns `${this.getReviewFinalizedStateLabel(...)} if finalized` once the review window can be finalized.
15. `renderCommitteeActions(...)` exits through `this.hideCommitteeActions()` when `capabilities.canFinalizeReviewResult` is true.
16. `renderReviewResultAction(...)` receives `proposal`, `acceptCount`, and `withholdCount`, then writes `Finalize the review result to move this proposal to ${nextState}.`
17. `renderCurrentVoteTotals(proposal)` marks the Voting ends card with `proposal-vote-status-card--deadline`, and CSS constrains it with `width: fit-content`.
18. `renderPayloadRows(...)` renders the New parameter value as `<small><span>New:</span><strong>${escapeHtml(next)}</strong></small>`, matching the Current value structure.

## Why

Final DAO proposals need to be scannable without forcing users to inspect raw proposal fields. This PR makes result state and reward accounting visible in the list and proposal modal, keeps longer context in a details drawer, and makes the review screen transition cleanly from committee voting to review finalization.

## Validation

- `git show issue-1424-results-rewards-ui:app.js | node --check --input-type=module -`
- `git show issue-1424-results-rewards-ui:dao.repo.js | node --check --input-type=module -`
- `git diff --check issue-1423-voting-flow-transaction-integration..issue-1424-results-rewards-ui`
- `git show issue-1424-review-finalize-ux:app.js | node --check --input-type=module -`
- `git diff --check issue-1424-results-rewards-ui..issue-1424-review-finalize-ux`

Closes #1424
Parent: #1413
Builds on #1423
Supersedes #1448
Next phase: #1425