### PR TITLE
Phase 7.B: Ready Actions / Apply Parameters Backend Integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -2789,9 +2789,9 @@ class DaoModal {
       const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward, getDaoCurrentAccountAddress(), now);
       const endDate = formatDaoDate(votingWindow.end);
 
-      if (endDate) {
+      if (endDate && now <= votingWindow.end) {
         chips.push({
-          value: `${now > votingWindow.end ? 'Ended' : 'Ends'} ${endDate}`,
+          value: `Ends ${endDate}`,
           tone: 'neutral',
         });
       }

--- a/app.js
+++ b/app.js
@@ -2774,18 +2774,17 @@ class DaoModal {
         tone: 'neutral',
       });
     } else {
-      const lifecycleAction = getDaoProposalLifecycleAction(proposal, reward);
-      const applyAction = lifecycleAction?.kind === 'apply_parameters'
-        ? lifecycleAction
-        : getDaoProposalApplyLifecycleAction(proposal);
+      const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward);
+      const claimAction = lifecycleActions.find((action) => action.kind === 'claim_reward');
+      const applyAction = lifecycleActions.find((action) => action.kind === 'apply_parameters');
 
-      if (reward?.claimStatus === 'Claimable') {
+      if (claimAction) {
         chips.push({
           value: 'Ready to claim',
-          tone: reward.statusTone,
+          tone: reward?.statusTone,
         });
       }
-      if (lifecycleAction?.kind === 'burn_reward') {
+      if (lifecycleActions.some((action) => action.kind === 'burn_reward')) {
         chips.push({
           value: 'Ready to burn',
           tone: 'neutral',
@@ -4101,24 +4100,36 @@ function isDaoProposalCommitteeMember(proposal, currentAddress) {
   return proposal.committeeAddresses.some((address) => normalizeDaoAddress(address) === normalizedAddress);
 }
 
-function getDaoApplyParametersLifecycleAction(help, rowPreviewLabel = '') {
+function getDaoApplyParametersLifecycleAction(help, canSubmit, rowPreviewLabel = '') {
   const action = {
     kind: 'apply_parameters',
     title: 'Apply parameters',
     help,
     buttonLabel: 'Apply parameters',
-    canSubmit: false,
+    loadingLabel: 'Applying parameters...',
+    successMessage: 'Parameters applied',
+    refreshWarning: 'Parameters applied, but proposal or parameter refresh failed',
+    refreshNetworkParams: true,
+    canSubmit,
   };
   if (rowPreviewLabel) action.rowPreviewLabel = rowPreviewLabel;
   return action;
 }
 
 function getDaoProposalApplyLifecycleAction(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
-  if (getEffectiveDaoState(proposal) !== 'accepted' || !isDaoParameterProposalType(proposal)) return null;
+  if (getEffectiveDaoState(proposal) !== 'accepted') return null;
+
+  if (!isDaoParameterProposalType(proposal)) {
+    return getDaoApplyParametersLifecycleAction(
+      'This proposal type does not support parameter application.',
+      false,
+    );
+  }
 
   if (proposal?.emergency && !isDaoProposalCommitteeMember(proposal, currentAddress)) {
     return getDaoApplyParametersLifecycleAction(
       'Emergency proposal parameters can only be applied by a proposal committee member.',
+      false,
     );
   }
 
@@ -4129,11 +4140,13 @@ function getDaoProposalApplyLifecycleAction(proposal, currentAddress = getDaoCur
       eligibleAt
         ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
         : 'Apply timing is unavailable until the proposal includes grace-period timing.',
+      false,
     );
   }
 
   return getDaoApplyParametersLifecycleAction(
-    'This proposal is ready to apply. Backend submission for applying parameters lands in the next phase.',
+    'This proposal is ready to apply. Submit the transaction to apply the accepted parameter changes.',
+    true,
     'Ready to apply',
   );
 }
@@ -4246,13 +4259,13 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
   };
 }
 
-function getDaoProposalLifecycleAction(proposal, rewardSummary, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+function getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
   const state = getEffectiveDaoState(proposal);
 
   if (state === 'voting') {
     const votingWindow = getDaoProposalVotingWindow(proposal, now);
     if (votingWindow.end && now > votingWindow.end) {
-      return {
+      return [{
         kind: 'vote_result',
         title: 'Vote result',
         help: 'Voting has ended. Finalize the vote result to move this proposal to accepted or rejected.',
@@ -4260,20 +4273,21 @@ function getDaoProposalLifecycleAction(proposal, rewardSummary, currentAddress =
         loadingLabel: 'Finalizing vote result...',
         successMessage: 'Vote result finalized',
         refreshWarning: 'Vote result finalized, but proposal refresh failed',
-      };
+      }];
     }
-    return null;
+    return [];
   }
 
-  if (!isDaoFinalResultState(state)) return null;
+  if (!isDaoFinalResultState(state)) return [];
 
+  const actions = [];
   const claimWindow = getDaoProposalClaimWindow(proposal);
   const pool = parseDaoUnsignedBigInt(proposal?.voterRewardPool) ?? 0n;
   const claimed = parseDaoUnsignedBigInt(proposal?.claimedReward) ?? 0n;
   const unclaimed = pool > claimed ? pool - claimed : 0n;
 
   if (claimWindow.end && now > claimWindow.end && unclaimed > 0n) {
-    return {
+    actions.push({
       kind: 'burn_reward',
       title: 'Reward burn',
       help: 'The claim window has ended. Burn the unclaimed reward pool so the proposal accounting is finalized.',
@@ -4281,13 +4295,19 @@ function getDaoProposalLifecycleAction(proposal, rewardSummary, currentAddress =
       loadingLabel: 'Burning reward...',
       successMessage: 'Unclaimed reward burned',
       refreshWarning: 'Reward burned, but proposal refresh failed',
-    };
+    });
   }
 
-  if (claimWindow.start && claimWindow.end && now >= claimWindow.start && now <= claimWindow.end && unclaimed > 0n) {
-    if (!currentAddress || rewardSummary?.claimStatus !== 'Claimable') return null;
-
-    return {
+  if (
+    claimWindow.start &&
+    claimWindow.end &&
+    now >= claimWindow.start &&
+    now <= claimWindow.end &&
+    unclaimed > 0n &&
+    currentAddress &&
+    rewardSummary?.claimStatus === 'Claimable'
+  ) {
+    actions.push({
       kind: 'claim_reward',
       title: 'Reward claim',
       help: rewardSummary.claimEstimate === null
@@ -4297,10 +4317,12 @@ function getDaoProposalLifecycleAction(proposal, rewardSummary, currentAddress =
       loadingLabel: 'Claiming reward...',
       successMessage: 'Reward claimed',
       refreshWarning: 'Reward claimed, but proposal refresh failed',
-    };
+    });
   }
 
-  return getDaoProposalApplyLifecycleAction(proposal, currentAddress, now);
+  const applyAction = getDaoProposalApplyLifecycleAction(proposal, currentAddress, now);
+  if (applyAction) actions.push(applyAction);
+  return actions;
 }
 
 function formatDaoDetailValue(value) {
@@ -4368,9 +4390,6 @@ class ProposalInfoModal {
     this.reviewResultHelp = document.getElementById('proposalReviewResultHelp');
     this.reviewResultButton = document.getElementById('proposalReviewResultSubmit');
     this.lifecycleActionSection = document.getElementById('proposalLifecycleActionSection');
-    this.lifecycleActionTitle = document.getElementById('proposalLifecycleActionTitle');
-    this.lifecycleActionHelp = document.getElementById('proposalLifecycleActionHelp');
-    this.lifecycleActionButton = document.getElementById('proposalLifecycleActionSubmit');
     this.voteActionSection = document.getElementById('proposalVoteActionSection');
     this.voteActionHelp = document.getElementById('proposalVoteActionHelp');
     this.voteStatusGrid = document.getElementById('proposalVoteStatusGrid');
@@ -4387,7 +4406,8 @@ class ProposalInfoModal {
     this.isSubmitting = false;
     this.canSubmitCommitteeReview = false;
     this.canSubmitReviewResult = false;
-    this.currentLifecycleAction = null;
+    this.currentLifecycleActions = [];
+    this.submittingLifecycleAction = null;
     this.canSubmitVote = false;
     this.submitButtonLabel = this.submitButton?.textContent || 'Submit review';
     this.reviewResultButtonLabel = this.reviewResultButton?.textContent || 'Finalize review result';
@@ -4399,7 +4419,7 @@ class ProposalInfoModal {
     if (this.withholdReasonSelect) this.withholdReasonSelect.addEventListener('change', () => this.handleWithholdReasonChange());
     if (this.submitButton) this.submitButton.addEventListener('click', () => this.handleCommitteeSubmit());
     if (this.reviewResultButton) this.reviewResultButton.addEventListener('click', () => this.handleReviewResultSubmit());
-    if (this.lifecycleActionButton) this.lifecycleActionButton.addEventListener('click', () => this.handleLifecycleActionSubmit());
+    if (this.lifecycleActionSection) this.lifecycleActionSection.addEventListener('click', (event) => this.handleLifecycleActionClick(event));
     if (this.voteSpendInput) this.voteSpendInput.addEventListener('input', () => this.handleVoteSpendInput());
     if (this.voteOptions) this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
     if (this.voteSubmitButton) this.voteSubmitButton.addEventListener('click', () => this.handleVoteSubmit());
@@ -4475,7 +4495,7 @@ class ProposalInfoModal {
     const proposalType = proposal.proposalType || proposal.type;
     const resultSummary = getDaoProposalResultSummary(proposal);
     const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
-    const lifecycleAction = getDaoProposalLifecycleAction(proposal, rewardSummary, currentAddress);
+    const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
     const committeeReviewSection = state === 'review'
       ? this.renderSection('Committee Review', [
         ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
@@ -4518,7 +4538,7 @@ class ProposalInfoModal {
       this.hideCommitteeActions();
       this.hideReviewResultAction();
     }
-    this.renderLifecycleAction(lifecycleAction);
+    this.renderLifecycleActions(lifecycleActions);
     this.renderVoteActions({ proposal, state });
   }
 
@@ -5123,23 +5143,39 @@ class ProposalInfoModal {
     this.updateSubmitButtons();
   }
 
-  renderLifecycleAction(action) {
-    this.currentLifecycleAction = action;
-    if (!this.lifecycleActionSection || !action) {
+  renderLifecycleActions(actions) {
+    this.currentLifecycleActions = Array.isArray(actions) ? actions : [];
+    if (!this.lifecycleActionSection || this.currentLifecycleActions.length === 0) {
       this.hideLifecycleAction();
       return;
     }
 
+    this.lifecycleActionSection.innerHTML = this.currentLifecycleActions
+      .map((action, index) => `
+        <div class="proposal-lifecycle-action">
+          <div class="proposal-committee-actions-header">
+            <h3>${escapeHtml(action.title)}</h3>
+            <p>${escapeHtml(action.help)}</p>
+          </div>
+          <button
+            type="button"
+            class="btn btn--primary btn--pill btn--full"
+            data-lifecycle-action-index="${index}"
+          >${escapeHtml(action.buttonLabel)}</button>
+        </div>
+      `)
+      .join('');
     this.lifecycleActionSection.classList.remove('hidden');
-    if (this.lifecycleActionTitle) this.lifecycleActionTitle.textContent = action.title;
-    if (this.lifecycleActionHelp) this.lifecycleActionHelp.textContent = action.help;
-    if (this.lifecycleActionButton) this.lifecycleActionButton.textContent = action.buttonLabel;
     this.updateSubmitButtons();
   }
 
   hideLifecycleAction() {
-    this.currentLifecycleAction = null;
-    this.lifecycleActionSection?.classList.add('hidden');
+    this.currentLifecycleActions = [];
+    this.submittingLifecycleAction = null;
+    if (this.lifecycleActionSection) {
+      this.lifecycleActionSection.innerHTML = '';
+      this.lifecycleActionSection.classList.add('hidden');
+    }
     this.updateSubmitButtons();
   }
 
@@ -5431,8 +5467,6 @@ class ProposalInfoModal {
     const disableCommittee = this.isSubmitting || !this.canSubmitCommitteeReview;
     const isSameVote = Boolean(this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote);
     const disableResult = this.isSubmitting || !this.canSubmitReviewResult;
-    const canSubmitLifecycle = this.currentLifecycleAction?.canSubmit !== false;
-    const disableLifecycle = this.isSubmitting || !this.currentLifecycleAction || !canSubmitLifecycle;
     const disableVote = this.isSubmitting || !this.canSubmitVote;
 
     if (this.acceptButton) this.acceptButton.disabled = disableCommittee || this.currentCommitteeVote === 'accept';
@@ -5447,11 +5481,12 @@ class ProposalInfoModal {
       this.reviewResultButton.disabled = disableResult;
       this.reviewResultButton.textContent = this.isSubmitting && this.canSubmitReviewResult ? 'Finalizing...' : this.reviewResultButtonLabel;
     }
-    if (this.lifecycleActionButton) {
-      this.lifecycleActionButton.disabled = disableLifecycle;
-      this.lifecycleActionButton.textContent = this.isSubmitting && this.currentLifecycleAction && canSubmitLifecycle
-        ? this.currentLifecycleAction.loadingLabel
-        : this.currentLifecycleAction?.buttonLabel || '';
+    for (const button of this.lifecycleActionSection?.querySelectorAll('button[data-lifecycle-action-index]') || []) {
+      const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
+      const isSubmittingAction = this.isSubmitting && action === this.submittingLifecycleAction;
+      const canSubmitLifecycle = action?.canSubmit !== false;
+      button.disabled = this.isSubmitting || !action || !canSubmitLifecycle;
+      button.textContent = isSubmittingAction ? action.loadingLabel : action?.buttonLabel || '';
     }
     if (this.voteSubmitButton) {
       this.voteSubmitButton.disabled = disableVote;
@@ -5550,9 +5585,13 @@ class ProposalInfoModal {
     this.renderCurrentProposal();
   }
 
-  async refreshAfterDaoAction(warningMessage) {
+  async refreshAfterDaoAction(warningMessage, { refreshNetworkParams = false } = {}) {
     try {
       await this.refreshCurrentProposal();
+      if (refreshNetworkParams) {
+        const refreshed = await getNetworkParams(true);
+        if (!refreshed) throw new Error('Network parameter refresh failed');
+      }
     } catch (error) {
       console.warn('Failed to refresh proposal after DAO action:', error);
       showToast(warningMessage, 4000, 'warning');
@@ -5669,9 +5708,17 @@ class ProposalInfoModal {
     }
   }
 
-  async handleLifecycleActionSubmit() {
-    const action = this.currentLifecycleAction;
-    if (this.isSubmitting || !action) return;
+  handleLifecycleActionClick(event) {
+    const button = event.target?.closest?.('button[data-lifecycle-action-index]');
+    if (!button || !this.lifecycleActionSection?.contains(button)) return;
+
+    const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
+    this.handleLifecycleActionSubmit(action);
+  }
+
+  async handleLifecycleActionSubmit(action) {
+    const canSubmitLifecycle = action?.canSubmit !== false;
+    if (this.isSubmitting || !action || !canSubmitLifecycle) return;
 
     const proposal = this.getCurrentProposal();
     if (!proposal) {
@@ -5683,6 +5730,7 @@ class ProposalInfoModal {
       return;
     }
 
+    this.submittingLifecycleAction = action;
     this.setSubmitting(true);
     const loadingToastId = showToast(action.loadingLabel, 0, 'loading');
 
@@ -5705,6 +5753,9 @@ class ProposalInfoModal {
         case 'burn_reward':
           result = await daoRepo.burnReward(request);
           break;
+        case 'apply_parameters':
+          result = await daoRepo.applyParameters(request);
+          break;
         default:
           throw new Error(`Unknown DAO lifecycle action: ${action.kind}`);
       }
@@ -5715,12 +5766,13 @@ class ProposalInfoModal {
       }
 
       showToast(action.successMessage, 3000, 'success');
-      await this.refreshAfterDaoAction(action.refreshWarning);
+      await this.refreshAfterDaoAction(action.refreshWarning, { refreshNetworkParams: action.refreshNetworkParams });
     } catch (error) {
       console.warn('Failed to submit DAO lifecycle action:', error);
       showToast(error?.message || `${action.title} failed`, 3000, 'warning');
     } finally {
       if (loadingToastId) hideToast(loadingToastId);
+      this.submittingLifecycleAction = null;
       this.setSubmitting(false);
     }
   }

--- a/app.js
+++ b/app.js
@@ -2736,7 +2736,7 @@ class DaoModal {
       li.classList.add('chat-item', 'dao-proposal-row');
 
       const titleText = String(p.title || '').trim() || 'Proposal';
-      const rowTitleText = p.number ? `${p.number}: ${titleText}` : titleText;
+      const rowTitleText = p.number ? `#${p.number}: ${titleText}` : titleText;
       const title = escapeHtml(rowTitleText);
       const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
       const previewHtml = this.renderProposalRowPreview(p);

--- a/app.js
+++ b/app.js
@@ -2466,6 +2466,16 @@ function formatDaoTimestamp(ts) {
   }
 }
 
+function formatDaoDate(ts) {
+  const n = Number(ts || 0);
+  if (!n) return '';
+  try {
+    return new Date(n).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
 function getDaoUiStateLabel(key) {
   if (key === 'discussion') return 'Review';
   return getDaoStateLabel(key);
@@ -2773,6 +2783,24 @@ class DaoModal {
         value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,
         tone: 'neutral',
       });
+    } else if (state === 'voting') {
+      const now = Date.now();
+      const votingWindow = getDaoProposalVotingWindow(proposal, now);
+      const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward, getDaoCurrentAccountAddress(), now);
+      const endDate = formatDaoDate(votingWindow.end);
+
+      if (endDate) {
+        chips.push({
+          value: `${now > votingWindow.end ? 'Ended' : 'Ends'} ${endDate}`,
+          tone: 'neutral',
+        });
+      }
+      if (lifecycleActions.some((action) => action.kind === 'vote_result')) {
+        chips.push({
+          value: 'Ready to finalize',
+          tone: 'neutral',
+        });
+      }
     } else {
       const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward);
       const claimAction = lifecycleActions.find((action) => action.kind === 'claim_reward');

--- a/app.js
+++ b/app.js
@@ -2476,11 +2476,6 @@ function formatDaoDate(ts) {
   }
 }
 
-function getDaoUiStateLabel(key) {
-  if (key === 'discussion') return 'Review';
-  return getDaoStateLabel(key);
-}
-
 class DaoModal {
   constructor() {
     this.selectedGroupKey = 'active';
@@ -2642,10 +2637,6 @@ class DaoModal {
     this.render();
   }
 
-  getProposals() {
-    return daoRepo.getProposalsForUi(this.selectedGroupKey);
-  }
-
   render() {
     const proposalsActive = daoRepo.getProposalsForUi('active');
     const proposalsArchived = daoRepo.getProposalsForUi('archived');
@@ -2661,7 +2652,7 @@ class DaoModal {
 
     // Update header title
     const groupLabel = this.selectedGroupKey === 'archived' ? 'Archived' : 'Active';
-    const label = getDaoUiStateLabel(this.selectedStateKey);
+    const label = getDaoStateLabel(this.selectedStateKey);
     if (this.titleEl) this.titleEl.textContent = `DAO - ${groupLabel} - ${label}`;
 
     // Update group toggle labels + selection
@@ -2681,7 +2672,7 @@ class DaoModal {
       const labelEl = document.getElementById(`daoStatusOption${s.label.replace(/\s+/g, '')}`);
       const countEl = option?.querySelector('.dao-status-count');
       const count = counts[s.key] || 0;
-      const displayLabel = getDaoUiStateLabel(s.key);
+      const displayLabel = getDaoStateLabel(s.key);
 
       if (labelEl) labelEl.textContent = displayLabel;
       if (countEl) {
@@ -2738,7 +2729,7 @@ class DaoModal {
       const titleText = String(p.title || '').trim() || 'Proposal';
       const rowTitleText = p.number ? `#${p.number}: ${titleText}` : titleText;
       const title = escapeHtml(rowTitleText);
-      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
+      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType) || 'Proposal');
       const previewHtml = this.renderProposalRowPreview(p);
 
       li.tabIndex = 0;
@@ -2935,10 +2926,8 @@ class AddProposalModal {
     if (this.startDelayInput) this.startDelayInput.value = '0';
     if (this.gracePeriodInput) this.gracePeriodInput.value = '';
     this.renderOptions(['yes', 'no']);
-    this.renderProposalFee();
     this.renderGracePeriodDefaultHint();
     this.refreshProposalFee();
-    this.renderConfigLoadingState();
     this.refreshSelectedConfigOptions();
     setTimeout(() => {
       this.titleInput?.focus();
@@ -3251,12 +3240,11 @@ class AddProposalModal {
     return this.getConfigOptions().find((option) => option.key === key) || null;
   }
 
-  renderParameterChanges(rows = null) {
+  renderParameterChanges(rows) {
     if (!this.changesList) return;
 
     const options = this.getConfigOptions();
-    const sourceRows = rows || this.getParameterChanges();
-    const validRows = sourceRows
+    const validRows = rows
       .filter((row) => options.some((option) => option.key === row.key))
       .map((row) => ({ key: row.key, value: row.value }));
 
@@ -3490,7 +3478,6 @@ class AddProposalModal {
       confirmProposalModal.open(draft);
     } catch (e) {
       this.showValidationError(e);
-      return;
     }
   }
 }
@@ -3671,6 +3658,9 @@ class ConfirmProposalModal {
     const proposalType = tx.proposalType;
     const changes = Array.isArray(tx[proposalType]?.changes) ? tx[proposalType].changes : [];
     const gracePeriodSummary = formatDaoDurationSummary(tx.gracePeriod);
+    const formattedOptions = tx.options
+      .map((option, index) => `${index + 1}. ${option}`)
+      .join('\n');
 
     this.setTitle('Review Proposal');
     this.content.innerHTML = [
@@ -3683,7 +3673,7 @@ class ConfirmProposalModal {
         ['Type', getDaoTypeLabel(proposalType)],
         ['Emergency', tx.emergency ? 'Yes' : 'No'],
         ['Description', tx.description],
-        ['Options', this.formatProposalOptions(tx.options)],
+        ['Options', formattedOptions],
         ['Review starts', formatDaoDurationSummary(draft.startDelayMs)],
         ['Grace period', gracePeriodSummary],
       ]),
@@ -3693,7 +3683,6 @@ class ConfirmProposalModal {
   }
 
   renderSection(title, rows) {
-    const gridClass = rows.length === 2 ? 'dao-confirm-grid dao-confirm-grid--two' : 'dao-confirm-grid';
     const rowHtml = rows
       .map(([label, value]) => {
         const displayValue = formatDaoConfirmValue(value);
@@ -3710,13 +3699,13 @@ class ConfirmProposalModal {
     return `
       <section class="dao-confirm-section">
         <h3>${escapeHtml(title)}</h3>
-        <div class="${gridClass}">${rowHtml}</div>
+        <div class="dao-confirm-grid">${rowHtml}</div>
       </section>
     `;
   }
 
   getSectionRowClass(label, value) {
-    const fullWidthLabels = ['Description', 'Options', 'from', 'description', 'options'];
+    const fullWidthLabels = ['Description', 'Options'];
     if (!fullWidthLabels.includes(label)) return 'dao-confirm-row';
 
     const text = String(value);
@@ -3726,12 +3715,6 @@ class ConfirmProposalModal {
       return 'dao-confirm-row dao-confirm-row--full';
     }
     return 'dao-confirm-row';
-  }
-
-  formatProposalOptions(options) {
-    return Array.isArray(options) && options.length
-      ? options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : options;
   }
 
   renderChanges(changes) {
@@ -3782,7 +3765,7 @@ function getDaoCurrentAccountAddress() {
 }
 
 function getDaoProposalReviewWindow(proposal) {
-  const start = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const start = Number(proposal?.startTime || 0);
   const duration = Number(proposal?.reviewDuration);
   if (!start || !Number.isFinite(duration) || duration < 0) {
     return {
@@ -3824,7 +3807,7 @@ function getDaoProposalReviewWindow(proposal) {
 }
 
 function getDaoProposalVotingWindow(proposal, now = Date.now()) {
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   if (
@@ -3905,14 +3888,10 @@ function formatDaoScaledBigInt(value, scale, decimals = 3) {
 }
 
 function formatDaoVoteWeightUnits(value, suffix) {
-  if (typeof value === 'bigint') {
-    const formatted = formatDaoScaledBigInt(value, DAO_VOTE_WEIGHT_PRECISION_BIGINT, 3);
-    return formatted === null ? 'Unavailable' : `${formatted} ${suffix}`;
-  }
-
-  const n = Number(value);
-  if (!Number.isFinite(n)) return 'Unavailable';
-  return `${formatDaoShortNumber(n / DAO_VOTE_WEIGHT_PRECISION, 3)} ${suffix}`;
+  const bigintValue = parseDaoUnsignedBigInt(value);
+  if (bigintValue === null) return 'Unavailable';
+  const formatted = formatDaoScaledBigInt(bigintValue, DAO_VOTE_WEIGHT_PRECISION_BIGINT, 3);
+  return formatted === null ? 'Unavailable' : `${formatted} ${suffix}`;
 }
 
 function formatDaoVotingPower(value) {
@@ -3929,12 +3908,9 @@ function formatDaoPercent(value) {
 }
 
 function formatDaoLibWei(value) {
-  try {
-    const weiValue = typeof value === 'bigint' ? value : BigInt(value || 0);
-    return `${formatDaoShortNumber(EthNum.toStr(weiValue))} LIB`;
-  } catch {
-    return 'Unavailable';
-  }
+  const weiValue = parseDaoUnsignedBigInt(value);
+  if (weiValue === null) return 'Unavailable';
+  return `${formatDaoShortNumber(EthNum.toStr(weiValue))} LIB`;
 }
 
 function parseDaoUnsignedBigInt(value) {
@@ -3943,6 +3919,16 @@ function parseDaoUnsignedBigInt(value) {
   if (typeof value === 'number') {
     if (!Number.isFinite(value) || value < 0) return null;
     return BigInt(Math.trunc(value));
+  }
+  if (typeof value === 'object') {
+    if (value.dataType !== 'bi') return null;
+    const hexText = String(value.value ?? '').trim();
+    if (!/^[0-9a-f]+$/i.test(hexText)) return null;
+    try {
+      return BigInt(`0x${hexText}`);
+    } catch {
+      return null;
+    }
   }
 
   const text = String(value).trim();
@@ -3968,12 +3954,11 @@ function formatDaoBigIntPercent(part, total) {
 }
 
 function getDaoProposalOptions(proposal) {
-  if (!Array.isArray(proposal?.options) || proposal.options.length === 0) return ['Yes', 'No'];
-  return proposal.options.map((option, index) => String(option || `Option ${index + 1}`));
+  return proposal.options.map((option) => String(option));
 }
 
 function getDaoVoteTotals(proposal) {
-  const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+  const totalVote = proposal.totalVote;
   if (totalVote.length === 0) return [];
 
   const options = getDaoProposalOptions(proposal);
@@ -4067,7 +4052,7 @@ function getDaoClaimList(proposal) {
 }
 
 function getDaoProposalClaimWindow(proposal) {
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   const claimDuration = Number(proposal?.claimDuration);
@@ -4100,7 +4085,7 @@ function getDaoProposalApplyWindow(proposal, now = Date.now()) {
     return { eligibleAt: backendEligibleAt, isReady: now >= backendEligibleAt };
   }
 
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   const gracePeriod = Number(proposal?.gracePeriod);
@@ -4118,7 +4103,7 @@ function getDaoProposalApplyWindow(proposal, now = Date.now()) {
 }
 
 function isDaoParameterProposalType(proposal) {
-  const type = String(proposal?.proposalType || proposal?.type || '').toLowerCase();
+  const type = String(proposal?.proposalType || '').toLowerCase();
   return type === 'governance' || type === 'economic' || type === 'protocol';
 }
 
@@ -4271,7 +4256,7 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
     ? safePool > safeClaimed ? safePool - safeClaimed : 0n
     : null;
 
-  const summary = {
+  return {
     claimEstimate,
     claimStatus,
     claimWindowLabel: formatDaoClaimWindowLabel(claimWindow, now),
@@ -4280,9 +4265,6 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
     initialBurned,
     pool,
     unclaimed,
-  };
-  return {
-    ...summary,
     statusTone: claimStatus === 'Claimable' ? 'accept' : '',
   };
 }
@@ -4361,10 +4343,6 @@ function formatDaoDetailValue(value) {
   return String(value);
 }
 
-function getDaoBooleanCapability(proposal, key) {
-  return typeof proposal?.[key] === 'boolean' ? proposal[key] : null;
-}
-
 function parseDaoPositiveLibAmount(value) {
   const text = String(value || '').trim();
   if (!/^\d+(?:\.\d{1,18})?$/.test(text)) return null;
@@ -4420,7 +4398,6 @@ class ProposalInfoModal {
     this.lifecycleActionSection = document.getElementById('proposalLifecycleActionSection');
     this.voteActionSection = document.getElementById('proposalVoteActionSection');
     this.voteActionHelp = document.getElementById('proposalVoteActionHelp');
-    this.voteStatusGrid = document.getElementById('proposalVoteStatusGrid');
     this.voteOptions = document.getElementById('proposalVoteOptions');
     this.voteSpendInput = document.getElementById('proposalVoteSpend');
     this.votePreview = document.getElementById('proposalVotePreview');
@@ -4514,13 +4491,11 @@ class ProposalInfoModal {
     const currentAddress = getDaoCurrentAccountAddress();
     const currentVote = committeeVotes.find((vote) => vote?.memberAddress === currentAddress) || null;
     const capabilities = this.getReviewCapabilities({
-      proposal,
       state,
       reviewWindow,
       currentAddress,
       committeeAddressSet,
     });
-    const proposalType = proposal.proposalType || proposal.type;
     const resultSummary = getDaoProposalResultSummary(proposal);
     const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
     const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
@@ -4551,10 +4526,8 @@ class ProposalInfoModal {
     if (this.detailsContent) {
       this.detailsContent.innerHTML = this.renderProposalDetails({
         proposal,
-        proposalType,
         state,
         reviewWindow,
-        resultSummary,
         rewardSummary,
       });
     }
@@ -4567,24 +4540,13 @@ class ProposalInfoModal {
       this.hideReviewResultAction();
     }
     this.renderLifecycleActions(lifecycleActions);
-    this.renderVoteActions({ proposal, state });
+    this.renderVoteActions(proposal, state);
   }
 
-  getReviewCapabilities({ proposal, state, reviewWindow, currentAddress, committeeAddressSet }) {
-    const backendCommitteeMember = getDaoBooleanCapability(proposal, 'isCommitteeMemberForProposal');
-    const isCommitteeMember = backendCommitteeMember ?? Boolean(currentAddress && committeeAddressSet.has(currentAddress));
-
-    const backendCanCommitteeVote = getDaoBooleanCapability(proposal, 'canCommitteeVote');
-    const canCommitteeVote = backendCanCommitteeVote ?? (
-      state === 'review' &&
-      reviewWindow.canCommitteeVote &&
-      isCommitteeMember
-    );
-
-    const backendCanFinalizeReviewResult = getDaoBooleanCapability(proposal, 'canFinalizeReviewResult');
-    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && (
-      backendCanFinalizeReviewResult ?? reviewWindow.canFinalizeReviewResult
-    );
+  getReviewCapabilities({ state, reviewWindow, currentAddress, committeeAddressSet }) {
+    const isCommitteeMember = Boolean(currentAddress && committeeAddressSet.has(currentAddress));
+    const canCommitteeVote = state === 'review' && reviewWindow.canCommitteeVote && isCommitteeMember;
+    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && reviewWindow.canFinalizeReviewResult;
 
     return { isCommitteeMember, canCommitteeVote, canFinalizeReviewResult };
   }
@@ -4596,14 +4558,15 @@ class ProposalInfoModal {
   }
 
   renderProposalTitle(proposal) {
-    const description = proposal.description || proposal.summary || '';
+    const description = proposal.description || '';
+    const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
     const descriptionHtml = description
       ? `<p class="proposal-info-description">${escapeHtml(description)}</p>`
       : '';
 
     return `
       <div class="proposal-info-heading">
-        <h2 class="proposal-info-title">${escapeHtml(this.getProposalTitle(proposal))}</h2>
+        <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
         ${descriptionHtml}
       </div>
     `;
@@ -4626,7 +4589,7 @@ class ProposalInfoModal {
         const isWinner = index === winnerIndex;
         const units = this.getCurrentVoteSegmentUnits(row.total, totalWeight);
         const power = formatDaoVotingPower(row.total);
-        const percent = this.formatCurrentVotePercent(row.total, totalWeight);
+        const percent = formatDaoBigIntPercent(row.total, totalWeight);
         const valueLabel = totalWeight > 0n ? `${power} / ${percent}` : power;
         const title = totalWeight > 0n
           ? `${row.option}: ${power}, ${percent}`
@@ -4677,29 +4640,12 @@ class ProposalInfoModal {
   }
 
   getCurrentVoteTotalRows(proposal) {
-    const options = this.getVoteOptions(proposal);
-    const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+    const options = getDaoProposalOptions(proposal);
+    const totalVote = proposal.totalVote;
     return options.map((option, index) => ({
       option,
-      total: this.parseCurrentVoteTotal(totalVote[index]),
+      total: parseDaoUnsignedBigInt(totalVote[index]) ?? 0n,
     }));
-  }
-
-  parseCurrentVoteTotal(value) {
-    if (typeof value === 'bigint') return value >= 0n ? value : 0n;
-    if (typeof value === 'number') {
-      if (!Number.isFinite(value) || value <= 0) return 0n;
-      return BigInt(Math.trunc(value));
-    }
-
-    const text = String(value ?? '').trim();
-    if (!text) return 0n;
-    try {
-      const parsed = BigInt(text);
-      return parsed >= 0n ? parsed : 0n;
-    } catch {
-      return 0n;
-    }
   }
 
   getCurrentVoteSegmentUnits(part, total) {
@@ -4707,18 +4653,6 @@ class ProposalInfoModal {
     if (part <= 0n) return 0;
     const units = Number((part * 1000n) / total);
     return Math.max(1, units);
-  }
-
-  formatCurrentVotePercent(part, total) {
-    if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return '0%';
-    const tenths = (part * 1000n + total / 2n) / total;
-    const whole = tenths / 10n;
-    const fraction = tenths % 10n;
-    return fraction === 0n ? `${whole}%` : `${whole}.${fraction}%`;
-  }
-
-  getProposalTitle(proposal) {
-    return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
   }
 
   renderProposalResults(result) {
@@ -4809,8 +4743,6 @@ class ProposalInfoModal {
     const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
     const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
     const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
-    const acceptSegmentWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-segment--winner' : '';
-    const withholdSegmentWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-segment--winner' : '';
 
     return `
       <section class="proposal-info-section">
@@ -4848,11 +4780,11 @@ class ProposalInfoModal {
           </div>
           <div class="proposal-result-meter-track" aria-hidden="true">
             <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptSegmentWinnerClass}${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
               style="--result-segment-units: ${acceptUnits};"
             ></span>
             <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdSegmentWinnerClass}${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
               style="--result-segment-units: ${withholdUnits};"
             ></span>
           </div>
@@ -4892,32 +4824,27 @@ class ProposalInfoModal {
     ]);
   }
 
-  getVoteStatusData(proposal) {
+  renderVotingDetails(proposal) {
     const votingWindow = getDaoProposalVotingWindow(proposal);
     const totalVote = Array.isArray(proposal.totalVote) ? proposal.totalVote : [];
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     const totalVoteText = totalVote.length
       ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
       : 'No votes yet';
-    return { votingWindow, totalVoteText };
-  }
-
-  renderVotingDetails(proposal) {
-    const { votingWindow, totalVoteText } = this.getVoteStatusData(proposal);
     return this.renderSection('Voting Details', [
       ['Voting state', votingWindow.label],
       ['Current totals', totalVoteText],
     ]);
   }
 
-  renderProposalDetails({ proposal, proposalType, state, reviewWindow, resultSummary, rewardSummary }) {
+  renderProposalDetails({ proposal, state, reviewWindow, rewardSummary }) {
     const sections = [
       this.renderSection('Overview', [
         ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
-        ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
+        ['Type', getDaoTypeLabel(proposal.proposalType) || 'Unavailable'],
         ['Status', getDaoStateLabel(state) || state],
-        ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
-        ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
+        ['Created', formatDaoDetailTimestamp(proposal.created)],
+        ['Updated', formatDaoDetailTimestamp(proposal.state_changed)],
       ]),
       this.renderSection('Review Timeline', [
         ['Window state', reviewWindow.label],
@@ -4929,20 +4856,18 @@ class ProposalInfoModal {
       this.renderProposalRewards(rewardSummary),
     ].filter(Boolean);
 
-    if (sections.length === 0) return '';
-
     return `
       <details class="proposal-more">
         <summary>
           <span class="proposal-more-title">Show proposal details</span>
-          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, resultSummary, rewardSummary))}</span>
+          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, rewardSummary))}</span>
         </summary>
         <div class="proposal-more-content">${sections.join('')}</div>
       </details>
     `;
   }
 
-  getProposalDetailsSummary(state, resultSummary, rewardSummary) {
+  getProposalDetailsSummary(state, rewardSummary) {
     const parts = ['Overview', 'review timeline'];
     if (state !== 'review') parts.push('proposal body');
     if (state === 'voting') parts.push('voting totals');
@@ -4999,9 +4924,7 @@ class ProposalInfoModal {
   }
 
   renderProposalBody(proposal) {
-    const options = Array.isArray(proposal.options) && proposal.options.length
-      ? proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : 'Unavailable';
+    const options = proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n');
 
     return this.renderSection('Proposal Body', [
       ['Emergency', proposal.emergency ? 'Yes' : 'No'],
@@ -5010,9 +4933,8 @@ class ProposalInfoModal {
   }
 
   renderParameterChanges(proposal) {
-    const fields = proposal.fields && typeof proposal.fields === 'object' ? proposal.fields : {};
     const payloads = ['governance', 'economic', 'protocol']
-      .map((key) => [key, proposal[key] || fields[key]])
+      .map((key) => [key, proposal[key]])
       .filter(([, payload]) => payload && typeof payload === 'object');
 
     if (payloads.length === 0) {
@@ -5038,7 +4960,7 @@ class ProposalInfoModal {
     `;
   }
 
-  getParameterChangeRowClass(parts, { isSingleRow = false } = {}) {
+  getParameterChangeRowClass(parts, isSingleRow) {
     const normalizedParts = parts.map((part) => String(part ?? '').trim());
     const shouldUseWideRow = normalizedParts.some((part) => part.length > 22)
       || normalizedParts.join(' ').length > 52;
@@ -5049,7 +4971,7 @@ class ProposalInfoModal {
     ].filter(Boolean).join(' ');
   }
 
-  renderPayloadRows(payload, payloadTitle = '') {
+  renderPayloadRows(payload, payloadTitle) {
     const titleHtml = payloadTitle
       ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
       : '';
@@ -5063,7 +4985,7 @@ class ProposalInfoModal {
           const next = formatDaoDetailValue(change?.value);
           const rowClass = this.getParameterChangeRowClass(
             [key, `Current: ${current}`, `New: ${next}`],
-            { isSingleRow: index === changes.length - 1 && changes.length % 2 === 1 },
+            index === changes.length - 1 && changes.length % 2 === 1,
           );
           return `
           <div class="${rowClass}">
@@ -5088,7 +5010,7 @@ class ProposalInfoModal {
         const displayValue = formatDaoDetailValue(value);
         const rowClass = this.getParameterChangeRowClass(
           [key, displayValue],
-          { isSingleRow: index === entries.length - 1 && entries.length % 2 === 1 },
+          index === entries.length - 1 && entries.length % 2 === 1,
         );
         return `
         <div class="${rowClass}">
@@ -5172,7 +5094,7 @@ class ProposalInfoModal {
   }
 
   renderLifecycleActions(actions) {
-    this.currentLifecycleActions = Array.isArray(actions) ? actions : [];
+    this.currentLifecycleActions = actions;
     if (!this.lifecycleActionSection || this.currentLifecycleActions.length === 0) {
       this.hideLifecycleAction();
       return;
@@ -5208,17 +5130,13 @@ class ProposalInfoModal {
   }
 
   resetVoteState(proposal) {
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     this.voteWeights = options.map(() => 0);
     this.voteSpendLib = '';
     if (this.voteSpendInput) this.voteSpendInput.value = '';
   }
 
-  getVoteOptions(proposal) {
-    return getDaoProposalOptions(proposal);
-  }
-
-  renderVoteActions({ proposal, state }) {
+  renderVoteActions(proposal, state) {
     if (!this.voteActionSection) return;
     if (state !== 'voting') {
       this.hideVoteActions();
@@ -5231,7 +5149,7 @@ class ProposalInfoModal {
       return;
     }
 
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     if (this.voteWeights.length !== options.length) {
       this.voteWeights = options.map(() => 0);
     }
@@ -5257,7 +5175,6 @@ class ProposalInfoModal {
       `;
     }
 
-    this.renderVoteStatus(proposal);
     this.updateVotePreview(proposal);
   }
 
@@ -5286,11 +5203,6 @@ class ProposalInfoModal {
         >
       </label>
     `;
-  }
-
-  renderVoteStatus(proposal) {
-    if (!this.voteStatusGrid) return;
-    this.voteStatusGrid.innerHTML = '';
   }
 
   handleVoteWeightInput(event) {
@@ -5341,7 +5253,7 @@ class ProposalInfoModal {
     }
     this.votePreview.classList.remove('proposal-vote-preview--message');
 
-    const optionRows = this.getVoteOptions(proposal)
+    const optionRows = getDaoProposalOptions(proposal)
       .map((option, index) => {
         const weight = this.voteWeights[index] || 0;
         const share = weight / submission.totalWeight;
@@ -5375,7 +5287,8 @@ class ProposalInfoModal {
     `;
   }
 
-  getVoteSubmission(proposal, timestamp = getTransactionTimestamp()) {
+  getVoteSubmission(proposal) {
+    const timestamp = getTransactionTimestamp();
     const validation = this.getVotePreviewValidation(proposal, timestamp);
     if (!validation.ok) {
       return { ok: false, message: validation.message, tone: 'warning' };
@@ -5606,16 +5519,18 @@ class ProposalInfoModal {
     return injectTx(transaction, txid);
   }
 
-  async refreshCurrentProposal() {
-    await daoRepo.refresh({ force: true });
-    if (daoModal?.isActive?.()) daoModal.render();
-
-    this.renderCurrentProposal();
-  }
-
   async refreshAfterDaoAction(warningMessage, { refreshNetworkParams = false } = {}) {
     try {
-      await this.refreshCurrentProposal();
+      await daoRepo.refresh({ force: true });
+      if (daoModal?.isActive?.()) daoModal.render();
+
+      const proposal = this.getCurrentProposal();
+      if (proposal) {
+        this.renderProposal(proposal);
+      } else {
+        this.renderNotFound();
+      }
+
       if (refreshNetworkParams) {
         const refreshed = await getNetworkParams(true);
         if (!refreshed) throw new Error('Network parameter refresh failed');
@@ -5623,15 +5538,6 @@ class ProposalInfoModal {
     } catch (error) {
       console.warn('Failed to refresh proposal after DAO action:', error);
       showToast(warningMessage, 4000, 'warning');
-    }
-  }
-
-  renderCurrentProposal() {
-    const proposal = this.getCurrentProposal();
-    if (proposal) {
-      this.renderProposal(proposal);
-    } else {
-      this.renderNotFound();
     }
   }
 
@@ -5745,8 +5651,7 @@ class ProposalInfoModal {
   }
 
   async handleLifecycleActionSubmit(action) {
-    const canSubmitLifecycle = action?.canSubmit !== false;
-    if (this.isSubmitting || !action || !canSubmitLifecycle) return;
+    if (this.isSubmitting || !action || action.canSubmit === false) return;
 
     const proposal = this.getCurrentProposal();
     if (!proposal) {
@@ -5861,9 +5766,6 @@ class ProposalInfoModal {
     enterFullscreen();
   }
 
-  isActive() {
-    return this.modal.classList.contains('active');
-  }
 }
 
 const proposalInfoModal = new ProposalInfoModal();

--- a/app.js
+++ b/app.js
@@ -2735,14 +2735,15 @@ class DaoModal {
       const li = document.createElement('li');
       li.classList.add('chat-item', 'dao-proposal-row');
 
-      const titleText = p.title || (p.number ? `Proposal #${p.number}` : 'Proposal');
-      const title = escapeHtml(titleText);
+      const titleText = String(p.title || '').trim() || 'Proposal';
+      const rowTitleText = p.number ? `${p.number}: ${titleText}` : titleText;
+      const title = escapeHtml(rowTitleText);
       const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
       const previewHtml = this.renderProposalRowPreview(p);
 
       li.tabIndex = 0;
       li.setAttribute('role', 'button');
-      li.setAttribute('aria-label', `Open ${titleText}`);
+      li.setAttribute('aria-label', `Open ${rowTitleText}`);
       li.innerHTML = `
         <div class="dao-row-content">
           <div class="dao-row-title">${title}</div>

--- a/app.js
+++ b/app.js
@@ -2786,16 +2786,16 @@ class DaoModal {
     } else if (state === 'voting') {
       const now = Date.now();
       const votingWindow = getDaoProposalVotingWindow(proposal, now);
-      const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward, getDaoCurrentAccountAddress(), now);
       const endDate = formatDaoDate(votingWindow.end);
+      const votingEnded = Boolean(votingWindow.end && now > votingWindow.end);
 
-      if (endDate && now <= votingWindow.end) {
+      if (endDate && !votingEnded) {
         chips.push({
           value: `Ends ${endDate}`,
           tone: 'neutral',
         });
       }
-      if (lifecycleActions.some((action) => action.kind === 'vote_result')) {
+      if (votingEnded) {
         chips.push({
           value: 'Ready to finalize',
           tone: 'neutral',

--- a/app.js
+++ b/app.js
@@ -2749,8 +2749,7 @@ class DaoModal {
           <div class="dao-row-title">${title}</div>
           <div class="dao-row-meta">
             <span class="dao-row-meta-item dao-row-meta-item--type">
-              <span class="dao-row-meta-label">Type</span>
-              <strong class="dao-row-meta-value">${typeLabel}</strong>
+              ${typeLabel}
             </span>
             ${previewHtml}
           </div>

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -420,6 +420,23 @@ export function buildDaoBurnRewardTransaction({
   });
 }
 
+export function buildDaoApplyParametersTransaction({
+  from,
+  proposal,
+  timestamp,
+  networkId,
+} = {}) {
+  return buildDaoProposalActionTransaction({
+    type: 'dao_apply_parameters',
+    from,
+    proposal,
+    timestamp,
+    networkId,
+    timestampLabel: 'Apply parameters timestamp',
+    fromLabel: 'Apply parameters sender',
+  });
+}
+
 async function submitDaoTransaction({ transaction, submitTransaction, errorMessage }) {
   try {
     if (typeof submitTransaction !== 'function') {
@@ -971,6 +988,18 @@ export const daoRepo = {
       networkId,
       submitTransaction,
       errorMessage: 'Reward burn failed',
+    });
+  },
+
+  async applyParameters({ from, proposal, timestamp, networkId, submitTransaction } = {}) {
+    return submitDaoProposalAction({
+      buildTransaction: buildDaoApplyParametersTransaction,
+      from,
+      proposal,
+      timestamp,
+      networkId,
+      submitTransaction,
+      errorMessage: 'Apply parameters failed',
     });
   },
 };

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -88,8 +88,7 @@ export function getDaoStateLabel(key) {
 }
 
 export function getEffectiveDaoState(proposal) {
-  const state = proposal?.status || proposal?.state || 'review';
-  return state === 'discussion' ? 'review' : state;
+  return proposal?.status || proposal?.state || 'review';
 }
 
 const DAO_PROPOSAL_QUERY_BATCH_SIZE = 10;
@@ -251,7 +250,7 @@ export function buildDaoProposalCreateTransaction({
 }
 
 function getDaoProposalTransactionId(proposal) {
-  return requireDaoDraftString(proposal?.accountId || proposal?.proposalId || proposal?.id, 'DAO proposal account ID');
+  return requireDaoDraftString(proposal?.accountId, 'DAO proposal account ID');
 }
 
 function buildDaoProposalActionTransaction({
@@ -515,65 +514,36 @@ function normalizeDaoTimestamp(value) {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
-function normalizeDaoVoteNumber(value) {
-  if (typeof value === 'bigint') return Number(value);
-  const n = Number(value || 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function getDaoProposalDescription(proposal) {
-  return String(proposal?.description || proposal?.summary || '').trim();
-}
-
-function getDaoProposalFields(proposal) {
-  const fields = proposal?.fields && typeof proposal.fields === 'object' ? { ...proposal.fields } : {};
-  if (proposal?.governance) fields.governance = proposal.governance;
-  if (proposal?.economic) fields.economic = proposal.economic;
-  if (proposal?.protocol) fields.protocol = proposal.protocol;
-  return fields;
-}
-
-function getDaoProposalVotes(proposal) {
-  if (proposal?.votes && typeof proposal.votes === 'object') return proposal.votes;
-
-  const totals = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
-  return {
-    yes: normalizeDaoVoteNumber(totals[0]),
-    no: normalizeDaoVoteNumber(totals[1]),
-    by: {},
-  };
-}
-
 function mapBackendProposalToStoreProposal(proposal) {
   if (!proposal || typeof proposal !== 'object') return null;
 
   const number = normalizeDaoPositiveInteger(proposal.number);
   if (!number) return null;
 
-  const accountId = proposal.id || proposal.accountId || proposal.proposalId;
-  const nonce = String(accountId || proposal.nonce || number);
-  const type = proposal.proposalType || proposal.type || '';
+  const accountId = String(proposal.id || '').trim();
+  if (!accountId) return null;
+
+  const nonce = accountId;
+  const proposalType = String(proposal.proposalType || '').trim();
+  if (!proposalType) return null;
+
   const state = getEffectiveDaoState(proposal);
-  const created = normalizeDaoTimestamp(proposal.creationTime || proposal.created || proposal.timestamp);
-  const stateChanged = normalizeDaoTimestamp(proposal.timestamp || proposal.state_changed || created);
-  const description = getDaoProposalDescription(proposal);
+  const created = normalizeDaoTimestamp(proposal.creationTime);
+  const stateChanged = normalizeDaoTimestamp(proposal.timestamp);
+  const title = String(proposal.title || proposal.description || '').trim();
 
   return {
     ...proposal,
     accountId,
     number,
     nonce,
-    title: String(proposal.title || '').trim(),
-    summary: description,
-    description,
-    type,
-    proposalType: type,
+    title,
+    description: String(proposal.description || '').trim(),
+    proposalType,
     state,
     status: state,
     state_changed: stateChanged,
     created,
-    fields: getDaoProposalFields(proposal),
-    votes: getDaoProposalVotes(proposal),
   };
 }
 
@@ -584,7 +554,6 @@ function getDaoStoreMeta(proposal) {
     state: proposal.state,
     status: proposal.status,
     state_changed: proposal.state_changed,
-    type: proposal.type,
     proposalType: proposal.proposalType,
     nonce: proposal.nonce,
   };
@@ -617,12 +586,10 @@ async function fetchBackendProposal(queryDaoApi, proposalNumber) {
   const body = await queryDaoApi(`/dao/proposals/${proposalNumber}`);
   if (!body) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: no response`);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   if (body.error || !body.proposal) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: proposal unavailable`, body.error || body);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   return body.proposal;
@@ -685,13 +652,6 @@ function normalizeDaoStore(store) {
     const full = safe.proposals[id];
     if (!full) continue;
 
-    // Migration: older versions wrote a synthetic `state: 'archived'`.
-    // We cannot reliably recover the original state; map to a server-supported final state.
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-
     const state = getEffectiveDaoState({ status: full.status || meta.status, state: full.state || meta.state });
     const enteredAt = Number(full.state_changed || meta.state_changed || full.created || 0);
     const isArchivable = DAO_ARCHIVABLE_STATE_KEYS.includes(state);
@@ -706,7 +666,7 @@ function normalizeDaoStore(store) {
           title: meta.title,
           state,
           state_changed: enteredAt,
-          type: meta.type,
+          proposalType: meta.proposalType,
           nonce: meta.nonce,
         });
         archivedIds.add(id);
@@ -724,17 +684,6 @@ function normalizeDaoStore(store) {
     const id = daoProposalId(m.number, m.nonce);
     return Boolean(safe.proposals[id]);
   });
-
-  // Migration: older versions stored `state: 'archived'` for archived items.
-  for (const meta of safe.archivedProposals) {
-    const id = daoProposalId(meta.number, meta.nonce);
-    const full = safe.proposals[id];
-    if (!full) continue;
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-  }
 
   safe.meta.active = safe.activeProposals.length;
   safe.meta.archived = safe.archivedProposals.length;
@@ -755,42 +704,36 @@ function storeToUiList(store, groupKey) {
       const id = daoProposalId(m.number, m.nonce);
       const p = safe.proposals?.[id];
       if (!p) return null;
-      const description = p.description || p.summary;
       const state = getEffectiveDaoState({ status: p.status || m.status, state: p.state || m.state });
-      const type = p.proposalType || p.type;
       return {
         id,
         number: p.number,
         accountId: p.accountId,
         nonce: p.nonce,
         title: p.title,
-        summary: description,
-        description,
-        type,
-        proposalType: type,
+        description: p.description,
+        proposalType: p.proposalType,
         emergency: Boolean(p.emergency),
         createdAt: p.created,
         state,
         status: state,
         stateEnteredAt: p.state_changed,
-        fields: p.fields || {},
-        options: Array.isArray(p.options) ? p.options : ['yes', 'no'],
-        totalVote: Array.isArray(p.totalVote) ? p.totalVote : undefined,
-        committeeVotes: Array.isArray(p.committeeVotes) ? p.committeeVotes : [],
-        committeeAddresses: Array.isArray(p.committeeAddresses) ? p.committeeAddresses : [],
+        options: p.options,
+        totalVote: p.totalVote,
+        committeeVotes: p.committeeVotes,
+        committeeAddresses: p.committeeAddresses,
         voterRewardPool: p.voterRewardPool,
         claimedReward: p.claimedReward,
         initialBurnedReward: p.initialBurnedReward,
         finalBurnedReward: p.finalBurnedReward,
-        voterList: Array.isArray(p.voterList) ? p.voterList : [],
-        claimList: Array.isArray(p.claimList) ? p.claimList : [],
+        voterList: p.voterList,
+        claimList: p.claimList,
         startTime: p.startTime,
         reviewDuration: p.reviewDuration,
         votingDuration: p.votingDuration,
         claimDuration: p.claimDuration,
         gracePeriod: p.gracePeriod,
         applyEligibleAt: p.applyEligibleAt,
-        votes: p.votes || { yes: 0, no: 0, by: {} },
         archivedAt: p.archivedAt || 0,
       };
     })
@@ -808,7 +751,7 @@ export function setDaoBackendFetcher(fetcher) {
   _backendFetcher = typeof fetcher === 'function' ? fetcher : null;
 }
 
-async function refreshInternal({ force } = {}) {
+async function refreshInternal({ force }) {
   if (_loadingPromise && !force) return _loadingPromise;
   if (_store && !force) return _store;
 
@@ -850,7 +793,7 @@ export const daoRepo = {
   },
 
   getProposalsForUi(groupKey) {
-    return storeToUiList(_store, groupKey || 'active');
+    return storeToUiList(_store, groupKey);
   },
 
   async createProposal({ draft, timestamp, networkId, submitTransaction } = {}) {

--- a/index.html
+++ b/index.html
@@ -493,13 +493,7 @@
               </div>
               <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalReviewResultSubmit">Finalize review result</button>
             </section>
-            <section class="proposal-lifecycle-actions hidden" id="proposalLifecycleActionSection" aria-label="Proposal lifecycle action">
-              <div class="proposal-committee-actions-header">
-                <h3 id="proposalLifecycleActionTitle">Proposal action</h3>
-                <p id="proposalLifecycleActionHelp"></p>
-              </div>
-              <button type="button" class="btn btn--primary btn--pill btn--full" id="proposalLifecycleActionSubmit"></button>
-            </section>
+            <section class="proposal-lifecycle-actions hidden" id="proposalLifecycleActionSection" aria-label="Proposal lifecycle action"></section>
             <section class="proposal-vote-actions hidden" id="proposalVoteActionSection" aria-label="Proposal voting actions">
               <div class="proposal-committee-actions-header">
                 <h3>Vote preview</h3>

--- a/index.html
+++ b/index.html
@@ -499,7 +499,6 @@
                 <h3>Vote preview</h3>
                 <p id="proposalVoteActionHelp"></p>
               </div>
-              <div class="proposal-vote-status-grid" id="proposalVoteStatusGrid"></div>
               <div class="proposal-vote-options" id="proposalVoteOptions"></div>
               <div class="proposal-vote-spend-row">
                 <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -2384,10 +2384,6 @@ input[type='file'].form-control::file-selector-button {
   border-left: 0;
 }
 
-#proposalInfoModal .proposal-result-meter-segment--winner {
-  background: var(--primary-color);
-}
-
 #proposalInfoModal .proposal-result-meter-segment--palette-0 {
   background: #3d3dce;
 }
@@ -2439,7 +2435,6 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-change-row {
   flex: 0 1 calc(50% - 4px);
   min-width: min(100%, 180px);
-  min-inline-size: 0;
 }
 
 #proposalInfoModal .proposal-change-row--single {
@@ -2519,19 +2514,7 @@ input[type='file'].form-control::file-selector-button {
   font-size: 13px;
 }
 
-#confirmProposalModal .dao-confirm-change-values small {
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-change-values small {
-  text-align: center;
-}
-
 #confirmProposalModal .dao-confirm-change-values strong {
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-change-values strong {
   text-align: center;
 }
 
@@ -2580,13 +2563,9 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-info + .proposal-committee-actions,
-#proposalInfoModal .proposal-info + .proposal-review-result-actions,
-#proposalInfoModal .proposal-info + .proposal-lifecycle-actions,
-#proposalInfoModal .proposal-info + .proposal-vote-actions,
 #proposalInfoModal .proposal-committee-actions + .proposal-review-result-actions,
 #proposalInfoModal .proposal-review-result-actions + .proposal-lifecycle-actions,
-#proposalInfoModal .proposal-lifecycle-actions + .proposal-vote-actions,
-#proposalInfoModal .proposal-review-result-actions + .proposal-vote-actions {
+#proposalInfoModal .proposal-lifecycle-actions + .proposal-vote-actions {
   margin-top: 10px;
 }
 
@@ -2599,10 +2578,6 @@ input[type='file'].form-control::file-selector-button {
   display: grid;
   gap: 8px;
   padding: 10px;
-}
-
-#proposalInfoModal .proposal-vote-actions {
-  gap: 8px;
 }
 
 #proposalInfoModal .proposal-lifecycle-action {
@@ -2802,10 +2777,6 @@ input[type='file'].form-control::file-selector-button {
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(0, 1fr);
-}
-
-#proposalInfoModal .proposal-vote-status-grid:empty {
-  display: none;
 }
 
 #proposalInfoModal .proposal-vote-current-meter {

--- a/styles.css
+++ b/styles.css
@@ -7979,6 +7979,7 @@ small {
   min-width: 0;
   overflow: visible;
   overflow-wrap: anywhere;
+  text-align: left;
   text-overflow: clip;
   white-space: normal;
 }

--- a/styles.css
+++ b/styles.css
@@ -2605,6 +2605,11 @@ input[type='file'].form-control::file-selector-button {
   gap: 8px;
 }
 
+#proposalInfoModal .proposal-lifecycle-action {
+  display: grid;
+  gap: 8px;
+}
+
 #proposalInfoModal .proposal-lifecycle-actions .proposal-committee-actions-header,
 #proposalInfoModal .proposal-vote-actions .proposal-committee-actions-header {
   display: grid;

--- a/styles.css
+++ b/styles.css
@@ -8005,27 +8005,6 @@ small {
   max-width: 34%;
 }
 
-#daoModal .dao-row-meta-label {
-  flex: 0 0 auto;
-  font-family: var(--font-primary);
-  font-size: 11px;
-  font-weight: var(--font-weight-medium);
-  line-height: 1.2;
-}
-
-#daoModal .dao-row-meta-value {
-  color: var(--text-color);
-  display: block;
-  font-family: var(--font-primary);
-  font-size: 12px;
-  font-weight: var(--font-weight-semibold);
-  line-height: 1.2;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 #daoModal .dao-row-previews {
   display: flex;
   flex: 1 1 auto;

--- a/styles.css
+++ b/styles.css
@@ -8002,7 +8002,13 @@ small {
 
 #daoModal .dao-row-meta-item--type {
   flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
   max-width: 34%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 #daoModal .dao-row-previews {


### PR DESCRIPTION
## What Changed

This PR connects the ready apply-parameters action to the backend DAO transaction path and lets proposal detail render multiple lifecycle actions.

- `buildDaoApplyParametersTransaction(...)` adds the `dao_apply_parameters` transaction builder behind the DAO repository boundary.
- `daoRepo.applyParameters(...)` submits apply-parameters transactions through the shared proposal-action submit helper.
- `getDaoApplyParametersLifecycleAction(help, canSubmit, rowPreviewLabel)` now marks ready apply actions as submittable while keeping unsupported, ineligible, or not-yet-ready states disabled.
- `getDaoProposalLifecycleActions(...)` replaces the singular lifecycle action derivation so vote finalization, reward claim/burn, and apply-parameters actions can coexist.
- `renderLifecycleActions(actions)` renders indexed lifecycle buttons, and `handleLifecycleActionSubmit(action)` dispatches `apply_parameters` to `daoRepo.applyParameters(request)`.
- DAO rows are tightened with proposal-number title prefixes, voting timing chips, simplified type chips, and compact ready-action previews.

## Fixed Flow

1. A user opens an accepted governance/economic/protocol proposal after the apply grace period has ended.
2. `getDaoProposalLifecycleActions(...)` includes an `apply_parameters` action with `canSubmit: true` and `refreshNetworkParams: true`.
3. The modal renders the action button from `renderLifecycleActions(actions)` using `data-lifecycle-action-index`.
4. Clicking the button submits `dao_apply_parameters` through `daoRepo.applyParameters(request)`.
5. On success, the proposal/list state and network parameters refresh; on failure, the error is shown and the action remains retryable.

## Added Flow And Code References

1. `buildDaoProposalActionTransaction({ type, from, proposal, timestamp, networkId, ... })` centralizes shared proposal action transaction fields: `type`, `timestamp`, `networkId`, `from`, and `proposalId`.
2. `buildDaoApplyParametersTransaction(...)` calls that helper with `type: 'dao_apply_parameters'`, `timestampLabel: 'Apply parameters timestamp'`, and `fromLabel: 'Apply parameters sender'`.
3. `submitDaoProposalAction(...)` builds the transaction, calls `submitDaoTransaction({ transaction, submitTransaction, errorMessage })`, and converts validation failures into `{ ok: false, error, transaction: null }`.
4. `daoRepo.applyParameters(...)` passes `buildTransaction: buildDaoApplyParametersTransaction` and `errorMessage: 'Apply parameters failed'`.
5. `getDaoApplyParametersLifecycleAction(help, canSubmit, rowPreviewLabel = '')` now includes `loadingLabel: 'Applying parameters...'`, `successMessage: 'Parameters applied'`, `refreshNetworkParams: true`, and `canSubmit`.
6. `getDaoProposalApplyLifecycleAction(...)` returns disabled apply actions for unsupported proposal types, emergency proposals where the wallet is not a committee member, or proposals whose apply window is not ready.
7. Ready apply proposals return `getDaoApplyParametersLifecycleAction('This proposal is ready to apply. Submit the transaction to apply the accepted parameter changes.', true, 'Ready to apply')`.
8. `getDaoProposalLifecycleActions(...)` returns arrays: voting-ended proposals return `[ { kind: 'vote_result', ... } ]`, final states can push `burn_reward`, `claim_reward`, and then `apply_parameters`.
9. `renderLifecycleActions(actions)` maps each action into a `.proposal-lifecycle-action` block with `data-lifecycle-action-index="${index}"`.
10. `handleLifecycleActionClick(event)` resolves `this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)]` and passes that action to `handleLifecycleActionSubmit(action)`.
11. `handleLifecycleActionSubmit(action)` guards with `action?.canSubmit !== false`, builds the shared request object, and dispatches `case 'apply_parameters': result = await daoRepo.applyParameters(request);`.
12. Successful lifecycle actions call `this.refreshAfterDaoAction(action.refreshWarning, { refreshNetworkParams: action.refreshNetworkParams })`.
13. `renderProposalRowPreview(proposal)` reads `const lifecycleActions = getDaoProposalLifecycleActions(proposal, reward)` so claim, burn, and apply preview chips can be evaluated together.
14. Voting rows add `Ends ${endDate}` before the voting window ends and `Ready to finalize` after it ends.
15. DAO list rows prefix titles with ``const rowTitleText = p.number ? `#${p.number}: ${titleText}` : titleText`` so proposal numbers are visible without a separate chip.

## Why

Phase 7.B completes the apply-parameters ready action by keeping transaction construction and submission in `dao.repo.js`, while the modal stays responsible for action derivation, button state, and refresh behavior.

## Validation

- `git show issue-1427-ready-actions-backend-integration:app.js | node --check --input-type=module -`
- `git show issue-1427-ready-actions-backend-integration:dao.repo.js | node --check --input-type=module -`
- `git diff --check issue-1426-ready-actions-ui..issue-1427-ready-actions-backend-integration`

Closes #1427
Parent: #1413
Builds on #1426
