### PR TITLE
Phase 7.C: DAO Proposal Compatibility Cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -2476,10 +2476,6 @@ function formatDaoDate(ts) {
   }
 }
 
-function getDaoUiStateLabel(key) {
-  return getDaoStateLabel(key);
-}
-
 class DaoModal {
   constructor() {
     this.selectedGroupKey = 'active';
@@ -2641,10 +2637,6 @@ class DaoModal {
     this.render();
   }
 
-  getProposals() {
-    return daoRepo.getProposalsForUi(this.selectedGroupKey);
-  }
-
   render() {
     const proposalsActive = daoRepo.getProposalsForUi('active');
     const proposalsArchived = daoRepo.getProposalsForUi('archived');
@@ -2660,7 +2652,7 @@ class DaoModal {
 
     // Update header title
     const groupLabel = this.selectedGroupKey === 'archived' ? 'Archived' : 'Active';
-    const label = getDaoUiStateLabel(this.selectedStateKey);
+    const label = getDaoStateLabel(this.selectedStateKey);
     if (this.titleEl) this.titleEl.textContent = `DAO - ${groupLabel} - ${label}`;
 
     // Update group toggle labels + selection
@@ -2680,7 +2672,7 @@ class DaoModal {
       const labelEl = document.getElementById(`daoStatusOption${s.label.replace(/\s+/g, '')}`);
       const countEl = option?.querySelector('.dao-status-count');
       const count = counts[s.key] || 0;
-      const displayLabel = getDaoUiStateLabel(s.key);
+      const displayLabel = getDaoStateLabel(s.key);
 
       if (labelEl) labelEl.textContent = displayLabel;
       if (countEl) {
@@ -2934,10 +2926,8 @@ class AddProposalModal {
     if (this.startDelayInput) this.startDelayInput.value = '0';
     if (this.gracePeriodInput) this.gracePeriodInput.value = '';
     this.renderOptions(['yes', 'no']);
-    this.renderProposalFee();
     this.renderGracePeriodDefaultHint();
     this.refreshProposalFee();
-    this.renderConfigLoadingState();
     this.refreshSelectedConfigOptions();
     setTimeout(() => {
       this.titleInput?.focus();
@@ -3250,12 +3240,11 @@ class AddProposalModal {
     return this.getConfigOptions().find((option) => option.key === key) || null;
   }
 
-  renderParameterChanges(rows = null) {
+  renderParameterChanges(rows) {
     if (!this.changesList) return;
 
     const options = this.getConfigOptions();
-    const sourceRows = rows || this.getParameterChanges();
-    const validRows = sourceRows
+    const validRows = rows
       .filter((row) => options.some((option) => option.key === row.key))
       .map((row) => ({ key: row.key, value: row.value }));
 
@@ -3489,7 +3478,6 @@ class AddProposalModal {
       confirmProposalModal.open(draft);
     } catch (e) {
       this.showValidationError(e);
-      return;
     }
   }
 }
@@ -3670,6 +3658,9 @@ class ConfirmProposalModal {
     const proposalType = tx.proposalType;
     const changes = Array.isArray(tx[proposalType]?.changes) ? tx[proposalType].changes : [];
     const gracePeriodSummary = formatDaoDurationSummary(tx.gracePeriod);
+    const formattedOptions = tx.options
+      .map((option, index) => `${index + 1}. ${option}`)
+      .join('\n');
 
     this.setTitle('Review Proposal');
     this.content.innerHTML = [
@@ -3682,7 +3673,7 @@ class ConfirmProposalModal {
         ['Type', getDaoTypeLabel(proposalType)],
         ['Emergency', tx.emergency ? 'Yes' : 'No'],
         ['Description', tx.description],
-        ['Options', this.formatProposalOptions(tx.options)],
+        ['Options', formattedOptions],
         ['Review starts', formatDaoDurationSummary(draft.startDelayMs)],
         ['Grace period', gracePeriodSummary],
       ]),
@@ -3692,7 +3683,6 @@ class ConfirmProposalModal {
   }
 
   renderSection(title, rows) {
-    const gridClass = rows.length === 2 ? 'dao-confirm-grid dao-confirm-grid--two' : 'dao-confirm-grid';
     const rowHtml = rows
       .map(([label, value]) => {
         const displayValue = formatDaoConfirmValue(value);
@@ -3709,13 +3699,13 @@ class ConfirmProposalModal {
     return `
       <section class="dao-confirm-section">
         <h3>${escapeHtml(title)}</h3>
-        <div class="${gridClass}">${rowHtml}</div>
+        <div class="dao-confirm-grid">${rowHtml}</div>
       </section>
     `;
   }
 
   getSectionRowClass(label, value) {
-    const fullWidthLabels = ['Description', 'Options', 'from', 'description', 'options'];
+    const fullWidthLabels = ['Description', 'Options'];
     if (!fullWidthLabels.includes(label)) return 'dao-confirm-row';
 
     const text = String(value);
@@ -3725,12 +3715,6 @@ class ConfirmProposalModal {
       return 'dao-confirm-row dao-confirm-row--full';
     }
     return 'dao-confirm-row';
-  }
-
-  formatProposalOptions(options) {
-    return Array.isArray(options) && options.length
-      ? options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : options;
   }
 
   renderChanges(changes) {
@@ -4272,7 +4256,7 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
     ? safePool > safeClaimed ? safePool - safeClaimed : 0n
     : null;
 
-  const summary = {
+  return {
     claimEstimate,
     claimStatus,
     claimWindowLabel: formatDaoClaimWindowLabel(claimWindow, now),
@@ -4281,9 +4265,6 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
     initialBurned,
     pool,
     unclaimed,
-  };
-  return {
-    ...summary,
     statusTone: claimStatus === 'Claimable' ? 'accept' : '',
   };
 }
@@ -4417,7 +4398,6 @@ class ProposalInfoModal {
     this.lifecycleActionSection = document.getElementById('proposalLifecycleActionSection');
     this.voteActionSection = document.getElementById('proposalVoteActionSection');
     this.voteActionHelp = document.getElementById('proposalVoteActionHelp');
-    this.voteStatusGrid = document.getElementById('proposalVoteStatusGrid');
     this.voteOptions = document.getElementById('proposalVoteOptions');
     this.voteSpendInput = document.getElementById('proposalVoteSpend');
     this.votePreview = document.getElementById('proposalVotePreview');
@@ -4516,7 +4496,6 @@ class ProposalInfoModal {
       currentAddress,
       committeeAddressSet,
     });
-    const proposalType = proposal.proposalType;
     const resultSummary = getDaoProposalResultSummary(proposal);
     const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
     const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
@@ -4547,10 +4526,8 @@ class ProposalInfoModal {
     if (this.detailsContent) {
       this.detailsContent.innerHTML = this.renderProposalDetails({
         proposal,
-        proposalType,
         state,
         reviewWindow,
-        resultSummary,
         rewardSummary,
       });
     }
@@ -4563,7 +4540,7 @@ class ProposalInfoModal {
       this.hideReviewResultAction();
     }
     this.renderLifecycleActions(lifecycleActions);
-    this.renderVoteActions({ proposal, state });
+    this.renderVoteActions(proposal, state);
   }
 
   getReviewCapabilities({ state, reviewWindow, currentAddress, committeeAddressSet }) {
@@ -4582,13 +4559,14 @@ class ProposalInfoModal {
 
   renderProposalTitle(proposal) {
     const description = proposal.description || '';
+    const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
     const descriptionHtml = description
       ? `<p class="proposal-info-description">${escapeHtml(description)}</p>`
       : '';
 
     return `
       <div class="proposal-info-heading">
-        <h2 class="proposal-info-title">${escapeHtml(this.getProposalTitle(proposal))}</h2>
+        <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
         ${descriptionHtml}
       </div>
     `;
@@ -4611,7 +4589,7 @@ class ProposalInfoModal {
         const isWinner = index === winnerIndex;
         const units = this.getCurrentVoteSegmentUnits(row.total, totalWeight);
         const power = formatDaoVotingPower(row.total);
-        const percent = this.formatCurrentVotePercent(row.total, totalWeight);
+        const percent = formatDaoBigIntPercent(row.total, totalWeight);
         const valueLabel = totalWeight > 0n ? `${power} / ${percent}` : power;
         const title = totalWeight > 0n
           ? `${row.option}: ${power}, ${percent}`
@@ -4662,16 +4640,12 @@ class ProposalInfoModal {
   }
 
   getCurrentVoteTotalRows(proposal) {
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     const totalVote = proposal.totalVote;
     return options.map((option, index) => ({
       option,
-      total: this.parseCurrentVoteTotal(totalVote[index]),
+      total: parseDaoUnsignedBigInt(totalVote[index]) ?? 0n,
     }));
-  }
-
-  parseCurrentVoteTotal(value) {
-    return parseDaoUnsignedBigInt(value) ?? 0n;
   }
 
   getCurrentVoteSegmentUnits(part, total) {
@@ -4679,18 +4653,6 @@ class ProposalInfoModal {
     if (part <= 0n) return 0;
     const units = Number((part * 1000n) / total);
     return Math.max(1, units);
-  }
-
-  formatCurrentVotePercent(part, total) {
-    if (typeof part !== 'bigint' || typeof total !== 'bigint' || total <= 0n) return '0%';
-    const tenths = (part * 1000n + total / 2n) / total;
-    const whole = tenths / 10n;
-    const fraction = tenths % 10n;
-    return fraction === 0n ? `${whole}%` : `${whole}.${fraction}%`;
-  }
-
-  getProposalTitle(proposal) {
-    return proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
   }
 
   renderProposalResults(result) {
@@ -4781,8 +4743,6 @@ class ProposalInfoModal {
     const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
     const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
     const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
-    const acceptSegmentWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-segment--winner' : '';
-    const withholdSegmentWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-segment--winner' : '';
 
     return `
       <section class="proposal-info-section">
@@ -4820,11 +4780,11 @@ class ProposalInfoModal {
           </div>
           <div class="proposal-result-meter-track" aria-hidden="true">
             <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptSegmentWinnerClass}${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
               style="--result-segment-units: ${acceptUnits};"
             ></span>
             <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdSegmentWinnerClass}${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
               style="--result-segment-units: ${withholdUnits};"
             ></span>
           </div>
@@ -4864,29 +4824,24 @@ class ProposalInfoModal {
     ]);
   }
 
-  getVoteStatusData(proposal) {
+  renderVotingDetails(proposal) {
     const votingWindow = getDaoProposalVotingWindow(proposal);
     const totalVote = Array.isArray(proposal.totalVote) ? proposal.totalVote : [];
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     const totalVoteText = totalVote.length
       ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
       : 'No votes yet';
-    return { votingWindow, totalVoteText };
-  }
-
-  renderVotingDetails(proposal) {
-    const { votingWindow, totalVoteText } = this.getVoteStatusData(proposal);
     return this.renderSection('Voting Details', [
       ['Voting state', votingWindow.label],
       ['Current totals', totalVoteText],
     ]);
   }
 
-  renderProposalDetails({ proposal, proposalType, state, reviewWindow, resultSummary, rewardSummary }) {
+  renderProposalDetails({ proposal, state, reviewWindow, rewardSummary }) {
     const sections = [
       this.renderSection('Overview', [
         ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
-        ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
+        ['Type', getDaoTypeLabel(proposal.proposalType) || 'Unavailable'],
         ['Status', getDaoStateLabel(state) || state],
         ['Created', formatDaoDetailTimestamp(proposal.created)],
         ['Updated', formatDaoDetailTimestamp(proposal.state_changed)],
@@ -4901,20 +4856,18 @@ class ProposalInfoModal {
       this.renderProposalRewards(rewardSummary),
     ].filter(Boolean);
 
-    if (sections.length === 0) return '';
-
     return `
       <details class="proposal-more">
         <summary>
           <span class="proposal-more-title">Show proposal details</span>
-          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, resultSummary, rewardSummary))}</span>
+          <span class="proposal-more-note">${escapeHtml(this.getProposalDetailsSummary(state, rewardSummary))}</span>
         </summary>
         <div class="proposal-more-content">${sections.join('')}</div>
       </details>
     `;
   }
 
-  getProposalDetailsSummary(state, resultSummary, rewardSummary) {
+  getProposalDetailsSummary(state, rewardSummary) {
     const parts = ['Overview', 'review timeline'];
     if (state !== 'review') parts.push('proposal body');
     if (state === 'voting') parts.push('voting totals');
@@ -5007,7 +4960,7 @@ class ProposalInfoModal {
     `;
   }
 
-  getParameterChangeRowClass(parts, { isSingleRow = false } = {}) {
+  getParameterChangeRowClass(parts, isSingleRow) {
     const normalizedParts = parts.map((part) => String(part ?? '').trim());
     const shouldUseWideRow = normalizedParts.some((part) => part.length > 22)
       || normalizedParts.join(' ').length > 52;
@@ -5018,7 +4971,7 @@ class ProposalInfoModal {
     ].filter(Boolean).join(' ');
   }
 
-  renderPayloadRows(payload, payloadTitle = '') {
+  renderPayloadRows(payload, payloadTitle) {
     const titleHtml = payloadTitle
       ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
       : '';
@@ -5032,7 +4985,7 @@ class ProposalInfoModal {
           const next = formatDaoDetailValue(change?.value);
           const rowClass = this.getParameterChangeRowClass(
             [key, `Current: ${current}`, `New: ${next}`],
-            { isSingleRow: index === changes.length - 1 && changes.length % 2 === 1 },
+            index === changes.length - 1 && changes.length % 2 === 1,
           );
           return `
           <div class="${rowClass}">
@@ -5057,7 +5010,7 @@ class ProposalInfoModal {
         const displayValue = formatDaoDetailValue(value);
         const rowClass = this.getParameterChangeRowClass(
           [key, displayValue],
-          { isSingleRow: index === entries.length - 1 && entries.length % 2 === 1 },
+          index === entries.length - 1 && entries.length % 2 === 1,
         );
         return `
         <div class="${rowClass}">
@@ -5141,7 +5094,7 @@ class ProposalInfoModal {
   }
 
   renderLifecycleActions(actions) {
-    this.currentLifecycleActions = Array.isArray(actions) ? actions : [];
+    this.currentLifecycleActions = actions;
     if (!this.lifecycleActionSection || this.currentLifecycleActions.length === 0) {
       this.hideLifecycleAction();
       return;
@@ -5177,17 +5130,13 @@ class ProposalInfoModal {
   }
 
   resetVoteState(proposal) {
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     this.voteWeights = options.map(() => 0);
     this.voteSpendLib = '';
     if (this.voteSpendInput) this.voteSpendInput.value = '';
   }
 
-  getVoteOptions(proposal) {
-    return getDaoProposalOptions(proposal);
-  }
-
-  renderVoteActions({ proposal, state }) {
+  renderVoteActions(proposal, state) {
     if (!this.voteActionSection) return;
     if (state !== 'voting') {
       this.hideVoteActions();
@@ -5200,7 +5149,7 @@ class ProposalInfoModal {
       return;
     }
 
-    const options = this.getVoteOptions(proposal);
+    const options = getDaoProposalOptions(proposal);
     if (this.voteWeights.length !== options.length) {
       this.voteWeights = options.map(() => 0);
     }
@@ -5226,7 +5175,6 @@ class ProposalInfoModal {
       `;
     }
 
-    this.renderVoteStatus(proposal);
     this.updateVotePreview(proposal);
   }
 
@@ -5255,11 +5203,6 @@ class ProposalInfoModal {
         >
       </label>
     `;
-  }
-
-  renderVoteStatus(proposal) {
-    if (!this.voteStatusGrid) return;
-    this.voteStatusGrid.innerHTML = '';
   }
 
   handleVoteWeightInput(event) {
@@ -5310,7 +5253,7 @@ class ProposalInfoModal {
     }
     this.votePreview.classList.remove('proposal-vote-preview--message');
 
-    const optionRows = this.getVoteOptions(proposal)
+    const optionRows = getDaoProposalOptions(proposal)
       .map((option, index) => {
         const weight = this.voteWeights[index] || 0;
         const share = weight / submission.totalWeight;
@@ -5344,7 +5287,8 @@ class ProposalInfoModal {
     `;
   }
 
-  getVoteSubmission(proposal, timestamp = getTransactionTimestamp()) {
+  getVoteSubmission(proposal) {
+    const timestamp = getTransactionTimestamp();
     const validation = this.getVotePreviewValidation(proposal, timestamp);
     if (!validation.ok) {
       return { ok: false, message: validation.message, tone: 'warning' };
@@ -5575,16 +5519,18 @@ class ProposalInfoModal {
     return injectTx(transaction, txid);
   }
 
-  async refreshCurrentProposal() {
-    await daoRepo.refresh({ force: true });
-    if (daoModal?.isActive?.()) daoModal.render();
-
-    this.renderCurrentProposal();
-  }
-
   async refreshAfterDaoAction(warningMessage, { refreshNetworkParams = false } = {}) {
     try {
-      await this.refreshCurrentProposal();
+      await daoRepo.refresh({ force: true });
+      if (daoModal?.isActive?.()) daoModal.render();
+
+      const proposal = this.getCurrentProposal();
+      if (proposal) {
+        this.renderProposal(proposal);
+      } else {
+        this.renderNotFound();
+      }
+
       if (refreshNetworkParams) {
         const refreshed = await getNetworkParams(true);
         if (!refreshed) throw new Error('Network parameter refresh failed');
@@ -5592,15 +5538,6 @@ class ProposalInfoModal {
     } catch (error) {
       console.warn('Failed to refresh proposal after DAO action:', error);
       showToast(warningMessage, 4000, 'warning');
-    }
-  }
-
-  renderCurrentProposal() {
-    const proposal = this.getCurrentProposal();
-    if (proposal) {
-      this.renderProposal(proposal);
-    } else {
-      this.renderNotFound();
     }
   }
 
@@ -5714,8 +5651,7 @@ class ProposalInfoModal {
   }
 
   async handleLifecycleActionSubmit(action) {
-    const canSubmitLifecycle = action?.canSubmit !== false;
-    if (this.isSubmitting || !action || !canSubmitLifecycle) return;
+    if (this.isSubmitting || !action || action.canSubmit === false) return;
 
     const proposal = this.getCurrentProposal();
     if (!proposal) {
@@ -5830,9 +5766,6 @@ class ProposalInfoModal {
     enterFullscreen();
   }
 
-  isActive() {
-    return this.modal.classList.contains('active');
-  }
 }
 
 const proposalInfoModal = new ProposalInfoModal();

--- a/app.js
+++ b/app.js
@@ -2477,7 +2477,6 @@ function formatDaoDate(ts) {
 }
 
 function getDaoUiStateLabel(key) {
-  if (key === 'discussion') return 'Review';
   return getDaoStateLabel(key);
 }
 
@@ -2738,7 +2737,7 @@ class DaoModal {
       const titleText = String(p.title || '').trim() || 'Proposal';
       const rowTitleText = p.number ? `#${p.number}: ${titleText}` : titleText;
       const title = escapeHtml(rowTitleText);
-      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType || p.type) || 'Proposal');
+      const typeLabel = escapeHtml(getDaoTypeLabel(p.proposalType) || 'Proposal');
       const previewHtml = this.renderProposalRowPreview(p);
 
       li.tabIndex = 0;
@@ -4118,7 +4117,7 @@ function getDaoProposalApplyWindow(proposal, now = Date.now()) {
 }
 
 function isDaoParameterProposalType(proposal) {
-  const type = String(proposal?.proposalType || proposal?.type || '').toLowerCase();
+  const type = String(proposal?.proposalType || '').toLowerCase();
   return type === 'governance' || type === 'economic' || type === 'protocol';
 }
 
@@ -4520,7 +4519,7 @@ class ProposalInfoModal {
       currentAddress,
       committeeAddressSet,
     });
-    const proposalType = proposal.proposalType || proposal.type;
+    const proposalType = proposal.proposalType;
     const resultSummary = getDaoProposalResultSummary(proposal);
     const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
     const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
@@ -4596,7 +4595,7 @@ class ProposalInfoModal {
   }
 
   renderProposalTitle(proposal) {
-    const description = proposal.description || proposal.summary || '';
+    const description = proposal.description || '';
     const descriptionHtml = description
       ? `<p class="proposal-info-description">${escapeHtml(description)}</p>`
       : '';
@@ -5010,9 +5009,8 @@ class ProposalInfoModal {
   }
 
   renderParameterChanges(proposal) {
-    const fields = proposal.fields && typeof proposal.fields === 'object' ? proposal.fields : {};
     const payloads = ['governance', 'economic', 'protocol']
-      .map((key) => [key, proposal[key] || fields[key]])
+      .map((key) => [key, proposal[key]])
       .filter(([, payload]) => payload && typeof payload === 'object');
 
     if (payloads.length === 0) {

--- a/app.js
+++ b/app.js
@@ -3781,7 +3781,7 @@ function getDaoCurrentAccountAddress() {
 }
 
 function getDaoProposalReviewWindow(proposal) {
-  const start = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const start = Number(proposal?.startTime || 0);
   const duration = Number(proposal?.reviewDuration);
   if (!start || !Number.isFinite(duration) || duration < 0) {
     return {
@@ -3823,7 +3823,7 @@ function getDaoProposalReviewWindow(proposal) {
 }
 
 function getDaoProposalVotingWindow(proposal, now = Date.now()) {
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   if (
@@ -3904,14 +3904,10 @@ function formatDaoScaledBigInt(value, scale, decimals = 3) {
 }
 
 function formatDaoVoteWeightUnits(value, suffix) {
-  if (typeof value === 'bigint') {
-    const formatted = formatDaoScaledBigInt(value, DAO_VOTE_WEIGHT_PRECISION_BIGINT, 3);
-    return formatted === null ? 'Unavailable' : `${formatted} ${suffix}`;
-  }
-
-  const n = Number(value);
-  if (!Number.isFinite(n)) return 'Unavailable';
-  return `${formatDaoShortNumber(n / DAO_VOTE_WEIGHT_PRECISION, 3)} ${suffix}`;
+  const bigintValue = parseDaoUnsignedBigInt(value);
+  if (bigintValue === null) return 'Unavailable';
+  const formatted = formatDaoScaledBigInt(bigintValue, DAO_VOTE_WEIGHT_PRECISION_BIGINT, 3);
+  return formatted === null ? 'Unavailable' : `${formatted} ${suffix}`;
 }
 
 function formatDaoVotingPower(value) {
@@ -3928,12 +3924,9 @@ function formatDaoPercent(value) {
 }
 
 function formatDaoLibWei(value) {
-  try {
-    const weiValue = typeof value === 'bigint' ? value : BigInt(value || 0);
-    return `${formatDaoShortNumber(EthNum.toStr(weiValue))} LIB`;
-  } catch {
-    return 'Unavailable';
-  }
+  const weiValue = parseDaoUnsignedBigInt(value);
+  if (weiValue === null) return 'Unavailable';
+  return `${formatDaoShortNumber(EthNum.toStr(weiValue))} LIB`;
 }
 
 function parseDaoUnsignedBigInt(value) {
@@ -3942,6 +3935,16 @@ function parseDaoUnsignedBigInt(value) {
   if (typeof value === 'number') {
     if (!Number.isFinite(value) || value < 0) return null;
     return BigInt(Math.trunc(value));
+  }
+  if (typeof value === 'object') {
+    if (value.dataType !== 'bi') return null;
+    const hexText = String(value.value ?? '').trim();
+    if (!/^[0-9a-f]+$/i.test(hexText)) return null;
+    try {
+      return BigInt(`0x${hexText}`);
+    } catch {
+      return null;
+    }
   }
 
   const text = String(value).trim();
@@ -3967,12 +3970,11 @@ function formatDaoBigIntPercent(part, total) {
 }
 
 function getDaoProposalOptions(proposal) {
-  if (!Array.isArray(proposal?.options) || proposal.options.length === 0) return ['Yes', 'No'];
-  return proposal.options.map((option, index) => String(option || `Option ${index + 1}`));
+  return proposal.options.map((option) => String(option));
 }
 
 function getDaoVoteTotals(proposal) {
-  const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+  const totalVote = proposal.totalVote;
   if (totalVote.length === 0) return [];
 
   const options = getDaoProposalOptions(proposal);
@@ -4066,7 +4068,7 @@ function getDaoClaimList(proposal) {
 }
 
 function getDaoProposalClaimWindow(proposal) {
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   const claimDuration = Number(proposal?.claimDuration);
@@ -4099,7 +4101,7 @@ function getDaoProposalApplyWindow(proposal, now = Date.now()) {
     return { eligibleAt: backendEligibleAt, isReady: now >= backendEligibleAt };
   }
 
-  const reviewStart = Number(proposal?.startTime || proposal?.created || proposal?.creationTime || 0);
+  const reviewStart = Number(proposal?.startTime || 0);
   const reviewDuration = Number(proposal?.reviewDuration);
   const votingDuration = Number(proposal?.votingDuration);
   const gracePeriod = Number(proposal?.gracePeriod);
@@ -4360,10 +4362,6 @@ function formatDaoDetailValue(value) {
   return String(value);
 }
 
-function getDaoBooleanCapability(proposal, key) {
-  return typeof proposal?.[key] === 'boolean' ? proposal[key] : null;
-}
-
 function parseDaoPositiveLibAmount(value) {
   const text = String(value || '').trim();
   if (!/^\d+(?:\.\d{1,18})?$/.test(text)) return null;
@@ -4513,7 +4511,6 @@ class ProposalInfoModal {
     const currentAddress = getDaoCurrentAccountAddress();
     const currentVote = committeeVotes.find((vote) => vote?.memberAddress === currentAddress) || null;
     const capabilities = this.getReviewCapabilities({
-      proposal,
       state,
       reviewWindow,
       currentAddress,
@@ -4569,21 +4566,10 @@ class ProposalInfoModal {
     this.renderVoteActions({ proposal, state });
   }
 
-  getReviewCapabilities({ proposal, state, reviewWindow, currentAddress, committeeAddressSet }) {
-    const backendCommitteeMember = getDaoBooleanCapability(proposal, 'isCommitteeMemberForProposal');
-    const isCommitteeMember = backendCommitteeMember ?? Boolean(currentAddress && committeeAddressSet.has(currentAddress));
-
-    const backendCanCommitteeVote = getDaoBooleanCapability(proposal, 'canCommitteeVote');
-    const canCommitteeVote = backendCanCommitteeVote ?? (
-      state === 'review' &&
-      reviewWindow.canCommitteeVote &&
-      isCommitteeMember
-    );
-
-    const backendCanFinalizeReviewResult = getDaoBooleanCapability(proposal, 'canFinalizeReviewResult');
-    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && (
-      backendCanFinalizeReviewResult ?? reviewWindow.canFinalizeReviewResult
-    );
+  getReviewCapabilities({ state, reviewWindow, currentAddress, committeeAddressSet }) {
+    const isCommitteeMember = Boolean(currentAddress && committeeAddressSet.has(currentAddress));
+    const canCommitteeVote = state === 'review' && reviewWindow.canCommitteeVote && isCommitteeMember;
+    const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && reviewWindow.canFinalizeReviewResult;
 
     return { isCommitteeMember, canCommitteeVote, canFinalizeReviewResult };
   }
@@ -4677,7 +4663,7 @@ class ProposalInfoModal {
 
   getCurrentVoteTotalRows(proposal) {
     const options = this.getVoteOptions(proposal);
-    const totalVote = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
+    const totalVote = proposal.totalVote;
     return options.map((option, index) => ({
       option,
       total: this.parseCurrentVoteTotal(totalVote[index]),
@@ -4685,20 +4671,7 @@ class ProposalInfoModal {
   }
 
   parseCurrentVoteTotal(value) {
-    if (typeof value === 'bigint') return value >= 0n ? value : 0n;
-    if (typeof value === 'number') {
-      if (!Number.isFinite(value) || value <= 0) return 0n;
-      return BigInt(Math.trunc(value));
-    }
-
-    const text = String(value ?? '').trim();
-    if (!text) return 0n;
-    try {
-      const parsed = BigInt(text);
-      return parsed >= 0n ? parsed : 0n;
-    } catch {
-      return 0n;
-    }
+    return parseDaoUnsignedBigInt(value) ?? 0n;
   }
 
   getCurrentVoteSegmentUnits(part, total) {
@@ -4915,8 +4888,8 @@ class ProposalInfoModal {
         ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
         ['Type', getDaoTypeLabel(proposalType) || 'Unavailable'],
         ['Status', getDaoStateLabel(state) || state],
-        ['Created', formatDaoDetailTimestamp(proposal.created || proposal.creationTime)],
-        ['Updated', formatDaoDetailTimestamp(proposal.state_changed || proposal.timestamp || proposal.created)],
+        ['Created', formatDaoDetailTimestamp(proposal.created)],
+        ['Updated', formatDaoDetailTimestamp(proposal.state_changed)],
       ]),
       this.renderSection('Review Timeline', [
         ['Window state', reviewWindow.label],
@@ -4998,9 +4971,7 @@ class ProposalInfoModal {
   }
 
   renderProposalBody(proposal) {
-    const options = Array.isArray(proposal.options) && proposal.options.length
-      ? proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n')
-      : 'Unavailable';
+    const options = proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n');
 
     return this.renderSection('Proposal Body', [
       ['Emergency', proposal.emergency ? 'Yes' : 'No'],

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -514,10 +514,6 @@ function normalizeDaoTimestamp(value) {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
-function getDaoProposalDescription(proposal) {
-  return String(proposal?.description || '').trim();
-}
-
 function mapBackendProposalToStoreProposal(proposal) {
   if (!proposal || typeof proposal !== 'object') return null;
 
@@ -534,7 +530,6 @@ function mapBackendProposalToStoreProposal(proposal) {
   const state = getEffectiveDaoState(proposal);
   const created = normalizeDaoTimestamp(proposal.creationTime);
   const stateChanged = normalizeDaoTimestamp(proposal.timestamp);
-  const description = getDaoProposalDescription(proposal);
   const title = String(proposal.title || proposal.description || '').trim();
 
   return {
@@ -543,7 +538,7 @@ function mapBackendProposalToStoreProposal(proposal) {
     number,
     nonce,
     title,
-    description,
+    description: String(proposal.description || '').trim(),
     proposalType,
     state,
     status: state,
@@ -591,12 +586,10 @@ async function fetchBackendProposal(queryDaoApi, proposalNumber) {
   const body = await queryDaoApi(`/dao/proposals/${proposalNumber}`);
   if (!body) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: no response`);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   if (body.error || !body.proposal) {
     console.warn(`Skipping DAO proposal #${proposalNumber}: proposal unavailable`, body.error || body);
-    // TODO: Retry skipped proposal accounts after the initial list render.
     return null;
   }
   return body.proposal;
@@ -711,7 +704,6 @@ function storeToUiList(store, groupKey) {
       const id = daoProposalId(m.number, m.nonce);
       const p = safe.proposals?.[id];
       if (!p) return null;
-      const description = p.description;
       const state = getEffectiveDaoState({ status: p.status || m.status, state: p.state || m.state });
       return {
         id,
@@ -719,7 +711,7 @@ function storeToUiList(store, groupKey) {
         accountId: p.accountId,
         nonce: p.nonce,
         title: p.title,
-        description,
+        description: p.description,
         proposalType: p.proposalType,
         emergency: Boolean(p.emergency),
         createdAt: p.created,
@@ -759,7 +751,7 @@ export function setDaoBackendFetcher(fetcher) {
   _backendFetcher = typeof fetcher === 'function' ? fetcher : null;
 }
 
-async function refreshInternal({ force } = {}) {
+async function refreshInternal({ force }) {
   if (_loadingPromise && !force) return _loadingPromise;
   if (_store && !force) return _store;
 
@@ -801,7 +793,7 @@ export const daoRepo = {
   },
 
   getProposalsForUi(groupKey) {
-    return storeToUiList(_store, groupKey || 'active');
+    return storeToUiList(_store, groupKey);
   },
 
   async createProposal({ draft, timestamp, networkId, submitTransaction } = {}) {

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -532,16 +532,17 @@ function mapBackendProposalToStoreProposal(proposal) {
   if (!proposalType) return null;
 
   const state = getEffectiveDaoState(proposal);
-  const created = normalizeDaoTimestamp(proposal.creationTime || proposal.created || proposal.timestamp);
-  const stateChanged = normalizeDaoTimestamp(proposal.timestamp || proposal.state_changed || created);
+  const created = normalizeDaoTimestamp(proposal.creationTime);
+  const stateChanged = normalizeDaoTimestamp(proposal.timestamp);
   const description = getDaoProposalDescription(proposal);
+  const title = String(proposal.title || proposal.description || '').trim();
 
   return {
     ...proposal,
     accountId,
     number,
     nonce,
-    title: String(proposal.title || '').trim(),
+    title,
     description,
     proposalType,
     state,
@@ -725,16 +726,16 @@ function storeToUiList(store, groupKey) {
         state,
         status: state,
         stateEnteredAt: p.state_changed,
-        options: Array.isArray(p.options) ? p.options : ['yes', 'no'],
-        totalVote: Array.isArray(p.totalVote) ? p.totalVote : undefined,
-        committeeVotes: Array.isArray(p.committeeVotes) ? p.committeeVotes : [],
-        committeeAddresses: Array.isArray(p.committeeAddresses) ? p.committeeAddresses : [],
+        options: p.options,
+        totalVote: p.totalVote,
+        committeeVotes: p.committeeVotes,
+        committeeAddresses: p.committeeAddresses,
         voterRewardPool: p.voterRewardPool,
         claimedReward: p.claimedReward,
         initialBurnedReward: p.initialBurnedReward,
         finalBurnedReward: p.finalBurnedReward,
-        voterList: Array.isArray(p.voterList) ? p.voterList : [],
-        claimList: Array.isArray(p.claimList) ? p.claimList : [],
+        voterList: p.voterList,
+        claimList: p.claimList,
         startTime: p.startTime,
         reviewDuration: p.reviewDuration,
         votingDuration: p.votingDuration,

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -88,8 +88,7 @@ export function getDaoStateLabel(key) {
 }
 
 export function getEffectiveDaoState(proposal) {
-  const state = proposal?.status || proposal?.state || 'review';
-  return state === 'discussion' ? 'review' : state;
+  return proposal?.status || proposal?.state || 'review';
 }
 
 const DAO_PROPOSAL_QUERY_BATCH_SIZE = 10;
@@ -251,7 +250,7 @@ export function buildDaoProposalCreateTransaction({
 }
 
 function getDaoProposalTransactionId(proposal) {
-  return requireDaoDraftString(proposal?.accountId || proposal?.proposalId || proposal?.id, 'DAO proposal account ID');
+  return requireDaoDraftString(proposal?.accountId, 'DAO proposal account ID');
 }
 
 function buildDaoProposalActionTransaction({
@@ -515,33 +514,8 @@ function normalizeDaoTimestamp(value) {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
-function normalizeDaoVoteNumber(value) {
-  if (typeof value === 'bigint') return Number(value);
-  const n = Number(value || 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
 function getDaoProposalDescription(proposal) {
-  return String(proposal?.description || proposal?.summary || '').trim();
-}
-
-function getDaoProposalFields(proposal) {
-  const fields = proposal?.fields && typeof proposal.fields === 'object' ? { ...proposal.fields } : {};
-  if (proposal?.governance) fields.governance = proposal.governance;
-  if (proposal?.economic) fields.economic = proposal.economic;
-  if (proposal?.protocol) fields.protocol = proposal.protocol;
-  return fields;
-}
-
-function getDaoProposalVotes(proposal) {
-  if (proposal?.votes && typeof proposal.votes === 'object') return proposal.votes;
-
-  const totals = Array.isArray(proposal?.totalVote) ? proposal.totalVote : [];
-  return {
-    yes: normalizeDaoVoteNumber(totals[0]),
-    no: normalizeDaoVoteNumber(totals[1]),
-    by: {},
-  };
+  return String(proposal?.description || '').trim();
 }
 
 function mapBackendProposalToStoreProposal(proposal) {
@@ -550,9 +524,13 @@ function mapBackendProposalToStoreProposal(proposal) {
   const number = normalizeDaoPositiveInteger(proposal.number);
   if (!number) return null;
 
-  const accountId = proposal.id || proposal.accountId || proposal.proposalId;
-  const nonce = String(accountId || proposal.nonce || number);
-  const type = proposal.proposalType || proposal.type || '';
+  const accountId = String(proposal.id || '').trim();
+  if (!accountId) return null;
+
+  const nonce = accountId;
+  const proposalType = String(proposal.proposalType || '').trim();
+  if (!proposalType) return null;
+
   const state = getEffectiveDaoState(proposal);
   const created = normalizeDaoTimestamp(proposal.creationTime || proposal.created || proposal.timestamp);
   const stateChanged = normalizeDaoTimestamp(proposal.timestamp || proposal.state_changed || created);
@@ -564,16 +542,12 @@ function mapBackendProposalToStoreProposal(proposal) {
     number,
     nonce,
     title: String(proposal.title || '').trim(),
-    summary: description,
     description,
-    type,
-    proposalType: type,
+    proposalType,
     state,
     status: state,
     state_changed: stateChanged,
     created,
-    fields: getDaoProposalFields(proposal),
-    votes: getDaoProposalVotes(proposal),
   };
 }
 
@@ -584,7 +558,6 @@ function getDaoStoreMeta(proposal) {
     state: proposal.state,
     status: proposal.status,
     state_changed: proposal.state_changed,
-    type: proposal.type,
     proposalType: proposal.proposalType,
     nonce: proposal.nonce,
   };
@@ -685,13 +658,6 @@ function normalizeDaoStore(store) {
     const full = safe.proposals[id];
     if (!full) continue;
 
-    // Migration: older versions wrote a synthetic `state: 'archived'`.
-    // We cannot reliably recover the original state; map to a server-supported final state.
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-
     const state = getEffectiveDaoState({ status: full.status || meta.status, state: full.state || meta.state });
     const enteredAt = Number(full.state_changed || meta.state_changed || full.created || 0);
     const isArchivable = DAO_ARCHIVABLE_STATE_KEYS.includes(state);
@@ -706,7 +672,7 @@ function normalizeDaoStore(store) {
           title: meta.title,
           state,
           state_changed: enteredAt,
-          type: meta.type,
+          proposalType: meta.proposalType,
           nonce: meta.nonce,
         });
         archivedIds.add(id);
@@ -724,17 +690,6 @@ function normalizeDaoStore(store) {
     const id = daoProposalId(m.number, m.nonce);
     return Boolean(safe.proposals[id]);
   });
-
-  // Migration: older versions stored `state: 'archived'` for archived items.
-  for (const meta of safe.archivedProposals) {
-    const id = daoProposalId(meta.number, meta.nonce);
-    const full = safe.proposals[id];
-    if (!full) continue;
-    if ((full.status || full.state || meta.status || meta.state) === 'archived') {
-      full.state = full.archivedFromState || 'applied';
-      meta.state = meta.archivedFromState || full.state;
-    }
-  }
 
   safe.meta.active = safe.activeProposals.length;
   safe.meta.archived = safe.archivedProposals.length;
@@ -755,25 +710,21 @@ function storeToUiList(store, groupKey) {
       const id = daoProposalId(m.number, m.nonce);
       const p = safe.proposals?.[id];
       if (!p) return null;
-      const description = p.description || p.summary;
+      const description = p.description;
       const state = getEffectiveDaoState({ status: p.status || m.status, state: p.state || m.state });
-      const type = p.proposalType || p.type;
       return {
         id,
         number: p.number,
         accountId: p.accountId,
         nonce: p.nonce,
         title: p.title,
-        summary: description,
         description,
-        type,
-        proposalType: type,
+        proposalType: p.proposalType,
         emergency: Boolean(p.emergency),
         createdAt: p.created,
         state,
         status: state,
         stateEnteredAt: p.state_changed,
-        fields: p.fields || {},
         options: Array.isArray(p.options) ? p.options : ['yes', 'no'],
         totalVote: Array.isArray(p.totalVote) ? p.totalVote : undefined,
         committeeVotes: Array.isArray(p.committeeVotes) ? p.committeeVotes : [],
@@ -790,7 +741,6 @@ function storeToUiList(store, groupKey) {
         claimDuration: p.claimDuration,
         gracePeriod: p.gracePeriod,
         applyEligibleAt: p.applyEligibleAt,
-        votes: p.votes || { yes: 0, no: 0, by: {} },
         archivedAt: p.archivedAt || 0,
       };
     })

--- a/index.html
+++ b/index.html
@@ -499,7 +499,6 @@
                 <h3>Vote preview</h3>
                 <p id="proposalVoteActionHelp"></p>
               </div>
-              <div class="proposal-vote-status-grid" id="proposalVoteStatusGrid"></div>
               <div class="proposal-vote-options" id="proposalVoteOptions"></div>
               <div class="proposal-vote-spend-row">
                 <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -2384,10 +2384,6 @@ input[type='file'].form-control::file-selector-button {
   border-left: 0;
 }
 
-#proposalInfoModal .proposal-result-meter-segment--winner {
-  background: var(--primary-color);
-}
-
 #proposalInfoModal .proposal-result-meter-segment--palette-0 {
   background: #3d3dce;
 }
@@ -2439,7 +2435,6 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-change-row {
   flex: 0 1 calc(50% - 4px);
   min-width: min(100%, 180px);
-  min-inline-size: 0;
 }
 
 #proposalInfoModal .proposal-change-row--single {
@@ -2519,19 +2514,7 @@ input[type='file'].form-control::file-selector-button {
   font-size: 13px;
 }
 
-#confirmProposalModal .dao-confirm-change-values small {
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-change-values small {
-  text-align: center;
-}
-
 #confirmProposalModal .dao-confirm-change-values strong {
-  text-align: center;
-}
-
-#proposalInfoModal .proposal-change-values strong {
   text-align: center;
 }
 
@@ -2580,13 +2563,9 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-info + .proposal-committee-actions,
-#proposalInfoModal .proposal-info + .proposal-review-result-actions,
-#proposalInfoModal .proposal-info + .proposal-lifecycle-actions,
-#proposalInfoModal .proposal-info + .proposal-vote-actions,
 #proposalInfoModal .proposal-committee-actions + .proposal-review-result-actions,
 #proposalInfoModal .proposal-review-result-actions + .proposal-lifecycle-actions,
-#proposalInfoModal .proposal-lifecycle-actions + .proposal-vote-actions,
-#proposalInfoModal .proposal-review-result-actions + .proposal-vote-actions {
+#proposalInfoModal .proposal-lifecycle-actions + .proposal-vote-actions {
   margin-top: 10px;
 }
 
@@ -2599,10 +2578,6 @@ input[type='file'].form-control::file-selector-button {
   display: grid;
   gap: 8px;
   padding: 10px;
-}
-
-#proposalInfoModal .proposal-vote-actions {
-  gap: 8px;
 }
 
 #proposalInfoModal .proposal-lifecycle-action {
@@ -2802,10 +2777,6 @@ input[type='file'].form-control::file-selector-button {
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(0, 1fr);
-}
-
-#proposalInfoModal .proposal-vote-status-grid:empty {
-  display: none;
 }
 
 #proposalInfoModal .proposal-vote-current-meter {


### PR DESCRIPTION
## What Changed

This PR removes legacy DAO proposal compatibility fallbacks now that proposal records are expected to come from the backend-shaped DAO account payload.

- `mapBackendProposalToStoreProposal(...)` now requires a backend proposal account id, creation timestamp, timestamp, proposal type, and server-shaped payload instead of synthesizing fallback `type`, `summary`, `fields`, or `votes` values.
- `storeToUiList(...)` passes through canonical proposal fields directly, including `proposalType`, `options`, `totalVote`, committee data, voter/claim lists, timing, and reward accounting.
- Proposal detail helpers now read canonical `startTime`, `description`, `created`, `state_changed`, `proposalType`, `options`, and `totalVote` fields without falling back to older mock/local aliases.
- BigInt formatting now routes through `parseDaoUnsignedBigInt(...)`, including backend `{ dataType: 'bi', value }` records, so vote and reward display paths share the same parsing behavior.

## Fixed Flow

1. The DAO repository receives backend proposal account payloads from `/dao/proposals/:number`.
2. `mapBackendProposalToStoreProposal(...)` validates the required account id and proposal type, then stores canonical proposal fields.
3. `storeToUiList(...)` exposes those canonical fields to the DAO list and proposal detail modal without rebuilding legacy compatibility shapes.
4. The modal renders review, voting, rewards, parameter changes, and lifecycle actions from the same server-backed proposal data shape.

## Added Flow And Code References

1. `getEffectiveDaoState(proposal)` now returns the backend `status || state || 'review'` value directly instead of remapping old `discussion` state aliases.
2. `getDaoProposalTransactionId(proposal)` requires `proposal.accountId`, removing fallback ids that are not valid DAO proposal account addresses.
3. `mapBackendProposalToStoreProposal(proposal)` rejects proposals without a backend `id` or `proposalType`, derives `accountId`, `nonce`, `created`, `state_changed`, `title`, and `description` from canonical fields, and stops writing `summary`, `type`, `fields`, and synthetic `votes`.
4. `normalizeDaoStore(store)` removes archived-state migration logic for older synthetic `state: 'archived'` records and archives using canonical `proposalType` metadata.
5. `storeToUiList(store, groupKey)` returns proposal UI records from stored canonical fields instead of adding default options, empty committee arrays, synthetic votes, or alias fields.
6. Review/voting/claim/apply window helpers use `proposal.startTime` as the timeline source instead of falling back to `created` or `creationTime`.
7. `formatDaoVoteWeightUnits(...)`, `formatDaoLibWei(...)`, and `ProposalInfoModal.parseCurrentVoteTotal(...)` all normalize through `parseDaoUnsignedBigInt(...)`.
8. `parseDaoUnsignedBigInt(...)` now supports backend BigInt envelope values shaped as `{ dataType: 'bi', value: '<hex>' }`.
9. `ProposalInfoModal.getReviewCapabilities(...)` derives committee permissions from current UI state and `committeeAddresses` instead of backend boolean compatibility flags.
10. `renderProposalBody(...)` and `renderParameterChanges(...)` read `proposal.options` and typed payloads directly.

## Why

The earlier DAO UI branches carried compatibility paths for mock/local proposal shapes and older archived-state storage. After the backend integration branches, those fallbacks make the data flow harder to reason about and can hide malformed proposal payloads. This cleanup keeps the repository boundary responsible for accepting the backend proposal shape and makes the UI render from one canonical contract.

## Validation

- `git show issue-1427-cleanup-remove-dao-compat:app.js | node --check --input-type=module -`
- `git show issue-1427-cleanup-remove-dao-compat:dao.repo.js | node --check --input-type=module -`
- `git diff --check issue-1427-ready-actions-backend-integration..issue-1427-cleanup-remove-dao-compat`

Parent: #1413
Builds on #1451
Follow-up to #1427
