### PR TITLE
Show committee withhold reasons on withheld proposals

### DIFF
--- a/app.js
+++ b/app.js
@@ -4532,6 +4532,13 @@ class ProposalInfoModal {
         ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
       ])
       : '';
+    const committeeReviewReasons = state === 'review'
+      ? this.renderCommitteeWithholdReasons(
+        getDaoCommitteeWithholdReasonEntries(proposal)
+          .filter((entry) => entry.memberAddress !== currentAddress),
+        'Other committee withhold reasons',
+      )
+      : '';
 
     if (this.content) {
       this.content.innerHTML = [
@@ -4541,6 +4548,7 @@ class ProposalInfoModal {
         this.renderProposalResults(resultSummary),
         state === 'review' ? this.renderProposalBody(proposal) : '',
         committeeReviewSection,
+        committeeReviewReasons,
       ].filter(Boolean).join('');
     }
     if (this.detailsContent) {

--- a/app.js
+++ b/app.js
@@ -3989,6 +3989,25 @@ function getDaoFinalOutcome(proposal) {
   return { label, tone };
 }
 
+function getDaoCommitteeWithholdReasonEntries(proposal) {
+  const committeeAddresses = Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : [];
+  const committeeAddressSet = new Set(committeeAddresses);
+  const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
+  const entries = [];
+
+  for (const vote of committeeVotes) {
+    if (vote?.vote !== 'withhold' || !committeeAddressSet.has(vote.memberAddress)) continue;
+    if (typeof vote.withheldReason !== 'string') continue;
+
+    const reason = vote.withheldReason.trim();
+    if (!reason) continue;
+
+    entries.push({ memberAddress: vote.memberAddress, reason });
+  }
+
+  return entries;
+}
+
 function getDaoCommitteeReviewResultSummary(proposal) {
   const state = getEffectiveDaoState(proposal);
   if (state !== 'withheld' && !(proposal?.emergency && isDaoFinalResultState(state))) return null;
@@ -4007,6 +4026,7 @@ function getDaoCommitteeReviewResultSummary(proposal) {
     source: 'committee',
     tone: outcome.tone,
     withholdCount,
+    withholdReasonEntries: state === 'withheld' ? getDaoCommitteeWithholdReasonEntries(proposal) : [],
   };
 }
 
@@ -4743,6 +4763,10 @@ class ProposalInfoModal {
     const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
     const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
     const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
+    const withholdReasons = this.renderCommitteeWithholdReasons(
+      result.withholdReasonEntries,
+      'Committee withhold reasons',
+    );
 
     return `
       <section class="proposal-info-section">
@@ -4789,7 +4813,34 @@ class ProposalInfoModal {
             ></span>
           </div>
         </div>
+        ${withholdReasons}
       </section>
+    `;
+  }
+
+  renderCommitteeWithholdReasons(entries, heading) {
+    if (entries.length === 0) return '';
+
+    const reasonCounts = new Map();
+    for (const entry of entries) {
+      reasonCounts.set(entry.reason, (reasonCounts.get(entry.reason) || 0) + 1);
+    }
+
+    const rows = Array.from(reasonCounts, ([reason, count]) => {
+      const countLabel = `${count} ${count === 1 ? 'vote' : 'votes'}`;
+      return `
+        <li class="proposal-withhold-reason-row">
+          <span class="proposal-withhold-reason-text">${escapeHtml(reason)}</span>
+          <span class="proposal-withhold-reason-count">${escapeHtml(countLabel)}</span>
+        </li>
+      `;
+    }).join('');
+
+    return `
+      <div class="proposal-withhold-reasons">
+        <h4>${escapeHtml(heading)}</h4>
+        <ul class="proposal-withhold-reason-list">${rows}</ul>
+      </div>
     `;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2420,6 +2420,55 @@ input[type='file'].form-control::file-selector-button {
   background: rgba(101, 103, 107, 0.18);
 }
 
+#proposalInfoModal .proposal-withhold-reasons {
+  border-top: 1px solid var(--border-color);
+  display: grid;
+  gap: 8px;
+  padding-top: 10px;
+}
+
+#proposalInfoModal .proposal-withhold-reasons h4 {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.35;
+  margin: 0;
+}
+
+#proposalInfoModal .proposal-withhold-reason-list {
+  display: grid;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#proposalInfoModal .proposal-withhold-reason-row {
+  align-items: start;
+  background: var(--input-background);
+  border-radius: 8px;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 8px 10px;
+}
+
+#proposalInfoModal .proposal-withhold-reason-text {
+  color: var(--text-color);
+  font-size: 13px;
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+#proposalInfoModal .proposal-withhold-reason-count {
+  color: var(--secondary-text-color);
+  font-size: 11px;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
 #confirmProposalModal .dao-confirm-change,
 #proposalInfoModal .proposal-change-row {
   background: var(--input-background);


### PR DESCRIPTION
## What Changed

This PR shows available committee withhold reasons on finalized `withheld` proposals.

- Validates reason entries against the proposal's snapshotted committee and current `withhold` votes, omitting blank or malformed reasons.
- Groups exact duplicate reasons in payload order and shows singular or plural vote counts.
- Renders escaped reason text beneath the existing committee Results meter, with mobile-safe multiline wrapping.
- Keeps emergency accepted/rejected/applied results and all non-`withheld` states unchanged.

## Fixed Flow

1. Committee review finalizes a proposal as `withheld`.
2. The client reads qualifying current withhold reasons already present in the proposal payload.
3. Exact duplicates are grouped and rendered beneath Results.
4. If no qualifying reason exists, no heading or empty container is shown.

## Why

The server already retains each committee member's current vote and `withheldReason`, but the finalized proposal UI only rendered aggregate counts. Once action controls disappeared, reviewers had no read-only place to see why the committee withheld the proposal.

## Validation

- `node --check app.js`
- `git diff --check main..issue-1457-withheld-reasons`
- Focused logic checks for committee membership, vote type, malformed and blank reasons, duplicate grouping, and escaping.
- Headless Chromium checks for literal HTML-like text and 1,000-character multiline wrapping at 390px.

Closes #1457