### PR TITLE
Show other committee withhold reasons during active review

### DIFF
--- a/app.js
+++ b/app.js
@@ -4532,6 +4532,13 @@ class ProposalInfoModal {
         ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
       ])
       : '';
+    const committeeReviewReasons = state === 'review'
+      ? this.renderCommitteeWithholdReasons(
+        getDaoCommitteeWithholdReasonEntries(proposal)
+          .filter((entry) => entry.memberAddress !== currentAddress),
+        'Other committee withhold reasons',
+      )
+      : '';
 
     if (this.content) {
       this.content.innerHTML = [
@@ -4541,6 +4548,7 @@ class ProposalInfoModal {
         this.renderProposalResults(resultSummary),
         state === 'review' ? this.renderProposalBody(proposal) : '',
         committeeReviewSection,
+        committeeReviewReasons,
       ].filter(Boolean).join('');
     }
     if (this.detailsContent) {


### PR DESCRIPTION
## What Changed

This stacked PR shows other committee members' current withhold reasons while a proposal remains in `review`.

- Reuses #1458's validated reason extraction, grouped renderer, and responsive styles.
- Filters the signed-in address at the review call site so the member's own reason remains only under `Your vote`.
- Appends the read-only reason list immediately after the existing Committee Review summary.
- Leaves the reason dropdown, submission controls, polling behavior, and finalization logic unchanged.

## Fixed Flow

1. A proposal remains in committee review, including after its review timer ends but before finalization.
2. The client reads the latest qualifying committee withhold entries.
3. The signed-in member's entry is removed from the shared list.
4. Other reasons are grouped and rendered; an empty result renders no section.

## Why

The proposal payload already exposes current committee votes and reasons during review, but the modal only showed aggregate counts and the signed-in member's own vote. This adds the missing review context without mixing read-only reasons into the submission dropdown.

## Validation

- `node --check app.js`
- `git diff --check issue-1457-withheld-reasons..issue-1456-review-withhold-reasons`
- Focused logic checks for current-user exclusion, post-exclusion grouping, empty suppression, review-state gating, and timer-ended review.
- Headless Chromium checks for literal HTML-like text and mobile wrapping.

Depends on #1458.

Closes #1456