### PR TITLE
Default proposal vote options to no then yes

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,6 +86,7 @@ import {
   getDaoStateLabel,
   getDaoTypeLabel,
   getEffectiveDaoState,
+  isDaoAffirmativeOption,
   setDaoBackendFetcher,
 } from './dao.repo.js';
 
@@ -2925,7 +2926,7 @@ class AddProposalModal {
     if (this.emergencySelect) this.emergencySelect.value = 'false';
     if (this.startDelayInput) this.startDelayInput.value = '0';
     if (this.gracePeriodInput) this.gracePeriodInput.value = '';
-    this.renderOptions(['yes', 'no']);
+    this.renderOptions(['no', 'yes']);
     this.renderGracePeriodDefaultHint();
     this.refreshProposalFee();
     this.refreshSelectedConfigOptions();
@@ -3383,9 +3384,8 @@ class AddProposalModal {
       throw this.createValidationError('Every option needs text', inputs[emptyIndex]);
     }
 
-    const firstOption = options[0].toLowerCase();
-    if (!['yes', 'accept', 'approve'].includes(firstOption)) {
-      throw this.createValidationError('The first option must be yes, accept, or approve', inputs[0]);
+    if (!options.some(isDaoAffirmativeOption)) {
+      throw this.createValidationError('Include yes, accept, or approve as an option', inputs[0]);
     }
     return options;
   }
@@ -4040,8 +4040,9 @@ function getDaoVoteResultSummary(proposal) {
   const { totalWeight, winner } = getDaoVoteWinner(totals);
   if (totalWeight <= 0n) return null;
 
-  const outcome = winner.index === 0 ? 'Accepted' : 'Rejected';
-  const tone = winner.index === 0 ? 'accepted' : 'rejected';
+  const accepted = isDaoAffirmativeOption(winner.option);
+  const outcome = accepted ? 'Accepted' : 'Rejected';
+  const tone = accepted ? 'accepted' : 'rejected';
 
   return { headline: outcome, outcome, source: 'vote', tone, totalWeight, totals, winner };
 }

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -79,6 +79,10 @@ const DAO_AFFIRMATIVE_OPTION_STRINGS = ['yes', 'accept', 'approve'];
 const DAO_PROPOSALS_META_ID_STRING = 'dao proposals meta';
 export const DAO_PROPOSAL_TITLE_MAX_LENGTH = 100;
 
+export function isDaoAffirmativeOption(option) {
+  return DAO_AFFIRMATIVE_OPTION_STRINGS.includes(option.trim().toLowerCase());
+}
+
 export function getDaoTypeLabel(typeKey) {
   return DAO_TYPE_OPTIONS.find((t) => t.key === typeKey)?.label || typeKey || '';
 }
@@ -146,8 +150,8 @@ function normalizeDaoDraftOptions(options) {
   }
 
   const safeOptions = options.map((option) => requireDaoDraftString(option, 'DAO proposal option'));
-  if (!DAO_AFFIRMATIVE_OPTION_STRINGS.includes(safeOptions[0].toLowerCase())) {
-    throw new Error('The first DAO proposal option must be yes, accept, or approve');
+  if (!safeOptions.some(isDaoAffirmativeOption)) {
+    throw new Error('DAO proposal options must include yes, accept, or approve');
   }
   return safeOptions;
 }

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
                   <span class="dao-form-add-icon" aria-hidden="true"><span class="plus-glyph">+</span></span>
                   <span>Add option</span>
                 </button>
-                <div class="dao-form-help">2 to 10 options. The first option must be yes, accept, or approve.</div>
+                <div class="dao-form-help">2 to 10 options. Include yes, accept, or approve as an option.</div>
               </div>
               <div class="form-group dao-form-section">
                 <label>Timing</label>


### PR DESCRIPTION
## What Changed

This PR defaults new DAO proposal vote options to `no`, then `yes`, while preserving affirmative outcome semantics.

- `isDaoAffirmativeOption` centralizes recognition of `yes`, `accept`, and `approve`.
- Form and repository validation now allow the affirmative option at any index.
- Vote-result presentation derives acceptance from the winning option text instead of assuming index `0`.

## Fixed Flow

1. A user opens Add Proposal and sees `no` followed by `yes`.
2. Validation recognizes `yes` at index `1` and allows the draft.
3. Result rendering normalizes the winning option text.
4. A winning affirmative option is shown as accepted; any other winner is shown as rejected.

## Why

The client previously coupled approval semantics to array position, so reversing the defaults would fail validation and invert displayed outcomes. Using the option value as the source of truth removes that positional assumption.

The current server `dev` branch still validates and finalizes proposals using index `0`; its companion change must be deployed before this client change.

## Validation

- `node --check app.js`
- `node --check dao.repo.js`
- `git diff --check`

Closes #1460