### PR TITLE
Fix Current Vote labels collapsing on narrow screens

### DIFF
--- a/app.js
+++ b/app.js
@@ -4541,13 +4541,10 @@ class ProposalInfoModal {
     const winnerIndex = totalWeight > 0n
       ? rows.reduce((winner, row, index) => (row.total > rows[winner].total ? index : winner), 0)
       : -1;
-    const labelLayout = rows.length === 2 ? 'balanced' : 'segmented';
-
     const labels = rows
       .map((row, index) => {
         const position = index === 0 ? 'start' : index === rows.length - 1 ? 'end' : 'center';
         const isWinner = index === winnerIndex;
-        const units = this.getCurrentVoteSegmentUnits(row.total, totalWeight);
         const power = formatDaoVotingPower(row.total);
         const percent = formatDaoBigIntPercent(row.total, totalWeight);
         const valueLabel = totalWeight > 0n ? `${power} / ${percent}` : power;
@@ -4558,7 +4555,6 @@ class ProposalInfoModal {
         return `
           <div
             class="proposal-vote-current-label proposal-vote-current-label--${position}${isWinner ? ' proposal-vote-current-label--winner' : ''}"
-            style="--vote-total-segment-units: ${units};"
             title="${escapeDaoFormAttribute(title)}"
             aria-label="${escapeDaoFormAttribute(title)}"
           >
@@ -4586,7 +4582,7 @@ class ProposalInfoModal {
       <section class="proposal-info-section proposal-vote-current-section">
         <h3>Current Vote</h3>
         <div class="proposal-vote-current-meter" aria-label="Current vote totals">
-          <div class="proposal-vote-current-labels proposal-vote-current-labels--${labelLayout}">${labels}</div>
+          <div class="proposal-vote-current-labels">${labels}</div>
           <div class="proposal-vote-current-track" aria-hidden="true">${segments}</div>
         </div>
         <div class="proposal-vote-status-grid proposal-vote-status-grid--current">

--- a/styles.css
+++ b/styles.css
@@ -2844,14 +2844,12 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-vote-current-label {
   display: grid;
-  flex: var(--vote-total-segment-units) 1 0;
+  /* Equal label columns so zero/near-zero vote options stay readable.
+     Vote-bar segments keep --vote-total-segment-units for proportion. */
+  flex: 1 1 0;
   gap: 4px;
   min-width: 0;
   padding: 0 4px;
-}
-
-#proposalInfoModal .proposal-vote-current-labels--balanced .proposal-vote-current-label {
-  flex: 1 1 0;
 }
 
 #proposalInfoModal .proposal-vote-current-label--start {
@@ -2873,7 +2871,7 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-vote-current-label > small {
   max-width: 100%;
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }
 
 #proposalInfoModal .proposal-vote-current-label > span {

--- a/styles.css
+++ b/styles.css
@@ -2844,8 +2844,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-vote-current-label {
   display: grid;
-  /* Equal label columns so zero/near-zero vote options stay readable.
-     Vote-bar segments keep --vote-total-segment-units for proportion. */
+  /* Equal columns; bar segments stay vote-proportional via --vote-total-segment-units. */
   flex: 1 1 0;
   gap: 4px;
   min-width: 0;


### PR DESCRIPTION
## What Changed

Current Vote labels now stay readable on narrow screens without changing the vote distribution shown by the bar.

- Labels use equal-width columns and wrap at natural word boundaries.
- Vote totals continue to size only the proportional bar segments.

## Fixed Flow

1. Each option receives equal label space, including zero- and near-zero-vote options.
2. Long option names and `power / percentage` values wrap normally.
3. The bar independently keeps its vote-proportional segment widths.

## Why

Labels previously reused the bar's vote proportions, so low-vote options collapsed into one-character-wide columns. Separating label layout from bar layout keeps every option readable while preserving accurate vote visualization.

## Validation

- `node --check app.js`
- `git diff --check origin/main...HEAD`
- Browser layout checks at 320px and 1024px with two options, dominant and zero votes, long labels, and long power values

Closes #1467