### PR TITLE
Reconcile pending DAO actions on settlement

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ import {
   DAO_PROPOSAL_TITLE_MAX_LENGTH,
   daoRepo,
   DAO_STATES,
-  getDaoPendingToastMessage,
+  getDaoTransactionMessage,
   getDaoProposalClaimWindow,
   getDaoRewardClaimStatus,
   getDaoStateLabel,
@@ -94,7 +94,7 @@ import {
   getEffectiveDaoState,
   hasPendingDaoAction,
   isDaoProposalClaimable,
-  isDaoSettledPending,
+  isDaoTransactionType,
   normalizeDaoAddress,
   parseDaoUnsignedBigInt,
   setDaoBackendFetcher,
@@ -4111,9 +4111,6 @@ function getDaoApplyParametersLifecycleAction(help, canSubmit, rowPreviewLabel =
     help,
     buttonLabel: 'Apply parameters',
     loadingLabel: 'Applying parameters...',
-    successMessage: 'Parameters applied',
-    refreshWarning: 'Parameters applied, but proposal or parameter refresh failed',
-    refreshNetworkParams: true,
     canSubmit,
   };
   if (rowPreviewLabel) action.rowPreviewLabel = rowPreviewLabel;
@@ -4248,8 +4245,6 @@ function getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress 
         help: 'Voting has ended. Finalize the vote result to move this proposal to accepted or rejected.',
         buttonLabel: 'Finalize vote result',
         loadingLabel: 'Finalizing vote result...',
-        successMessage: 'Vote result finalized',
-        refreshWarning: 'Vote result finalized, but proposal refresh failed',
       }];
     }
     return [];
@@ -4270,8 +4265,6 @@ function getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress 
       help: 'The claim window has ended. Burn the unclaimed reward pool so the proposal accounting is finalized.',
       buttonLabel: 'Burn unclaimed reward',
       loadingLabel: 'Burning reward...',
-      successMessage: 'Unclaimed reward burned',
-      refreshWarning: 'Reward burned, but proposal refresh failed',
     });
   }
 
@@ -4291,8 +4284,6 @@ function getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress 
         : `Your estimated claim is ${formatDaoLibWei(rewardSummary.claimEstimate)}. Submit the claim and refresh proposal accounting.`,
       buttonLabel: 'Claim reward',
       loadingLabel: 'Claiming reward...',
-      successMessage: 'Reward claimed',
-      refreshWarning: 'Reward claimed, but proposal refresh failed',
     });
   }
 
@@ -5083,7 +5074,7 @@ class ProposalInfoModal {
     this.reviewResultSection.classList.remove('hidden');
     if (this.reviewResultHelp) {
       if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_RESULT)) {
-        this.reviewResultHelp.textContent = getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending');
+        this.reviewResultHelp.textContent = getDaoTransactionMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending');
       } else {
         const nextState = this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount);
         this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to ${nextState}.`;
@@ -5109,7 +5100,7 @@ class ProposalInfoModal {
       .map((action, index) => {
         const actionType = getDaoTypeForLifecycleKind(action.kind);
         const help = actionType && this.isDaoActionPending(actionType)
-          ? getDaoPendingToastMessage(actionType, 'pending')
+          ? getDaoTransactionMessage(actionType, 'pending')
           : action.help;
         return `
         <div class="proposal-lifecycle-action">
@@ -5168,7 +5159,7 @@ class ProposalInfoModal {
     this.voteActionSection.classList.remove('hidden');
     if (this.voteActionHelp) {
       this.voteActionHelp.textContent = this.isDaoActionPending(DAO_ACTION_TYPES.VOTE)
-        ? getDaoPendingToastMessage(DAO_ACTION_TYPES.VOTE, 'pending')
+        ? getDaoTransactionMessage(DAO_ACTION_TYPES.VOTE, 'pending')
         : 'Allocate options and spend LIB to preview voting power.';
     }
     if (this.voteSubmitButton) {
@@ -5416,29 +5407,26 @@ class ProposalInfoModal {
   }
 
   isDaoActionPending(type) {
-    return hasPendingDaoAction(myData?.pending, {
+    return hasPendingDaoAction(
+      myData?.pending,
       type,
-      proposalStoreId: this._currentProposalId || '',
-      from: getDaoCurrentAccountAddress(),
-    });
+      this._currentProposalId,
+      getDaoCurrentAccountAddress(),
+    );
   }
 
-  recordAcceptedDaoAction({ type, proposal, response }) {
-    const txid = response?.txid;
-    if (!txid || !myData?.pending) return false;
-
-    const pendingAction = myData.pending.find((pendingTx) => pendingTx.txid === txid);
-    if (!pendingAction) return false;
-
+  recordAcceptedDaoAction(result, proposal) {
+    const pendingAction = myData.pending.find(
+      (pendingTx) => pendingTx.txid === result.response.txid
+    );
+    assert(pendingAction, `Accepted DAO transaction missing pending entry: ${result.response.txid}`);
+    assert(this._currentProposalId, 'Accepted DAO transaction missing proposal store ID');
     Object.assign(pendingAction, {
-      type,
-      proposalStoreId: this._currentProposalId || proposal?.id || '',
-      proposalId: proposal?.accountId || '',
-      proposalNumber: proposal?.number || 0,
-      from: getDaoCurrentAccountAddress(),
-      action: type,
+      proposalStoreId: this._currentProposalId,
+      proposalId: proposal.accountId,
+      proposalNumber: proposal.number,
+      from: result.transaction.from,
     });
-    return true;
   }
 
   async submitDaoTransaction(transaction) {
@@ -5454,6 +5442,7 @@ class ProposalInfoModal {
   }
 
   updateSubmitButtons() {
+    const pendingLabel = 'Pending confirmation...';
     const pendingCommittee = this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_VOTE);
     const pendingReviewResult = this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_RESULT);
     const pendingVote = this.isDaoActionPending(DAO_ACTION_TYPES.VOTE);
@@ -5468,15 +5457,19 @@ class ProposalInfoModal {
     if (this.customReasonInput) this.customReasonInput.disabled = disableCommittee || isSameVote;
     if (this.submitButton) {
       this.submitButton.disabled = disableCommittee || isSameVote;
-      this.submitButton.textContent = pendingCommittee
-        ? 'Pending confirmation...'
-        : (this.isSubmitting && this.canSubmitCommitteeReview ? 'Submitting...' : this.submitButtonLabel);
+      this.submitButton.textContent = this.submitButtonLabel;
+      if (this.isSubmitting && this.canSubmitCommitteeReview) {
+        this.submitButton.textContent = 'Submitting...';
+      }
+      if (pendingCommittee) this.submitButton.textContent = pendingLabel;
     }
     if (this.reviewResultButton) {
       this.reviewResultButton.disabled = disableResult;
-      this.reviewResultButton.textContent = pendingReviewResult
-        ? 'Pending confirmation...'
-        : (this.isSubmitting && this.canSubmitReviewResult ? 'Finalizing...' : this.reviewResultButtonLabel);
+      this.reviewResultButton.textContent = this.reviewResultButtonLabel;
+      if (this.isSubmitting && this.canSubmitReviewResult) {
+        this.reviewResultButton.textContent = 'Finalizing...';
+      }
+      if (pendingReviewResult) this.reviewResultButton.textContent = pendingLabel;
     }
     for (const button of this.lifecycleActionSection?.querySelectorAll('button[data-lifecycle-action-index]') || []) {
       const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
@@ -5485,15 +5478,17 @@ class ProposalInfoModal {
       const isSubmittingAction = this.isSubmitting && action === this.submittingLifecycleAction;
       const canSubmitLifecycle = action?.canSubmit !== false;
       button.disabled = this.isSubmitting || !action || !canSubmitLifecycle || pendingLifecycle;
-      button.textContent = pendingLifecycle
-        ? 'Pending confirmation...'
-        : (isSubmittingAction ? action.loadingLabel : action?.buttonLabel || '');
+      button.textContent = action?.buttonLabel || '';
+      if (isSubmittingAction) button.textContent = action.loadingLabel;
+      if (pendingLifecycle) button.textContent = pendingLabel;
     }
     if (this.voteSubmitButton) {
       this.voteSubmitButton.disabled = disableVote;
-      this.voteSubmitButton.textContent = pendingVote
-        ? 'Pending confirmation...'
-        : (this.isSubmitting && this.canSubmitVote ? 'Submitting...' : this.voteSubmitButtonLabel);
+      this.voteSubmitButton.textContent = this.voteSubmitButtonLabel;
+      if (this.isSubmitting && this.canSubmitVote) {
+        this.voteSubmitButton.textContent = 'Submitting...';
+      }
+      if (pendingVote) this.voteSubmitButton.textContent = pendingLabel;
     }
     if (this.voteSpendInput) this.voteSpendInput.disabled = this.isSubmitting || pendingVote;
     if (this.voteOptions) {
@@ -5527,7 +5522,7 @@ class ProposalInfoModal {
   setCommitteeActionHelp(state, reviewWindow) {
     if (!this.committeeActionHelp) return;
     if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_VOTE)) {
-      this.committeeActionHelp.textContent = getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending');
+      this.committeeActionHelp.textContent = getDaoTransactionMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending');
       return;
     }
     if (!this.canSubmitCommitteeReview) {
@@ -5579,7 +5574,7 @@ class ProposalInfoModal {
   async handleCommitteeSubmit() {
     if (this.isSubmitting || !this.canSubmitCommitteeReview) return;
     if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_VOTE)) {
-      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending'), 2500, 'info');
+      showToast(getDaoTransactionMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending'), 2500, 'info');
       return;
     }
     if (this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote) {
@@ -5629,12 +5624,8 @@ class ProposalInfoModal {
         return;
       }
 
-      this.recordAcceptedDaoAction({
-        type: DAO_ACTION_TYPES.COMMITTEE_VOTE,
-        proposal,
-        response: result.response,
-      });
-      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending'), 4000, 'info');
+      this.recordAcceptedDaoAction(result, proposal);
+      showToast(getDaoTransactionMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending'), 4000, 'info');
       this.updateSubmitButtons();
       this.setCommitteeActionHelp();
     } catch (error) {
@@ -5649,7 +5640,7 @@ class ProposalInfoModal {
   async handleReviewResultSubmit() {
     if (this.isSubmitting || !this.canSubmitReviewResult) return;
     if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_RESULT)) {
-      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending'), 2500, 'info');
+      showToast(getDaoTransactionMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending'), 2500, 'info');
       return;
     }
 
@@ -5680,12 +5671,8 @@ class ProposalInfoModal {
         return;
       }
 
-      this.recordAcceptedDaoAction({
-        type: DAO_ACTION_TYPES.COMMITTEE_RESULT,
-        proposal,
-        response: result.response,
-      });
-      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending'), 4000, 'info');
+      this.recordAcceptedDaoAction(result, proposal);
+      showToast(getDaoTransactionMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending'), 4000, 'info');
       this.updateSubmitButtons();
     } catch (error) {
       console.warn('Failed to finalize review result:', error);
@@ -5713,7 +5700,7 @@ class ProposalInfoModal {
       return;
     }
     if (this.isDaoActionPending(actionType)) {
-      showToast(getDaoPendingToastMessage(actionType, 'pending'), 2500, 'info');
+      showToast(getDaoTransactionMessage(actionType, 'pending'), 2500, 'info');
       return;
     }
 
@@ -5762,12 +5749,8 @@ class ProposalInfoModal {
         return;
       }
 
-      this.recordAcceptedDaoAction({
-        type: actionType,
-        proposal,
-        response: result.response,
-      });
-      showToast(getDaoPendingToastMessage(actionType, 'pending'), 4000, 'info');
+      this.recordAcceptedDaoAction(result, proposal);
+      showToast(getDaoTransactionMessage(actionType, 'pending'), 4000, 'info');
       this.updateSubmitButtons();
     } catch (error) {
       console.warn('Failed to submit DAO lifecycle action:', error);
@@ -5782,7 +5765,7 @@ class ProposalInfoModal {
   async handleVoteSubmit() {
     if (this.isSubmitting || !this.canSubmitVote) return;
     if (this.isDaoActionPending(DAO_ACTION_TYPES.VOTE)) {
-      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.VOTE, 'pending'), 2500, 'info');
+      showToast(getDaoTransactionMessage(DAO_ACTION_TYPES.VOTE, 'pending'), 2500, 'info');
       return;
     }
 
@@ -5822,12 +5805,8 @@ class ProposalInfoModal {
         return;
       }
 
-      this.recordAcceptedDaoAction({
-        type: DAO_ACTION_TYPES.VOTE,
-        proposal,
-        response: result.response,
-      });
-      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.VOTE, 'pending'), 4000, 'info');
+      this.recordAcceptedDaoAction(result, proposal);
+      showToast(getDaoTransactionMessage(DAO_ACTION_TYPES.VOTE, 'pending'), 4000, 'info');
       this.updateSubmitButtons();
     } catch (error) {
       console.warn('Failed to submit vote:', error);
@@ -32911,6 +32890,7 @@ async function checkPendingTransactionsOnce() {
     const pendingTxInfo = myData.pending[i];
     const { txid, type, submittedts } = pendingTxInfo;
     const reactionPending = pendingTxInfo.reactionPending;
+    const isPendingDaoTransaction = isDaoTransactionType(type);
     if (reactionPending && reactionPending.status !== 'pending') {
       continue;
     }
@@ -32954,9 +32934,9 @@ async function checkPendingTransactionsOnce() {
           chatModal.refreshCurrentView(txid);
           await chatsScreen.updateChatList();
         }
-        if (isDaoSettledPending(pendingTxInfo)) {
+        if (isPendingDaoTransaction) {
           await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'timeout');
-          showToast(getDaoPendingToastMessage(type, 'timeout'), 0, 'warning');
+          showToast(getDaoTransactionMessage(type, 'timeout'), 0, 'warning');
         }
         continue;
       }
@@ -33016,9 +32996,9 @@ async function checkPendingTransactionsOnce() {
           console.log(`DEBUG: reclaim_toll transaction successfully processed!`);
         }
 
-        if (isDaoSettledPending(pendingTxInfo)) {
+        if (isPendingDaoTransaction) {
           await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'success');
-          showToast(getDaoPendingToastMessage(type, 'success'), 3000, 'success');
+          showToast(getDaoTransactionMessage(type, 'success'), 3000, 'success');
         }
       } else if (res?.transaction?.success === false) {
         console.log(`DEBUG: txid ${txid} failed, removing completely`);
@@ -33091,22 +33071,21 @@ async function checkPendingTransactionsOnce() {
             if (failureReason !== 'user is trying to reclaim toll but the toll pool is empty') {
               showToast(`Reclaim toll failed: ${userFailureReason}`, 0, 'error');
             }
-          } else if (!isDaoSettledPending(pendingTxInfo)) {
+          } else if (!isPendingDaoTransaction) {
             // for messages, transfer etc.
             showToast(userFailureReason, 0, 'error');
           }
 
-          if (!reactionPending && !pendingTxInfo.editPending && !isDaoSettledPending(pendingTxInfo)) {
+          if (!reactionPending && !pendingTxInfo.editPending && !isPendingDaoTransaction) {
             const toAddress = pendingTxInfo.to;
             updateTransactionStatus(txid, toAddress, 'failed', type);
             chatModal.refreshCurrentView(txid);
           }
         }
-        if (!reactionPending && isDaoSettledPending(pendingTxInfo)) {
+        if (!reactionPending && isPendingDaoTransaction) {
           await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'failure');
-          showToast(getDaoPendingToastMessage(type, 'failure', {
-            failureReason: userFailureReason,
-          }), 0, 'error');
+          const failureMessage = getDaoTransactionMessage(type, 'failure');
+          showToast(`${failureMessage}: ${userFailureReason}`, 0, 'error');
         }
 
         // refresh the validator modal if this is a withdraw_stake/deposit_stake and validator modal is open

--- a/app.js
+++ b/app.js
@@ -79,17 +79,22 @@ import { stringify, parse } from './external/stringify-shardus.js';
 import {
   buildDaoProposalCreateDraft,
   createDaoBackendFetcher,
+  DAO_ACTION_TYPES,
   DAO_CONFIG_CHANGE_OPTIONS,
   DAO_PROPOSAL_CREATE_TYPE,
   DAO_PROPOSAL_TITLE_MAX_LENGTH,
   daoRepo,
   DAO_STATES,
+  getDaoPendingToastMessage,
   getDaoProposalClaimWindow,
   getDaoRewardClaimStatus,
   getDaoStateLabel,
+  getDaoTypeForLifecycleKind,
   getDaoTypeLabel,
   getEffectiveDaoState,
+  hasPendingDaoAction,
   isDaoProposalClaimable,
+  isDaoSettledPending,
   normalizeDaoAddress,
   parseDaoUnsignedBigInt,
   setDaoBackendFetcher,
@@ -2597,7 +2602,7 @@ class DaoModal {
     return this.modal.classList.contains('active');
   }
 
-  async refreshAfterProposalSettlement(proposalId) {
+  async refreshAfterDaoSettlement(pendingTxInfo, outcome) {
     try {
       await daoRepo.refresh({ force: true });
     } catch (error) {
@@ -2605,7 +2610,16 @@ class DaoModal {
     }
 
     if (this.isActive()) this.render();
-    proposalInfoModal.refreshIfOpen(proposalId);
+    proposalInfoModal.refreshIfOpen(pendingTxInfo.proposalStoreId);
+
+    if (outcome === 'success' && pendingTxInfo.type === DAO_ACTION_TYPES.APPLY_PARAMETERS) {
+      try {
+        const refreshed = await getNetworkParams(true);
+        if (!refreshed) throw new Error('Network parameter refresh failed');
+      } catch (error) {
+        console.warn('DAO network parameter refresh failed after settlement:', error);
+      }
+    }
   }
 
   toggleStatusMenu(e) {
@@ -5068,8 +5082,12 @@ class ProposalInfoModal {
     this.canSubmitReviewResult = true;
     this.reviewResultSection.classList.remove('hidden');
     if (this.reviewResultHelp) {
-      const nextState = this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount);
-      this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to ${nextState}.`;
+      if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_RESULT)) {
+        this.reviewResultHelp.textContent = getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending');
+      } else {
+        const nextState = this.getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount);
+        this.reviewResultHelp.textContent = `${reviewWindow.label}. Finalize the review result to move this proposal to ${nextState}.`;
+      }
     }
     this.updateSubmitButtons();
   }
@@ -5088,11 +5106,16 @@ class ProposalInfoModal {
     }
 
     this.lifecycleActionSection.innerHTML = this.currentLifecycleActions
-      .map((action, index) => `
+      .map((action, index) => {
+        const actionType = getDaoTypeForLifecycleKind(action.kind);
+        const help = actionType && this.isDaoActionPending(actionType)
+          ? getDaoPendingToastMessage(actionType, 'pending')
+          : action.help;
+        return `
         <div class="proposal-lifecycle-action">
           <div class="proposal-committee-actions-header">
             <h3>${escapeHtml(action.title)}</h3>
-            <p>${escapeHtml(action.help)}</p>
+            <p>${escapeHtml(help)}</p>
           </div>
           <button
             type="button"
@@ -5100,7 +5123,8 @@ class ProposalInfoModal {
             data-lifecycle-action-index="${index}"
           >${escapeHtml(action.buttonLabel)}</button>
         </div>
-      `)
+      `;
+      })
       .join('');
     this.lifecycleActionSection.classList.remove('hidden');
     this.updateSubmitButtons();
@@ -5143,7 +5167,9 @@ class ProposalInfoModal {
 
     this.voteActionSection.classList.remove('hidden');
     if (this.voteActionHelp) {
-      this.voteActionHelp.textContent = 'Allocate options and spend LIB to preview voting power.';
+      this.voteActionHelp.textContent = this.isDaoActionPending(DAO_ACTION_TYPES.VOTE)
+        ? getDaoPendingToastMessage(DAO_ACTION_TYPES.VOTE, 'pending')
+        : 'Allocate options and spend LIB to preview voting power.';
     }
     if (this.voteSubmitButton) {
       this.voteSubmitButton.textContent = this.voteSubmitButtonLabel;
@@ -5385,6 +5411,42 @@ class ProposalInfoModal {
     return `<div class="proposal-vote-preview-message proposal-vote-preview-message--${tone}">${escapeHtml(message)}</div>`;
   }
 
+  getCurrentProposal() {
+    return this._currentProposalId ? daoRepo.getProposalById(this._currentProposalId) : null;
+  }
+
+  isDaoActionPending(type) {
+    return hasPendingDaoAction(myData?.pending, {
+      type,
+      proposalStoreId: this._currentProposalId || '',
+      from: getDaoCurrentAccountAddress(),
+    });
+  }
+
+  recordAcceptedDaoAction({ type, proposal, response }) {
+    const txid = response?.txid;
+    if (!txid || !myData?.pending) return false;
+
+    const pendingAction = myData.pending.find((pendingTx) => pendingTx.txid === txid);
+    if (!pendingAction) return false;
+
+    Object.assign(pendingAction, {
+      type,
+      proposalStoreId: this._currentProposalId || proposal?.id || '',
+      proposalId: proposal?.accountId || '',
+      proposalNumber: proposal?.number || 0,
+      from: getDaoCurrentAccountAddress(),
+      action: type,
+    });
+    return true;
+  }
+
+  async submitDaoTransaction(transaction) {
+    if (!myAccount?.keys) throw new Error('Wallet keys unavailable');
+    const txid = await signObj(transaction, myAccount.keys);
+    return injectTx(transaction, txid);
+  }
+
   setSubmitting(isSubmitting) {
     this.isSubmitting = Boolean(isSubmitting);
     if (this.closeButton) this.closeButton.disabled = this.isSubmitting;
@@ -5392,10 +5454,13 @@ class ProposalInfoModal {
   }
 
   updateSubmitButtons() {
-    const disableCommittee = this.isSubmitting || !this.canSubmitCommitteeReview;
+    const pendingCommittee = this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_VOTE);
+    const pendingReviewResult = this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_RESULT);
+    const pendingVote = this.isDaoActionPending(DAO_ACTION_TYPES.VOTE);
+    const disableCommittee = this.isSubmitting || !this.canSubmitCommitteeReview || pendingCommittee;
     const isSameVote = Boolean(this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote);
-    const disableResult = this.isSubmitting || !this.canSubmitReviewResult;
-    const disableVote = this.isSubmitting || !this.canSubmitVote;
+    const disableResult = this.isSubmitting || !this.canSubmitReviewResult || pendingReviewResult;
+    const disableVote = this.isSubmitting || !this.canSubmitVote || pendingVote;
 
     if (this.acceptButton) this.acceptButton.disabled = disableCommittee || this.currentCommitteeVote === 'accept';
     if (this.withholdButton) this.withholdButton.disabled = disableCommittee || this.currentCommitteeVote === 'withhold';
@@ -5403,33 +5468,44 @@ class ProposalInfoModal {
     if (this.customReasonInput) this.customReasonInput.disabled = disableCommittee || isSameVote;
     if (this.submitButton) {
       this.submitButton.disabled = disableCommittee || isSameVote;
-      this.submitButton.textContent = this.isSubmitting && this.canSubmitCommitteeReview ? 'Submitting...' : this.submitButtonLabel;
+      this.submitButton.textContent = pendingCommittee
+        ? 'Pending confirmation...'
+        : (this.isSubmitting && this.canSubmitCommitteeReview ? 'Submitting...' : this.submitButtonLabel);
     }
     if (this.reviewResultButton) {
       this.reviewResultButton.disabled = disableResult;
-      this.reviewResultButton.textContent = this.isSubmitting && this.canSubmitReviewResult ? 'Finalizing...' : this.reviewResultButtonLabel;
+      this.reviewResultButton.textContent = pendingReviewResult
+        ? 'Pending confirmation...'
+        : (this.isSubmitting && this.canSubmitReviewResult ? 'Finalizing...' : this.reviewResultButtonLabel);
     }
     for (const button of this.lifecycleActionSection?.querySelectorAll('button[data-lifecycle-action-index]') || []) {
       const action = this.currentLifecycleActions[Number(button.dataset.lifecycleActionIndex)];
+      const actionType = getDaoTypeForLifecycleKind(action?.kind);
+      const pendingLifecycle = Boolean(actionType && this.isDaoActionPending(actionType));
       const isSubmittingAction = this.isSubmitting && action === this.submittingLifecycleAction;
       const canSubmitLifecycle = action?.canSubmit !== false;
-      button.disabled = this.isSubmitting || !action || !canSubmitLifecycle;
-      button.textContent = isSubmittingAction ? action.loadingLabel : action?.buttonLabel || '';
+      button.disabled = this.isSubmitting || !action || !canSubmitLifecycle || pendingLifecycle;
+      button.textContent = pendingLifecycle
+        ? 'Pending confirmation...'
+        : (isSubmittingAction ? action.loadingLabel : action?.buttonLabel || '');
     }
     if (this.voteSubmitButton) {
       this.voteSubmitButton.disabled = disableVote;
-      this.voteSubmitButton.textContent = this.isSubmitting && this.canSubmitVote ? 'Submitting...' : this.voteSubmitButtonLabel;
+      this.voteSubmitButton.textContent = pendingVote
+        ? 'Pending confirmation...'
+        : (this.isSubmitting && this.canSubmitVote ? 'Submitting...' : this.voteSubmitButtonLabel);
     }
-    if (this.voteSpendInput) this.voteSpendInput.disabled = this.isSubmitting;
+    if (this.voteSpendInput) this.voteSpendInput.disabled = this.isSubmitting || pendingVote;
     if (this.voteOptions) {
       for (const input of this.voteOptions.querySelectorAll('input[data-vote-option-index]')) {
-        input.disabled = this.isSubmitting;
+        input.disabled = this.isSubmitting || pendingVote;
       }
     }
   }
 
   handleCommitteeChoiceClick(choice) {
     if (this.isSubmitting || !this.canSubmitCommitteeReview) return;
+    if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_VOTE)) return;
     if (choice === this.currentCommitteeVote) return;
     this.setCommitteeChoice(choice);
     this.scrollToCommitteeActionBottom();
@@ -5450,6 +5526,10 @@ class ProposalInfoModal {
 
   setCommitteeActionHelp(state, reviewWindow) {
     if (!this.committeeActionHelp) return;
+    if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_VOTE)) {
+      this.committeeActionHelp.textContent = getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending');
+      return;
+    }
     if (!this.canSubmitCommitteeReview) {
       this.committeeActionHelp.textContent = state === 'review'
         ? `${reviewWindow?.label || 'Committee review unavailable'}. Committee review submission is unavailable.`
@@ -5496,40 +5576,12 @@ class ProposalInfoModal {
       : String(this.withholdReasonSelect?.value || '').trim();
   }
 
-  getCurrentProposal() {
-    return this._currentProposalId ? daoRepo.getProposalById(this._currentProposalId) : null;
-  }
-
-  async submitDaoTransaction(transaction) {
-    if (!myAccount?.keys) throw new Error('Wallet keys unavailable');
-    const txid = await signObj(transaction, myAccount.keys);
-    return injectTx(transaction, txid);
-  }
-
-  async refreshAfterDaoAction(warningMessage, { refreshNetworkParams = false } = {}) {
-    try {
-      await daoRepo.refresh({ force: true });
-      if (daoModal?.isActive?.()) daoModal.render();
-
-      const proposal = this.getCurrentProposal();
-      if (proposal) {
-        this.renderProposal(proposal);
-      } else {
-        this.renderNotFound();
-      }
-
-      if (refreshNetworkParams) {
-        const refreshed = await getNetworkParams(true);
-        if (!refreshed) throw new Error('Network parameter refresh failed');
-      }
-    } catch (error) {
-      console.warn('Failed to refresh proposal after DAO action:', error);
-      showToast(warningMessage, 4000, 'warning');
-    }
-  }
-
   async handleCommitteeSubmit() {
     if (this.isSubmitting || !this.canSubmitCommitteeReview) return;
+    if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_VOTE)) {
+      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending'), 2500, 'info');
+      return;
+    }
     if (this.currentCommitteeVote && this.committeeChoice === this.currentCommitteeVote) {
       showToast(`You already submitted ${this.formatCommitteeChoice(this.currentCommitteeVote)}`, 2500, 'info');
       return;
@@ -5577,8 +5629,14 @@ class ProposalInfoModal {
         return;
       }
 
-      showToast('Committee review submitted', 3000, 'success');
-      await this.refreshAfterDaoAction('Committee review submitted, but proposal refresh failed');
+      this.recordAcceptedDaoAction({
+        type: DAO_ACTION_TYPES.COMMITTEE_VOTE,
+        proposal,
+        response: result.response,
+      });
+      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_VOTE, 'pending'), 4000, 'info');
+      this.updateSubmitButtons();
+      this.setCommitteeActionHelp();
     } catch (error) {
       console.warn('Failed to submit committee review:', error);
       showToast(error?.message || 'Committee review submission failed', 3000, 'warning');
@@ -5590,6 +5648,10 @@ class ProposalInfoModal {
 
   async handleReviewResultSubmit() {
     if (this.isSubmitting || !this.canSubmitReviewResult) return;
+    if (this.isDaoActionPending(DAO_ACTION_TYPES.COMMITTEE_RESULT)) {
+      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending'), 2500, 'info');
+      return;
+    }
 
     const proposal = this.getCurrentProposal();
     if (!proposal) {
@@ -5618,8 +5680,13 @@ class ProposalInfoModal {
         return;
       }
 
-      showToast('Review result finalized', 3000, 'success');
-      await this.refreshAfterDaoAction('Review result finalized, but proposal refresh failed');
+      this.recordAcceptedDaoAction({
+        type: DAO_ACTION_TYPES.COMMITTEE_RESULT,
+        proposal,
+        response: result.response,
+      });
+      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.COMMITTEE_RESULT, 'pending'), 4000, 'info');
+      this.updateSubmitButtons();
     } catch (error) {
       console.warn('Failed to finalize review result:', error);
       showToast(error?.message || 'Review result finalization failed', 3000, 'warning');
@@ -5639,6 +5706,16 @@ class ProposalInfoModal {
 
   async handleLifecycleActionSubmit(action) {
     if (this.isSubmitting || !action || action.canSubmit === false) return;
+
+    const actionType = getDaoTypeForLifecycleKind(action.kind);
+    if (!actionType) {
+      showToast(`Unknown DAO lifecycle action: ${action.kind}`, 3000, 'warning');
+      return;
+    }
+    if (this.isDaoActionPending(actionType)) {
+      showToast(getDaoPendingToastMessage(actionType, 'pending'), 2500, 'info');
+      return;
+    }
 
     const proposal = this.getCurrentProposal();
     if (!proposal) {
@@ -5685,8 +5762,13 @@ class ProposalInfoModal {
         return;
       }
 
-      showToast(action.successMessage, 3000, 'success');
-      await this.refreshAfterDaoAction(action.refreshWarning, { refreshNetworkParams: action.refreshNetworkParams });
+      this.recordAcceptedDaoAction({
+        type: actionType,
+        proposal,
+        response: result.response,
+      });
+      showToast(getDaoPendingToastMessage(actionType, 'pending'), 4000, 'info');
+      this.updateSubmitButtons();
     } catch (error) {
       console.warn('Failed to submit DAO lifecycle action:', error);
       showToast(error?.message || `${action.title} failed`, 3000, 'warning');
@@ -5699,6 +5781,10 @@ class ProposalInfoModal {
 
   async handleVoteSubmit() {
     if (this.isSubmitting || !this.canSubmitVote) return;
+    if (this.isDaoActionPending(DAO_ACTION_TYPES.VOTE)) {
+      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.VOTE, 'pending'), 2500, 'info');
+      return;
+    }
 
     const proposal = this.getCurrentProposal();
     if (!proposal) {
@@ -5736,8 +5822,13 @@ class ProposalInfoModal {
         return;
       }
 
-      showToast('Vote submitted', 3000, 'success');
-      await this.refreshAfterDaoAction('Vote submitted, but proposal refresh failed');
+      this.recordAcceptedDaoAction({
+        type: DAO_ACTION_TYPES.VOTE,
+        proposal,
+        response: result.response,
+      });
+      showToast(getDaoPendingToastMessage(DAO_ACTION_TYPES.VOTE, 'pending'), 4000, 'info');
+      this.updateSubmitButtons();
     } catch (error) {
       console.warn('Failed to submit vote:', error);
       showToast(error?.message || 'Vote submission failed', 3000, 'warning');
@@ -32863,10 +32954,9 @@ async function checkPendingTransactionsOnce() {
           chatModal.refreshCurrentView(txid);
           await chatsScreen.updateChatList();
         }
-        if (type === DAO_PROPOSAL_CREATE_TYPE) {
-          // Unresolved: clear local pending and reconcile DAO data without success/failure UX.
-          await daoModal.refreshAfterProposalSettlement(pendingTxInfo.proposalStoreId);
-          showToast('Proposal confirmation is taking longer than expected', 0, 'warning');
+        if (isDaoSettledPending(pendingTxInfo)) {
+          await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'timeout');
+          showToast(getDaoPendingToastMessage(type, 'timeout'), 0, 'warning');
         }
         continue;
       }
@@ -32926,9 +33016,9 @@ async function checkPendingTransactionsOnce() {
           console.log(`DEBUG: reclaim_toll transaction successfully processed!`);
         }
 
-        if (type === DAO_PROPOSAL_CREATE_TYPE) {
-          await daoModal.refreshAfterProposalSettlement(pendingTxInfo.proposalStoreId);
-          showToast('Proposal confirmed', 3000, 'success');
+        if (isDaoSettledPending(pendingTxInfo)) {
+          await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'success');
+          showToast(getDaoPendingToastMessage(type, 'success'), 3000, 'success');
         }
       } else if (res?.transaction?.success === false) {
         console.log(`DEBUG: txid ${txid} failed, removing completely`);
@@ -33001,20 +33091,24 @@ async function checkPendingTransactionsOnce() {
             if (failureReason !== 'user is trying to reclaim toll but the toll pool is empty') {
               showToast(`Reclaim toll failed: ${userFailureReason}`, 0, 'error');
             }
-          } else if (type === DAO_PROPOSAL_CREATE_TYPE) {
-            await daoModal.refreshAfterProposalSettlement(pendingTxInfo.proposalStoreId);
-            showToast(`Proposal creation failed: ${userFailureReason}`, 0, 'error');
-          } else {
+          } else if (!isDaoSettledPending(pendingTxInfo)) {
             // for messages, transfer etc.
             showToast(userFailureReason, 0, 'error');
           }
 
-          if (!reactionPending && !pendingTxInfo.editPending) {
+          if (!reactionPending && !pendingTxInfo.editPending && !isDaoSettledPending(pendingTxInfo)) {
             const toAddress = pendingTxInfo.to;
             updateTransactionStatus(txid, toAddress, 'failed', type);
             chatModal.refreshCurrentView(txid);
           }
         }
+        if (!reactionPending && isDaoSettledPending(pendingTxInfo)) {
+          await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'failure');
+          showToast(getDaoPendingToastMessage(type, 'failure', {
+            failureReason: userFailureReason,
+          }), 0, 'error');
+        }
+
         // refresh the validator modal if this is a withdraw_stake/deposit_stake and validator modal is open
         if (type === 'withdraw_stake' || type === 'deposit_stake') {
           // remove from wallet history

--- a/app.js
+++ b/app.js
@@ -2603,14 +2603,20 @@ class DaoModal {
   }
 
   async refreshAfterDaoSettlement(pendingTxInfo, outcome) {
+    let didRefreshDaoData = false;
     try {
       await daoRepo.refresh({ force: true });
+      didRefreshDaoData = true;
     } catch (error) {
       console.warn('DAO settlement refresh failed:', error);
     }
 
-    if (this.isActive()) this.render();
-    proposalInfoModal.refreshIfOpen(pendingTxInfo.proposalStoreId);
+    // A confirmed action must remain blocked until the UI can render fresh
+    // proposal state. Failed and timed-out actions can safely release the UI.
+    if (didRefreshDaoData || outcome !== 'success') {
+      if (this.isActive()) this.render();
+      proposalInfoModal.refreshIfOpen(pendingTxInfo.proposalStoreId);
+    }
 
     if (outcome === 'success' && pendingTxInfo.type === DAO_ACTION_TYPES.APPLY_PARAMETERS) {
       try {
@@ -2620,6 +2626,8 @@ class DaoModal {
         console.warn('DAO network parameter refresh failed after settlement:', error);
       }
     }
+
+    return didRefreshDaoData;
   }
 
   toggleStatusMenu(e) {
@@ -32997,8 +33005,13 @@ async function checkPendingTransactionsOnce() {
         }
 
         if (isPendingDaoTransaction) {
-          await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'success');
-          showToast(getDaoTransactionMessage(type, 'success'), 3000, 'success');
+          const didRefreshDaoData = await daoModal.refreshAfterDaoSettlement(pendingTxInfo, 'success');
+          if (didRefreshDaoData) {
+            showToast(getDaoTransactionMessage(type, 'success'), 3000, 'success');
+          } else if (!myData.pending.some((pendingTx) => pendingTx.txid === txid)) {
+            // Keep the pending guard active and retry reconciliation on the next poll.
+            myData.pending.push(pendingTxInfo);
+          }
         }
       } else if (res?.transaction?.success === false) {
         console.log(`DEBUG: txid ${txid} failed, removing completely`);

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -82,6 +82,107 @@ const DAO_PROPOSALS_META_ID_STRING = 'dao proposals meta';
 export const DAO_PROPOSAL_TITLE_MAX_LENGTH = 100;
 export const DAO_PROPOSAL_CREATE_TYPE = 'dao_proposal_create';
 
+export const DAO_ACTION_TYPES = Object.freeze({
+  COMMITTEE_VOTE: 'dao_committee_vote',
+  COMMITTEE_RESULT: 'dao_committee_result',
+  VOTE: 'dao_vote',
+  VOTE_RESULT: 'dao_vote_result',
+  CLAIM_REWARD: 'dao_claim_reward',
+  BURN_REWARD: 'dao_burn_reward',
+  APPLY_PARAMETERS: 'dao_apply_parameters',
+});
+
+const DAO_LIFECYCLE_KIND_TO_TYPE = Object.freeze({
+  vote_result: DAO_ACTION_TYPES.VOTE_RESULT,
+  claim_reward: DAO_ACTION_TYPES.CLAIM_REWARD,
+  burn_reward: DAO_ACTION_TYPES.BURN_REWARD,
+  apply_parameters: DAO_ACTION_TYPES.APPLY_PARAMETERS,
+});
+
+const DAO_TYPE_TOASTS = Object.freeze({
+  [DAO_PROPOSAL_CREATE_TYPE]: {
+    pending: 'Proposal submitted—pending confirmation',
+    success: 'Proposal confirmed',
+    failure: 'Proposal creation failed',
+    timeout: 'Proposal confirmation is taking longer than expected',
+  },
+  [DAO_ACTION_TYPES.COMMITTEE_VOTE]: {
+    pending: 'Committee review submitted—pending confirmation',
+    success: 'Committee review confirmed',
+    failure: 'Committee review failed',
+    timeout: 'Committee review confirmation is taking longer than expected',
+  },
+  [DAO_ACTION_TYPES.COMMITTEE_RESULT]: {
+    pending: 'Review result submitted—pending confirmation',
+    success: 'Review result confirmed',
+    failure: 'Review result failed',
+    timeout: 'Review result confirmation is taking longer than expected',
+  },
+  [DAO_ACTION_TYPES.VOTE]: {
+    pending: 'Vote submitted—pending confirmation',
+    success: 'Vote confirmed',
+    failure: 'Vote failed',
+    timeout: 'Vote confirmation is taking longer than expected',
+  },
+  [DAO_ACTION_TYPES.VOTE_RESULT]: {
+    pending: 'Vote result submitted—pending confirmation',
+    success: 'Vote result confirmed',
+    failure: 'Vote result failed',
+    timeout: 'Vote result confirmation is taking longer than expected',
+  },
+  [DAO_ACTION_TYPES.CLAIM_REWARD]: {
+    pending: 'Reward claim submitted—pending confirmation',
+    success: 'Reward claim confirmed',
+    failure: 'Reward claim failed',
+    timeout: 'Reward claim confirmation is taking longer than expected',
+  },
+  [DAO_ACTION_TYPES.BURN_REWARD]: {
+    pending: 'Reward burn submitted—pending confirmation',
+    success: 'Reward burn confirmed',
+    failure: 'Reward burn failed',
+    timeout: 'Reward burn confirmation is taking longer than expected',
+  },
+  [DAO_ACTION_TYPES.APPLY_PARAMETERS]: {
+    pending: 'Parameter apply submitted—pending confirmation',
+    success: 'Parameters applied',
+    failure: 'Parameter apply failed',
+    timeout: 'Parameter apply confirmation is taking longer than expected',
+  },
+});
+
+const DAO_SETTLED_TYPES = new Set(Object.keys(DAO_TYPE_TOASTS));
+
+export function isDaoSettledPending(pendingTxInfo) {
+  return DAO_SETTLED_TYPES.has(pendingTxInfo?.type);
+}
+
+export function getDaoTypeForLifecycleKind(kind) {
+  return DAO_LIFECYCLE_KIND_TO_TYPE[kind] || '';
+}
+
+export function hasPendingDaoAction(pendingList, { type, proposalStoreId, from = '' } = {}) {
+  if (!Array.isArray(pendingList) || !type || !proposalStoreId) return false;
+
+  const normalizedFrom = from ? String(from) : '';
+  return pendingList.some((entry) => {
+    if (!entry || entry.type !== type) return false;
+    if (entry.proposalStoreId !== proposalStoreId) return false;
+    if (normalizedFrom && entry.from && entry.from !== normalizedFrom) return false;
+    return true;
+  });
+}
+
+export function getDaoPendingToastMessage(type, outcome, { failureReason = '' } = {}) {
+  const toasts = DAO_TYPE_TOASTS[type];
+  if (!toasts) return '';
+
+  if (outcome === 'success') return toasts.success;
+  if (outcome === 'timeout') return toasts.timeout;
+  if (outcome === 'failure') {
+    return failureReason ? `${toasts.failure}: ${failureReason}` : toasts.failure;
+  }
+  return toasts.pending;
+}
 export function getDaoTypeLabel(typeKey) {
   return DAO_TYPE_OPTIONS.find((t) => t.key === typeKey)?.label || typeKey || '';
 }

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -99,7 +99,7 @@ const DAO_LIFECYCLE_KIND_TO_TYPE = Object.freeze({
   apply_parameters: DAO_ACTION_TYPES.APPLY_PARAMETERS,
 });
 
-const DAO_TYPE_TOASTS = Object.freeze({
+const DAO_TRANSACTION_MESSAGES = Object.freeze({
   [DAO_PROPOSAL_CREATE_TYPE]: {
     pending: 'Proposal submitted—pending confirmation',
     success: 'Proposal confirmed',
@@ -150,38 +150,34 @@ const DAO_TYPE_TOASTS = Object.freeze({
   },
 });
 
-const DAO_SETTLED_TYPES = new Set(Object.keys(DAO_TYPE_TOASTS));
+const DAO_TRANSACTION_TYPE_SET = new Set(Object.keys(DAO_TRANSACTION_MESSAGES));
 
-export function isDaoSettledPending(pendingTxInfo) {
-  return DAO_SETTLED_TYPES.has(pendingTxInfo?.type);
+export function isDaoTransactionType(type) {
+  return DAO_TRANSACTION_TYPE_SET.has(type);
 }
 
 export function getDaoTypeForLifecycleKind(kind) {
   return DAO_LIFECYCLE_KIND_TO_TYPE[kind] || '';
 }
 
-export function hasPendingDaoAction(pendingList, { type, proposalStoreId, from = '' } = {}) {
-  if (!Array.isArray(pendingList) || !type || !proposalStoreId) return false;
+export function hasPendingDaoAction(pendingList, type, proposalStoreId, from) {
+  if (!Array.isArray(pendingList) || !type || !proposalStoreId || !from) return false;
 
-  const normalizedFrom = from ? String(from) : '';
   return pendingList.some((entry) => {
     if (!entry || entry.type !== type) return false;
     if (entry.proposalStoreId !== proposalStoreId) return false;
-    if (normalizedFrom && entry.from && entry.from !== normalizedFrom) return false;
-    return true;
+    return entry.from === from;
   });
 }
 
-export function getDaoPendingToastMessage(type, outcome, { failureReason = '' } = {}) {
-  const toasts = DAO_TYPE_TOASTS[type];
-  if (!toasts) return '';
+export function getDaoTransactionMessage(type, outcome) {
+  const messages = DAO_TRANSACTION_MESSAGES[type];
+  if (!messages) throw new Error(`Unknown DAO transaction type: ${type}`);
 
-  if (outcome === 'success') return toasts.success;
-  if (outcome === 'timeout') return toasts.timeout;
-  if (outcome === 'failure') {
-    return failureReason ? `${toasts.failure}: ${failureReason}` : toasts.failure;
-  }
-  return toasts.pending;
+  const message = messages[outcome];
+  if (!message) throw new Error(`Unknown DAO transaction outcome: ${outcome}`);
+
+  return message;
 }
 export function getDaoTypeLabel(typeKey) {
   return DAO_TYPE_OPTIONS.find((t) => t.key === typeKey)?.label || typeKey || '';
@@ -394,7 +390,7 @@ export function buildDaoCommitteeVoteTransaction({
   if (txTimestamp <= 0) throw new Error('Committee review timestamp is required');
 
   const transaction = {
-    type: 'dao_committee_vote',
+    type: DAO_ACTION_TYPES.COMMITTEE_VOTE,
     timestamp: txTimestamp,
     networkId: requireDaoDraftString(networkId, 'Network ID'),
     from: requireDaoDraftString(from, 'Committee review sender'),
@@ -418,7 +414,7 @@ export function buildDaoCommitteeResultTransaction({
   networkId,
 } = {}) {
   return buildDaoProposalActionTransaction({
-    type: 'dao_committee_result',
+    type: DAO_ACTION_TYPES.COMMITTEE_RESULT,
     from,
     proposal,
     timestamp,
@@ -462,7 +458,7 @@ export function buildDaoVoteTransaction({
   }
 
   return {
-    type: 'dao_vote',
+    type: DAO_ACTION_TYPES.VOTE,
     timestamp: txTimestamp,
     networkId: requireDaoDraftString(networkId, 'Network ID'),
     from: requireDaoDraftString(from, 'Vote sender'),
@@ -479,7 +475,7 @@ export function buildDaoVoteResultTransaction({
   networkId,
 } = {}) {
   return buildDaoProposalActionTransaction({
-    type: 'dao_vote_result',
+    type: DAO_ACTION_TYPES.VOTE_RESULT,
     from,
     proposal,
     timestamp,
@@ -496,7 +492,7 @@ export function buildDaoClaimRewardTransaction({
   networkId,
 } = {}) {
   return buildDaoProposalActionTransaction({
-    type: 'dao_claim_reward',
+    type: DAO_ACTION_TYPES.CLAIM_REWARD,
     from,
     proposal,
     timestamp,
@@ -513,7 +509,7 @@ export function buildDaoBurnRewardTransaction({
   networkId,
 } = {}) {
   return buildDaoProposalActionTransaction({
-    type: 'dao_burn_reward',
+    type: DAO_ACTION_TYPES.BURN_REWARD,
     from,
     proposal,
     timestamp,
@@ -530,7 +526,7 @@ export function buildDaoApplyParametersTransaction({
   networkId,
 } = {}) {
   return buildDaoProposalActionTransaction({
-    type: 'dao_apply_parameters',
+    type: DAO_ACTION_TYPES.APPLY_PARAMETERS,
     from,
     proposal,
     timestamp,


### PR DESCRIPTION
## What Changed

This PR extends the #1464 receipt-settlement pattern to all DAO proposal actions.

- `ProposalInfoModal` committee/vote/lifecycle handlers now treat injection as pending: store action metadata, re-enable navigation, show pending toasts, and disable matching actions on reopen to prevent duplicates.
- `dao.settlement.js` covers `dao_committee_vote`, `dao_committee_result`, `dao_vote`, `dao_vote_result`, `dao_claim_reward`, `dao_burn_reward`, and `dao_apply_parameters`, including action-specific toasts and network-param refresh after successful apply.
- `checkPendingTransactions()` settles those types by force-refreshing `daoRepo`, rerendering open list/detail (including Claimable counts), and showing distinct success/failure/unresolved timeout states without forcing navigation.

## Fixed Flow

1. User submits a DAO action; controls are disabled only during signing/injection.
2. Injection accepted → pending metadata is stored, pending toast is shown, matching action stays disabled if the proposal is reopened.
3. Receipt succeeds → DAO data refreshes once; open list/detail update in place; apply also refreshes network params; confirmed toast appears.
4. Receipt fails or times out → pending clears, server state is reconciled, eligible actions re-enable, and failure vs unresolved timeout stay distinct.

## Why

Injection acceptance is not settlement. Refreshing immediately could show stale proposal state and allow duplicate submissions. Receipt-driven settlement keeps UI and pending state aligned.

## Validation

- `node --test tests/dao-proposal-create-settlement.test.mjs tests/dao-actions-settlement.test.mjs`

Closes #1465

Stacked on #1470 (`fix/1464-proposal-create-settlement`).

Made with [Cursor](https://cursor.com)