### PR TITLE
Align DAO lifecycle readiness with server transition timestamps

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,6 +87,7 @@ import {
   DAO_STATES,
   getDaoTransactionMessage,
   getDaoProposalClaimWindow,
+  getDaoProposalTimeline,
   getDaoRewardClaimStatus,
   getDaoStateLabel,
   getDaoTypeForLifecycleKind,
@@ -2685,7 +2686,7 @@ class DaoModal {
     const proposalsActive = daoRepo.getProposalsForUi('active');
     const proposalsArchived = daoRepo.getProposalsForUi('archived');
     const currentAddress = getDaoCurrentAccountAddress();
-    const now = Date.now();
+    const now = getTransactionTimestamp();
     const isClaimableFilter = this.selectedFilterKey === DAO_CLAIMABLE_FILTER.key;
     const groupedProposals = this.selectedGroupKey === 'archived' ? proposalsArchived : proposalsActive;
     const claimableProposals = [...proposalsActive, ...proposalsArchived]
@@ -2829,7 +2830,7 @@ class DaoModal {
         tone: 'neutral',
       });
     } else if (state === 'voting') {
-      const now = Date.now();
+      const now = getTransactionTimestamp();
       const votingWindow = getDaoProposalVotingWindow(proposal, now);
       const endDate = formatDaoDate(votingWindow.end);
       const votingEnded = Boolean(votingWindow.end && now > votingWindow.end);
@@ -3806,10 +3807,9 @@ function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
 }
 
-function getDaoProposalReviewWindow(proposal) {
-  const start = Number(proposal?.startTime || 0);
-  const duration = Number(proposal?.reviewDuration);
-  if (!start || !Number.isFinite(duration) || duration < 0) {
+function getDaoProposalReviewWindow(proposal, now = getTransactionTimestamp()) {
+  const timeline = getDaoProposalTimeline(proposal);
+  if (!timeline) {
     return {
       start: 0,
       end: 0,
@@ -3819,8 +3819,8 @@ function getDaoProposalReviewWindow(proposal) {
     };
   }
 
-  const end = start + duration;
-  const now = Date.now();
+  const start = timeline.reviewStart;
+  const end = timeline.reviewEnd;
   if (now < start) {
     return {
       start,
@@ -3848,17 +3848,9 @@ function getDaoProposalReviewWindow(proposal) {
   };
 }
 
-function getDaoProposalVotingWindow(proposal, now = Date.now()) {
-  const reviewStart = Number(proposal?.startTime || 0);
-  const reviewDuration = Number(proposal?.reviewDuration);
-  const votingDuration = Number(proposal?.votingDuration);
-  if (
-    !reviewStart ||
-    !Number.isFinite(reviewDuration) ||
-    reviewDuration < 0 ||
-    !Number.isFinite(votingDuration) ||
-    votingDuration < 0
-  ) {
+function getDaoProposalVotingWindow(proposal, now = getTransactionTimestamp()) {
+  const timeline = getDaoProposalTimeline(proposal);
+  if (!timeline) {
     return {
       start: 0,
       end: 0,
@@ -3868,8 +3860,8 @@ function getDaoProposalVotingWindow(proposal, now = Date.now()) {
     };
   }
 
-  const start = reviewStart + reviewDuration;
-  const end = start + votingDuration;
+  const start = timeline.votingStart;
+  const end = timeline.votingEnd;
   if (now < start) {
     return {
       start,
@@ -4074,30 +4066,17 @@ function getDaoVoterEntries(proposal) {
     .filter((entry) => entry.address && Number.isFinite(entry.timestamp) && entry.timestamp > 0);
 }
 
-function getDaoProposalApplyWindow(proposal, now = Date.now()) {
+function getDaoProposalApplyWindow(proposal, now = getTransactionTimestamp()) {
   if (proposal?.emergency) {
     return { eligibleAt: null, isReady: true };
   }
 
-  const backendEligibleAt = Number(proposal?.applyEligibleAt);
-  if (Number.isFinite(backendEligibleAt) && backendEligibleAt > 0) {
-    return { eligibleAt: backendEligibleAt, isReady: now >= backendEligibleAt };
-  }
-
-  const reviewStart = Number(proposal?.startTime || 0);
-  const reviewDuration = Number(proposal?.reviewDuration);
-  const votingDuration = Number(proposal?.votingDuration);
-  const gracePeriod = Number(proposal?.gracePeriod);
-  if (
-    !Number.isFinite(reviewStart) ||
-    !Number.isFinite(reviewDuration) ||
-    !Number.isFinite(votingDuration) ||
-    !Number.isFinite(gracePeriod)
-  ) {
+  const timeline = getDaoProposalTimeline(proposal);
+  if (!timeline) {
     return { eligibleAt: null, isReady: false };
   }
 
-  const eligibleAt = reviewStart + reviewDuration + votingDuration + gracePeriod;
+  const eligibleAt = timeline.applyEligibleAt;
   return { eligibleAt, isReady: now >= eligibleAt };
 }
 
@@ -4125,7 +4104,11 @@ function getDaoApplyParametersLifecycleAction(help, canSubmit, rowPreviewLabel =
   return action;
 }
 
-function getDaoProposalApplyLifecycleAction(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+function getDaoProposalApplyLifecycleAction(
+  proposal,
+  currentAddress = getDaoCurrentAccountAddress(),
+  now = getTransactionTimestamp(),
+) {
   if (getEffectiveDaoState(proposal) !== 'accepted') return null;
 
   if (!isDaoParameterProposalType(proposal)) {
@@ -4188,7 +4171,11 @@ function getDaoClaimRewardEstimate({ pool, claimed, voterEntries, voterIndex, vo
   return reward;
 }
 
-function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+function getDaoProposalRewardSummary(
+  proposal,
+  currentAddress = getDaoCurrentAccountAddress(),
+  now = getTransactionTimestamp(),
+) {
   const state = getEffectiveDaoState(proposal);
   const isRewardState = state === 'accepted' || state === 'rejected' || state === 'applied' || state === 'withheld';
   if (!isRewardState) return null;
@@ -4241,7 +4228,12 @@ function getDaoProposalRewardSummary(proposal, currentAddress = getDaoCurrentAcc
   };
 }
 
-function getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress = getDaoCurrentAccountAddress(), now = Date.now()) {
+function getDaoProposalLifecycleActions(
+  proposal,
+  rewardSummary,
+  currentAddress = getDaoCurrentAccountAddress(),
+  now = getTransactionTimestamp(),
+) {
   const state = getEffectiveDaoState(proposal);
 
   if (state === 'voting') {
@@ -5154,7 +5146,7 @@ class ProposalInfoModal {
     }
 
     const votingWindow = getDaoProposalVotingWindow(proposal);
-    if (votingWindow.end && Date.now() > votingWindow.end) {
+    if (!votingWindow.canPreviewVote) {
       this.hideVoteActions();
       return;
     }

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -614,6 +614,40 @@ function normalizeDaoTimestamp(value) {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
+// Mirrors the authoritative helpers in Liberdus/server src/accounts/daoProposalAccount.ts.
+export function getDaoProposalTimeline(proposal) {
+  const reviewStart = Number(proposal?.startTime);
+  const reviewDuration = Number(proposal?.reviewDuration);
+  const votingDuration = Number(proposal?.votingDuration);
+  const claimDuration = Number(proposal?.claimDuration);
+  const gracePeriod = Number(proposal?.gracePeriod);
+  const durations = [reviewDuration, votingDuration, claimDuration, gracePeriod];
+  if (reviewStart <= 0 || !Number.isFinite(reviewStart)
+    || durations.some((duration) => duration < 0 || !Number.isFinite(duration))) {
+    return null;
+  }
+
+  const reviewEnd = reviewStart + reviewDuration;
+  const votingStart = Number(proposal?.votingStartedAt ?? reviewEnd);
+  const votingEnd = proposal?.emergency
+    ? votingStart
+    : votingStart + votingDuration;
+  const claimStart = Number(proposal?.votingEndedAt ?? votingEnd);
+  if (votingStart <= 0 || !Number.isFinite(votingStart)
+    || claimStart <= 0 || !Number.isFinite(claimStart)) return null;
+
+  return {
+    reviewStart,
+    reviewEnd,
+    votingStart,
+    votingEnd,
+    claimStart,
+    claimEnd: claimStart + claimDuration,
+    applyEligibleAt: claimStart + gracePeriod,
+    votingDuration,
+  };
+}
+
 export function normalizeDaoAddress(value) {
   const address = String(value || '').trim();
   if (!/^(?:0x)?[0-9a-fA-F]{40}(?:0{24})?$/.test(address)) return '';
@@ -645,30 +679,16 @@ export function parseDaoUnsignedBigInt(value) {
 }
 
 export function getDaoProposalClaimWindow(proposal) {
-  const votingEndedAt = normalizeDaoTimestamp(proposal?.votingEndedAt);
-  const claimDuration = Number(proposal?.claimDuration);
-  if (!votingEndedAt || !Number.isFinite(claimDuration) || claimDuration < 0) {
+  const timeline = getDaoProposalTimeline(proposal);
+  if (!timeline) {
     return { start: null, end: null, votingStart: null, votingDuration: null };
   }
 
-  const votingDurationValue = Number(proposal?.votingDuration);
-  const votingDuration = Number.isFinite(votingDurationValue) && votingDurationValue >= 0
-    ? votingDurationValue
-    : null;
-  let votingStart = normalizeDaoTimestamp(proposal?.votingStartedAt);
-  if (!votingStart) {
-    const reviewStart = Number(proposal?.startTime);
-    const reviewDuration = Number(proposal?.reviewDuration);
-    if (Number.isFinite(reviewStart) && Number.isFinite(reviewDuration)) {
-      votingStart = reviewStart + reviewDuration;
-    }
-  }
-
   return {
-    start: votingEndedAt,
-    end: votingEndedAt + claimDuration,
-    votingStart: votingStart || null,
-    votingDuration,
+    start: timeline.claimStart,
+    end: timeline.claimEnd,
+    votingStart: timeline.votingStart,
+    votingDuration: timeline.votingDuration,
   };
 }
 
@@ -925,7 +945,6 @@ function storeToUiList(store, groupKey) {
         votingDuration: p.votingDuration,
         claimDuration: p.claimDuration,
         gracePeriod: p.gracePeriod,
-        applyEligibleAt: p.applyEligibleAt,
         archivedAt: p.archivedAt || 0,
       };
     })


### PR DESCRIPTION
## What Changed

This PR aligns the web client's DAO lifecycle readiness with the proposal timing enforced by the server.

- `getDaoProposalTimeline` derives review, voting, claim, and apply boundaries from the proposal's snapshotted durations and stored transition timestamps.
- Voting availability, vote-weight timing, claims, reward burns, and parameter application now share the same timeline.
- DAO readiness uses the network-corrected transaction timestamp so UI actions match the timestamp submitted for validation.
- Emergency proposals retain their zero-length community voting phase and immediate apply behavior.

## Fixed Flow

1. The client queries the raw proposal account and reads its snapshotted durations.
2. `votingStartedAt` anchors the voting window after the committee result transition, with `reviewEnd` used until that transition occurs.
3. `votingEndedAt` anchors claim and grace periods after vote-result finalization, with `votingEnd` used until that transition occurs.
4. The UI enables voting, finalization, claim, burn, and apply actions using the same effective boundaries as the server.

## Why

The client previously reconstructed voting and apply timing from the original schedule. Late committee-result or vote-result transactions therefore allowed the UI to advance before the server considered the next action valid. Using the proposal's transition timestamps preserves each snapshotted phase duration and keeps frontend readiness aligned with server validation.

## Validation

- `node --experimental-default-type=module tests/dao-timeline.test.mjs`
- `node --experimental-default-type=module --check app.js`
- `node --experimental-default-type=module --check dao.repo.js`
- `git diff --check`

Closes #1472