### PR TITLE
Clear DAO vote form after confirmed receipt

### DIFF
--- a/app.js
+++ b/app.js
@@ -2616,7 +2616,9 @@ class DaoModal {
     // proposal state. Failed and timed-out actions can safely release the UI.
     if (didRefreshDaoData || outcome !== 'success') {
       if (this.isActive()) this.render();
-      proposalInfoModal.refreshIfOpen(pendingTxInfo.proposalStoreId);
+      proposalInfoModal.refreshIfOpen(pendingTxInfo.proposalStoreId, {
+        resetVoteForm: outcome === 'success' && pendingTxInfo.type === DAO_ACTION_TYPES.VOTE,
+      });
     }
 
     if (outcome === 'success' && pendingTxInfo.type === DAO_ACTION_TYPES.APPLY_PARAMETERS) {
@@ -5823,11 +5825,12 @@ class ProposalInfoModal {
     enterFullscreen();
   }
 
-  refreshIfOpen(proposalId) {
+  refreshIfOpen(proposalId, { resetVoteForm = false } = {}) {
     if (!this.modal.classList.contains('active') || this._currentProposalId !== proposalId) return;
 
     const proposal = this.getCurrentProposal();
     if (proposal) {
+      if (resetVoteForm) this.resetVoteState(proposal);
       this.renderProposal(proposal);
     } else {
       this.renderNotFound();


### PR DESCRIPTION
## Summary

- reset DAO vote allocations and LIB spend only after a successful vote receipt and the existing proposal refresh
- preserve entered values while pending and after failed, timed-out, unrelated, or different-proposal settlements
- reuse the existing vote-state reset and preview render path without adding another network query

## Root cause

The receipt-driven proposal refresh updated vote totals and proposal status, but the form renderer preserved `voteWeights` whenever the option count was unchanged and restored `voteSpendLib`. That left the just-submitted values visible after confirmation.

## User impact

After a vote is confirmed, the matching open proposal now shows refreshed totals with an empty form ready for another additive vote. Inputs remain available for retry when a vote fails or times out.

## Validation

- `node --check app.js`
- `git diff --check`
- focused 10-scenario settlement harness covering successful, failed, timed-out, unrelated, refresh-failure, inactive-modal, and different-proposal cases

Closes #1474