### PR TITLE
Confirm DAO review decisions and votes before submission

### DIFF
--- a/app.js
+++ b/app.js
@@ -5587,14 +5587,14 @@ class ProposalInfoModal {
       }
     }
 
-    const decision = this.formatCommitteeChoice(this.committeeChoice);
-    if (!window.confirm(`Submit review decision: ${decision}?`)) return;
-
     const reviewWindow = getDaoProposalReviewWindow(proposal);
     if (!reviewWindow.canCommitteeVote) {
       showToast(reviewWindow.label, 2500, 'warning');
       return;
     }
+
+    const decision = this.formatCommitteeChoice(this.committeeChoice);
+    if (!window.confirm(`Submit review decision: ${decision}?`)) return;
 
     this.setSubmitting(true);
     const loadingToastId = showToast('Submitting committee review...', 0, 'loading');

--- a/app.js
+++ b/app.js
@@ -5764,14 +5764,21 @@ class ProposalInfoModal {
       return;
     }
 
-    const submission = this.getVoteSubmission(proposal);
+    let submission = this.getVoteSubmission(proposal);
     if (!submission.ok) {
       showToast(submission.message, 3000, 'warning');
       this.updateVotePreview(proposal);
       return;
     }
 
-    if (!window.confirm(`Submit this vote and spend ${formatDaoLibWei(submission.spendWei)}?`)) return;
+    if (!window.confirm(`Submit this vote and spend ${EthNum.toStr(submission.spendWei)} LIB?`)) return;
+
+    submission = this.getVoteSubmission(proposal);
+    if (!submission.ok) {
+      showToast(submission.message, 3000, 'warning');
+      this.updateVotePreview(proposal);
+      return;
+    }
 
     this.setSubmitting(true);
     const loadingToastId = showToast('Submitting vote...', 0, 'loading');

--- a/app.js
+++ b/app.js
@@ -5587,6 +5587,9 @@ class ProposalInfoModal {
       }
     }
 
+    const decision = this.formatCommitteeChoice(this.committeeChoice);
+    if (!window.confirm(`Submit review decision: ${decision}?`)) return;
+
     this.setSubmitting(true);
     const loadingToastId = showToast('Submitting committee review...', 0, 'loading');
 
@@ -5767,6 +5770,8 @@ class ProposalInfoModal {
       this.updateVotePreview(proposal);
       return;
     }
+
+    if (!window.confirm(`Submit this vote and spend ${formatDaoLibWei(submission.spendWei)}?`)) return;
 
     this.setSubmitting(true);
     const loadingToastId = showToast('Submitting vote...', 0, 'loading');

--- a/app.js
+++ b/app.js
@@ -5590,6 +5590,12 @@ class ProposalInfoModal {
     const decision = this.formatCommitteeChoice(this.committeeChoice);
     if (!window.confirm(`Submit review decision: ${decision}?`)) return;
 
+    const reviewWindow = getDaoProposalReviewWindow(proposal);
+    if (!reviewWindow.canCommitteeVote) {
+      showToast(reviewWindow.label, 2500, 'warning');
+      return;
+    }
+
     this.setSubmitting(true);
     const loadingToastId = showToast('Submitting committee review...', 0, 'loading');
 


### PR DESCRIPTION
## What Changed

This PR adds native browser confirmation before DAO committee-review and vote submissions.

- `handleCommitteeSubmit` confirms the selected Accept or Withhold decision after validation.
- `handleVoteSubmit` confirms the validated LIB spend amount before submitting.
- Canceling either prompt preserves the current form state and sends no transaction.

## Fixed Flow

1. The user completes a valid committee review or vote.
2. Existing eligibility, pending-state, wallet, and input validation runs.
3. A native confirmation summarizes the consequential action.
4. Cancel returns without changing state; confirm continues through the existing pending transaction flow.

## Why

Previously, pressing Submit review or Submit vote immediately started transaction submission. The confirmation step gives users one final chance to catch an unintended decision or spend without adding a new custom modal or changing existing DAO state handling.

## Validation

- `node --check app.js`
- `node --test tests/dao-timeline.test.mjs`
- `git diff --check`

Closes #1480