### PR TITLE
Refresh DAO proposal modal when submission windows expire

### DIFF
--- a/app.js
+++ b/app.js
@@ -5774,7 +5774,7 @@ class ProposalInfoModal {
     let submission = this.getVoteSubmission(proposal);
     if (!submission.ok) {
       showToast(submission.message, 3000, 'warning');
-      this.refreshVoteValidationUi(proposal);
+      this.renderProposal(proposal);
       return;
     }
 
@@ -5783,7 +5783,7 @@ class ProposalInfoModal {
     submission = this.getVoteSubmission(proposal);
     if (!submission.ok) {
       showToast(submission.message, 3000, 'warning');
-      this.refreshVoteValidationUi(proposal);
+      this.renderProposal(proposal);
       return;
     }
 
@@ -5816,15 +5816,6 @@ class ProposalInfoModal {
       if (loadingToastId) hideToast(loadingToastId);
       this.setSubmitting(false);
     }
-  }
-
-  refreshVoteValidationUi(proposal) {
-    const votingWindow = getDaoProposalVotingWindow(proposal);
-    if (votingWindow.canPreviewVote) {
-      this.updateVotePreview(proposal);
-      return;
-    }
-    this.renderProposal(proposal);
   }
 
   close() {

--- a/app.js
+++ b/app.js
@@ -5590,6 +5590,7 @@ class ProposalInfoModal {
     const reviewWindow = getDaoProposalReviewWindow(proposal);
     if (!reviewWindow.canCommitteeVote) {
       showToast(reviewWindow.label, 2500, 'warning');
+      this.renderProposal(proposal);
       return;
     }
 
@@ -5773,7 +5774,7 @@ class ProposalInfoModal {
     let submission = this.getVoteSubmission(proposal);
     if (!submission.ok) {
       showToast(submission.message, 3000, 'warning');
-      this.updateVotePreview(proposal);
+      this.refreshVoteValidationUi(proposal);
       return;
     }
 
@@ -5782,7 +5783,7 @@ class ProposalInfoModal {
     submission = this.getVoteSubmission(proposal);
     if (!submission.ok) {
       showToast(submission.message, 3000, 'warning');
-      this.updateVotePreview(proposal);
+      this.refreshVoteValidationUi(proposal);
       return;
     }
 
@@ -5815,6 +5816,15 @@ class ProposalInfoModal {
       if (loadingToastId) hideToast(loadingToastId);
       this.setSubmitting(false);
     }
+  }
+
+  refreshVoteValidationUi(proposal) {
+    const votingWindow = getDaoProposalVotingWindow(proposal);
+    if (votingWindow.canPreviewVote) {
+      this.updateVotePreview(proposal);
+      return;
+    }
+    this.renderProposal(proposal);
   }
 
   close() {


### PR DESCRIPTION
## What Changed

This PR refreshes the open DAO proposal modal when click-time validation finds that a submission is no longer eligible.

- `handleCommitteeSubmit()` rerenders the proposal after the review window rejects submission.
- `handleVoteSubmit()` rerenders after validation fails either before or after confirmation.
- The rerender uses the loaded proposal, preserves entered vote state, and does not add a network request.

## Fixed Flow

1. A proposal detail modal remains open while its review or voting window expires.
2. The user attempts to submit the stale action.
3. Existing click-time validation blocks the transaction and shows its warning.
4. The proposal rerenders immediately, removing stale controls and exposing the appropriate current actions.

## Why

The submission guards already prevented invalid transactions, but the open modal could continue showing controls from its previous render. Reusing the existing proposal renderer synchronizes the time-based UI without requiring a proposal requery; backend validation remains authoritative.

## Validation

- `node --check app.js`
- `git diff --check origin/main -- app.js`

Closes #1482