### PR TITLE
Show emergency status on finalized proposals

### DIFF
--- a/app.js
+++ b/app.js
@@ -3990,6 +3990,10 @@ function isDaoFinalResultState(state) {
   return state === 'accepted' || state === 'rejected' || state === 'applied';
 }
 
+function isDaoFinalizedState(state) {
+  return state === 'withheld' || isDaoFinalResultState(state);
+}
+
 function getDaoFinalOutcome(proposal) {
   const state = getEffectiveDaoState(proposal);
   const label = getDaoStateLabel(state) || state || 'Unavailable';
@@ -4482,6 +4486,7 @@ class ProposalInfoModal {
     if (this.content) {
       this.content.innerHTML = [
         this.renderProposalTitle(proposal),
+        isDaoFinalizedState(state) ? this.renderProposalEmergencyStatus(proposal) : '',
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResults(resultSummary),
@@ -4536,6 +4541,17 @@ class ProposalInfoModal {
         <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
         ${descriptionHtml}
       </div>
+    `;
+  }
+
+  renderProposalEmergencyStatus(proposal) {
+    const label = proposal.emergency ? 'Emergency proposal' : 'Standard proposal';
+    const emergencyClass = proposal.emergency ? ' proposal-type-indicator--emergency' : '';
+
+    return `
+      <p class="proposal-type-indicator${emergencyClass}">
+        ${escapeHtml(label)}
+      </p>
     `;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2111,6 +2111,25 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
+#proposalInfoModal .proposal-type-indicator {
+  background: var(--input-background);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  justify-self: center;
+  line-height: 1.25;
+  margin: 0;
+  padding: 6px 12px;
+}
+
+#proposalInfoModal .proposal-type-indicator--emergency {
+  background: rgba(196, 45, 45, 0.12);
+  border-color: rgba(196, 45, 45, 0.3);
+  color: #8f1d16;
+}
+
 #confirmProposalModal .dao-confirm-section,
 #proposalInfoModal .proposal-info-section {
   display: grid;


### PR DESCRIPTION
## What Changed

This PR makes a proposal's emergency status visible at a glance in finalized proposal views.

- `isDaoFinalizedState` identifies withheld, rejected, accepted, and applied proposals as finalized for summary display.
- `renderProposalEmergencyStatus` shows **Emergency proposal** or **Standard proposal** directly above **Parameter Changes**.
- Emergency proposals receive distinct warning styling, while the existing emergency field remains in the expandable proposal details.

## Fixed Flow

1. A user opens a finalized proposal.
2. The modal checks the proposal's finalized state and existing `emergency` value.
3. The proposal classification appears above the parameter changes without requiring the details section to be expanded.
4. The user can immediately distinguish emergency and standard proposals.

## Why

Previously, finalized proposals exposed their emergency status only inside the collapsed details section. The new summary indicator reuses the proposal's existing emergency flag so the classification is visible in the primary proposal view without duplicating state.

## Validation

- `git diff --check`
- `node --check app.js`
- `node --check dao.repo.js`
- `node --test tests/dao-timeline.test.mjs`
- Manual mobile visual check at 532 × 1020

Closes #1484