### PR TITLE
Improve DAO committee review status display

### DIFF
--- a/app.js
+++ b/app.js
@@ -4450,8 +4450,7 @@ class ProposalInfoModal {
       : '';
     if (this.content) {
       this.content.innerHTML = [
-        this.renderProposalTitle(proposal),
-        this.renderProposalEmergencyStatus(proposal),
+        this.renderProposalTitle(proposal, this.renderProposalEmergencyStatus(proposal)),
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResults(resultSummary, proposal),
@@ -4503,7 +4502,7 @@ class ProposalInfoModal {
     return '';
   }
 
-  renderProposalTitle(proposal) {
+  renderProposalTitle(proposal, emergencyHtml = '') {
     const description = proposal.description || '';
     const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
     const descriptionHtml = description
@@ -4513,6 +4512,7 @@ class ProposalInfoModal {
     return `
       <div class="proposal-info-heading">
         <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
+        ${emergencyHtml}
         ${descriptionHtml}
       </div>
     `;

--- a/app.js
+++ b/app.js
@@ -4544,9 +4544,9 @@ class ProposalInfoModal {
         const isWinner = index === winnerIndex;
         const power = formatDaoVotingPower(row.total);
         const percent = formatDaoBigIntPercent(row.total, totalWeight);
-        const valueLabel = totalWeight > 0n ? `${power} / ${percent}` : power;
+        const valueLabel = totalWeight > 0n ? `${percent} (${power})` : power;
         const title = totalWeight > 0n
-          ? `${row.option}: ${power}, ${percent}`
+          ? `${row.option}: ${percent}, ${power}`
           : `${row.option}: ${power}`;
 
         return `
@@ -4623,7 +4623,7 @@ class ProposalInfoModal {
         const position = index === 0 ? 'start' : 'end';
         const isWinner = index === winnerIndex;
         const percent = this.formatCountPercent(row.total, submittedCount);
-        const valueLabel = submittedCount > 0 ? `${row.total} / ${percent}` : `${row.total} votes`;
+        const valueLabel = submittedCount > 0 ? `${percent} (${row.total} ${row.total === 1 ? 'vote' : 'votes'})` : `${row.total} votes`;
         const title = `${row.option}: ${valueLabel}`;
 
         return `
@@ -4750,7 +4750,7 @@ class ProposalInfoModal {
             ? 'end'
             : 'center';
         const style = `--result-segment-units: ${units};`;
-        const label = `${row.option}: ${power}, ${percent}`;
+        const label = `${row.option}: ${percent}, ${power}`;
         return `
           <div
             class="proposal-result-meter-label proposal-result-meter-label--${position}${paletteClass}${isWinner ? ' proposal-result-meter-label--winner' : ''}"
@@ -4759,7 +4759,7 @@ class ProposalInfoModal {
             aria-label="${escapeDaoFormAttribute(label)}"
           >
             <span>${escapeHtml(row.option)}</span>
-            <small>${escapeHtml(displayPower)} / ${escapeHtml(percent)}</small>
+            <small>${escapeHtml(percent)} (${escapeHtml(displayPower)})</small>
           </div>
         `;
       })
@@ -4839,20 +4839,20 @@ class ProposalInfoModal {
             <div
               class="proposal-result-meter-label proposal-result-meter-label--start proposal-result-meter-label--accept${acceptWinnerClass}"
               style="--result-segment-units: ${acceptUnits};"
-              title="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
-              aria-label="${escapeDaoFormAttribute(`Accept: ${acceptCount}, ${acceptPercent}`)}"
+              title="${escapeDaoFormAttribute(`Accept: ${acceptPercent} (${acceptCount} votes)`)}"
+              aria-label="${escapeDaoFormAttribute(`Accept: ${acceptPercent} (${acceptCount} votes)`)}"
             >
               <span>Accept</span>
-              <small>${escapeHtml(`${acceptCount} / ${acceptPercent}`)}</small>
+              <small>${escapeHtml(`${acceptPercent} (${acceptCount} votes)`)}</small>
             </div>
             <div
               class="proposal-result-meter-label proposal-result-meter-label--end proposal-result-meter-label--withhold${withholdWinnerClass}"
               style="--result-segment-units: ${withholdUnits};"
-              title="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
-              aria-label="${escapeDaoFormAttribute(`Withhold: ${withholdCount}, ${withholdPercent}`)}"
+              title="${escapeDaoFormAttribute(`Withhold: ${withholdPercent} (${withholdCount} votes)`)}"
+              aria-label="${escapeDaoFormAttribute(`Withhold: ${withholdPercent} (${withholdCount} votes)`)}"
             >
               <span>Withhold</span>
-              <small>${escapeHtml(`${withholdCount} / ${withholdPercent}`)}</small>
+              <small>${escapeHtml(`${withholdPercent} (${withholdCount} votes)`)}</small>
             </div>
           </div>
           <div class="proposal-result-meter-track" aria-hidden="true">

--- a/app.js
+++ b/app.js
@@ -4451,7 +4451,7 @@ class ProposalInfoModal {
     if (this.content) {
       this.content.innerHTML = [
         this.renderProposalTitle(proposal),
-        isDaoFinalizedState(state) ? this.renderProposalEmergencyStatus(proposal) : '',
+        this.renderProposalEmergencyStatus(proposal),
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResults(resultSummary, proposal),
@@ -4949,7 +4949,7 @@ class ProposalInfoModal {
   getProposalDetailsSummary(state, rewardSummary) {
     const parts = ['Overview', 'review timeline'];
     if (state === 'review') parts.push('committee review');
-    if (state !== 'review') parts.push('proposal body');
+    if (state !== 'review') parts.push('proposal options');
     if (state === 'voting') parts.push('voting totals');
     if (rewardSummary) parts.push('reward accounting');
     return parts.join(', ');
@@ -5004,12 +5004,21 @@ class ProposalInfoModal {
   }
 
   renderProposalBody(proposal) {
-    const options = proposal.options.map((option, index) => `${index + 1}. ${option}`).join('\n');
+    const optionCards = (Array.isArray(proposal.options) ? proposal.options : [])
+      .map((option, index) => `
+        <div class="proposal-option-card">
+          <span class="proposal-option-card-number">${index + 1}</span>
+          <span class="proposal-option-card-label">${escapeHtml(option)}</span>
+        </div>
+      `)
+      .join('');
 
-    return this.renderSection('Proposal Body', [
-      ['Emergency', proposal.emergency ? 'Yes' : 'No'],
-      ['Options', options],
-    ]);
+    return `
+      <section class="proposal-info-section">
+        <h3>Proposal Options</h3>
+        <div class="proposal-option-cards">${optionCards}</div>
+      </section>
+    `;
   }
 
   renderParameterChanges(proposal) {

--- a/app.js
+++ b/app.js
@@ -4001,24 +4001,48 @@ function getDaoFinalOutcome(proposal) {
   return { label, tone };
 }
 
+function getDaoCommitteeReview(proposal) {
+  const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
+  const committeeAddresses = Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : [];
+  const committeeAddressSet = new Set(committeeAddresses);
+  const votes = [];
+  let acceptCount = 0;
+  let withholdCount = 0;
+
+  for (const vote of committeeVotes) {
+    if (!vote || !committeeAddressSet.has(vote.memberAddress)) continue;
+    assert(vote.vote === 'accept' || vote.vote === 'withhold', `Unknown committee vote: ${vote.vote}`);
+    votes.push(vote);
+    if (vote.vote === 'accept') {
+      acceptCount += 1;
+    } else {
+      withholdCount += 1;
+    }
+  }
+
+  return {
+    acceptCount,
+    committeeAddresses,
+    committeeAddressSet,
+    votes,
+    withholdCount,
+  };
+}
+
 function getDaoCommitteeReviewResultSummary(proposal) {
   const state = getEffectiveDaoState(proposal);
   if (state !== 'withheld' && !(proposal?.emergency && isDaoFinalResultState(state))) return null;
 
-  const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
-  const committeeAddresses = Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : [];
-  const committeeAddressSet = new Set(committeeAddresses);
-  const acceptCount = committeeVotes.filter((vote) => vote?.vote === 'accept' && committeeAddressSet.has(vote.memberAddress)).length;
-  const withholdCount = committeeVotes.filter((vote) => vote?.vote === 'withhold' && committeeAddressSet.has(vote.memberAddress)).length;
+  const committeeReview = getDaoCommitteeReview(proposal);
   const outcome = getDaoFinalOutcome(proposal);
 
   return {
-    acceptCount,
-    committeeSize: committeeAddresses.length,
+    acceptCount: committeeReview.acceptCount,
+    committeeSize: committeeReview.committeeAddresses.length,
     headline: outcome.label,
     source: 'committee',
     tone: outcome.tone,
-    withholdCount,
+    withholdCount: committeeReview.withholdCount,
   };
 }
 
@@ -4426,13 +4450,10 @@ class ProposalInfoModal {
     const state = getEffectiveDaoState(proposal);
     this.setTitle(getDaoStateLabel(state) || state || 'Proposal');
     const reviewWindow = getDaoProposalReviewWindow(proposal);
-    const committeeVotes = Array.isArray(proposal.committeeVotes) ? proposal.committeeVotes : [];
-    const committeeAddresses = Array.isArray(proposal.committeeAddresses) ? proposal.committeeAddresses : [];
-    const committeeAddressSet = new Set(committeeAddresses);
-    const acceptCount = committeeVotes.filter((vote) => vote?.vote === 'accept' && committeeAddressSet.has(vote.memberAddress)).length;
-    const withholdCount = committeeVotes.filter((vote) => vote?.vote === 'withhold' && committeeAddressSet.has(vote.memberAddress)).length;
+    const committeeReview = getDaoCommitteeReview(proposal);
+    const { acceptCount, committeeAddresses, committeeAddressSet, votes, withholdCount } = committeeReview;
     const currentAddress = getDaoCurrentAccountAddress();
-    const currentVote = committeeVotes.find((vote) => vote?.memberAddress === currentAddress) || null;
+    const currentVote = votes.find((vote) => vote.memberAddress === currentAddress) || null;
     const capabilities = this.getReviewCapabilities({
       state,
       reviewWindow,
@@ -4450,20 +4471,13 @@ class ProposalInfoModal {
       : '';
     if (this.content) {
       this.content.innerHTML = [
-        this.renderProposalTitle(proposal, this.renderProposalEmergencyStatus(proposal)),
+        this.renderProposalTitle(proposal),
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
-        this.renderProposalResults(resultSummary, proposal),
+        this.renderProposalResults(resultSummary, committeeReview, currentAddress),
         state === 'review' ? this.renderProposalBody(proposal) : '',
         state === 'review'
-          ? this.renderCommitteeReviewStatus({
-            acceptCount,
-            withholdCount,
-            reviewWindow,
-            committeeVotes,
-            committeeAddressSet,
-            currentAddress,
-          })
+          ? this.renderCommitteeReviewStatus(committeeReview, reviewWindow, currentAddress)
           : '',
       ].filter(Boolean).join('');
     }
@@ -4496,15 +4510,11 @@ class ProposalInfoModal {
     return { isCommitteeMember, canCommitteeVote, canFinalizeReviewResult };
   }
 
-  getCommitteeVoteTone(vote) {
-    if (vote?.vote === 'accept') return 'accept';
-    if (vote?.vote === 'withhold') return 'withhold';
-    return '';
-  }
-
-  renderProposalTitle(proposal, emergencyHtml = '') {
+  renderProposalTitle(proposal) {
     const description = proposal.description || '';
     const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
+    const emergencyLabel = proposal.emergency ? 'Emergency proposal' : 'Standard proposal';
+    const emergencyClass = proposal.emergency ? ' proposal-type-indicator--emergency' : '';
     const descriptionHtml = description
       ? `<p class="proposal-info-description">${escapeHtml(description)}</p>`
       : '';
@@ -4512,84 +4522,48 @@ class ProposalInfoModal {
     return `
       <div class="proposal-info-heading">
         <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
-        ${emergencyHtml}
+        <p class="proposal-type-indicator${emergencyClass}">${escapeHtml(emergencyLabel)}</p>
         ${descriptionHtml}
       </div>
     `;
   }
 
-  renderProposalEmergencyStatus(proposal) {
-    const label = proposal.emergency ? 'Emergency proposal' : 'Standard proposal';
-    const emergencyClass = proposal.emergency ? ' proposal-type-indicator--emergency' : '';
-
-    return `
-      <p class="proposal-type-indicator${emergencyClass}">
-        ${escapeHtml(label)}
-      </p>
-    `;
-  }
-
   renderCurrentVoteTotals(proposal) {
     const votingWindow = getDaoProposalVotingWindow(proposal);
-    const rows = this.getCurrentVoteTotalRows(proposal);
-    if (rows.length === 0) return '';
+    const totals = this.getCurrentVoteTotalRows(proposal);
+    if (totals.length === 0) return '';
 
-    const totalWeight = rows.reduce((sum, row) => sum + row.total, 0n);
+    const totalWeight = totals.reduce((sum, row) => sum + row.total, 0n);
     const winnerIndex = totalWeight > 0n
-      ? rows.reduce((winner, row, index) => (row.total > rows[winner].total ? index : winner), 0)
+      ? totals.reduce((winner, row, index) => (row.total > totals[winner].total ? index : winner), 0)
       : -1;
-    const labels = rows
-      .map((row, index) => {
-        const position = index === 0 ? 'start' : index === rows.length - 1 ? 'end' : 'center';
-        const isWinner = index === winnerIndex;
-        const power = formatDaoVotingPower(row.total);
-        const percent = formatDaoBigIntPercent(row.total, totalWeight);
-        const valueLabel = totalWeight > 0n ? `${percent} (${power})` : power;
-        const title = totalWeight > 0n
-          ? `${row.option}: ${percent}, ${power}`
-          : `${row.option}: ${power}`;
+    const rows = totals.map((row, index) => {
+      const power = formatDaoVotingPower(row.total);
+      const percent = formatDaoBigIntPercent(row.total, totalWeight);
+      const valueLabel = totalWeight > 0n ? `${percent} (${power})` : power;
+      const title = totalWeight > 0n
+        ? `${row.option}: ${percent}, ${power}`
+        : `${row.option}: ${power}`;
 
-        return `
-          <div
-            class="proposal-vote-current-label proposal-vote-current-label--${position}${isWinner ? ' proposal-vote-current-label--winner' : ''}"
-            title="${escapeDaoFormAttribute(title)}"
-            aria-label="${escapeDaoFormAttribute(title)}"
-          >
-            <span>${escapeHtml(row.option)}</span>
-            <small>${escapeHtml(valueLabel)}</small>
-          </div>
-        `;
-      })
-      .join('');
+      return {
+        isEmpty: row.total === 0n,
+        isWinner: index === winnerIndex,
+        label: row.option,
+        title,
+        tone: '',
+        units: this.getCurrentVoteSegmentUnits(row.total, totalWeight),
+        valueLabel,
+      };
+    });
 
-    const segments = rows
-      .map((row, index) => {
-        const isWinner = index === winnerIndex;
-        const units = this.getCurrentVoteSegmentUnits(row.total, totalWeight);
-        return `
-          <span
-            class="proposal-vote-current-segment${isWinner ? ' proposal-vote-current-segment--winner' : ''}${row.total === 0n ? ' proposal-vote-current-segment--empty' : ''}"
-            style="--vote-total-segment-units: ${units};"
-          ></span>
-        `;
-      })
-      .join('');
-
-    return `
-      <section class="proposal-info-section proposal-vote-current-section">
-        <h3>Current Vote</h3>
-        <div class="proposal-vote-current-meter" aria-label="Current vote totals">
-          <div class="proposal-vote-current-labels">${labels}</div>
-          <div class="proposal-vote-current-track" aria-hidden="true">${segments}</div>
-        </div>
-        <div class="proposal-vote-status-grid proposal-vote-status-grid--current">
-          <div class="proposal-vote-status-card proposal-vote-status-card--deadline">
-            <span>Voting ends</span>
-            <strong>${escapeHtml(formatDaoDetailTimestamp(votingWindow.end))}</strong>
-          </div>
-        </div>
-      </section>
-    `;
+    return this.renderCurrentTallySection({
+      ariaLabel: 'Current vote totals',
+      deadline: votingWindow.end,
+      deadlineLabel: 'Voting ends',
+      footerHtml: '',
+      heading: 'Current Vote',
+      rows,
+    });
   }
 
   getCurrentVoteTotalRows(proposal) {
@@ -4608,76 +4582,108 @@ class ProposalInfoModal {
     return Math.max(1, units);
   }
 
-  renderCommitteeReviewStatus({ acceptCount, withholdCount, reviewWindow, committeeVotes, committeeAddressSet, currentAddress }) {
-    const submittedCount = acceptCount + withholdCount;
-    const rows = [
-      { option: 'Accept', total: acceptCount, tone: 'accept' },
-      { option: 'Withhold', total: withholdCount, tone: 'withhold' },
-    ];
-    let winnerIndex = -1;
-    if (submittedCount > 0 && acceptCount !== withholdCount) {
-      winnerIndex = acceptCount > withholdCount ? 0 : 1;
-    }
+  renderCurrentTallySection({ ariaLabel, deadline, deadlineLabel, footerHtml, heading, rows }) {
     const labels = rows
       .map((row, index) => {
-        const position = index === 0 ? 'start' : 'end';
-        const isWinner = index === winnerIndex;
-        const percent = this.formatCountPercent(row.total, submittedCount);
-        const valueLabel = submittedCount > 0 ? `${percent} (${row.total} ${row.total === 1 ? 'vote' : 'votes'})` : `${row.total} votes`;
-        const title = `${row.option}: ${valueLabel}`;
+        const position = index === 0 ? 'start' : index === rows.length - 1 ? 'end' : 'center';
+        const toneClass = row.tone ? ` proposal-vote-current-label--${row.tone}` : '';
+        const winnerClass = row.isWinner ? ' proposal-vote-current-label--winner' : '';
 
         return `
           <div
-            class="proposal-vote-current-label proposal-vote-current-label--${position} proposal-vote-current-label--${row.tone}${isWinner ? ' proposal-vote-current-label--winner' : ''}"
-            title="${escapeDaoFormAttribute(title)}"
-            aria-label="${escapeDaoFormAttribute(title)}"
+            class="proposal-vote-current-label proposal-vote-current-label--${position}${toneClass}${winnerClass}"
+            title="${escapeDaoFormAttribute(row.title)}"
+            aria-label="${escapeDaoFormAttribute(row.title)}"
           >
-            <span>${escapeHtml(row.option)}</span>
-            <small>${escapeHtml(valueLabel)}</small>
+            <span>${escapeHtml(row.label)}</span>
+            <small>${escapeHtml(row.valueLabel)}</small>
           </div>
         `;
       })
       .join('');
-
     const segments = rows
       .map((row) => {
-        const units = this.getCountResultSegmentUnits(row.total, submittedCount);
+        const toneClass = row.tone ? ` proposal-vote-current-segment--${row.tone}` : '';
+        const winnerClass = row.isWinner ? ' proposal-vote-current-segment--winner' : '';
+        const emptyClass = row.isEmpty ? ' proposal-vote-current-segment--empty' : '';
+
         return `
           <span
-            class="proposal-vote-current-segment proposal-vote-current-segment--${row.tone}${row.total === 0 ? ' proposal-vote-current-segment--empty' : ''}"
-            style="--vote-total-segment-units: ${units};"
+            class="proposal-vote-current-segment${toneClass}${winnerClass}${emptyClass}"
+            style="--vote-total-segment-units: ${row.units};"
           ></span>
         `;
       })
       .join('');
 
-    const votesHtml = this.renderCommitteeVoteList(
-      committeeVotes,
-      committeeAddressSet,
-      currentAddress,
-    );
-
     return `
       <section class="proposal-info-section proposal-vote-current-section">
-        <h3>Committee Review</h3>
-        <div class="proposal-vote-current-meter" aria-label="Committee review vote totals">
+        <h3>${escapeHtml(heading)}</h3>
+        <div class="proposal-vote-current-meter" aria-label="${escapeDaoFormAttribute(ariaLabel)}">
           <div class="proposal-vote-current-labels">${labels}</div>
           <div class="proposal-vote-current-track" aria-hidden="true">${segments}</div>
         </div>
         <div class="proposal-vote-status-grid proposal-vote-status-grid--current">
           <div class="proposal-vote-status-card proposal-vote-status-card--deadline">
-            <span>Review ends</span>
-            <strong>${escapeHtml(formatDaoDetailTimestamp(reviewWindow.end))}</strong>
+            <span>${escapeHtml(deadlineLabel)}</span>
+            <strong>${escapeHtml(formatDaoDetailTimestamp(deadline))}</strong>
           </div>
         </div>
-        ${votesHtml}
+        ${footerHtml}
       </section>
     `;
   }
 
-  renderCommitteeVoteList(committeeVotes, committeeAddressSet, currentAddress) {
-    const votes = committeeVotes
-      .filter((vote) => vote && committeeAddressSet.has(vote.memberAddress));
+  renderCommitteeReviewStatus(committeeReview, reviewWindow, currentAddress) {
+    const { acceptCount, withholdCount } = committeeReview;
+    const submittedCount = acceptCount + withholdCount;
+    let winnerTone = '';
+    if (submittedCount > 0 && acceptCount !== withholdCount) {
+      winnerTone = acceptCount > withholdCount ? 'accept' : 'withhold';
+    }
+    const rows = this.getCommitteeTallyRows(acceptCount, withholdCount)
+      .map((row) => {
+        const valueLabel = submittedCount > 0 ? row.shareLabel : row.countLabel;
+        return {
+          isEmpty: row.count === 0,
+          isWinner: row.tone === winnerTone,
+          label: row.label,
+          title: `${row.label}: ${valueLabel}`,
+          tone: row.tone,
+          units: row.units,
+          valueLabel,
+        };
+      });
+
+    return this.renderCurrentTallySection({
+      ariaLabel: 'Committee review vote totals',
+      deadline: reviewWindow.end,
+      deadlineLabel: 'Review ends',
+      footerHtml: this.renderCommitteeVoteList(committeeReview, currentAddress),
+      heading: 'Committee Review',
+      rows,
+    });
+  }
+
+  getCommitteeTallyRows(acceptCount, withholdCount) {
+    const submittedCount = acceptCount + withholdCount;
+    return [
+      { count: acceptCount, label: 'Accept', tone: 'accept' },
+      { count: withholdCount, label: 'Withhold', tone: 'withhold' },
+    ].map((row) => {
+      const countLabel = `${row.count} ${row.count === 1 ? 'vote' : 'votes'}`;
+      const percent = this.formatCountPercent(row.count, submittedCount);
+      return {
+        ...row,
+        countLabel,
+        shareLabel: `${percent} (${countLabel})`,
+        units: this.getCountSegmentUnits(row.count, submittedCount),
+      };
+    });
+  }
+
+  renderCommitteeVoteList(committeeReview, currentAddress) {
+    const { votes } = committeeReview;
     if (votes.length === 0) return '';
 
     const { usernames, netidAccounts } = signInModal.getSignInUsernames();
@@ -4703,7 +4709,6 @@ class ProposalInfoModal {
           username: contact?.username || storedUsernamesByAddress.get(address) || 'Unknown',
           address,
         };
-        const tone = this.getCommitteeVoteTone(vote);
         const youLabel = address === normalizedCurrentAddress ? ' (you)' : '';
         return `
           <li class="proposal-committee-vote-row">
@@ -4711,7 +4716,7 @@ class ProposalInfoModal {
               <strong>${escapeHtml(`${getContactDisplayName(displayContact)}${youLabel}`)}</strong>
               <small>${escapeHtml(`${address.slice(0, 4)}…${address.slice(-4)}`)}</small>
             </span>
-            <span class="proposal-committee-vote-choice${tone ? ` proposal-committee-vote-choice--${tone}` : ''}">${escapeHtml(this.formatCommitteeVote(vote))}</span>
+            <span class="proposal-committee-vote-choice proposal-committee-vote-choice--${vote.vote}">${escapeHtml(this.formatCommitteeVote(vote))}</span>
           </li>
         `;
       })
@@ -4725,10 +4730,10 @@ class ProposalInfoModal {
     `;
   }
 
-  renderProposalResults(result, proposal) {
+  renderProposalResults(result, committeeReview, currentAddress) {
     if (!result) return '';
     if (result.source === 'committee') {
-      return this.renderCommitteeResults(result, proposal);
+      return this.renderCommitteeResults(result, committeeReview, currentAddress);
     }
 
     const winnerLabel = result.winner ? `${result.winner.option} (${result.outcome})` : 'Unavailable';
@@ -4801,25 +4806,43 @@ class ProposalInfoModal {
     `;
   }
 
-  renderCommitteeResults(result, proposal) {
+  renderCommitteeResults(result, committeeReview, currentAddress) {
     const acceptCount = Number(result.acceptCount || 0);
     const withholdCount = Number(result.withholdCount || 0);
-    const submittedCount = acceptCount + withholdCount;
     const committeeSize = Number(result.committeeSize || 0);
     const committeeSizeLabel = committeeSize > 0 ? String(committeeSize) : 'Unavailable';
-    const acceptPercent = this.formatCountPercent(acceptCount, submittedCount);
-    const withholdPercent = this.formatCountPercent(withholdCount, submittedCount);
-    const acceptUnits = this.getCountResultSegmentUnits(acceptCount, submittedCount);
-    const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
-    const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
-    const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
-    const committeeVotes = Array.isArray(proposal.committeeVotes) ? proposal.committeeVotes : [];
-    const committeeAddressSet = new Set(Array.isArray(proposal.committeeAddresses) ? proposal.committeeAddresses : []);
-    const votesHtml = this.renderCommitteeVoteList(
-      committeeVotes,
-      committeeAddressSet,
-      getDaoCurrentAccountAddress(),
-    );
+    let winnerTone = '';
+    if (result.tone === 'accepted') {
+      winnerTone = 'accept';
+    } else if (result.tone === 'rejected') {
+      winnerTone = 'withhold';
+    }
+    const rows = this.getCommitteeTallyRows(acceptCount, withholdCount);
+    const labels = rows
+      .map((row, index) => {
+        const position = index === 0 ? 'start' : 'end';
+        const winnerClass = row.tone === winnerTone ? ' proposal-result-meter-label--winner' : '';
+        return `
+          <div
+            class="proposal-result-meter-label proposal-result-meter-label--${position} proposal-result-meter-label--${row.tone}${winnerClass}"
+            style="--result-segment-units: ${row.units};"
+            title="${escapeDaoFormAttribute(`${row.label}: ${row.shareLabel}`)}"
+            aria-label="${escapeDaoFormAttribute(`${row.label}: ${row.shareLabel}`)}"
+          >
+            <span>${escapeHtml(row.label)}</span>
+            <small>${escapeHtml(row.shareLabel)}</small>
+          </div>
+        `;
+      })
+      .join('');
+    const segments = rows
+      .map((row) => `
+        <span
+          class="proposal-result-meter-segment proposal-result-meter-segment--${row.tone}${row.count === 0 ? ' proposal-result-meter-segment--empty' : ''}"
+          style="--result-segment-units: ${row.units};"
+        ></span>
+      `)
+      .join('');
 
     return `
       <section class="proposal-info-section">
@@ -4835,38 +4858,10 @@ class ProposalInfoModal {
           </div>
         </div>
         <div class="proposal-result-meter" aria-label="Committee result breakdown">
-          <div class="proposal-result-meter-labels proposal-result-meter-labels--balanced">
-            <div
-              class="proposal-result-meter-label proposal-result-meter-label--start proposal-result-meter-label--accept${acceptWinnerClass}"
-              style="--result-segment-units: ${acceptUnits};"
-              title="${escapeDaoFormAttribute(`Accept: ${acceptPercent} (${acceptCount} votes)`)}"
-              aria-label="${escapeDaoFormAttribute(`Accept: ${acceptPercent} (${acceptCount} votes)`)}"
-            >
-              <span>Accept</span>
-              <small>${escapeHtml(`${acceptPercent} (${acceptCount} votes)`)}</small>
-            </div>
-            <div
-              class="proposal-result-meter-label proposal-result-meter-label--end proposal-result-meter-label--withhold${withholdWinnerClass}"
-              style="--result-segment-units: ${withholdUnits};"
-              title="${escapeDaoFormAttribute(`Withhold: ${withholdPercent} (${withholdCount} votes)`)}"
-              aria-label="${escapeDaoFormAttribute(`Withhold: ${withholdPercent} (${withholdCount} votes)`)}"
-            >
-              <span>Withhold</span>
-              <small>${escapeHtml(`${withholdPercent} (${withholdCount} votes)`)}</small>
-            </div>
-          </div>
-          <div class="proposal-result-meter-track" aria-hidden="true">
-            <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--accept${acceptCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
-              style="--result-segment-units: ${acceptUnits};"
-            ></span>
-            <span
-              class="proposal-result-meter-segment proposal-result-meter-segment--withhold${withholdCount === 0 ? ' proposal-result-meter-segment--empty' : ''}"
-              style="--result-segment-units: ${withholdUnits};"
-            ></span>
-          </div>
+          <div class="proposal-result-meter-labels proposal-result-meter-labels--balanced">${labels}</div>
+          <div class="proposal-result-meter-track" aria-hidden="true">${segments}</div>
         </div>
-        ${votesHtml}
+        ${this.renderCommitteeVoteList(committeeReview, currentAddress)}
       </section>
     `;
   }
@@ -4877,7 +4872,7 @@ class ProposalInfoModal {
     return Math.max(1, units);
   }
 
-  getCountResultSegmentUnits(part, total) {
+  getCountSegmentUnits(part, total) {
     if (!Number.isFinite(part) || !Number.isFinite(total) || total <= 0) return 1;
     if (part <= 0) return 0;
     return Math.max(1, Math.round((part / total) * 1000));
@@ -4963,9 +4958,8 @@ class ProposalInfoModal {
     const rowHtml = rows
       .map(([label, value, tone]) => {
         const displayValue = formatDaoDetailValue(value);
-        const rowClass = this.getSectionRowClass(label, displayValue);
         const classes = [
-          rowClass,
+          'proposal-info-row',
           tone ? `proposal-info-row--${tone}` : '',
         ].filter(Boolean);
 
@@ -4986,25 +4980,8 @@ class ProposalInfoModal {
     `;
   }
 
-  getSectionRowClass(label, value) {
-    if (label === 'Description') {
-      return 'proposal-info-row proposal-info-row--full';
-    }
-    if (label !== 'Options') {
-      return 'proposal-info-row';
-    }
-
-    const lines = String(value).split('\n');
-    const longestLineLength = Math.max(...lines.map((line) => line.length));
-    if (lines.length > 4 || longestLineLength > 42 || String(value).length > 120) {
-      return 'proposal-info-row proposal-info-row--full';
-    }
-
-    return 'proposal-info-row';
-  }
-
   renderProposalBody(proposal) {
-    const optionCards = (Array.isArray(proposal.options) ? proposal.options : [])
+    const optionCards = getDaoProposalOptions(proposal)
       .map((option, index) => `
         <div class="proposal-option-card">
           <span class="proposal-option-card-number">${index + 1}</span>
@@ -5093,7 +5070,7 @@ class ProposalInfoModal {
   }
 
   formatCommitteeVote(vote) {
-    if (vote.vote !== 'withhold') return 'Accept';
+    if (vote.vote === 'accept') return 'Accept';
     const reason = String(vote.withheldReason || '').trim();
     if (!reason) return 'Withhold';
     return `Withhold - ${reason}`;

--- a/app.js
+++ b/app.js
@@ -4011,7 +4011,10 @@ function getDaoCommitteeReview(proposal) {
 
   for (const vote of committeeVotes) {
     if (!vote || !committeeAddressSet.has(vote.memberAddress)) continue;
-    assert(vote.vote === 'accept' || vote.vote === 'withhold', `Unknown committee vote: ${vote.vote}`);
+    if (vote.vote !== 'accept' && vote.vote !== 'withhold') {
+      console.warn('Skipping unknown committee vote:', vote.vote);
+      continue;
+    }
     votes.push(vote);
     if (vote.vote === 'accept') {
       acceptCount += 1;
@@ -4637,16 +4640,12 @@ class ProposalInfoModal {
   renderCommitteeReviewStatus(committeeReview, reviewWindow, currentAddress) {
     const { acceptCount, withholdCount } = committeeReview;
     const submittedCount = acceptCount + withholdCount;
-    let winnerTone = '';
-    if (submittedCount > 0 && acceptCount !== withholdCount) {
-      winnerTone = acceptCount > withholdCount ? 'accept' : 'withhold';
-    }
     const rows = this.getCommitteeTallyRows(acceptCount, withholdCount)
       .map((row) => {
         const valueLabel = submittedCount > 0 ? row.shareLabel : row.countLabel;
         return {
           isEmpty: row.count === 0,
-          isWinner: row.tone === winnerTone,
+          isWinner: false,
           label: row.label,
           title: `${row.label}: ${valueLabel}`,
           tone: row.tone,

--- a/app.js
+++ b/app.js
@@ -4475,14 +4475,6 @@ class ProposalInfoModal {
         ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
       ])
       : '';
-    const committeeReviewReasons = state === 'review'
-      ? this.renderCommitteeWithholdReasons(
-        getDaoCommitteeWithholdReasonEntries(proposal)
-          .filter((entry) => entry.memberAddress !== currentAddress),
-        'Other committee withhold reasons',
-      )
-      : '';
-
     if (this.content) {
       this.content.innerHTML = [
         this.renderProposalTitle(proposal),
@@ -4491,8 +4483,18 @@ class ProposalInfoModal {
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResults(resultSummary),
         state === 'review' ? this.renderProposalBody(proposal) : '',
-        committeeReviewSection,
-        committeeReviewReasons,
+        state === 'review'
+          ? this.renderCommitteeReviewStatus({
+            acceptCount,
+            withholdCount,
+            reviewWindow,
+            committeeVotes,
+            committeeAddressSet,
+            currentAddress,
+            currentVote,
+            capabilities,
+          })
+          : '',
       ].filter(Boolean).join('');
     }
     if (this.detailsContent) {
@@ -4501,6 +4503,7 @@ class ProposalInfoModal {
         state,
         reviewWindow,
         rewardSummary,
+        committeeReviewSection,
       });
     }
 
@@ -4632,6 +4635,101 @@ class ProposalInfoModal {
     if (part <= 0n) return 0;
     const units = Number((part * 1000n) / total);
     return Math.max(1, units);
+  }
+
+  renderCommitteeReviewStatus({ acceptCount, withholdCount, reviewWindow, committeeVotes, committeeAddressSet, currentAddress, currentVote, capabilities }) {
+    const submittedCount = acceptCount + withholdCount;
+    const rows = [
+      { option: 'Accept', total: acceptCount, tone: 'accept' },
+      { option: 'Withhold', total: withholdCount, tone: 'withhold' },
+    ];
+    const topCount = Math.max(...rows.map((row) => row.total));
+    const topRows = rows.filter((row) => row.total === topCount);
+    const winnerIndex = submittedCount > 0 && topRows.length === 1 ? rows.indexOf(topRows[0]) : -1;
+    const labels = rows
+      .map((row, index) => {
+        const position = index === 0 ? 'start' : 'end';
+        const isWinner = index === winnerIndex;
+        const percent = this.formatCountPercent(row.total, submittedCount);
+        const valueLabel = submittedCount > 0 ? `${row.total} / ${percent}` : `${row.total} votes`;
+        const title = `${row.option}: ${valueLabel}`;
+
+        return `
+          <div
+            class="proposal-vote-current-label proposal-vote-current-label--${position} proposal-vote-current-label--${row.tone}${isWinner ? ' proposal-vote-current-label--winner' : ''}"
+            title="${escapeDaoFormAttribute(title)}"
+            aria-label="${escapeDaoFormAttribute(title)}"
+          >
+            <span>${escapeHtml(row.option)}</span>
+            <small>${escapeHtml(valueLabel)}</small>
+          </div>
+        `;
+      })
+      .join('');
+
+    const segments = rows
+      .map((row) => {
+        const units = this.getCountResultSegmentUnits(row.total, submittedCount);
+        return `
+          <span
+            class="proposal-vote-current-segment proposal-vote-current-segment--${row.tone}${row.total === 0 ? ' proposal-vote-current-segment--empty' : ''}"
+            style="--vote-total-segment-units: ${units};"
+          ></span>
+        `;
+      })
+      .join('');
+
+    const yourVoteLabel = currentVote
+      ? this.formatCommitteeVote(currentVote)
+      : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member';
+    const yourVoteTone = this.getCommitteeVoteTone(currentVote);
+    const otherVoteRows = committeeVotes
+      .filter((vote) => vote && committeeAddressSet.has(vote.memberAddress) && vote.memberAddress !== currentAddress)
+      .map((vote) => {
+        const tone = this.getCommitteeVoteTone(vote);
+        return `
+          <li class="proposal-committee-vote-row">
+            <span class="proposal-committee-vote-address">${escapeHtml(this.formatCommitteeAddress(vote.memberAddress))}</span>
+            <span class="proposal-committee-vote-choice${tone ? ` proposal-committee-vote-choice--${tone}` : ''}">${escapeHtml(this.formatCommitteeVote(vote))}</span>
+          </li>
+        `;
+      })
+      .join('');
+    const otherVotesHtml = otherVoteRows
+      ? `
+        <div class="proposal-committee-votes">
+          <h4>Other committee votes</h4>
+          <ul class="proposal-committee-vote-list">${otherVoteRows}</ul>
+        </div>
+      `
+      : '';
+
+    return `
+      <section class="proposal-info-section proposal-vote-current-section">
+        <h3>Committee Review</h3>
+        <div class="proposal-vote-current-meter" aria-label="Committee review vote totals">
+          <div class="proposal-vote-current-labels">${labels}</div>
+          <div class="proposal-vote-current-track" aria-hidden="true">${segments}</div>
+        </div>
+        <div class="proposal-vote-status-grid proposal-vote-status-grid--current">
+          <div class="proposal-vote-status-card">
+            <span>Your vote</span>
+            <strong${yourVoteTone ? ` class="proposal-committee-vote-choice--${yourVoteTone}"` : ''}>${escapeHtml(yourVoteLabel)}</strong>
+          </div>
+          <div class="proposal-vote-status-card proposal-vote-status-card--deadline">
+            <span>Review ends</span>
+            <strong>${escapeHtml(formatDaoDetailTimestamp(reviewWindow.end))}</strong>
+          </div>
+        </div>
+        ${otherVotesHtml}
+      </section>
+    `;
+  }
+
+  formatCommitteeAddress(address) {
+    const value = String(address || '');
+    if (value.length <= 16) return value;
+    return `${value.slice(0, 8)}...${value.slice(-6)}`;
   }
 
   renderProposalResults(result) {
@@ -4847,7 +4945,7 @@ class ProposalInfoModal {
     ]);
   }
 
-  renderProposalDetails({ proposal, state, reviewWindow, rewardSummary }) {
+  renderProposalDetails({ proposal, state, reviewWindow, rewardSummary, committeeReviewSection }) {
     const sections = [
       this.renderSection('Overview', [
         ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
@@ -4861,6 +4959,7 @@ class ProposalInfoModal {
         ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
         ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
       ]),
+      committeeReviewSection || '',
       state === 'voting' ? this.renderVotingDetails(proposal) : '',
       state === 'review' ? '' : this.renderProposalBody(proposal),
       this.renderProposalRewards(rewardSummary),
@@ -4879,6 +4978,7 @@ class ProposalInfoModal {
 
   getProposalDetailsSummary(state, rewardSummary) {
     const parts = ['Overview', 'review timeline'];
+    if (state === 'review') parts.push('committee review');
     if (state !== 'review') parts.push('proposal body');
     if (state === 'voting') parts.push('voting totals');
     if (rewardSummary) parts.push('reward accounting');

--- a/app.js
+++ b/app.js
@@ -4678,21 +4678,68 @@ class ProposalInfoModal {
     `;
   }
 
-  formatCommitteeAddress(address) {
+  getCommitteeMemberDisplayInfo(address, storedUsernamesByAddress) {
     const value = String(address || '');
-    if (value.length <= 16) return value;
-    return `${value.slice(0, 8)}...${value.slice(-6)}`;
+    let normalizedAddress = value;
+    try {
+      normalizedAddress = normalizeAddress(value);
+    } catch {
+      // Keep the original value as a safe display fallback for malformed data.
+    }
+
+    const currentAccountAddress = myAccount?.keys?.address
+      ? normalizeAddress(myAccount.keys.address)
+      : '';
+    const contact = normalizedAddress === currentAccountAddress
+      ? myAccount
+      : myData?.contacts?.[normalizedAddress] || myData?.contacts?.[value];
+    const storedUsername = storedUsernamesByAddress.get(normalizedAddress) || '';
+    const displayContact = {
+      ...contact,
+      username: contact?.username || storedUsername,
+      address: normalizedAddress,
+    };
+    const name = (displayContact.name || displayContact.username)
+      ? getContactDisplayName(displayContact)
+      : 'Unknown';
+    const shortAddress = normalizedAddress.length > 8
+      ? `${normalizedAddress.slice(0, 4)}…${normalizedAddress.slice(-4)}`
+      : normalizedAddress;
+
+    return { name, shortAddress };
+  }
+
+  getStoredUsernamesByAddress() {
+    const { usernames, netidAccounts } = signInModal.getSignInUsernames();
+    const storedUsernamesByAddress = new Map();
+
+    usernames.forEach((username) => {
+      const address = netidAccounts.usernames[username]?.address;
+      try {
+        storedUsernamesByAddress.set(normalizeAddress(address), username);
+      } catch {
+        // Ignore malformed local account records.
+      }
+    });
+
+    return storedUsernamesByAddress;
   }
 
   renderCommitteeVoteListEntries(committeeVotes, committeeAddressSet, currentAddress) {
+    const storedUsernamesByAddress = this.getStoredUsernamesByAddress();
+
     return committeeVotes
       .filter((vote) => vote && committeeAddressSet.has(vote.memberAddress))
       .map((vote) => {
         const tone = this.getCommitteeVoteTone(vote);
         const youLabel = vote.memberAddress === currentAddress ? ' (you)' : '';
+        const member = this.getCommitteeMemberDisplayInfo(vote.memberAddress, storedUsernamesByAddress);
         return `
           <li class="proposal-committee-vote-row">
-            <span class="proposal-committee-vote-address">${escapeHtml(`${this.formatCommitteeAddress(vote.memberAddress)}${youLabel}`)}</span>
+            <span class="proposal-committee-vote-address">
+              <span class="proposal-committee-vote-name">${escapeHtml(`${member.name}${youLabel}`)}</span>
+              <span class="proposal-committee-vote-short-address">${escapeHtml(member.shortAddress)}</span>
+            </span>
             <span class="proposal-committee-vote-choice${tone ? ` proposal-committee-vote-choice--${tone}` : ''}">${escapeHtml(this.formatCommitteeVote(vote))}</span>
           </li>
         `;

--- a/app.js
+++ b/app.js
@@ -4001,25 +4001,6 @@ function getDaoFinalOutcome(proposal) {
   return { label, tone };
 }
 
-function getDaoCommitteeWithholdReasonEntries(proposal) {
-  const committeeAddresses = Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : [];
-  const committeeAddressSet = new Set(committeeAddresses);
-  const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
-  const entries = [];
-
-  for (const vote of committeeVotes) {
-    if (vote?.vote !== 'withhold' || !committeeAddressSet.has(vote.memberAddress)) continue;
-    if (typeof vote.withheldReason !== 'string') continue;
-
-    const reason = vote.withheldReason.trim();
-    if (!reason) continue;
-
-    entries.push({ memberAddress: vote.memberAddress, reason });
-  }
-
-  return entries;
-}
-
 function getDaoCommitteeReviewResultSummary(proposal) {
   const state = getEffectiveDaoState(proposal);
   if (state !== 'withheld' && !(proposal?.emergency && isDaoFinalResultState(state))) return null;
@@ -4038,7 +4019,6 @@ function getDaoCommitteeReviewResultSummary(proposal) {
     source: 'committee',
     tone: outcome.tone,
     withholdCount,
-    withholdReasonEntries: state === 'withheld' ? getDaoCommitteeWithholdReasonEntries(proposal) : [],
   };
 }
 
@@ -4474,7 +4454,7 @@ class ProposalInfoModal {
         isDaoFinalizedState(state) ? this.renderProposalEmergencyStatus(proposal) : '',
         this.renderParameterChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
-        this.renderProposalResults(resultSummary),
+        this.renderProposalResults(resultSummary, proposal),
         state === 'review' ? this.renderProposalBody(proposal) : '',
         state === 'review'
           ? this.renderCommitteeReviewStatus({
@@ -4484,8 +4464,6 @@ class ProposalInfoModal {
             committeeVotes,
             committeeAddressSet,
             currentAddress,
-            currentVote,
-            capabilities,
           })
           : '',
       ].filter(Boolean).join('');
@@ -4630,7 +4608,7 @@ class ProposalInfoModal {
     return Math.max(1, units);
   }
 
-  renderCommitteeReviewStatus({ acceptCount, withholdCount, reviewWindow, committeeVotes, committeeAddressSet, currentAddress, currentVote, capabilities }) {
+  renderCommitteeReviewStatus({ acceptCount, withholdCount, reviewWindow, committeeVotes, committeeAddressSet, currentAddress }) {
     const submittedCount = acceptCount + withholdCount;
     const rows = [
       { option: 'Accept', total: acceptCount, tone: 'accept' },
@@ -4672,27 +4650,12 @@ class ProposalInfoModal {
       })
       .join('');
 
-    const yourVoteLabel = currentVote
-      ? this.formatCommitteeVote(currentVote)
-      : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member';
-    const yourVoteTone = this.getCommitteeVoteTone(currentVote);
-    const otherVoteRows = committeeVotes
-      .filter((vote) => vote && committeeAddressSet.has(vote.memberAddress) && vote.memberAddress !== currentAddress)
-      .map((vote) => {
-        const tone = this.getCommitteeVoteTone(vote);
-        return `
-          <li class="proposal-committee-vote-row">
-            <span class="proposal-committee-vote-address">${escapeHtml(this.formatCommitteeAddress(vote.memberAddress))}</span>
-            <span class="proposal-committee-vote-choice${tone ? ` proposal-committee-vote-choice--${tone}` : ''}">${escapeHtml(this.formatCommitteeVote(vote))}</span>
-          </li>
-        `;
-      })
-      .join('');
-    const otherVotesHtml = otherVoteRows
+    const voteRows = this.renderCommitteeVoteListEntries(committeeVotes, committeeAddressSet, currentAddress);
+    const votesHtml = voteRows
       ? `
         <div class="proposal-committee-votes">
-          <h4>Other committee votes</h4>
-          <ul class="proposal-committee-vote-list">${otherVoteRows}</ul>
+          <h4>Committee votes</h4>
+          <ul class="proposal-committee-vote-list">${voteRows}</ul>
         </div>
       `
       : '';
@@ -4705,16 +4668,12 @@ class ProposalInfoModal {
           <div class="proposal-vote-current-track" aria-hidden="true">${segments}</div>
         </div>
         <div class="proposal-vote-status-grid proposal-vote-status-grid--current">
-          <div class="proposal-vote-status-card">
-            <span>Your vote</span>
-            <strong${yourVoteTone ? ` class="proposal-committee-vote-choice--${yourVoteTone}"` : ''}>${escapeHtml(yourVoteLabel)}</strong>
-          </div>
           <div class="proposal-vote-status-card proposal-vote-status-card--deadline">
             <span>Review ends</span>
             <strong>${escapeHtml(formatDaoDetailTimestamp(reviewWindow.end))}</strong>
           </div>
         </div>
-        ${otherVotesHtml}
+        ${votesHtml}
       </section>
     `;
   }
@@ -4725,10 +4684,26 @@ class ProposalInfoModal {
     return `${value.slice(0, 8)}...${value.slice(-6)}`;
   }
 
-  renderProposalResults(result) {
+  renderCommitteeVoteListEntries(committeeVotes, committeeAddressSet, currentAddress) {
+    return committeeVotes
+      .filter((vote) => vote && committeeAddressSet.has(vote.memberAddress))
+      .map((vote) => {
+        const tone = this.getCommitteeVoteTone(vote);
+        const youLabel = vote.memberAddress === currentAddress ? ' (you)' : '';
+        return `
+          <li class="proposal-committee-vote-row">
+            <span class="proposal-committee-vote-address">${escapeHtml(`${this.formatCommitteeAddress(vote.memberAddress)}${youLabel}`)}</span>
+            <span class="proposal-committee-vote-choice${tone ? ` proposal-committee-vote-choice--${tone}` : ''}">${escapeHtml(this.formatCommitteeVote(vote))}</span>
+          </li>
+        `;
+      })
+      .join('');
+  }
+
+  renderProposalResults(result, proposal) {
     if (!result) return '';
     if (result.source === 'committee') {
-      return this.renderCommitteeResults(result);
+      return this.renderCommitteeResults(result, proposal);
     }
 
     const winnerLabel = result.winner ? `${result.winner.option} (${result.outcome})` : 'Unavailable';
@@ -4801,7 +4776,7 @@ class ProposalInfoModal {
     `;
   }
 
-  renderCommitteeResults(result) {
+  renderCommitteeResults(result, proposal) {
     const acceptCount = Number(result.acceptCount || 0);
     const withholdCount = Number(result.withholdCount || 0);
     const submittedCount = acceptCount + withholdCount;
@@ -4813,10 +4788,17 @@ class ProposalInfoModal {
     const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
     const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
     const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
-    const withholdReasons = this.renderCommitteeWithholdReasons(
-      result.withholdReasonEntries,
-      'Committee withhold reasons',
-    );
+    const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
+    const committeeAddressSet = new Set(Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : []);
+    const voteRows = this.renderCommitteeVoteListEntries(committeeVotes, committeeAddressSet, getDaoCurrentAccountAddress());
+    const votesHtml = voteRows
+      ? `
+        <div class="proposal-committee-votes">
+          <h4>Committee votes</h4>
+          <ul class="proposal-committee-vote-list">${voteRows}</ul>
+        </div>
+      `
+      : '';
 
     return `
       <section class="proposal-info-section">
@@ -4863,34 +4845,8 @@ class ProposalInfoModal {
             ></span>
           </div>
         </div>
-        ${withholdReasons}
+        ${votesHtml}
       </section>
-    `;
-  }
-
-  renderCommitteeWithholdReasons(entries, heading) {
-    if (entries.length === 0) return '';
-
-    const reasonCounts = new Map();
-    for (const entry of entries) {
-      reasonCounts.set(entry.reason, (reasonCounts.get(entry.reason) || 0) + 1);
-    }
-
-    const rows = Array.from(reasonCounts, ([reason, count]) => {
-      const countLabel = `${count} ${count === 1 ? 'vote' : 'votes'}`;
-      return `
-        <li class="proposal-withhold-reason-row">
-          <span class="proposal-withhold-reason-text">${escapeHtml(reason)}</span>
-          <span class="proposal-withhold-reason-count">${escapeHtml(countLabel)}</span>
-        </li>
-      `;
-    }).join('');
-
-    return `
-      <div class="proposal-withhold-reasons">
-        <h4>${escapeHtml(heading)}</h4>
-        <ul class="proposal-withhold-reason-list">${rows}</ul>
-      </div>
     `;
   }
 
@@ -5108,7 +5064,9 @@ class ProposalInfoModal {
 
   formatCommitteeVote(vote) {
     if (vote.vote !== 'withhold') return 'Accept';
-    return vote.withheldReason ? `Withhold - ${vote.withheldReason}` : 'Withhold';
+    const reason = String(vote.withheldReason || '').trim();
+    if (!reason) return 'Withhold';
+    return `Withhold - ${reason}`;
   }
 
   getReviewFinalizedStateLabel(proposal, acceptCount, withholdCount) {

--- a/app.js
+++ b/app.js
@@ -4614,9 +4614,10 @@ class ProposalInfoModal {
       { option: 'Accept', total: acceptCount, tone: 'accept' },
       { option: 'Withhold', total: withholdCount, tone: 'withhold' },
     ];
-    const topCount = Math.max(...rows.map((row) => row.total));
-    const topRows = rows.filter((row) => row.total === topCount);
-    const winnerIndex = submittedCount > 0 && topRows.length === 1 ? rows.indexOf(topRows[0]) : -1;
+    let winnerIndex = -1;
+    if (submittedCount > 0 && acceptCount !== withholdCount) {
+      winnerIndex = acceptCount > withholdCount ? 0 : 1;
+    }
     const labels = rows
       .map((row, index) => {
         const position = index === 0 ? 'start' : 'end';
@@ -4650,15 +4651,11 @@ class ProposalInfoModal {
       })
       .join('');
 
-    const voteRows = this.renderCommitteeVoteListEntries(committeeVotes, committeeAddressSet, currentAddress);
-    const votesHtml = voteRows
-      ? `
-        <div class="proposal-committee-votes">
-          <h4>Committee votes</h4>
-          <ul class="proposal-committee-vote-list">${voteRows}</ul>
-        </div>
-      `
-      : '';
+    const votesHtml = this.renderCommitteeVoteList(
+      committeeVotes,
+      committeeAddressSet,
+      currentAddress,
+    );
 
     return `
       <section class="proposal-info-section proposal-vote-current-section">
@@ -4678,73 +4675,54 @@ class ProposalInfoModal {
     `;
   }
 
-  getCommitteeMemberDisplayInfo(address, storedUsernamesByAddress) {
-    const value = String(address || '');
-    let normalizedAddress = value;
-    try {
-      normalizedAddress = normalizeAddress(value);
-    } catch {
-      // Keep the original value as a safe display fallback for malformed data.
-    }
+  renderCommitteeVoteList(committeeVotes, committeeAddressSet, currentAddress) {
+    const votes = committeeVotes
+      .filter((vote) => vote && committeeAddressSet.has(vote.memberAddress));
+    if (votes.length === 0) return '';
 
-    const currentAccountAddress = myAccount?.keys?.address
-      ? normalizeAddress(myAccount.keys.address)
-      : '';
-    const contact = normalizedAddress === currentAccountAddress
-      ? myAccount
-      : myData?.contacts?.[normalizedAddress] || myData?.contacts?.[value];
-    const storedUsername = storedUsernamesByAddress.get(normalizedAddress) || '';
-    const displayContact = {
-      ...contact,
-      username: contact?.username || storedUsername,
-      address: normalizedAddress,
-    };
-    const name = (displayContact.name || displayContact.username)
-      ? getContactDisplayName(displayContact)
-      : 'Unknown';
-    const shortAddress = normalizedAddress.length > 8
-      ? `${normalizedAddress.slice(0, 4)}…${normalizedAddress.slice(-4)}`
-      : normalizedAddress;
-
-    return { name, shortAddress };
-  }
-
-  getStoredUsernamesByAddress() {
     const { usernames, netidAccounts } = signInModal.getSignInUsernames();
     const storedUsernamesByAddress = new Map();
 
-    usernames.forEach((username) => {
-      const address = netidAccounts.usernames[username]?.address;
-      try {
-        storedUsernamesByAddress.set(normalizeAddress(address), username);
-      } catch {
-        // Ignore malformed local account records.
-      }
-    });
+    for (const username of usernames) {
+      const address = normalizeDaoAddress(netidAccounts.usernames[username]?.address);
+      if (address) storedUsernamesByAddress.set(address, username);
+    }
 
-    return storedUsernamesByAddress;
-  }
-
-  renderCommitteeVoteListEntries(committeeVotes, committeeAddressSet, currentAddress) {
-    const storedUsernamesByAddress = this.getStoredUsernamesByAddress();
-
-    return committeeVotes
-      .filter((vote) => vote && committeeAddressSet.has(vote.memberAddress))
+    const normalizedCurrentAddress = normalizeDaoAddress(currentAddress);
+    assert(normalizedCurrentAddress, 'Proposal modal requires a valid account address');
+    const rows = votes
       .map((vote) => {
+        const address = normalizeDaoAddress(vote.memberAddress);
+        assert(address, 'Committee vote requires a valid member address');
+
+        const contact = address === normalizedCurrentAddress
+          ? myAccount
+          : myData.contacts[address];
+        const displayContact = {
+          ...contact,
+          username: contact?.username || storedUsernamesByAddress.get(address) || 'Unknown',
+          address,
+        };
         const tone = this.getCommitteeVoteTone(vote);
-        const youLabel = vote.memberAddress === currentAddress ? ' (you)' : '';
-        const member = this.getCommitteeMemberDisplayInfo(vote.memberAddress, storedUsernamesByAddress);
+        const youLabel = address === normalizedCurrentAddress ? ' (you)' : '';
         return `
           <li class="proposal-committee-vote-row">
             <span class="proposal-committee-vote-address">
-              <span class="proposal-committee-vote-name">${escapeHtml(`${member.name}${youLabel}`)}</span>
-              <span class="proposal-committee-vote-short-address">${escapeHtml(member.shortAddress)}</span>
+              <strong>${escapeHtml(`${getContactDisplayName(displayContact)}${youLabel}`)}</strong>
+              <small>${escapeHtml(`${address.slice(0, 4)}…${address.slice(-4)}`)}</small>
             </span>
             <span class="proposal-committee-vote-choice${tone ? ` proposal-committee-vote-choice--${tone}` : ''}">${escapeHtml(this.formatCommitteeVote(vote))}</span>
           </li>
         `;
       })
       .join('');
+
+    return `
+      <div class="proposal-committee-votes">
+        <h4>Committee votes</h4>
+        <ul class="proposal-committee-vote-list">${rows}</ul>
+      </div>
+    `;
   }
 
   renderProposalResults(result, proposal) {
@@ -4835,17 +4813,13 @@ class ProposalInfoModal {
     const withholdUnits = this.getCountResultSegmentUnits(withholdCount, submittedCount);
     const acceptWinnerClass = result.tone === 'accepted' ? ' proposal-result-meter-label--winner' : '';
     const withholdWinnerClass = result.tone === 'rejected' ? ' proposal-result-meter-label--winner' : '';
-    const committeeVotes = Array.isArray(proposal?.committeeVotes) ? proposal.committeeVotes : [];
-    const committeeAddressSet = new Set(Array.isArray(proposal?.committeeAddresses) ? proposal.committeeAddresses : []);
-    const voteRows = this.renderCommitteeVoteListEntries(committeeVotes, committeeAddressSet, getDaoCurrentAccountAddress());
-    const votesHtml = voteRows
-      ? `
-        <div class="proposal-committee-votes">
-          <h4>Committee votes</h4>
-          <ul class="proposal-committee-vote-list">${voteRows}</ul>
-        </div>
-      `
-      : '';
+    const committeeVotes = Array.isArray(proposal.committeeVotes) ? proposal.committeeVotes : [];
+    const committeeAddressSet = new Set(Array.isArray(proposal.committeeAddresses) ? proposal.committeeAddresses : []);
+    const votesHtml = this.renderCommitteeVoteList(
+      committeeVotes,
+      committeeAddressSet,
+      getDaoCurrentAccountAddress(),
+    );
 
     return `
       <section class="proposal-info-section">
@@ -4955,7 +4929,7 @@ class ProposalInfoModal {
         ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
         ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
       ]),
-      committeeReviewSection || '',
+      committeeReviewSection,
       state === 'voting' ? this.renderVotingDetails(proposal) : '',
       state === 'review' ? '' : this.renderProposalBody(proposal),
       this.renderProposalRewards(rewardSummary),

--- a/app.js
+++ b/app.js
@@ -4465,13 +4465,6 @@ class ProposalInfoModal {
     const committeeReviewSection = state === 'review'
       ? this.renderSection('Committee Review', [
         ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
-        ['Accept votes', String(acceptCount)],
-        ['Withhold votes', String(withholdCount)],
-        [
-          'Your vote',
-          currentVote ? this.formatCommitteeVote(currentVote) : capabilities.isCommitteeMember ? 'Not submitted' : 'Not a committee member',
-          this.getCommitteeVoteTone(currentVote),
-        ],
         ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
       ])
       : '';

--- a/styles.css
+++ b/styles.css
@@ -2474,11 +2474,20 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-committee-vote-address {
   color: var(--text-color);
+  display: grid;
   font-size: 13px;
   line-height: 1.35;
   min-width: 0;
   overflow-wrap: anywhere;
-  white-space: pre-wrap;
+}
+
+#proposalInfoModal .proposal-committee-vote-name {
+  font-weight: var(--font-weight-medium);
+}
+
+#proposalInfoModal .proposal-committee-vote-short-address {
+  color: var(--secondary-text-color);
+  font-size: 11px;
 }
 
 #proposalInfoModal .proposal-committee-vote-choice {

--- a/styles.css
+++ b/styles.css
@@ -2274,9 +2274,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-card {
   background: rgba(255, 255, 255, 0.92);
-  border: 0 solid var(--border-color);
   border-radius: 0 0 8px 8px;
-  border-width: 0 1px 1px;
   box-shadow: 0 2px 2px rgba(28, 28, 33, 0.04);
   display: grid;
   gap: 6px;
@@ -2463,31 +2461,34 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-committee-vote-row {
-  align-items: start;
+  align-items: center;
   background: var(--input-background);
   border-radius: 8px;
   display: grid;
   gap: 8px;
   grid-template-columns: auto minmax(0, 1fr);
-  padding: 8px 10px;
+  padding: 6px 10px;
 }
 
 #proposalInfoModal .proposal-committee-vote-address {
   color: var(--text-color);
   display: grid;
   font-size: 13px;
-  line-height: 1.35;
+  gap: 0;
+  line-height: 1.2;
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
 #proposalInfoModal .proposal-committee-vote-address > strong {
   font-weight: var(--font-weight-medium);
+  padding-top: 1px;
 }
 
 #proposalInfoModal .proposal-committee-vote-address > small {
   color: var(--secondary-text-color);
   font-size: 11px;
+  line-height: 1.1;
 }
 
 #proposalInfoModal .proposal-committee-vote-choice {

--- a/styles.css
+++ b/styles.css
@@ -2481,11 +2481,11 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
-#proposalInfoModal .proposal-committee-vote-name {
+#proposalInfoModal .proposal-committee-vote-address > strong {
   font-weight: var(--font-weight-medium);
 }
 
-#proposalInfoModal .proposal-committee-vote-short-address {
+#proposalInfoModal .proposal-committee-vote-address > small {
   color: var(--secondary-text-color);
   font-size: 11px;
 }
@@ -2970,8 +2970,7 @@ input[type='file'].form-control::file-selector-button {
   text-align: right;
 }
 
-#proposalInfoModal .proposal-vote-status-card--deadline,
-#proposalInfoModal .proposal-vote-status-card--fit {
+#proposalInfoModal .proposal-vote-status-card--deadline {
   justify-self: end;
   max-width: 100%;
   width: fit-content;

--- a/styles.css
+++ b/styles.css
@@ -2377,8 +2377,12 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-result-meter-label > span {
   color: var(--secondary-text-color);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-bold);
   line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-result-meter-label > small {
+  font-weight: var(--font-weight-bold);
 }
 
 #proposalInfoModal .proposal-result-meter-label > span,
@@ -2932,13 +2936,14 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-vote-current-label > span {
   color: var(--secondary-text-color);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-bold);
   line-height: 1.35;
 }
 
 #proposalInfoModal .proposal-vote-current-label > small {
   color: var(--secondary-text-color);
   font-size: 12px;
+  font-weight: var(--font-weight-bold);
   line-height: 1.35;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -2159,6 +2159,49 @@ input[type='file'].form-control::file-selector-button {
   justify-content: center;
 }
 
+#proposalInfoModal .proposal-option-cards {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+#proposalInfoModal .proposal-option-card {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-width: 0;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+#proposalInfoModal .proposal-option-card-number {
+  align-items: center;
+  background: var(--input-background);
+  border-radius: 999px;
+  color: var(--secondary-text-color);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  height: 24px;
+  justify-content: center;
+  line-height: 1;
+  min-width: 24px;
+  padding: 0 4px;
+}
+
+#proposalInfoModal .proposal-option-card-label {
+  color: var(--text-color);
+  font-size: 13px;
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 #confirmProposalModal .dao-confirm-row,
 #proposalInfoModal .proposal-info-row {
   background: var(--input-background);

--- a/styles.css
+++ b/styles.css
@@ -2439,7 +2439,6 @@ input[type='file'].form-control::file-selector-button {
   background: rgba(101, 103, 107, 0.18);
 }
 
-#proposalInfoModal .proposal-withhold-reasons,
 #proposalInfoModal .proposal-committee-votes {
   border-top: 1px solid var(--border-color);
   display: grid;
@@ -2447,7 +2446,6 @@ input[type='file'].form-control::file-selector-button {
   padding-top: 10px;
 }
 
-#proposalInfoModal .proposal-withhold-reasons h4,
 #proposalInfoModal .proposal-committee-votes h4 {
   color: var(--text-color);
   font-size: 13px;
@@ -2456,7 +2454,6 @@ input[type='file'].form-control::file-selector-button {
   margin: 0;
 }
 
-#proposalInfoModal .proposal-withhold-reason-list,
 #proposalInfoModal .proposal-committee-vote-list {
   display: grid;
   gap: 6px;
@@ -2465,22 +2462,16 @@ input[type='file'].form-control::file-selector-button {
   padding: 0;
 }
 
-#proposalInfoModal .proposal-withhold-reason-row,
 #proposalInfoModal .proposal-committee-vote-row {
   align-items: start;
   background: var(--input-background);
   border-radius: 8px;
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   padding: 8px 10px;
 }
 
-#proposalInfoModal .proposal-committee-vote-row {
-  grid-template-columns: auto minmax(0, 1fr);
-}
-
-#proposalInfoModal .proposal-withhold-reason-text,
 #proposalInfoModal .proposal-committee-vote-address {
   color: var(--text-color);
   font-size: 13px;
@@ -2488,13 +2479,6 @@ input[type='file'].form-control::file-selector-button {
   min-width: 0;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
-}
-
-#proposalInfoModal .proposal-withhold-reason-count {
-  color: var(--secondary-text-color);
-  font-size: 11px;
-  line-height: 1.35;
-  white-space: nowrap;
 }
 
 #proposalInfoModal .proposal-committee-vote-choice {
@@ -2507,13 +2491,11 @@ input[type='file'].form-control::file-selector-button {
   text-align: right;
 }
 
-#proposalInfoModal .proposal-committee-vote-choice--accept,
-#proposalInfoModal .proposal-vote-status-card strong.proposal-committee-vote-choice--accept {
+#proposalInfoModal .proposal-committee-vote-choice--accept {
   color: #0f5f27;
 }
 
-#proposalInfoModal .proposal-committee-vote-choice--withhold,
-#proposalInfoModal .proposal-vote-status-card strong.proposal-committee-vote-choice--withhold {
+#proposalInfoModal .proposal-committee-vote-choice--withhold {
   color: #8f1d16;
 }
 
@@ -2979,7 +2961,8 @@ input[type='file'].form-control::file-selector-button {
   text-align: right;
 }
 
-#proposalInfoModal .proposal-vote-status-card--deadline {
+#proposalInfoModal .proposal-vote-status-card--deadline,
+#proposalInfoModal .proposal-vote-status-card--fit {
   justify-self: end;
   max-width: 100%;
   width: fit-content;

--- a/styles.css
+++ b/styles.css
@@ -2439,14 +2439,16 @@ input[type='file'].form-control::file-selector-button {
   background: rgba(101, 103, 107, 0.18);
 }
 
-#proposalInfoModal .proposal-withhold-reasons {
+#proposalInfoModal .proposal-withhold-reasons,
+#proposalInfoModal .proposal-committee-votes {
   border-top: 1px solid var(--border-color);
   display: grid;
   gap: 8px;
   padding-top: 10px;
 }
 
-#proposalInfoModal .proposal-withhold-reasons h4 {
+#proposalInfoModal .proposal-withhold-reasons h4,
+#proposalInfoModal .proposal-committee-votes h4 {
   color: var(--text-color);
   font-size: 13px;
   font-weight: var(--font-weight-semibold);
@@ -2454,7 +2456,8 @@ input[type='file'].form-control::file-selector-button {
   margin: 0;
 }
 
-#proposalInfoModal .proposal-withhold-reason-list {
+#proposalInfoModal .proposal-withhold-reason-list,
+#proposalInfoModal .proposal-committee-vote-list {
   display: grid;
   gap: 6px;
   list-style: none;
@@ -2462,7 +2465,8 @@ input[type='file'].form-control::file-selector-button {
   padding: 0;
 }
 
-#proposalInfoModal .proposal-withhold-reason-row {
+#proposalInfoModal .proposal-withhold-reason-row,
+#proposalInfoModal .proposal-committee-vote-row {
   align-items: start;
   background: var(--input-background);
   border-radius: 8px;
@@ -2472,7 +2476,12 @@ input[type='file'].form-control::file-selector-button {
   padding: 8px 10px;
 }
 
-#proposalInfoModal .proposal-withhold-reason-text {
+#proposalInfoModal .proposal-committee-vote-row {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+#proposalInfoModal .proposal-withhold-reason-text,
+#proposalInfoModal .proposal-committee-vote-address {
   color: var(--text-color);
   font-size: 13px;
   line-height: 1.35;
@@ -2486,6 +2495,26 @@ input[type='file'].form-control::file-selector-button {
   font-size: 11px;
   line-height: 1.35;
   white-space: nowrap;
+}
+
+#proposalInfoModal .proposal-committee-vote-choice {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.35;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+#proposalInfoModal .proposal-committee-vote-choice--accept,
+#proposalInfoModal .proposal-vote-status-card strong.proposal-committee-vote-choice--accept {
+  color: #0f5f27;
+}
+
+#proposalInfoModal .proposal-committee-vote-choice--withhold,
+#proposalInfoModal .proposal-vote-status-card strong.proposal-committee-vote-choice--withhold {
+  color: #8f1d16;
 }
 
 #confirmProposalModal .dao-confirm-change,
@@ -2877,6 +2906,14 @@ input[type='file'].form-control::file-selector-button {
   color: var(--primary-color);
 }
 
+#proposalInfoModal .proposal-vote-current-label--accept.proposal-vote-current-label--winner > span {
+  color: #0f5f27;
+}
+
+#proposalInfoModal .proposal-vote-current-label--withhold.proposal-vote-current-label--winner > span {
+  color: #8f1d16;
+}
+
 #proposalInfoModal .proposal-vote-current-track {
   background: var(--input-background);
   border: 1px solid var(--border-color);
@@ -2899,6 +2936,14 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-vote-current-segment--winner {
   background: var(--primary-color);
+}
+
+#proposalInfoModal .proposal-vote-current-segment--accept {
+  background: #1e7e34;
+}
+
+#proposalInfoModal .proposal-vote-current-segment--withhold {
+  background: #c42d2d;
 }
 
 #proposalInfoModal .proposal-vote-current-segment--empty {

--- a/styles.css
+++ b/styles.css
@@ -2471,24 +2471,29 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-committee-vote-address {
+  align-self: stretch;
   color: var(--text-color);
-  display: grid;
+  display: flex;
+  flex-direction: column;
   font-size: 13px;
-  gap: 0;
+  gap: 2px;
+  justify-content: flex-start;
   line-height: 1.2;
   min-width: 0;
   overflow-wrap: anywhere;
+  padding: 4px 0 2px;
 }
 
 #proposalInfoModal .proposal-committee-vote-address > strong {
   font-weight: var(--font-weight-medium);
-  padding-top: 1px;
 }
 
 #proposalInfoModal .proposal-committee-vote-address > small {
   color: var(--secondary-text-color);
   font-size: 11px;
   line-height: 1.1;
+  margin: 0;
+  padding: 0;
 }
 
 #proposalInfoModal .proposal-committee-vote-choice {

--- a/styles.css
+++ b/styles.css
@@ -2222,19 +2222,13 @@ input[type='file'].form-control::file-selector-button {
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
 }
 
-#confirmProposalModal .dao-confirm-row--full,
-#proposalInfoModal .proposal-info-row--full {
+#confirmProposalModal .dao-confirm-row--full {
   flex-basis: 100%;
 }
 
 #proposalInfoModal .proposal-info-row--accept {
   background: rgba(30, 126, 52, 0.16);
   border: 1px solid rgba(30, 126, 52, 0.34);
-}
-
-#proposalInfoModal .proposal-info-row--withhold {
-  background: rgba(196, 45, 45, 0.14);
-  border: 1px solid rgba(196, 45, 45, 0.32);
 }
 
 #confirmProposalModal .dao-confirm-label,
@@ -2252,10 +2246,6 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row--accept span {
   color: #1e7e34;
-}
-
-#proposalInfoModal .proposal-info-row--withhold span {
-  color: #b42318;
 }
 
 #confirmProposalModal .dao-confirm-value,
@@ -2284,10 +2274,6 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-info-row--accept .proposal-info-value {
   color: #0f5f27;
-}
-
-#proposalInfoModal .proposal-info-row--withhold .proposal-info-value {
-  color: #8f1d16;
 }
 
 #confirmProposalModal .dao-confirm-label,
@@ -2377,16 +2363,12 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-result-meter-label > span {
   color: var(--secondary-text-color);
   font-size: 12px;
-  font-weight: var(--font-weight-bold);
   line-height: 1.35;
-}
-
-#proposalInfoModal .proposal-result-meter-label > small {
-  font-weight: var(--font-weight-bold);
 }
 
 #proposalInfoModal .proposal-result-meter-label > span,
 #proposalInfoModal .proposal-result-meter-label > small {
+  font-weight: var(--font-weight-bold);
   max-width: 100%;
   min-width: 0;
   overflow-wrap: anywhere;
@@ -2394,14 +2376,6 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-meter-label--winner > span {
   color: var(--text-color);
-}
-
-#proposalInfoModal .proposal-result-meter-label--accept.proposal-result-meter-label--winner > span {
-  color: #0f5f27;
-}
-
-#proposalInfoModal .proposal-result-meter-label--withhold.proposal-result-meter-label--winner > span {
-  color: #8f1d16;
 }
 
 #proposalInfoModal .proposal-result-meter-label--palette-0 > span {
@@ -2470,18 +2444,6 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-result-meter-segment--palette-5 {
   background: #8d949e;
-}
-
-#proposalInfoModal .proposal-result-meter-segment--accept {
-  background: #1e7e34;
-}
-
-#proposalInfoModal .proposal-result-meter-segment--withhold {
-  background: #c42d2d;
-}
-
-#proposalInfoModal .proposal-result-meter-segment--empty {
-  background: rgba(101, 103, 107, 0.18);
 }
 
 #proposalInfoModal .proposal-committee-votes {
@@ -2553,10 +2515,14 @@ input[type='file'].form-control::file-selector-button {
   text-align: right;
 }
 
+#proposalInfoModal .proposal-result-meter-label--accept.proposal-result-meter-label--winner > span,
+#proposalInfoModal .proposal-vote-current-label--accept.proposal-vote-current-label--winner > span,
 #proposalInfoModal .proposal-committee-vote-choice--accept {
   color: #0f5f27;
 }
 
+#proposalInfoModal .proposal-result-meter-label--withhold.proposal-result-meter-label--winner > span,
+#proposalInfoModal .proposal-vote-current-label--withhold.proposal-vote-current-label--winner > span,
 #proposalInfoModal .proposal-committee-vote-choice--withhold {
   color: #8f1d16;
 }
@@ -2668,8 +2634,7 @@ input[type='file'].form-control::file-selector-button {
     flex-basis: calc((100% - 8px) / 2);
   }
 
-  #confirmProposalModal .dao-confirm-row--full,
-  #proposalInfoModal .proposal-info-row--full {
+  #confirmProposalModal .dao-confirm-row--full {
     flex-basis: 100%;
   }
 }
@@ -2928,6 +2893,7 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-vote-current-label > span,
 #proposalInfoModal .proposal-vote-current-label > small {
+  font-weight: var(--font-weight-bold);
   max-width: 100%;
   min-width: 0;
   overflow-wrap: break-word;
@@ -2936,27 +2902,17 @@ input[type='file'].form-control::file-selector-button {
 #proposalInfoModal .proposal-vote-current-label > span {
   color: var(--secondary-text-color);
   font-size: 12px;
-  font-weight: var(--font-weight-bold);
   line-height: 1.35;
 }
 
 #proposalInfoModal .proposal-vote-current-label > small {
   color: var(--secondary-text-color);
   font-size: 12px;
-  font-weight: var(--font-weight-bold);
   line-height: 1.35;
 }
 
 #proposalInfoModal .proposal-vote-current-label--winner > span {
   color: var(--primary-color);
-}
-
-#proposalInfoModal .proposal-vote-current-label--accept.proposal-vote-current-label--winner > span {
-  color: #0f5f27;
-}
-
-#proposalInfoModal .proposal-vote-current-label--withhold.proposal-vote-current-label--winner > span {
-  color: #8f1d16;
 }
 
 #proposalInfoModal .proposal-vote-current-track {
@@ -2983,14 +2939,17 @@ input[type='file'].form-control::file-selector-button {
   background: var(--primary-color);
 }
 
+#proposalInfoModal .proposal-result-meter-segment--accept,
 #proposalInfoModal .proposal-vote-current-segment--accept {
   background: #1e7e34;
 }
 
+#proposalInfoModal .proposal-result-meter-segment--withhold,
 #proposalInfoModal .proposal-vote-current-segment--withhold {
   background: #c42d2d;
 }
 
+#proposalInfoModal .proposal-result-meter-segment--empty,
 #proposalInfoModal .proposal-vote-current-segment--empty {
   background: rgba(101, 103, 107, 0.18);
 }


### PR DESCRIPTION
## What Changed

This PR makes DAO committee review progress and finalized outcomes easier to understand in the proposal details view.

- `getDaoCommitteeReview` validates and centralizes committee vote filtering, counts, membership, and display data for active and finalized reviews.
- Active reviews now show an accept/withhold tally, review deadline, and submitted committee votes with resolved names, shortened addresses, and withhold reasons.
- Finalized committee results retain the same member vote list and consistent count/percentage formatting.
- Proposal options use readable cards, while emergency or standard proposal status is shown alongside the proposal heading.
- Unknown committee vote values are skipped with a warning instead of breaking proposal rendering.

## Fixed Flow

1. A user opens a proposal that is in committee review or has a finalized committee outcome.
2. The modal derives one validated committee review model from the proposal snapshot.
3. The UI renders the aggregate tally and each recognized member vote from that shared model.
4. Unknown vote values are ignored safely, while proposal details and available DAO actions continue rendering.

## Why

Committee status was split across compact detail rows and withhold-only reason summaries, making it difficult to see overall progress or identify submitted votes. A shared review model keeps the aggregate and member-level views consistent while the updated layout makes proposal type, options, vote share, and committee outcomes easier to scan.

## Validation

- `node --check app.js`
- `node --check dao.repo.js`
- `git diff --check c89ae8edb546895850a389e6c8235860aedfb8ce..HEAD`
- `node --test tests/dao-timeline.test.mjs`

Closes #1488