### PR TITLE
Unify DAO proposal review display

### DIFF
--- a/app.js
+++ b/app.js
@@ -3570,11 +3570,156 @@ function formatDaoDurationDaysEstimate(ms) {
   return `about ${value} day${value === '1' ? '' : 's'}`;
 }
 
-function formatDaoConfirmValue(value) {
-  if (value === undefined || value === null || value === '') return '—';
-  if (Array.isArray(value)) return value.join(', ');
-  if (typeof value === 'object') return stringify(value);
-  return String(value);
+// Shared proposal display rendering used by both the pre-signing preview
+// (ConfirmProposalModal) and the proposal detail views (ProposalInfoModal).
+// A create draft wraps its fields in `transaction`; a stored proposal is flat.
+function normalizeDaoProposalDisplay(source) {
+  const proposal = source?.transaction && typeof source.transaction === 'object'
+    ? source.transaction
+    : source;
+  const fallbackTitle = proposal?.number ? `Proposal #${proposal.number}` : 'Proposal';
+  return {
+    title: proposal?.title || source?.displayTitle || fallbackTitle,
+    emergency: proposal?.emergency === true,
+    description: typeof proposal?.description === 'string' ? proposal.description : '',
+    options: Array.isArray(proposal?.options) ? proposal.options.map((option) => String(option)) : [],
+    payloads: ['governance', 'economic', 'protocol']
+      .map((key) => [key, proposal?.[key]])
+      .filter(([, payload]) => payload && typeof payload === 'object'),
+  };
+}
+
+function renderDaoProposalHeading(display) {
+  const emergencyLabel = display.emergency ? 'Emergency proposal' : 'Standard proposal';
+  const emergencyClass = display.emergency ? ' proposal-type-indicator--emergency' : '';
+  const descriptionHtml = display.description
+    ? `<p class="proposal-info-description">${escapeHtml(display.description)}</p>`
+    : '';
+
+  return `
+    <div class="proposal-info-heading">
+      <h2 class="proposal-info-title">${escapeHtml(display.title)}</h2>
+      <p class="proposal-type-indicator${emergencyClass}">${escapeHtml(emergencyLabel)}</p>
+      ${descriptionHtml}
+    </div>
+  `;
+}
+
+function renderDaoProposalInfoSection(title, rows) {
+  const rowHtml = rows
+    .map(([label, value, tone]) => {
+      const displayValue = formatDaoDetailValue(value);
+      const classes = [
+        'proposal-info-row',
+        tone ? `proposal-info-row--${tone}` : '',
+      ].filter(Boolean);
+
+      return `
+      <div class="${classes.join(' ')}">
+        <span>${escapeHtml(label)}</span>
+        <span class="proposal-info-value">${escapeHtml(displayValue)}</span>
+      </div>
+    `;
+    })
+    .join('');
+
+  return `
+    <section class="proposal-info-section">
+      <h3>${escapeHtml(title)}</h3>
+      <div class="proposal-info-grid">${rowHtml}</div>
+    </section>
+  `;
+}
+
+function renderDaoProposalOptionsSection(options) {
+  const optionCards = options
+    .map((option, index) => `
+      <div class="proposal-option-card">
+        <span class="proposal-option-card-number">${index + 1}</span>
+        <span class="proposal-option-card-label">${escapeHtml(option)}</span>
+      </div>
+    `)
+    .join('');
+
+  return `
+    <section class="proposal-info-section">
+      <h3>Proposal Options</h3>
+      <div class="proposal-option-cards">${optionCards}</div>
+    </section>
+  `;
+}
+
+function renderDaoProposalChangesSection(payloads) {
+  const hasRows = payloads.some(([, payload]) =>
+    Array.isArray(payload?.changes)
+      ? payload.changes.length > 0
+      : Object.values(payload).some((value) => value !== undefined && value !== null && String(value).length > 0)
+  );
+
+  if (payloads.length === 0 || !hasRows) {
+    return '<section class="proposal-info-section"><h3>Parameter Changes</h3><p class="proposal-info-muted">No parameter changes are available.</p></section>';
+  }
+
+  const payloadHtml = payloads
+    .map(([key, payload]) => {
+      const payloadTitle = getDaoTypeLabel(key) || key;
+      return `
+      <div class="proposal-payload">
+        ${renderDaoProposalPayloadRows(payload, payloadTitle)}
+      </div>
+    `;
+    })
+    .join('');
+
+  return `
+    <section class="proposal-info-section">
+      <h3>Parameter Changes</h3>
+      ${payloadHtml}
+    </section>
+  `;
+}
+
+function renderDaoProposalPayloadRows(payload, payloadTitle) {
+  const titleHtml = payloadTitle
+    ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
+    : '';
+
+  if (Array.isArray(payload?.changes)) {
+    return payload.changes
+      .map((change) => {
+        const key = change?.key || 'Unknown key';
+        const current = formatDaoDetailValue(change?.current);
+        const next = formatDaoDetailValue(change?.value);
+        return `
+        <div class="proposal-change-row">
+          ${titleHtml}
+          <span>${escapeHtml(key)}</span>
+          <div class="proposal-change-values">
+            <small><span>Current:</span><strong>${escapeHtml(current)}</strong></small>
+            <span class="proposal-change-arrow" aria-hidden="true">&rarr;</span>
+            <small><span>New:</span><strong>${escapeHtml(next)}</strong></small>
+          </div>
+        </div>
+      `;
+      })
+      .join('');
+  }
+
+  const entries = Object.entries(payload)
+    .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0);
+
+  return entries
+    .map(([key, value]) => {
+      const displayValue = formatDaoDetailValue(value);
+      return `
+      <div class="proposal-change-row">
+        ${titleHtml}
+        <span>${escapeHtml(key)}</span>
+        <strong>${escapeHtml(displayValue)}</strong>
+      </div>
+    `;
+    })
+    .join('');
 }
 
 class ConfirmProposalModal {
@@ -3695,93 +3840,29 @@ class ConfirmProposalModal {
     const draft = this.currentDraft;
     if (!draft?.transaction?.from) {
       this.setTitle('Review Proposal');
-      this.content.innerHTML = '<div class="dao-confirm-empty">Proposal draft is unavailable.</div>';
+      this.content.innerHTML = '<section class="proposal-info-section"><h3>Review Proposal</h3><p class="proposal-info-muted">Proposal draft is unavailable.</p></section>';
       return;
     }
 
     const tx = draft.transaction;
-    const proposalType = tx.proposalType;
-    const changes = Array.isArray(tx[proposalType]?.changes) ? tx[proposalType].changes : [];
-    const gracePeriodSummary = formatDaoDurationSummary(tx.gracePeriod);
-    const formattedOptions = tx.options
-      .map((option, index) => `${index + 1}. ${option}`)
-      .join('\n');
+    const display = normalizeDaoProposalDisplay(draft);
 
     this.setTitle('Review Proposal');
     this.content.innerHTML = [
-      this.renderSection('Cost and State', [
+      renderDaoProposalHeading(display),
+      renderDaoProposalChangesSection(display.payloads),
+      renderDaoProposalOptionsSection(display.options),
+      renderDaoProposalInfoSection('Overview', [
+        ['Type', getDaoTypeLabel(tx.proposalType)],
         ['Proposal fee', `${draft.proposalFeeUsdStr || '0'} USD`],
         ['Initial state', 'Review after signing'],
       ]),
-      this.renderSection('Proposal Body', [
-        ['Title', tx.title || draft.displayTitle],
-        ['Type', getDaoTypeLabel(proposalType)],
-        ['Emergency', tx.emergency ? 'Yes' : 'No'],
-        ['Description', tx.description],
-        ['Options', formattedOptions],
+      renderDaoProposalInfoSection('Review Timeline', [
         ['Review starts', formatDaoDurationSummary(draft.startDelayMs)],
-        ['Grace period', gracePeriodSummary],
+        ['Grace period', formatDaoDurationSummary(tx.gracePeriod)],
       ]),
-      this.renderChanges(changes),
-      '<div class="dao-confirm-help">The proposal fee is derived from DAO params and seeds the voter reward pool for regular proposals. Signing submits this proposal for review.</div>',
+      '<p class="proposal-info-muted">The proposal fee is derived from DAO params and seeds the voter reward pool for regular proposals. Signing submits this proposal for review.</p>',
     ].join('');
-  }
-
-  renderSection(title, rows) {
-    const rowHtml = rows
-      .map(([label, value]) => {
-        const displayValue = formatDaoConfirmValue(value);
-        const rowClass = this.getSectionRowClass(label, displayValue);
-        return `
-        <div class="${rowClass}">
-          <span class="dao-confirm-label">${escapeHtml(label)}</span>
-          <strong class="dao-confirm-value">${escapeHtml(displayValue)}</strong>
-        </div>
-      `;
-      })
-      .join('');
-
-    return `
-      <section class="dao-confirm-section">
-        <h3>${escapeHtml(title)}</h3>
-        <div class="dao-confirm-grid">${rowHtml}</div>
-      </section>
-    `;
-  }
-
-  getSectionRowClass(label, value) {
-    const fullWidthLabels = ['Description', 'Options'];
-    if (!fullWidthLabels.includes(label)) return 'dao-confirm-row';
-
-    const text = String(value);
-    const lines = text.split('\n');
-    const longestLineLength = Math.max(...lines.map((line) => line.length));
-    if (lines.length > 4 || longestLineLength > 42 || text.length > 120) {
-      return 'dao-confirm-row dao-confirm-row--full';
-    }
-    return 'dao-confirm-row';
-  }
-
-  renderChanges(changes) {
-    const changeRows = changes.length
-      ? changes.map((change, index) => `
-          <div class="dao-confirm-change">
-            <div class="dao-confirm-change-title">Change ${index + 1}: ${escapeHtml(change.key)}</div>
-            <div class="dao-confirm-change-values">
-              <small><span>Current:</span><strong>${escapeHtml(formatDaoConfirmValue(change.current))}</strong></small>
-              <span class="dao-confirm-change-arrow" aria-hidden="true">&rarr;</span>
-              <small><span>New:</span><strong>${escapeHtml(formatDaoConfirmValue(change.value))}</strong></small>
-            </div>
-          </div>
-        `).join('')
-      : '<div class="dao-confirm-empty">No parameter changes included.</div>';
-
-    return `
-      <section class="dao-confirm-section">
-        <h3>Parameter Changes</h3>
-        ${changeRows}
-      </section>
-    `;
   }
 
   setTitle(title) {
@@ -4467,7 +4548,7 @@ class ProposalInfoModal {
     const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
     const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
     const committeeReviewSection = state === 'review'
-      ? this.renderSection('Committee Review', [
+      ? renderDaoProposalInfoSection('Committee Review', [
         ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
         ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
       ])
@@ -4514,21 +4595,7 @@ class ProposalInfoModal {
   }
 
   renderProposalTitle(proposal) {
-    const description = proposal.description || '';
-    const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
-    const emergencyLabel = proposal.emergency ? 'Emergency proposal' : 'Standard proposal';
-    const emergencyClass = proposal.emergency ? ' proposal-type-indicator--emergency' : '';
-    const descriptionHtml = description
-      ? `<p class="proposal-info-description">${escapeHtml(description)}</p>`
-      : '';
-
-    return `
-      <div class="proposal-info-heading">
-        <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
-        <p class="proposal-type-indicator${emergencyClass}">${escapeHtml(emergencyLabel)}</p>
-        ${descriptionHtml}
-      </div>
-    `;
+    return renderDaoProposalHeading(normalizeDaoProposalDisplay(proposal));
   }
 
   renderCurrentVoteTotals(proposal) {
@@ -4884,7 +4951,7 @@ class ProposalInfoModal {
 
   renderProposalRewards(reward) {
     if (!reward) return '';
-    return this.renderSection('Rewards', [
+    return renderDaoProposalInfoSection('Rewards', [
       ['Claim status', reward.claimStatus, reward.statusTone],
       ['Claim estimate', reward.claimEstimate === null ? 'Unavailable' : formatDaoLibWei(reward.claimEstimate), reward.statusTone],
       ['Claim window', reward.claimWindowLabel],
@@ -4903,7 +4970,7 @@ class ProposalInfoModal {
     const totalVoteText = totalVote.length
       ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
       : 'No votes yet';
-    return this.renderSection('Voting Details', [
+    return renderDaoProposalInfoSection('Voting Details', [
       ['Voting state', votingWindow.label],
       ['Current totals', totalVoteText],
     ]);
@@ -4911,14 +4978,14 @@ class ProposalInfoModal {
 
   renderProposalDetails({ proposal, state, reviewWindow, rewardSummary, committeeReviewSection }) {
     const sections = [
-      this.renderSection('Overview', [
+      renderDaoProposalInfoSection('Overview', [
         ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
         ['Type', getDaoTypeLabel(proposal.proposalType) || 'Unavailable'],
         ['Status', getDaoStateLabel(state) || state],
         ['Created', formatDaoDetailTimestamp(proposal.created)],
         ['Updated', formatDaoDetailTimestamp(proposal.state_changed)],
       ]),
-      this.renderSection('Review Timeline', [
+      renderDaoProposalInfoSection('Review Timeline', [
         ['Window state', reviewWindow.label],
         ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
         ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
@@ -4953,119 +5020,12 @@ class ProposalInfoModal {
     if (this.title) this.title.textContent = title || 'Proposal';
   }
 
-  renderSection(title, rows) {
-    const rowHtml = rows
-      .map(([label, value, tone]) => {
-        const displayValue = formatDaoDetailValue(value);
-        const classes = [
-          'proposal-info-row',
-          tone ? `proposal-info-row--${tone}` : '',
-        ].filter(Boolean);
-
-        return `
-        <div class="${classes.join(' ')}">
-          <span>${escapeHtml(label)}</span>
-          <span class="proposal-info-value">${escapeHtml(displayValue)}</span>
-        </div>
-      `;
-      })
-      .join('');
-
-    return `
-      <section class="proposal-info-section">
-        <h3>${escapeHtml(title)}</h3>
-        <div class="proposal-info-grid">${rowHtml}</div>
-      </section>
-    `;
-  }
-
   renderProposalBody(proposal) {
-    const optionCards = getDaoProposalOptions(proposal)
-      .map((option, index) => `
-        <div class="proposal-option-card">
-          <span class="proposal-option-card-number">${index + 1}</span>
-          <span class="proposal-option-card-label">${escapeHtml(option)}</span>
-        </div>
-      `)
-      .join('');
-
-    return `
-      <section class="proposal-info-section">
-        <h3>Proposal Options</h3>
-        <div class="proposal-option-cards">${optionCards}</div>
-      </section>
-    `;
+    return renderDaoProposalOptionsSection(normalizeDaoProposalDisplay(proposal).options);
   }
 
   renderParameterChanges(proposal) {
-    const payloads = ['governance', 'economic', 'protocol']
-      .map((key) => [key, proposal[key]])
-      .filter(([, payload]) => payload && typeof payload === 'object');
-
-    if (payloads.length === 0) {
-      return '<section class="proposal-info-section"><h3>Parameter Changes</h3><p class="proposal-info-muted">No parameter changes are available.</p></section>';
-    }
-
-    const payloadHtml = payloads
-      .map(([key, payload]) => {
-        const payloadTitle = getDaoTypeLabel(key) || key;
-        return `
-        <div class="proposal-payload">
-          ${this.renderPayloadRows(payload, payloadTitle)}
-        </div>
-      `;
-      })
-      .join('');
-
-    return `
-      <section class="proposal-info-section">
-        <h3>Parameter Changes</h3>
-        ${payloadHtml}
-      </section>
-    `;
-  }
-
-  renderPayloadRows(payload, payloadTitle) {
-    const titleHtml = payloadTitle
-      ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
-      : '';
-
-    if (Array.isArray(payload?.changes)) {
-      return payload.changes
-        .map((change) => {
-          const key = change?.key || 'Unknown key';
-          const current = formatDaoDetailValue(change?.current);
-          const next = formatDaoDetailValue(change?.value);
-          return `
-          <div class="proposal-change-row">
-            ${titleHtml}
-            <span>${escapeHtml(key)}</span>
-            <div class="proposal-change-values">
-              <small><span>Current:</span><strong>${escapeHtml(current)}</strong></small>
-              <span class="proposal-change-arrow" aria-hidden="true">&rarr;</span>
-              <small><span>New:</span><strong>${escapeHtml(next)}</strong></small>
-            </div>
-          </div>
-        `;
-        })
-        .join('');
-    }
-
-    const entries = Object.entries(payload)
-      .filter(([, value]) => value !== undefined && value !== null && String(value).length > 0);
-
-    return entries
-      .map(([key, value]) => {
-        const displayValue = formatDaoDetailValue(value);
-        return `
-        <div class="proposal-change-row">
-          ${titleHtml}
-          <span>${escapeHtml(key)}</span>
-          <strong>${escapeHtml(displayValue)}</strong>
-        </div>
-      `;
-      })
-      .join('');
+    return renderDaoProposalChangesSection(normalizeDaoProposalDisplay(proposal).payloads);
   }
 
   formatCommitteeVote(vote) {

--- a/app.js
+++ b/app.js
@@ -3570,52 +3570,31 @@ function formatDaoDurationDaysEstimate(ms) {
   return `about ${value} day${value === '1' ? '' : 's'}`;
 }
 
-// Shared proposal display rendering used by both the pre-signing preview
-// (ConfirmProposalModal) and the proposal detail views (ProposalInfoModal).
-// A create draft wraps its fields in `transaction`; a stored proposal is flat.
-function normalizeDaoProposalDisplay(source) {
-  const proposal = source?.transaction && typeof source.transaction === 'object'
-    ? source.transaction
-    : source;
-  const fallbackTitle = proposal?.number ? `Proposal #${proposal.number}` : 'Proposal';
-  return {
-    title: proposal?.title || source?.displayTitle || fallbackTitle,
-    emergency: proposal?.emergency === true,
-    description: typeof proposal?.description === 'string' ? proposal.description : '',
-    options: Array.isArray(proposal?.options) ? proposal.options.map((option) => String(option)) : [],
-    payloads: ['governance', 'economic', 'protocol']
-      .map((key) => [key, proposal?.[key]])
-      .filter(([, payload]) => payload && typeof payload === 'object'),
-  };
-}
-
-function renderDaoProposalHeading(display) {
-  const emergencyLabel = display.emergency ? 'Emergency proposal' : 'Standard proposal';
-  const emergencyClass = display.emergency ? ' proposal-type-indicator--emergency' : '';
-  const descriptionHtml = display.description
-    ? `<p class="proposal-info-description">${escapeHtml(display.description)}</p>`
+function renderDaoProposalHeading(proposal) {
+  const title = proposal.title || (proposal.number ? `Proposal #${proposal.number}` : 'Proposal');
+  const emergencyLabel = proposal.emergency === true ? 'Emergency proposal' : 'Standard proposal';
+  const emergencyClass = proposal.emergency === true ? ' proposal-type-indicator--emergency' : '';
+  const descriptionHtml = proposal.description
+    ? `<p class="proposal-info-description">${escapeHtml(proposal.description)}</p>`
     : '';
 
   return `
     <div class="proposal-info-heading">
-      <h2 class="proposal-info-title">${escapeHtml(display.title)}</h2>
+      <h2 class="proposal-info-title">${escapeHtml(title)}</h2>
       <p class="proposal-type-indicator${emergencyClass}">${escapeHtml(emergencyLabel)}</p>
       ${descriptionHtml}
     </div>
   `;
 }
 
-function renderDaoProposalInfoSection(title, rows) {
+function renderDaoProposalSection(title, rows) {
   const rowHtml = rows
     .map(([label, value, tone]) => {
       const displayValue = formatDaoDetailValue(value);
-      const classes = [
-        'proposal-info-row',
-        tone ? `proposal-info-row--${tone}` : '',
-      ].filter(Boolean);
+      const toneClass = tone ? ` proposal-info-row--${tone}` : '';
 
       return `
-      <div class="${classes.join(' ')}">
+      <div class="proposal-info-row${toneClass}">
         <span>${escapeHtml(label)}</span>
         <span class="proposal-info-value">${escapeHtml(displayValue)}</span>
       </div>
@@ -3631,8 +3610,8 @@ function renderDaoProposalInfoSection(title, rows) {
   `;
 }
 
-function renderDaoProposalOptionsSection(options) {
-  const optionCards = options
+function renderDaoProposalOptions(proposal) {
+  const optionCards = getDaoProposalOptions(proposal)
     .map((option, index) => `
       <div class="proposal-option-card">
         <span class="proposal-option-card-number">${index + 1}</span>
@@ -3649,27 +3628,25 @@ function renderDaoProposalOptionsSection(options) {
   `;
 }
 
-function renderDaoProposalChangesSection(payloads) {
-  const hasRows = payloads.some(([, payload]) =>
-    Array.isArray(payload?.changes)
-      ? payload.changes.length > 0
-      : Object.values(payload).some((value) => value !== undefined && value !== null && String(value).length > 0)
-  );
-
-  if (payloads.length === 0 || !hasRows) {
-    return '<section class="proposal-info-section"><h3>Parameter Changes</h3><p class="proposal-info-muted">No parameter changes are available.</p></section>';
-  }
-
-  const payloadHtml = payloads
+function renderDaoProposalChanges(proposal) {
+  const payloadHtml = ['governance', 'economic', 'protocol']
+    .map((key) => [key, proposal[key]])
+    .filter(([, payload]) => payload && typeof payload === 'object')
     .map(([key, payload]) => {
-      const payloadTitle = getDaoTypeLabel(key) || key;
+      const rows = renderDaoProposalPayloadRows(payload, getDaoTypeLabel(key) || key);
+      if (!rows) return '';
+
       return `
       <div class="proposal-payload">
-        ${renderDaoProposalPayloadRows(payload, payloadTitle)}
+        ${rows}
       </div>
     `;
     })
     .join('');
+
+  if (!payloadHtml) {
+    return '<section class="proposal-info-section"><h3>Parameter Changes</h3><p class="proposal-info-muted">No parameter changes are available.</p></section>';
+  }
 
   return `
     <section class="proposal-info-section">
@@ -3680,9 +3657,7 @@ function renderDaoProposalChangesSection(payloads) {
 }
 
 function renderDaoProposalPayloadRows(payload, payloadTitle) {
-  const titleHtml = payloadTitle
-    ? `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`
-    : '';
+  const titleHtml = `<div class="proposal-payload-title">${escapeHtml(payloadTitle)}</div>`;
 
   if (Array.isArray(payload?.changes)) {
     return payload.changes
@@ -3845,19 +3820,17 @@ class ConfirmProposalModal {
     }
 
     const tx = draft.transaction;
-    const display = normalizeDaoProposalDisplay(draft);
-
     this.setTitle('Review Proposal');
     this.content.innerHTML = [
-      renderDaoProposalHeading(display),
-      renderDaoProposalChangesSection(display.payloads),
-      renderDaoProposalOptionsSection(display.options),
-      renderDaoProposalInfoSection('Overview', [
+      renderDaoProposalHeading(tx),
+      renderDaoProposalChanges(tx),
+      renderDaoProposalOptions(tx),
+      renderDaoProposalSection('Overview', [
         ['Type', getDaoTypeLabel(tx.proposalType)],
         ['Proposal fee', `${draft.proposalFeeUsdStr || '0'} USD`],
         ['Initial state', 'Review after signing'],
       ]),
-      renderDaoProposalInfoSection('Review Timeline', [
+      renderDaoProposalSection('Review Timeline', [
         ['Review starts', formatDaoDurationSummary(draft.startDelayMs)],
         ['Grace period', formatDaoDurationSummary(tx.gracePeriod)],
       ]),
@@ -4548,18 +4521,18 @@ class ProposalInfoModal {
     const rewardSummary = getDaoProposalRewardSummary(proposal, currentAddress);
     const lifecycleActions = getDaoProposalLifecycleActions(proposal, rewardSummary, currentAddress);
     const committeeReviewSection = state === 'review'
-      ? renderDaoProposalInfoSection('Committee Review', [
+      ? renderDaoProposalSection('Committee Review', [
         ['Committee size', committeeAddresses.length ? String(committeeAddresses.length) : 'Unavailable'],
         ['Next state', this.getNextStateHint(proposal, acceptCount, withholdCount, reviewWindow)],
       ])
       : '';
     if (this.content) {
       this.content.innerHTML = [
-        this.renderProposalTitle(proposal),
-        this.renderParameterChanges(proposal),
+        renderDaoProposalHeading(proposal),
+        renderDaoProposalChanges(proposal),
         state === 'voting' ? this.renderCurrentVoteTotals(proposal) : '',
         this.renderProposalResults(resultSummary, committeeReview, currentAddress),
-        state === 'review' ? this.renderProposalBody(proposal) : '',
+        state === 'review' ? renderDaoProposalOptions(proposal) : '',
         state === 'review'
           ? this.renderCommitteeReviewStatus(committeeReview, reviewWindow, currentAddress)
           : '',
@@ -4592,10 +4565,6 @@ class ProposalInfoModal {
     const canFinalizeReviewResult = Boolean(currentAddress) && state === 'review' && reviewWindow.canFinalizeReviewResult;
 
     return { isCommitteeMember, canCommitteeVote, canFinalizeReviewResult };
-  }
-
-  renderProposalTitle(proposal) {
-    return renderDaoProposalHeading(normalizeDaoProposalDisplay(proposal));
   }
 
   renderCurrentVoteTotals(proposal) {
@@ -4951,7 +4920,7 @@ class ProposalInfoModal {
 
   renderProposalRewards(reward) {
     if (!reward) return '';
-    return renderDaoProposalInfoSection('Rewards', [
+    return renderDaoProposalSection('Rewards', [
       ['Claim status', reward.claimStatus, reward.statusTone],
       ['Claim estimate', reward.claimEstimate === null ? 'Unavailable' : formatDaoLibWei(reward.claimEstimate), reward.statusTone],
       ['Claim window', reward.claimWindowLabel],
@@ -4970,7 +4939,7 @@ class ProposalInfoModal {
     const totalVoteText = totalVote.length
       ? totalVote.map((value, index) => `${options[index] || `Option ${index + 1}`}: ${formatDaoVotingPower(value)}`).join('\n')
       : 'No votes yet';
-    return renderDaoProposalInfoSection('Voting Details', [
+    return renderDaoProposalSection('Voting Details', [
       ['Voting state', votingWindow.label],
       ['Current totals', totalVoteText],
     ]);
@@ -4978,21 +4947,21 @@ class ProposalInfoModal {
 
   renderProposalDetails({ proposal, state, reviewWindow, rewardSummary, committeeReviewSection }) {
     const sections = [
-      renderDaoProposalInfoSection('Overview', [
+      renderDaoProposalSection('Overview', [
         ['Number', proposal.number ? `#${proposal.number}` : 'Unavailable'],
         ['Type', getDaoTypeLabel(proposal.proposalType) || 'Unavailable'],
         ['Status', getDaoStateLabel(state) || state],
         ['Created', formatDaoDetailTimestamp(proposal.created)],
         ['Updated', formatDaoDetailTimestamp(proposal.state_changed)],
       ]),
-      renderDaoProposalInfoSection('Review Timeline', [
+      renderDaoProposalSection('Review Timeline', [
         ['Window state', reviewWindow.label],
         ['Review starts', formatDaoDetailTimestamp(reviewWindow.start)],
         ['Review ends', formatDaoDetailTimestamp(reviewWindow.end)],
       ]),
       committeeReviewSection,
       state === 'voting' ? this.renderVotingDetails(proposal) : '',
-      state === 'review' ? '' : this.renderProposalBody(proposal),
+      state === 'review' ? '' : renderDaoProposalOptions(proposal),
       this.renderProposalRewards(rewardSummary),
     ].filter(Boolean);
 
@@ -5018,14 +4987,6 @@ class ProposalInfoModal {
 
   setTitle(title) {
     if (this.title) this.title.textContent = title || 'Proposal';
-  }
-
-  renderProposalBody(proposal) {
-    return renderDaoProposalOptionsSection(normalizeDaoProposalDisplay(proposal).options);
-  }
-
-  renderParameterChanges(proposal) {
-    return renderDaoProposalChangesSection(normalizeDaoProposalDisplay(proposal).payloads);
   }
 
   formatCommitteeVote(vote) {

--- a/index.html
+++ b/index.html
@@ -447,7 +447,7 @@
         </div>
         <div class="modal-content">
           <div class="form-container">
-            <div class="dao-confirm" id="confirmProposalContent"></div>
+            <div class="proposal-info" id="confirmProposalContent"></div>
             <div class="form-actions dao-confirm-actions">
               <button type="button" id="backConfirmProposal" class="btn btn--secondary btn--pill btn--full">Back</button>
               <button type="button" id="signConfirmProposal" class="btn btn--primary btn--pill btn--full">Sign Proposal</button>

--- a/styles.css
+++ b/styles.css
@@ -2080,7 +2080,7 @@ input[type='file'].form-control::file-selector-button {
   padding-right: 8px;
 }
 
-#confirmProposalModal .dao-confirm,
+#confirmProposalModal .proposal-info,
 #proposalInfoModal .proposal-info,
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
@@ -2093,16 +2093,19 @@ input[type='file'].form-control::file-selector-button {
   width: 100%;
 }
 
+#confirmProposalModal .proposal-info-heading,
 #proposalInfoModal .proposal-info-heading {
   display: grid;
   gap: 4px;
   text-align: center;
 }
 
+#confirmProposalModal .proposal-info-title,
 #proposalInfoModal .proposal-info-title {
   margin-bottom: 0;
 }
 
+#confirmProposalModal .proposal-info-description,
 #proposalInfoModal .proposal-info-description {
   color: var(--secondary-text-color);
   font-size: 14px;
@@ -2111,6 +2114,7 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
+#confirmProposalModal .proposal-type-indicator,
 #proposalInfoModal .proposal-type-indicator {
   background: var(--input-background);
   border: 1px solid var(--border-color);
@@ -2124,19 +2128,20 @@ input[type='file'].form-control::file-selector-button {
   padding: 6px 12px;
 }
 
+#confirmProposalModal .proposal-type-indicator--emergency,
 #proposalInfoModal .proposal-type-indicator--emergency {
   background: rgba(196, 45, 45, 0.12);
   border-color: rgba(196, 45, 45, 0.3);
   color: #8f1d16;
 }
 
-#confirmProposalModal .dao-confirm-section,
+#confirmProposalModal .proposal-info-section,
 #proposalInfoModal .proposal-info-section {
   display: grid;
   gap: 8px;
 }
 
-#confirmProposalModal .dao-confirm-section h3,
+#confirmProposalModal .proposal-info-section h3,
 #proposalInfoModal .proposal-info-section h3,
 #proposalInfoModal .proposal-committee-actions h3,
 #proposalInfoModal .proposal-review-result-actions h3,
@@ -2151,7 +2156,7 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#confirmProposalModal .dao-confirm-grid,
+#confirmProposalModal .proposal-info-grid,
 #proposalInfoModal .proposal-info-grid {
   display: flex;
   flex-wrap: wrap;
@@ -2159,12 +2164,14 @@ input[type='file'].form-control::file-selector-button {
   justify-content: center;
 }
 
+#confirmProposalModal .proposal-option-cards,
 #proposalInfoModal .proposal-option-cards {
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(0, 1fr);
 }
 
+#confirmProposalModal .proposal-option-card,
 #proposalInfoModal .proposal-option-card {
   align-items: center;
   background: rgba(255, 255, 255, 0.92);
@@ -2179,6 +2186,7 @@ input[type='file'].form-control::file-selector-button {
   text-align: left;
 }
 
+#confirmProposalModal .proposal-option-card-number,
 #proposalInfoModal .proposal-option-card-number {
   align-items: center;
   background: var(--input-background);
@@ -2194,6 +2202,7 @@ input[type='file'].form-control::file-selector-button {
   padding: 0 4px;
 }
 
+#confirmProposalModal .proposal-option-card-label,
 #proposalInfoModal .proposal-option-card-label {
   color: var(--text-color);
   font-size: 13px;
@@ -2202,7 +2211,7 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
-#confirmProposalModal .dao-confirm-row,
+#confirmProposalModal .proposal-info-row,
 #proposalInfoModal .proposal-info-row {
   background: var(--input-background);
   border-radius: 8px;
@@ -2216,14 +2225,11 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
+#confirmProposalModal .proposal-info-row,
 #proposalInfoModal .proposal-info-row {
   background: rgba(255, 255, 255, 0.92);
   border: 1px solid var(--border-color);
   box-shadow: 0 1px 2px rgba(28, 28, 33, 0.05);
-}
-
-#confirmProposalModal .dao-confirm-row--full {
-  flex-basis: 100%;
 }
 
 #proposalInfoModal .proposal-info-row--accept {
@@ -2231,8 +2237,8 @@ input[type='file'].form-control::file-selector-button {
   border: 1px solid rgba(30, 126, 52, 0.34);
 }
 
-#confirmProposalModal .dao-confirm-label,
-#confirmProposalModal .dao-confirm-change-title,
+#confirmProposalModal .proposal-info-row > span:not(.proposal-info-value),
+#confirmProposalModal .proposal-change-row span,
 #proposalInfoModal .proposal-info-row > span:not(.proposal-info-value),
 #proposalInfoModal .proposal-change-row span {
   color: var(--secondary-text-color);
@@ -2248,8 +2254,7 @@ input[type='file'].form-control::file-selector-button {
   color: #1e7e34;
 }
 
-#confirmProposalModal .dao-confirm-value,
-#confirmProposalModal .dao-confirm-change-values strong,
+#confirmProposalModal .proposal-change-row strong,
 #proposalInfoModal .proposal-change-row strong {
   color: var(--text-color);
   font-size: 13px;
@@ -2261,6 +2266,7 @@ input[type='file'].form-control::file-selector-button {
   white-space: pre-wrap;
 }
 
+#confirmProposalModal .proposal-info-value,
 #proposalInfoModal .proposal-info-value {
   color: var(--text-color);
   font-size: 13px;
@@ -2276,13 +2282,13 @@ input[type='file'].form-control::file-selector-button {
   color: #0f5f27;
 }
 
-#confirmProposalModal .dao-confirm-label,
+#confirmProposalModal .proposal-info-row > span:not(.proposal-info-value),
 #proposalInfoModal .proposal-info-row > span:not(.proposal-info-value) {
   align-self: start;
   justify-self: center;
 }
 
-#confirmProposalModal .dao-confirm-value,
+#confirmProposalModal .proposal-info-value,
 #proposalInfoModal .proposal-info-value {
   align-self: center;
   justify-self: center;
@@ -2527,7 +2533,7 @@ input[type='file'].form-control::file-selector-button {
   color: #8f1d16;
 }
 
-#confirmProposalModal .dao-confirm-change,
+#confirmProposalModal .proposal-change-row,
 #proposalInfoModal .proposal-change-row {
   background: var(--input-background);
   border-radius: 8px;
@@ -2539,7 +2545,7 @@ input[type='file'].form-control::file-selector-button {
   width: 100%;
 }
 
-#confirmProposalModal .dao-confirm-change-values,
+#confirmProposalModal .proposal-change-values,
 #proposalInfoModal .proposal-change-values {
   align-items: center;
   display: grid;
@@ -2549,8 +2555,8 @@ input[type='file'].form-control::file-selector-button {
   width: 100%;
 }
 
-#confirmProposalModal .dao-confirm-change-values small,
-#confirmProposalModal .dao-confirm-change-values strong,
+#confirmProposalModal .proposal-change-values small,
+#confirmProposalModal .proposal-change-values strong,
 #proposalInfoModal .proposal-change-values small,
 #proposalInfoModal .proposal-change-values strong {
   color: var(--text-color);
@@ -2559,7 +2565,8 @@ input[type='file'].form-control::file-selector-button {
   line-height: 1.35;
 }
 
-#confirmProposalModal .dao-confirm-change-values small,
+#confirmProposalModal .proposal-change-values small,
+#confirmProposalModal .proposal-change-values strong,
 #proposalInfoModal .proposal-change-values small,
 #proposalInfoModal .proposal-change-values strong {
   display: grid;
@@ -2569,8 +2576,9 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#confirmProposalModal .dao-confirm-change-values small > span,
-#confirmProposalModal .dao-confirm-change-values small > strong,
+#confirmProposalModal .proposal-change-values small > span,
+#confirmProposalModal .proposal-change-values small > strong,
+#confirmProposalModal .proposal-change-values strong > span,
 #proposalInfoModal .proposal-change-values small > span,
 #proposalInfoModal .proposal-change-values small > strong,
 #proposalInfoModal .proposal-change-values strong > span {
@@ -2578,25 +2586,23 @@ input[type='file'].form-control::file-selector-button {
   overflow-wrap: anywhere;
 }
 
-#confirmProposalModal .dao-confirm-change-values small > span,
+#confirmProposalModal .proposal-change-values small > span,
+#confirmProposalModal .proposal-change-values strong > span:first-child,
 #proposalInfoModal .proposal-change-values small > span,
 #proposalInfoModal .proposal-change-values strong > span:first-child {
   color: var(--secondary-text-color);
   font-size: 12px;
 }
 
-#confirmProposalModal .dao-confirm-change-values small > strong,
+#confirmProposalModal .proposal-change-values small > strong,
+#confirmProposalModal .proposal-change-values strong > span:last-child,
 #proposalInfoModal .proposal-change-values small > strong,
 #proposalInfoModal .proposal-change-values strong > span:last-child {
   color: var(--text-color);
   font-size: 13px;
 }
 
-#confirmProposalModal .dao-confirm-change-values strong {
-  text-align: center;
-}
-
-#confirmProposalModal .dao-confirm-change-arrow,
+#confirmProposalModal .proposal-change-arrow,
 #proposalInfoModal .proposal-change-arrow {
   color: var(--secondary-text-color);
   font-size: 15px;
@@ -2605,8 +2611,8 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#confirmProposalModal .dao-confirm-empty,
-#confirmProposalModal .dao-confirm-help,
+#confirmProposalModal .proposal-info-muted,
+#confirmProposalModal .proposal-change-row small,
 #proposalInfoModal .proposal-info-muted,
 #proposalInfoModal .proposal-committee-actions p,
 #proposalInfoModal .proposal-review-result-actions p,
@@ -2629,13 +2635,9 @@ input[type='file'].form-control::file-selector-button {
 }
 
 @media (max-width: 420px) {
-  #confirmProposalModal .dao-confirm-row,
+  #confirmProposalModal .proposal-info-row,
   #proposalInfoModal .proposal-info-row {
     flex-basis: calc((100% - 8px) / 2);
-  }
-
-  #confirmProposalModal .dao-confirm-row--full {
-    flex-basis: 100%;
   }
 }
 
@@ -2743,11 +2745,13 @@ input[type='file'].form-control::file-selector-button {
   padding: 10px;
 }
 
+#confirmProposalModal .proposal-payload,
 #proposalInfoModal .proposal-payload {
   display: grid;
   gap: 8px;
 }
 
+#confirmProposalModal .proposal-payload-title,
 #proposalInfoModal .proposal-payload-title {
   color: var(--text-color);
   font-size: 13px;


### PR DESCRIPTION
## What Changed

This PR unifies the DAO proposal review display across the pre-signing confirmation modal and the proposal detail modal.

- Shared proposal renderers now handle headings, parameter changes, options, and information sections.
- The confirmation modal uses the same proposal layout and ordering as the post-submission detail view.
- Confirm-specific styles and markup were consolidated into the shared `proposal-info` presentation.

## Updated Flow

1. A user completes the DAO proposal form and opens the signing review.
2. The draft is rendered with the shared proposal heading, parameter changes, options, overview, and timeline sections.
3. After submission, the proposal detail modal uses the same renderers for the corresponding data.
4. Both review surfaces stay visually and structurally consistent as the shared components evolve.

## Why

The two proposal review surfaces previously maintained separate markup and styles for the same proposal data. Consolidating them removes duplication and prevents their presentation from drifting apart.

## Validation

- `node --check app.js`
- `node --check dao.repo.js`
- `git diff --check main...HEAD`
