### PR TITLE
Show emergency and review-result badges in DAO lists

### DIFF
--- a/app.js
+++ b/app.js
@@ -2791,7 +2791,7 @@ class DaoModal {
 
       li.tabIndex = 0;
       li.setAttribute('role', 'button');
-      li.setAttribute('aria-label', `Open ${rowTitleText}`);
+      li.setAttribute('aria-label', `Open ${p.emergency === true ? 'emergency ' : ''}${rowTitleText}`);
       li.innerHTML = `
         <div class="dao-row-content">
           <div class="dao-row-title">${title}</div>
@@ -2824,8 +2824,25 @@ class DaoModal {
     const result = getDaoProposalResultSummary(proposal);
     const reward = getDaoProposalRewardSummary(proposal);
 
+    if (proposal.emergency === true) {
+      chips.push({
+        value: 'Emergency',
+        tone: 'emergency',
+      });
+    }
+
     if (state === 'review') {
       const reviewWindow = getDaoProposalReviewWindow(proposal);
+
+      if (reviewWindow.canFinalizeReviewResult) {
+        const { acceptCount, withholdCount } = getDaoCommitteeReview(proposal);
+        const isWithheld = withholdCount > acceptCount;
+
+        chips.push({
+          value: isWithheld ? 'Withheld' : 'Approved',
+          tone: isWithheld ? 'rejected' : 'accepted',
+        });
+      }
 
       chips.push({
         value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,

--- a/styles.css
+++ b/styles.css
@@ -8071,12 +8071,12 @@ small {
 #daoModal .dao-row-previews {
   display: flex;
   flex: 1 1 auto;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 4px;
   justify-content: flex-end;
   margin-left: auto;
   min-width: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 #daoModal .dao-row-preview {
@@ -8086,7 +8086,7 @@ small {
   border-radius: 8px;
   color: var(--text-color);
   display: inline-flex;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   font-size: 12px;
   font-weight: var(--font-weight-medium);
   line-height: 1.2;
@@ -8107,6 +8107,11 @@ small {
 #daoModal .dao-row-preview--rejected {
   background: rgba(196, 45, 45, 0.1);
   border-color: rgba(196, 45, 45, 0.28);
+}
+
+#daoModal .dao-row-preview--emergency {
+  background: rgba(239, 108, 0, 0.12);
+  border-color: rgba(239, 108, 0, 0.32);
 }
 
 #daoStatusContextMenu {


### PR DESCRIPTION
## What Changed

This PR makes emergency and completed committee-review status visible directly in DAO proposal lists.

- Adds an `Emergency` badge as the leftmost status chip for emergency proposals.
- Shows the committee's overall `Approved` or `Withheld` result once the review period is ready to finalize.
- Allows proposal chips to wrap so added status remains readable on narrow screens.
- Includes emergency status in the proposal row's accessible label.

## Fixed Flow

1. A proposal appears in an Active, Archived, or Claimable DAO list.
2. Emergency proposals are identified immediately by the leftmost badge.
3. When committee review ends, the current accept/withhold tally determines the result preview.
4. The row displays that result before `Ready to finalize` without clipping the chips.

## Why

Proposal rows previously omitted the emergency flag and did not expose the committee's final review outcome before finalization. Users had to open each proposal to understand those states. Rendering both from the proposal's existing source-of-truth data makes the list scannable without introducing separate UI state.

## Validation

- `node --check app.js`
- `node --test tests/dao-timeline.test.mjs`
- `git diff --check main...HEAD`

Closes #1487