### PR TITLE
Align DAO and Update menu icons with labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -1355,7 +1355,7 @@ class WelcomeMenuModal {
       this.launchButton.addEventListener('click', () => launchModal.open());
       this.launchButton.style.display = 'block';
       this.updateButton.addEventListener('click', () => aboutModal.openStore());
-      this.updateButton.style.display = 'block';
+      this.updateButton.style.display = 'flex';
     }
   }
 
@@ -2348,7 +2348,7 @@ class MenuModal {
 
       this.updateButton = document.getElementById('openUpdate');
       this.updateButton.addEventListener('click', () => updateWarningModal.open());
-      this.updateButton.style.display = 'block';
+      this.updateButton.style.display = 'flex';
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -2314,7 +2314,7 @@ class MenuModal {
     this.validatorButton.addEventListener('click', () => validatorStakingModal.open());
     this.daoButton = document.getElementById('openDao');
     if (network.name === 'Devnet') {
-      this.daoButton.style.display = 'block';
+      this.daoButton.style.display = 'flex';
       this.daoButton.addEventListener('click', () => daoModal.open());
     }
     this.inviteButton = document.getElementById('openInvite');


### PR DESCRIPTION
## What Changed

This PR aligns conditionally displayed DAO and Update menu icons with their labels.

- Reveals the DAO menu item with `display: flex` on Devnet.
- Reveals both mobile Update menu items with `display: flex` in the signed-in and welcome menus.
- Preserves the shared menu-row centering behavior across phone and laptop layouts.

## Fixed Flow

1. The app reveals a conditional DAO or Update menu item.
2. The item remains a flex container instead of switching to block layout.
3. The existing `align-items: center` styling centers its icon and label.
4. The conditional rows now match the other menu options.

## Why

The conditional menu items were revealed with `display: block`, overriding the shared flex layout and leaving their icons slightly higher than their labels.

## Validation

- `node --check app.js`
- `git diff --check main...HEAD`

Closes #1492