### PR TITLE
Skip excluded DAO proposals on Devnet

### DIFF
--- a/DAO.md
+++ b/DAO.md
@@ -96,11 +96,12 @@ Important implementation detail:
 
 ## Backend Data Boundary
 
-- `app.js` registers `setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork))`.
+- `app.js` registers `setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK))`.
 - `dao.repo.js` keeps endpoint querying and backend-to-UI mapping behind the repository boundary.
 - Proposal list loading uses the current server DAO query shape:
   - `GET /dao/proposals/meta` for `meta.count`
   - `GET /dao/proposals/:number` for each proposal number from `1..count`
+- On Devnet, proposal numbers `1`, `3`, `4`, `5`, `6`, and `31` are removed from the query list before proposal details are fetched.
 - The fetcher skips missing numbered proposals so nodes that have not yet surfaced an account do not block the whole list.
 
 ## What must change for a live backend
@@ -111,7 +112,7 @@ This section is the remaining integration checklist after moving the DAO list to
 
 `daoRepo` uses an injected fetcher and otherwise returns an empty store.
 
-The app passes `queryNetwork` into `createDaoBackendFetcher(...)`; the repository maps backend `DaoProposalAccount` payloads into the store shape the UI expects.
+The app passes `queryNetwork` and its Devnet flag into `createDaoBackendFetcher(...)`; the repository maps backend `DaoProposalAccount` payloads into the store shape the UI expects.
 
 ### 2) Define backend endpoints / payloads
 

--- a/app.js
+++ b/app.js
@@ -168,6 +168,7 @@ const MENU_NAVIGATION_LOCK_MS = 400;
 const MAX_CHAT_MESSAGE_BYTES = 1000; // 1000 bytes for chat messages
 const BRIDGE_USERNAME = 'liberdusbridge';
 const TRANSACTION_TIMESTAMP_OFFSET_MS = 500; // Transaction offset to allow for slow connections
+const IS_DEV_NETWORK = network?.name === 'Devnet';
 
 let myData = null;
 let myAccount = null; // this is set to myData.account for convience
@@ -2313,7 +2314,7 @@ class MenuModal {
     this.validatorButton = document.getElementById('openValidator');
     this.validatorButton.addEventListener('click', () => validatorStakingModal.open());
     this.daoButton = document.getElementById('openDao');
-    if (network.name === 'Devnet') {
+    if (IS_DEV_NETWORK) {
       this.daoButton.style.display = 'flex';
       this.daoButton.addEventListener('click', () => daoModal.open());
     }
@@ -2466,7 +2467,7 @@ const menuModal = new MenuModal();
 // =====================
 
 // DAO proposals are loaded via `daoRepo` and kept in memory (no localStorage persistence).
-setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork));
+setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
 
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };
 const DAO_FILTER_OPTIONS = [...DAO_STATES, DAO_CLAIMABLE_FILTER];

--- a/app.js
+++ b/app.js
@@ -2314,10 +2314,8 @@ class MenuModal {
     this.validatorButton = document.getElementById('openValidator');
     this.validatorButton.addEventListener('click', () => validatorStakingModal.open());
     this.daoButton = document.getElementById('openDao');
-    if (IS_DEV_NETWORK) {
-      this.daoButton.style.display = 'flex';
-      this.daoButton.addEventListener('click', () => daoModal.open());
-    }
+    this.daoButton.style.display = 'flex';
+    this.daoButton.addEventListener('click', () => daoModal.open());
     this.inviteButton = document.getElementById('openInvite');
     this.inviteButton.addEventListener('click', () => inviteModal.open());
     this.explorerButton = document.getElementById('openExplorer');

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -192,6 +192,7 @@ export function getEffectiveDaoState(proposal) {
 }
 
 const DAO_PROPOSAL_QUERY_BATCH_SIZE = 10;
+const DAO_DEVNET_EXCLUDED_PROPOSAL_NUMBERS = new Set([1, 3, 4, 5, 6, 31]);
 
 function requireDaoDraftString(value, label, maxLength) {
   const text = String(value ?? '').trim();
@@ -805,7 +806,7 @@ async function fetchBackendProposal(queryDaoApi, proposalNumber) {
   return body.proposal;
 }
 
-export function createDaoBackendFetcher(queryDaoApi) {
+export function createDaoBackendFetcher(queryDaoApi, isDevNetwork) {
   if (typeof queryDaoApi !== 'function') {
     return async () => createEmptyDaoStore();
   }
@@ -823,11 +824,18 @@ export function createDaoBackendFetcher(queryDaoApi) {
     const count = normalizeDaoPositiveInteger(meta?.count);
     if (!count) return buildStoreFromBackendProposals(meta, []);
 
+    const proposalNumbers = Array.from({ length: count }, (_, index) => index + 1)
+      .filter((proposalNumber) => (
+        !isDevNetwork || !DAO_DEVNET_EXCLUDED_PROPOSAL_NUMBERS.has(proposalNumber)
+      ));
     const proposals = [];
-    for (let start = 1; start <= count; start += DAO_PROPOSAL_QUERY_BATCH_SIZE) {
-      const end = Math.min(start + DAO_PROPOSAL_QUERY_BATCH_SIZE - 1, count);
+    for (let batchStart = 0; batchStart < proposalNumbers.length; batchStart += DAO_PROPOSAL_QUERY_BATCH_SIZE) {
+      const batchProposalNumbers = proposalNumbers.slice(
+        batchStart,
+        batchStart + DAO_PROPOSAL_QUERY_BATCH_SIZE
+      );
       const batch = await Promise.all(
-        Array.from({ length: end - start + 1 }, (_, index) => fetchBackendProposal(queryDaoApi, start + index))
+        batchProposalNumbers.map((proposalNumber) => fetchBackendProposal(queryDaoApi, proposalNumber))
       );
       proposals.push(...batch.filter(Boolean));
     }


### PR DESCRIPTION
## What Changed

This PR filters known Devnet proposals before proposal-detail requests while preserving full proposal querying on other networks.

- Adds a reusable `IS_DEV_NETWORK` flag and passes it into `createDaoBackendFetcher`.
- Excludes proposal numbers `1`, `3`, `4`, `5`, `6`, and `31` only on Devnet.
- Builds fetch batches from the filtered proposal-number list so excluded proposals are never queried.
- Makes the DAO menu entry available across configured networks.

## Fixed Flow

1. Load the proposal count from `/dao/proposals/meta`.
2. Build the proposal-number query list from `1` through `meta.count`.
3. On Devnet, remove the known excluded numbers before issuing detail requests.
4. Fetch the remaining proposals in batches; non-dev networks continue fetching every proposal number.

## Why

Known Devnet proposals should not be queried or rendered. Filtering at the repository boundary prevents unnecessary detail requests while leaving Testnet and other network behavior unchanged.

## Validation

- `node tests/dao-backend-fetcher.test.mjs`
- `node --check dao.repo.js`

Closes #1494