### PR TITLE
Render DAO modal from fresh refresh data

### DIFF
--- a/app.js
+++ b/app.js
@@ -2496,7 +2496,9 @@ class DaoModal {
     this.selectedFilterKey = 'voting';
     this._outsideClickHandler = null;
     this.refreshState = 'loading';
-    this.refreshRequestId = 0;
+    this.refreshSequence = 0;
+    this.openRefreshId = 0;
+    this.lastSuccessfulRefreshId = 0;
   }
 
   load() {
@@ -2558,7 +2560,8 @@ class DaoModal {
   }
 
   async _open() {
-    const requestId = ++this.refreshRequestId;
+    const refreshId = ++this.refreshSequence;
+    this.openRefreshId = refreshId;
     this.refreshState = 'loading';
 
     // Close the main menu if opened from it
@@ -2575,11 +2578,11 @@ class DaoModal {
 
     try {
       await daoRepo.refresh({ force: true });
-      if (!this.isActive()) return;
+      this.lastSuccessfulRefreshId = Math.max(this.lastSuccessfulRefreshId, refreshId);
+      if (!this.isActive() || refreshId !== this.openRefreshId) return;
       this.refreshState = 'ready';
     } catch (e) {
-      // Ignore stale failures and failures superseded by another successful refresh.
-      if (requestId !== this.refreshRequestId || this.refreshState === 'ready') return;
+      if (refreshId !== this.openRefreshId || this.lastSuccessfulRefreshId > refreshId) return;
       this.refreshState = 'error';
       console.warn('Failed to refresh DAO proposals:', e);
       showToast('Failed to load proposals', 2500, 'error');
@@ -2589,7 +2592,7 @@ class DaoModal {
   }
 
   close() {
-    this.refreshRequestId += 1;
+    this.openRefreshId = ++this.refreshSequence;
     this.closeStatusMenu();
     this.modal.classList.remove('active');
     enterFullscreen();
@@ -2610,6 +2613,7 @@ class DaoModal {
   }
 
   async refreshAfterDaoSettlement(pendingTxInfo, outcome) {
+    const refreshId = ++this.refreshSequence;
     let didRefreshDaoData = false;
     try {
       await daoRepo.refresh({ force: true });
@@ -2618,7 +2622,10 @@ class DaoModal {
       console.warn('DAO settlement refresh failed:', error);
     }
 
-    if (didRefreshDaoData && this.isActive()) this.refreshState = 'ready';
+    if (didRefreshDaoData) {
+      this.lastSuccessfulRefreshId = Math.max(this.lastSuccessfulRefreshId, refreshId);
+      if (this.isActive() && refreshId > this.openRefreshId) this.refreshState = 'ready';
+    }
 
     // A confirmed action must remain blocked until the UI can render fresh
     // proposal state. Failed and timed-out actions can safely release the UI.

--- a/app.js
+++ b/app.js
@@ -2495,7 +2495,7 @@ class DaoModal {
     this.selectedGroupKey = 'active';
     this.selectedFilterKey = 'voting';
     this._outsideClickHandler = null;
-    this.isLoading = false;
+    this.refreshState = 'loading';
   }
 
   load() {
@@ -2557,7 +2557,7 @@ class DaoModal {
   }
 
   async _open() {
-    this.isLoading = true;
+    this.refreshState = 'loading';
 
     // Close the main menu if opened from it
     if (menuModal?.isActive?.()) menuModal.close();
@@ -2573,11 +2573,12 @@ class DaoModal {
 
     try {
       await daoRepo.refresh({ force: true });
+      this.refreshState = 'ready';
     } catch (e) {
+      this.refreshState = 'error';
       console.warn('Failed to refresh DAO proposals:', e);
       showToast('Failed to load proposals', 2500, 'error');
     } finally {
-      this.isLoading = false;
       this.render();
     }
   }
@@ -2684,8 +2685,11 @@ class DaoModal {
   }
 
   render() {
-    const proposalsActive = daoRepo.getProposalsForUi('active');
-    const proposalsArchived = daoRepo.getProposalsForUi('archived');
+    const hasFreshData = this.refreshState === 'ready';
+    const isLoading = this.refreshState === 'loading';
+    const hasLoadError = this.refreshState === 'error';
+    const proposalsActive = hasFreshData ? daoRepo.getProposalsForUi('active') : [];
+    const proposalsArchived = hasFreshData ? daoRepo.getProposalsForUi('archived') : [];
     const currentAddress = getDaoCurrentAccountAddress();
     const now = getTransactionTimestamp();
     const isClaimableFilter = this.selectedFilterKey === DAO_CLAIMABLE_FILTER.key;
@@ -2710,12 +2714,12 @@ class DaoModal {
 
     // Update group toggle labels + selection
     if (this.groupActiveButton) {
-      this.groupActiveButton.textContent = `Active ${proposalsActive.length}`;
+      this.groupActiveButton.textContent = `Active ${hasFreshData ? proposalsActive.length : '—'}`;
       this.groupActiveButton.classList.toggle('active', this.selectedGroupKey !== 'archived');
       this.groupActiveButton.setAttribute('aria-selected', this.selectedGroupKey !== 'archived' ? 'true' : 'false');
     }
     if (this.groupArchivedButton) {
-      this.groupArchivedButton.textContent = `Archived ${proposalsArchived.length}`;
+      this.groupArchivedButton.textContent = `Archived ${hasFreshData ? proposalsArchived.length : '—'}`;
       this.groupArchivedButton.classList.toggle('active', this.selectedGroupKey === 'archived');
       this.groupArchivedButton.setAttribute('aria-selected', this.selectedGroupKey === 'archived' ? 'true' : 'false');
     }
@@ -2728,8 +2732,11 @@ class DaoModal {
 
       if (labelEl) labelEl.textContent = filter.label;
       if (countEl) {
-        countEl.textContent = String(count);
-        countEl.setAttribute('aria-label', `${count} ${filter.label.toLowerCase()} proposals`);
+        countEl.textContent = hasFreshData ? String(count) : '—';
+        countEl.setAttribute(
+          'aria-label',
+          hasFreshData ? `${count} ${filter.label.toLowerCase()} proposals` : `${filter.label} count unavailable`
+        );
       }
       if (option) {
         const selected = filter.key === this.selectedFilterKey;
@@ -2760,9 +2767,12 @@ class DaoModal {
       const sublineEl = lines[2] || null;
       const isArchived = this.selectedGroupKey === 'archived';
 
-      if (this.isLoading) {
+      if (isLoading) {
         if (headlineEl) headlineEl.textContent = 'Loading proposals…';
         if (sublineEl) sublineEl.textContent = 'Please wait';
+      } else if (hasLoadError) {
+        if (headlineEl) headlineEl.textContent = 'Failed to load proposals';
+        if (sublineEl) sublineEl.textContent = 'Close and reopen the DAO to retry';
       } else if (isClaimableFilter) {
         if (headlineEl) headlineEl.textContent = 'No claimable proposals found';
         if (sublineEl) sublineEl.textContent = 'You have no voter rewards ready to claim';
@@ -2813,7 +2823,7 @@ class DaoModal {
 
     // Show + button when modal is active
     if (this.addButton) {
-      this.addButton.classList.toggle('visible', this.isActive());
+      this.addButton.classList.toggle('visible', hasFreshData && this.isActive());
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -2577,8 +2577,14 @@ class DaoModal {
 
     try {
       await daoRepo.refresh({ force: true });
-      if (requestId !== this.refreshRequestId) return;
       this.successfulRefreshVersion += 1;
+      if (requestId !== this.refreshRequestId) {
+        if (this.isActive()) {
+          this.refreshState = 'ready';
+          this.render();
+        }
+        return;
+      }
       this.refreshState = 'ready';
     } catch (e) {
       if (requestId !== this.refreshRequestId) return;

--- a/app.js
+++ b/app.js
@@ -2497,7 +2497,6 @@ class DaoModal {
     this._outsideClickHandler = null;
     this.refreshState = 'loading';
     this.refreshRequestId = 0;
-    this.successfulRefreshVersion = 0;
   }
 
   load() {
@@ -2560,7 +2559,6 @@ class DaoModal {
 
   async _open() {
     const requestId = ++this.refreshRequestId;
-    const successfulRefreshVersion = this.successfulRefreshVersion;
     this.refreshState = 'loading';
 
     // Close the main menu if opened from it
@@ -2577,24 +2575,14 @@ class DaoModal {
 
     try {
       await daoRepo.refresh({ force: true });
-      this.successfulRefreshVersion += 1;
-      if (requestId !== this.refreshRequestId) {
-        if (this.isActive()) {
-          this.refreshState = 'ready';
-          this.render();
-        }
-        return;
-      }
+      if (!this.isActive()) return;
       this.refreshState = 'ready';
     } catch (e) {
-      if (requestId !== this.refreshRequestId) return;
-      if (successfulRefreshVersion !== this.successfulRefreshVersion) {
-        this.refreshState = 'ready';
-      } else {
-        this.refreshState = 'error';
-        console.warn('Failed to refresh DAO proposals:', e);
-        showToast('Failed to load proposals', 2500, 'error');
-      }
+      // Ignore stale failures and failures superseded by another successful refresh.
+      if (requestId !== this.refreshRequestId || this.refreshState === 'ready') return;
+      this.refreshState = 'error';
+      console.warn('Failed to refresh DAO proposals:', e);
+      showToast('Failed to load proposals', 2500, 'error');
     }
 
     this.render();
@@ -2630,10 +2618,7 @@ class DaoModal {
       console.warn('DAO settlement refresh failed:', error);
     }
 
-    if (didRefreshDaoData) {
-      this.successfulRefreshVersion += 1;
-      if (this.isActive()) this.refreshState = 'ready';
-    }
+    if (didRefreshDaoData && this.isActive()) this.refreshState = 'ready';
 
     // A confirmed action must remain blocked until the UI can render fresh
     // proposal state. Failed and timed-out actions can safely release the UI.
@@ -2709,8 +2694,6 @@ class DaoModal {
 
   render() {
     const hasFreshData = this.refreshState === 'ready';
-    const isLoading = this.refreshState === 'loading';
-    const hasLoadError = this.refreshState === 'error';
     const proposalsActive = hasFreshData ? daoRepo.getProposalsForUi('active') : [];
     const proposalsArchived = hasFreshData ? daoRepo.getProposalsForUi('archived') : [];
     const currentAddress = getDaoCurrentAccountAddress();
@@ -2790,10 +2773,10 @@ class DaoModal {
       const sublineEl = lines[2] || null;
       const isArchived = this.selectedGroupKey === 'archived';
 
-      if (isLoading) {
+      if (this.refreshState === 'loading') {
         if (headlineEl) headlineEl.textContent = 'Loading proposals…';
         if (sublineEl) sublineEl.textContent = 'Please wait';
-      } else if (hasLoadError) {
+      } else if (this.refreshState === 'error') {
         if (headlineEl) headlineEl.textContent = 'Failed to load proposals';
         if (sublineEl) sublineEl.textContent = 'Close and reopen the DAO to retry';
       } else if (isClaimableFilter) {

--- a/app.js
+++ b/app.js
@@ -2496,6 +2496,8 @@ class DaoModal {
     this.selectedFilterKey = 'voting';
     this._outsideClickHandler = null;
     this.refreshState = 'loading';
+    this.refreshRequestId = 0;
+    this.successfulRefreshVersion = 0;
   }
 
   load() {
@@ -2557,6 +2559,8 @@ class DaoModal {
   }
 
   async _open() {
+    const requestId = ++this.refreshRequestId;
+    const successfulRefreshVersion = this.successfulRefreshVersion;
     this.refreshState = 'loading';
 
     // Close the main menu if opened from it
@@ -2573,17 +2577,31 @@ class DaoModal {
 
     try {
       await daoRepo.refresh({ force: true });
+      this.successfulRefreshVersion += 1;
+      if (requestId !== this.refreshRequestId) {
+        if (this.isActive()) {
+          this.refreshState = 'ready';
+          this.render();
+        }
+        return;
+      }
       this.refreshState = 'ready';
     } catch (e) {
-      this.refreshState = 'error';
-      console.warn('Failed to refresh DAO proposals:', e);
-      showToast('Failed to load proposals', 2500, 'error');
-    } finally {
-      this.render();
+      if (requestId !== this.refreshRequestId) return;
+      if (successfulRefreshVersion !== this.successfulRefreshVersion) {
+        this.refreshState = 'ready';
+      } else {
+        this.refreshState = 'error';
+        console.warn('Failed to refresh DAO proposals:', e);
+        showToast('Failed to load proposals', 2500, 'error');
+      }
     }
+
+    this.render();
   }
 
   close() {
+    this.refreshRequestId += 1;
     this.closeStatusMenu();
     this.modal.classList.remove('active');
     enterFullscreen();
@@ -2610,6 +2628,11 @@ class DaoModal {
       didRefreshDaoData = true;
     } catch (error) {
       console.warn('DAO settlement refresh failed:', error);
+    }
+
+    if (didRefreshDaoData) {
+      this.successfulRefreshVersion += 1;
+      if (this.isActive()) this.refreshState = 'ready';
     }
 
     // A confirmed action must remain blocked until the UI can render fresh

--- a/app.js
+++ b/app.js
@@ -2577,14 +2577,8 @@ class DaoModal {
 
     try {
       await daoRepo.refresh({ force: true });
+      if (requestId !== this.refreshRequestId) return;
       this.successfulRefreshVersion += 1;
-      if (requestId !== this.refreshRequestId) {
-        if (this.isActive()) {
-          this.refreshState = 'ready';
-          this.render();
-        }
-        return;
-      }
       this.refreshState = 'ready';
     } catch (e) {
       if (requestId !== this.refreshRequestId) return;


### PR DESCRIPTION
## What Changed

This PR keeps the DAO modal in a loading state until it has proposal data fresh enough for the current opening.

- `DaoModal` now uses explicit `loading`, `ready`, and `error` states and withholds cached proposal rows and counts while opening.
- Proposal rows, filter counts, and the add-proposal action become available only after an eligible refresh succeeds.
- Ordered refresh IDs prevent a request from an older modal opening from marking a reopened modal as ready.
- A successful settlement refresh may supersede the opening refresh only when it started later, while filter selections made during loading are preserved.

## Fixed Flow

1. The user opens the DAO modal, which records the opening refresh ID and shows loading placeholders instead of cached proposals.
2. Filter changes remain responsive but cannot expose the existing repository snapshot.
3. The current opening refresh, or a genuinely newer settlement refresh, must succeed before the modal enters the ready state.
4. An older refresh completion cannot unlock the reopened modal; if the current refresh fails without a newer success, the modal shows an explicit error.
5. Once ready, proposal rows and filter counts render from the same completed repository snapshot.

## Why

The modal previously rendered cached repository data before its forced refresh completed, so counts and rows could come from different snapshots. Close/reopen timing also created a race where an older request could finish during a newer opening and incorrectly make that opening appear successful.

The repository remains intentionally in memory for proposal details, transaction handling, failure recovery, and its own version protection. The modal now adds a separate presentation boundary: cached repository data is retained, but it is not presented as current until the opening refresh—or a refresh proven to have started later—succeeds.

## Validation

- `node --check app.js`
- `node --test tests/dao-*.test.mjs`
- `git diff --check`

Closes #1496