### PR TITLE
Show proposal vote requirements in Vote preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -3907,6 +3907,10 @@ const DAO_VOTE_WEIGHT_MAX = 1_000_000;
 const DAO_VOTE_WEIGHT_PRECISION = 1_000_000_000_000;
 const DAO_VOTE_WEIGHT_PRECISION_BIGINT = 1_000_000_000_000n;
 const DAO_CLAIM_REWARD_PRECISION = 10n ** 18n;
+const DAO_VOTE_REQUIREMENT_HELP = {
+  voteThreshold: 'Minimum wallet balance required to vote on this proposal.',
+  minimumSpend: 'Minimum LIB you must spend for a valid vote on this proposal.',
+};
 
 function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
@@ -4507,6 +4511,7 @@ class ProposalInfoModal {
     if (this.submitButton) this.submitButton.addEventListener('click', () => this.handleCommitteeSubmit());
     if (this.reviewResultButton) this.reviewResultButton.addEventListener('click', () => this.handleReviewResultSubmit());
     if (this.lifecycleActionSection) this.lifecycleActionSection.addEventListener('click', (event) => this.handleLifecycleActionClick(event));
+    if (this.voteRequirements) this.voteRequirements.addEventListener('click', (event) => this.handleVoteRequirementHelpClick(event));
     if (this.voteSpendInput) this.voteSpendInput.addEventListener('input', () => this.handleVoteSpendInput());
     if (this.voteOptions) this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
     if (this.voteSubmitButton) this.voteSubmitButton.addEventListener('click', () => this.handleVoteSubmit());
@@ -5231,9 +5236,17 @@ class ProposalInfoModal {
     if (!this.voteRequirements) return;
 
     const rows = [
-      ['Vote Threshold', formatDaoProposalVoteRequirementLib(proposal.voteThresholdUsdStr)],
-      ['Minimum Vote Spend', formatDaoProposalVoteRequirementLib(proposal.minimumSpendUsdStr)],
-    ].filter(([, value]) => value !== null);
+      {
+        key: 'voteThreshold',
+        label: 'Vote Threshold',
+        value: formatDaoProposalVoteRequirementLib(proposal.voteThresholdUsdStr),
+      },
+      {
+        key: 'minimumSpend',
+        label: 'Minimum Vote Spend',
+        value: formatDaoProposalVoteRequirementLib(proposal.minimumSpendUsdStr),
+      },
+    ].filter((row) => row.value !== null);
 
     if (rows.length === 0) {
       this.voteRequirements.innerHTML = '';
@@ -5243,13 +5256,38 @@ class ProposalInfoModal {
 
     this.voteRequirements.classList.remove('hidden');
     this.voteRequirements.innerHTML = rows
-      .map(([label, value]) => `
-        <div class="proposal-vote-requirement">
-          <span>${escapeHtml(label)}</span>
-          <strong>${escapeHtml(value)}</strong>
-        </div>
-      `)
+      .map((row) => {
+        const help = DAO_VOTE_REQUIREMENT_HELP[row.key];
+        return `
+          <div class="proposal-vote-requirement">
+            <span class="proposal-vote-requirement-label">
+              ${escapeHtml(row.label)}
+              <button
+                type="button"
+                class="toll-info-icon proposal-vote-requirement-help"
+                data-icon="info"
+                data-vote-requirement-help="${escapeDaoFormAttribute(row.key)}"
+                title="${escapeDaoFormAttribute(help)}"
+                aria-label="${escapeDaoFormAttribute(`About ${row.label}`)}"
+              ></button>
+            </span>
+            <strong>${escapeHtml(row.value)}</strong>
+          </div>
+        `;
+      })
       .join('');
+  }
+
+  handleVoteRequirementHelpClick(event) {
+    const helpButton = event.target?.closest?.('[data-vote-requirement-help]');
+    if (!helpButton || !this.voteRequirements?.contains(helpButton)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const help = DAO_VOTE_REQUIREMENT_HELP[helpButton.dataset.voteRequirementHelp];
+    if (!help) return;
+    showToast(help, 0, 'info');
   }
 
   renderVoteOption(option, index) {

--- a/app.js
+++ b/app.js
@@ -5241,7 +5241,7 @@ class ProposalInfoModal {
     const rows = [
       {
         help: DAO_VOTE_HELP.voteThreshold,
-        label: 'Minimum Balance',
+        label: 'Vote Threshold',
         value: formatDaoProposalVoteRequirementLib(proposal.voteThresholdUsdStr),
       },
       {

--- a/app.js
+++ b/app.js
@@ -5238,12 +5238,12 @@ class ProposalInfoModal {
     const rows = [
       {
         key: 'voteThreshold',
-        label: 'Vote Threshold',
+        label: 'Minimum Balance',
         value: formatDaoProposalVoteRequirementLib(proposal.voteThresholdUsdStr),
       },
       {
         key: 'minimumSpend',
-        label: 'Minimum Vote Spend',
+        label: 'Minimum Spend',
         value: formatDaoProposalVoteRequirementLib(proposal.minimumSpendUsdStr),
       },
     ].filter((row) => row.value !== null);

--- a/app.js
+++ b/app.js
@@ -4439,6 +4439,14 @@ function getDaoUsdAsLibWei(usdValue) {
   }
 }
 
+// Snapshotted proposal USD rule → LIB display. null means the requirement does not apply.
+function formatDaoProposalVoteRequirementLib(usdValue) {
+  if (!(Number(usdValue || 0) > 0)) return null;
+  const weiAmount = getDaoUsdAsLibWei(usdValue);
+  if (weiAmount === null) return 'Unavailable';
+  return formatDaoLibWei(weiAmount);
+}
+
 function floorDaoVoteWeightEstimate(value) {
   const n = Number(value);
   if (!Number.isFinite(n) || n < 0) return null;

--- a/app.js
+++ b/app.js
@@ -3911,6 +3911,7 @@ const DAO_VOTE_REQUIREMENT_HELP = {
   voteThreshold: 'Minimum wallet balance required to vote on this proposal.',
   minimumSpend: 'Minimum LIB you must spend for a valid vote on this proposal.',
 };
+const DAO_VOTE_ALLOCATION_HELP = 'Allocation is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.';
 
 function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
@@ -4513,7 +4514,10 @@ class ProposalInfoModal {
     if (this.lifecycleActionSection) this.lifecycleActionSection.addEventListener('click', (event) => this.handleLifecycleActionClick(event));
     if (this.voteRequirements) this.voteRequirements.addEventListener('click', (event) => this.handleVoteRequirementHelpClick(event));
     if (this.voteSpendInput) this.voteSpendInput.addEventListener('input', () => this.handleVoteSpendInput());
-    if (this.voteOptions) this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
+    if (this.voteOptions) {
+      this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
+      this.voteOptions.addEventListener('click', (event) => this.handleVoteAllocationHelpClick(event));
+    }
     if (this.voteSubmitButton) this.voteSubmitButton.addEventListener('click', () => this.handleVoteSubmit());
 
     if (this.withholdReasonSelect) {
@@ -5211,10 +5215,19 @@ class ProposalInfoModal {
       this.voteOptions.innerHTML = `
         <div class="proposal-vote-options-header">
           <span>Option</span>
-          <span>Allocation</span>
+          <span class="proposal-vote-allocation-label">
+            Allocation
+            <button
+              type="button"
+              class="toll-info-icon proposal-vote-allocation-help"
+              data-icon="info"
+              data-vote-allocation-help
+              title="${escapeDaoFormAttribute(DAO_VOTE_ALLOCATION_HELP)}"
+              aria-label="About Allocation"
+            ></button>
+          </span>
         </div>
         ${options.map((option, index) => this.renderVoteOption(option, index)).join('')}
-        <div class="proposal-vote-options-help">Allocation is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.</div>
       `;
     }
     this.renderVoteRequirements(proposal);
@@ -5286,6 +5299,15 @@ class ProposalInfoModal {
     const help = DAO_VOTE_REQUIREMENT_HELP[helpButton.dataset.voteRequirementHelp];
     if (!help) return;
     showToast(help, 0, 'info');
+  }
+
+  handleVoteAllocationHelpClick(event) {
+    const helpButton = event.target?.closest?.('[data-vote-allocation-help]');
+    if (!helpButton || !this.voteOptions?.contains(helpButton)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    showToast(DAO_VOTE_ALLOCATION_HELP, 0, 'info');
   }
 
   renderVoteOption(option, index) {

--- a/app.js
+++ b/app.js
@@ -3907,11 +3907,11 @@ const DAO_VOTE_WEIGHT_MAX = 1_000_000;
 const DAO_VOTE_WEIGHT_PRECISION = 1_000_000_000_000;
 const DAO_VOTE_WEIGHT_PRECISION_BIGINT = 1_000_000_000_000n;
 const DAO_CLAIM_REWARD_PRECISION = 10n ** 18n;
-const DAO_VOTE_REQUIREMENT_HELP = {
+const DAO_VOTE_HELP = {
+  allocation: 'Allocation is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.',
   voteThreshold: 'Minimum wallet balance required to vote on this proposal.',
   minimumSpend: 'Minimum LIB you must spend for a valid vote on this proposal.',
 };
-const DAO_VOTE_ALLOCATION_HELP = 'Allocation is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.';
 
 function getDaoCurrentAccountAddress() {
   return myAccount?.keys?.address ? longAddress(myAccount.keys.address) : '';
@@ -4485,7 +4485,6 @@ class ProposalInfoModal {
     this.voteActionSection = document.getElementById('proposalVoteActionSection');
     this.voteActionHelp = document.getElementById('proposalVoteActionHelp');
     this.voteOptions = document.getElementById('proposalVoteOptions');
-    this.voteRequirements = document.getElementById('proposalVoteRequirements');
     this.voteSpendInput = document.getElementById('proposalVoteSpend');
     this.votePreview = document.getElementById('proposalVotePreview');
     this.voteSubmitButton = document.getElementById('proposalVoteSubmit');
@@ -4512,12 +4511,9 @@ class ProposalInfoModal {
     if (this.submitButton) this.submitButton.addEventListener('click', () => this.handleCommitteeSubmit());
     if (this.reviewResultButton) this.reviewResultButton.addEventListener('click', () => this.handleReviewResultSubmit());
     if (this.lifecycleActionSection) this.lifecycleActionSection.addEventListener('click', (event) => this.handleLifecycleActionClick(event));
-    if (this.voteRequirements) this.voteRequirements.addEventListener('click', (event) => this.handleVoteRequirementHelpClick(event));
+    if (this.voteActionSection) this.voteActionSection.addEventListener('click', (event) => this.handleVoteHelpClick(event));
     if (this.voteSpendInput) this.voteSpendInput.addEventListener('input', () => this.handleVoteSpendInput());
-    if (this.voteOptions) {
-      this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
-      this.voteOptions.addEventListener('click', (event) => this.handleVoteAllocationHelpClick(event));
-    }
+    if (this.voteOptions) this.voteOptions.addEventListener('input', (event) => this.handleVoteWeightInput(event));
     if (this.voteSubmitButton) this.voteSubmitButton.addEventListener('click', () => this.handleVoteSubmit());
 
     if (this.withholdReasonSelect) {
@@ -5219,18 +5215,18 @@ class ProposalInfoModal {
             Allocation
             <button
               type="button"
-              class="toll-info-icon proposal-vote-allocation-help"
+              class="toll-info-icon proposal-vote-help"
               data-icon="info"
-              data-vote-allocation-help
-              title="${escapeDaoFormAttribute(DAO_VOTE_ALLOCATION_HELP)}"
+              data-vote-help
+              title="${escapeDaoFormAttribute(DAO_VOTE_HELP.allocation)}"
               aria-label="About Allocation"
             ></button>
           </span>
         </div>
         ${options.map((option, index) => this.renderVoteOption(option, index)).join('')}
+        ${this.renderVoteRequirements(proposal)}
       `;
     }
-    this.renderVoteRequirements(proposal);
 
     this.updateVotePreview(proposal);
   }
@@ -5238,76 +5234,52 @@ class ProposalInfoModal {
   hideVoteActions() {
     this.canSubmitVote = false;
     this.voteActionSection?.classList.add('hidden');
-    if (this.voteRequirements) {
-      this.voteRequirements.innerHTML = '';
-      this.voteRequirements.classList.add('hidden');
-    }
     this.updateSubmitButtons();
   }
 
   renderVoteRequirements(proposal) {
-    if (!this.voteRequirements) return;
-
     const rows = [
       {
-        key: 'voteThreshold',
+        help: DAO_VOTE_HELP.voteThreshold,
         label: 'Minimum Balance',
         value: formatDaoProposalVoteRequirementLib(proposal.voteThresholdUsdStr),
       },
       {
-        key: 'minimumSpend',
+        help: DAO_VOTE_HELP.minimumSpend,
         label: 'Minimum Spend',
         value: formatDaoProposalVoteRequirementLib(proposal.minimumSpendUsdStr),
       },
     ].filter((row) => row.value !== null);
 
-    if (rows.length === 0) {
-      this.voteRequirements.innerHTML = '';
-      this.voteRequirements.classList.add('hidden');
-      return;
-    }
+    if (rows.length === 0) return '';
 
-    this.voteRequirements.classList.remove('hidden');
-    this.voteRequirements.innerHTML = rows
-      .map((row) => {
-        const help = DAO_VOTE_REQUIREMENT_HELP[row.key];
-        return `
+    return `
+      <div class="proposal-vote-requirements" aria-label="Vote requirements">
+        ${rows.map((row) => `
           <span class="proposal-vote-requirement-label">
             ${escapeHtml(row.label)}
             <button
               type="button"
-              class="toll-info-icon proposal-vote-requirement-help"
+              class="toll-info-icon proposal-vote-help"
               data-icon="info"
-              data-vote-requirement-help="${escapeDaoFormAttribute(row.key)}"
-              title="${escapeDaoFormAttribute(help)}"
+              data-vote-help
+              title="${escapeDaoFormAttribute(row.help)}"
               aria-label="${escapeDaoFormAttribute(`About ${row.label}`)}"
             ></button>
           </span>
           <span class="proposal-vote-requirement-value">${escapeHtml(row.value)}</span>
-        `;
-      })
-      .join('');
+        `).join('')}
+      </div>
+    `;
   }
 
-  handleVoteRequirementHelpClick(event) {
-    const helpButton = event.target?.closest?.('[data-vote-requirement-help]');
-    if (!helpButton || !this.voteRequirements?.contains(helpButton)) return;
+  handleVoteHelpClick(event) {
+    const helpButton = event.target?.closest?.('[data-vote-help]');
+    if (!helpButton) return;
 
     event.preventDefault();
     event.stopPropagation();
-
-    const help = DAO_VOTE_REQUIREMENT_HELP[helpButton.dataset.voteRequirementHelp];
-    if (!help) return;
-    showToast(help, 0, 'info');
-  }
-
-  handleVoteAllocationHelpClick(event) {
-    const helpButton = event.target?.closest?.('[data-vote-allocation-help]');
-    if (!helpButton || !this.voteOptions?.contains(helpButton)) return;
-
-    event.preventDefault();
-    event.stopPropagation();
-    showToast(DAO_VOTE_ALLOCATION_HELP, 0, 'info');
+    showToast(helpButton.title, 0, 'info');
   }
 
   renderVoteOption(option, index) {
@@ -5353,8 +5325,7 @@ class ProposalInfoModal {
   }
 
   hasStartedVoteInput() {
-    if (this.voteWeights.some((weight) => weight > 0)) return true;
-    return String(this.voteSpendLib || '').trim() !== '';
+    return this.voteWeights.some((weight) => weight > 0) || this.voteSpendLib.trim() !== '';
   }
 
   updateVotePreview(proposal) {
@@ -5365,15 +5336,12 @@ class ProposalInfoModal {
     }
 
     const submission = this.getVoteSubmission(proposal);
+    this.votePreview.classList.toggle('proposal-vote-preview--idle', !this.hasStartedVoteInput());
     if (!submission.ok) {
       this.canSubmitVote = false;
       this.updateSubmitButtons();
       this.votePreview.classList.add('proposal-vote-preview--message');
-      this.votePreview.innerHTML = this.renderVotePreviewMessage(
-        submission.message,
-        submission.tone,
-        { idle: !this.hasStartedVoteInput() },
-      );
+      this.votePreview.innerHTML = this.renderVotePreviewMessage(submission.message, submission.tone);
       return;
     }
 
@@ -5529,10 +5497,8 @@ class ProposalInfoModal {
     };
   }
 
-  renderVotePreviewMessage(message, tone, { idle = false } = {}) {
-    const idleClass = idle ? ' proposal-vote-preview-message--idle' : '';
-    const ariaHidden = idle ? ' aria-hidden="true"' : '';
-    return `<div class="proposal-vote-preview-message proposal-vote-preview-message--${tone}${idleClass}"${ariaHidden}>${escapeHtml(message)}</div>`;
+  renderVotePreviewMessage(message, tone) {
+    return `<div class="proposal-vote-preview-message proposal-vote-preview-message--${tone}">${escapeHtml(message)}</div>`;
   }
 
   getCurrentProposal() {

--- a/app.js
+++ b/app.js
@@ -5352,6 +5352,11 @@ class ProposalInfoModal {
     return Math.min(n, DAO_VOTE_WEIGHT_MAX);
   }
 
+  hasStartedVoteInput() {
+    if (this.voteWeights.some((weight) => weight > 0)) return true;
+    return String(this.voteSpendLib || '').trim() !== '';
+  }
+
   updateVotePreview(proposal) {
     if (!this.votePreview || !proposal) {
       this.canSubmitVote = false;
@@ -5364,7 +5369,11 @@ class ProposalInfoModal {
       this.canSubmitVote = false;
       this.updateSubmitButtons();
       this.votePreview.classList.add('proposal-vote-preview--message');
-      this.votePreview.innerHTML = this.renderVotePreviewMessage(submission.message, submission.tone);
+      this.votePreview.innerHTML = this.renderVotePreviewMessage(
+        submission.message,
+        submission.tone,
+        { idle: !this.hasStartedVoteInput() },
+      );
       return;
     }
 
@@ -5520,8 +5529,10 @@ class ProposalInfoModal {
     };
   }
 
-  renderVotePreviewMessage(message, tone) {
-    return `<div class="proposal-vote-preview-message proposal-vote-preview-message--${tone}">${escapeHtml(message)}</div>`;
+  renderVotePreviewMessage(message, tone, { idle = false } = {}) {
+    const idleClass = idle ? ' proposal-vote-preview-message--idle' : '';
+    const ariaHidden = idle ? ' aria-hidden="true"' : '';
+    return `<div class="proposal-vote-preview-message proposal-vote-preview-message--${tone}${idleClass}"${ariaHidden}>${escapeHtml(message)}</div>`;
   }
 
   getCurrentProposal() {

--- a/app.js
+++ b/app.js
@@ -4480,6 +4480,7 @@ class ProposalInfoModal {
     this.voteActionSection = document.getElementById('proposalVoteActionSection');
     this.voteActionHelp = document.getElementById('proposalVoteActionHelp');
     this.voteOptions = document.getElementById('proposalVoteOptions');
+    this.voteRequirements = document.getElementById('proposalVoteRequirements');
     this.voteSpendInput = document.getElementById('proposalVoteSpend');
     this.votePreview = document.getElementById('proposalVotePreview');
     this.voteSubmitButton = document.getElementById('proposalVoteSubmit');
@@ -5211,6 +5212,7 @@ class ProposalInfoModal {
         <div class="proposal-vote-options-help">Allocation is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.</div>
       `;
     }
+    this.renderVoteRequirements(proposal);
 
     this.updateVotePreview(proposal);
   }
@@ -5218,7 +5220,36 @@ class ProposalInfoModal {
   hideVoteActions() {
     this.canSubmitVote = false;
     this.voteActionSection?.classList.add('hidden');
+    if (this.voteRequirements) {
+      this.voteRequirements.innerHTML = '';
+      this.voteRequirements.classList.add('hidden');
+    }
     this.updateSubmitButtons();
+  }
+
+  renderVoteRequirements(proposal) {
+    if (!this.voteRequirements) return;
+
+    const rows = [
+      ['Vote Threshold', formatDaoProposalVoteRequirementLib(proposal.voteThresholdUsdStr)],
+      ['Minimum Vote Spend', formatDaoProposalVoteRequirementLib(proposal.minimumSpendUsdStr)],
+    ].filter(([, value]) => value !== null);
+
+    if (rows.length === 0) {
+      this.voteRequirements.innerHTML = '';
+      this.voteRequirements.classList.add('hidden');
+      return;
+    }
+
+    this.voteRequirements.classList.remove('hidden');
+    this.voteRequirements.innerHTML = rows
+      .map(([label, value]) => `
+        <div class="proposal-vote-requirement">
+          <span>${escapeHtml(label)}</span>
+          <strong>${escapeHtml(value)}</strong>
+        </div>
+      `)
+      .join('');
   }
 
   renderVoteOption(option, index) {

--- a/app.js
+++ b/app.js
@@ -5259,20 +5259,18 @@ class ProposalInfoModal {
       .map((row) => {
         const help = DAO_VOTE_REQUIREMENT_HELP[row.key];
         return `
-          <div class="proposal-vote-requirement">
-            <span class="proposal-vote-requirement-label">
-              ${escapeHtml(row.label)}
-              <button
-                type="button"
-                class="toll-info-icon proposal-vote-requirement-help"
-                data-icon="info"
-                data-vote-requirement-help="${escapeDaoFormAttribute(row.key)}"
-                title="${escapeDaoFormAttribute(help)}"
-                aria-label="${escapeDaoFormAttribute(`About ${row.label}`)}"
-              ></button>
-            </span>
-            <strong>${escapeHtml(row.value)}</strong>
-          </div>
+          <span class="proposal-vote-requirement-label">
+            ${escapeHtml(row.label)}
+            <button
+              type="button"
+              class="toll-info-icon proposal-vote-requirement-help"
+              data-icon="info"
+              data-vote-requirement-help="${escapeDaoFormAttribute(row.key)}"
+              title="${escapeDaoFormAttribute(help)}"
+              aria-label="${escapeDaoFormAttribute(`About ${row.label}`)}"
+            ></button>
+          </span>
+          <span class="proposal-vote-requirement-value">${escapeHtml(row.value)}</span>
         `;
       })
       .join('');

--- a/index.html
+++ b/index.html
@@ -612,6 +612,7 @@
                 <p id="proposalVoteActionHelp"></p>
               </div>
               <div class="proposal-vote-options" id="proposalVoteOptions"></div>
+              <div class="proposal-vote-requirements hidden" id="proposalVoteRequirements" aria-label="Vote requirements"></div>
               <div class="proposal-vote-spend-row">
                 <div class="form-group">
                   <label for="proposalVoteSpend">Spend amount</label>

--- a/index.html
+++ b/index.html
@@ -612,7 +612,6 @@
                 <p id="proposalVoteActionHelp"></p>
               </div>
               <div class="proposal-vote-options" id="proposalVoteOptions"></div>
-              <div class="proposal-vote-requirements hidden" id="proposalVoteRequirements" aria-label="Vote requirements"></div>
               <div class="proposal-vote-spend-row">
                 <div class="form-group">
                   <label for="proposalVoteSpend">Spend amount</label>

--- a/styles.css
+++ b/styles.css
@@ -2650,20 +2650,22 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
+#proposalInfoModal .proposal-lifecycle-actions,
+#proposalInfoModal .proposal-vote-actions {
+  display: grid;
+  gap: 8px;
+}
+
+#proposalInfoModal .proposal-committee-actions,
+#proposalInfoModal .proposal-review-result-actions,
 #proposalInfoModal .proposal-lifecycle-actions {
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  display: grid;
-  gap: 8px;
   padding: 10px;
 }
 
 #proposalInfoModal .proposal-vote-actions {
-  border: 0;
-  border-radius: 0;
   border-top: 1px solid var(--border-color);
-  display: grid;
-  gap: 8px;
   padding: 10px 0 0;
 }
 
@@ -3042,21 +3044,25 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#proposalInfoModal .proposal-vote-allocation-label {
+#proposalInfoModal .proposal-vote-allocation-label,
+#proposalInfoModal .proposal-vote-requirement-label {
   align-items: center;
   display: inline-flex;
   gap: 4px;
+}
+
+#proposalInfoModal .proposal-vote-allocation-label {
   justify-content: center;
   justify-self: center;
 }
 
-#proposalInfoModal .proposal-vote-allocation-help {
+#proposalInfoModal .proposal-vote-help {
   flex: 0 0 auto;
   margin-left: 0;
   transform: none;
 }
 
-#proposalInfoModal button.proposal-vote-allocation-help {
+#proposalInfoModal button.proposal-vote-help {
   background: transparent;
   border: 0;
   color: inherit;
@@ -3076,9 +3082,6 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-vote-requirement-label {
-  align-items: center;
-  display: inline-flex;
-  gap: 4px;
   min-width: 0;
 }
 
@@ -3086,19 +3089,6 @@ input[type='file'].form-control::file-selector-button {
   color: var(--text-color);
   text-align: right;
   white-space: nowrap;
-}
-
-#proposalInfoModal .proposal-vote-requirement-help {
-  flex: 0 0 auto;
-  margin-left: 0;
-  transform: none;
-}
-
-#proposalInfoModal button.proposal-vote-requirement-help {
-  background: transparent;
-  border: 0;
-  color: inherit;
-  padding: 0;
 }
 
 #proposalInfoModal .proposal-vote-option,
@@ -3213,7 +3203,7 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#proposalInfoModal .proposal-vote-preview-message--idle {
+#proposalInfoModal .proposal-vote-preview--idle {
   visibility: hidden;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3020,22 +3020,39 @@ input[type='file'].form-control::file-selector-button {
   gap: 8px;
 }
 
-#proposalInfoModal .proposal-vote-options-help,
 #proposalInfoModal .proposal-vote-options-header {
   color: var(--secondary-text-color);
-  font-size: 12px;
-  line-height: 1.35;
-}
-
-#proposalInfoModal .proposal-vote-options-header {
   display: grid;
+  font-size: 12px;
   font-weight: var(--font-weight-semibold);
   gap: 8px;
   grid-template-columns: minmax(0, 1fr) 92px;
+  line-height: 1.35;
 }
 
 #proposalInfoModal .proposal-vote-options-header span:last-child {
   text-align: center;
+}
+
+#proposalInfoModal .proposal-vote-allocation-label {
+  align-items: center;
+  display: inline-flex;
+  gap: 4px;
+  justify-content: center;
+  justify-self: center;
+}
+
+#proposalInfoModal .proposal-vote-allocation-help {
+  flex: 0 0 auto;
+  margin-left: 0;
+  transform: none;
+}
+
+#proposalInfoModal button.proposal-vote-allocation-help {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  padding: 0;
 }
 
 #proposalInfoModal .proposal-vote-requirements {

--- a/styles.css
+++ b/styles.css
@@ -3039,18 +3039,15 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-vote-requirements {
-  display: grid;
-  gap: 6px;
-}
-
-#proposalInfoModal .proposal-vote-requirement {
   align-items: baseline;
   color: var(--secondary-text-color);
-  display: flex;
+  column-gap: 8px;
+  display: grid;
   font-size: 12px;
-  gap: 8px;
-  justify-content: space-between;
+  grid-template-columns: auto auto;
+  justify-content: end;
   line-height: 1.35;
+  row-gap: 6px;
 }
 
 #proposalInfoModal .proposal-vote-requirement-label {
@@ -3058,6 +3055,12 @@ input[type='file'].form-control::file-selector-button {
   display: inline-flex;
   gap: 4px;
   min-width: 0;
+}
+
+#proposalInfoModal .proposal-vote-requirement-value {
+  color: var(--text-color);
+  text-align: right;
+  white-space: nowrap;
 }
 
 #proposalInfoModal .proposal-vote-requirement-help {
@@ -3071,13 +3074,6 @@ input[type='file'].form-control::file-selector-button {
   border: 0;
   color: inherit;
   padding: 0;
-}
-
-#proposalInfoModal .proposal-vote-requirement strong {
-  color: var(--text-color);
-  font-size: 13px;
-  font-weight: var(--font-weight-semibold);
-  text-align: right;
 }
 
 #proposalInfoModal .proposal-vote-option,

--- a/styles.css
+++ b/styles.css
@@ -3205,6 +3205,10 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
+#proposalInfoModal .proposal-vote-preview-message--idle {
+  visibility: hidden;
+}
+
 #proposalInfoModal .proposal-vote-preview-message--warning {
   background: rgba(196, 45, 45, 0.12);
   color: #8f1d16;

--- a/styles.css
+++ b/styles.css
@@ -2650,13 +2650,21 @@ input[type='file'].form-control::file-selector-button {
 
 #proposalInfoModal .proposal-committee-actions,
 #proposalInfoModal .proposal-review-result-actions,
-#proposalInfoModal .proposal-lifecycle-actions,
-#proposalInfoModal .proposal-vote-actions {
+#proposalInfoModal .proposal-lifecycle-actions {
   border: 1px solid var(--border-color);
   border-radius: 8px;
   display: grid;
   gap: 8px;
   padding: 10px;
+}
+
+#proposalInfoModal .proposal-vote-actions {
+  border: 0;
+  border-radius: 0;
+  border-top: 1px solid var(--border-color);
+  display: grid;
+  gap: 8px;
+  padding: 10px 0 0;
 }
 
 #proposalInfoModal .proposal-lifecycle-action {

--- a/styles.css
+++ b/styles.css
@@ -3038,6 +3038,28 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
+#proposalInfoModal .proposal-vote-requirements {
+  display: grid;
+  gap: 6px;
+}
+
+#proposalInfoModal .proposal-vote-requirement {
+  align-items: baseline;
+  color: var(--secondary-text-color);
+  display: flex;
+  font-size: 12px;
+  gap: 8px;
+  justify-content: space-between;
+  line-height: 1.35;
+}
+
+#proposalInfoModal .proposal-vote-requirement strong {
+  color: var(--text-color);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  text-align: right;
+}
+
 #proposalInfoModal .proposal-vote-option,
 #proposalInfoModal .proposal-vote-spend-row {
   align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -3053,6 +3053,26 @@ input[type='file'].form-control::file-selector-button {
   line-height: 1.35;
 }
 
+#proposalInfoModal .proposal-vote-requirement-label {
+  align-items: center;
+  display: inline-flex;
+  gap: 4px;
+  min-width: 0;
+}
+
+#proposalInfoModal .proposal-vote-requirement-help {
+  flex: 0 0 auto;
+  margin-left: 0;
+  transform: none;
+}
+
+#proposalInfoModal button.proposal-vote-requirement-help {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  padding: 0;
+}
+
 #proposalInfoModal .proposal-vote-requirement strong {
   color: var(--text-color);
   font-size: 13px;


### PR DESCRIPTION
## What Changed

This PR shows each voting proposal's snapshotted vote requirements before the user enters allocations or a spend amount.

- Displays the proposal's minimum wallet balance and minimum spend near the vote controls.
- Converts `voteThresholdUsdStr` and `minimumSpendUsdStr` to LIB through the same USD-to-LIB path used by vote validation.
- Omits zero or unset requirements and provides concise info controls for the requirement and allocation labels.
- Keeps the empty validation preview hidden until the user starts entering vote data.

## Fixed Flow

1. A user opens a proposal while voting is active.
2. Vote preview renders the requirements stored on that proposal account.
3. Applicable amounts appear in LIB before any vote input is entered.
4. Existing validation continues to enforce those same converted amounts when the user submits.

## Why

Previously, voters only discovered the proposal-specific balance and spend requirements after entering invalid values. Showing the snapshotted rules up front makes the proposal's actual requirements clear without substituting live DAO configuration values.

## Validation

- `git diff --check fbc02b69ea2d3264988ba4329ccda8a349353da1..HEAD`
- `node --check app.js`
- `node --test tests/dao-timeline.test.mjs tests/dao-backend-fetcher.test.mjs`

Closes #1502