### PR TITLE
Improve DAO proposal list status and timing tokens

### DIFF
--- a/app.js
+++ b/app.js
@@ -2506,17 +2506,21 @@ function formatDaoTime(ts) {
   }
 }
 
-function formatDaoApplyReadyAtLabel(eligibleAt, now = getTransactionTimestamp()) {
-  const at = Number(eligibleAt || 0);
+function formatDaoDayOrTime(ts, now = getTransactionTimestamp()) {
+  const at = Number(ts || 0);
   if (!at) return '';
-  const eligibleDate = new Date(at);
+  const atDate = new Date(at);
   const nowDate = new Date(now);
   const sameDay = (
-    eligibleDate.getFullYear() === nowDate.getFullYear()
-    && eligibleDate.getMonth() === nowDate.getMonth()
-    && eligibleDate.getDate() === nowDate.getDate()
+    atDate.getFullYear() === nowDate.getFullYear()
+    && atDate.getMonth() === nowDate.getMonth()
+    && atDate.getDate() === nowDate.getDate()
   );
-  const when = sameDay ? formatDaoTime(at) : formatDaoDate(at);
+  return sameDay ? formatDaoTime(at) : formatDaoDate(at);
+}
+
+function formatDaoReadyAtLabel(ts, now = getTransactionTimestamp()) {
+  const when = formatDaoDayOrTime(ts, now);
   return when ? `Ready at ${when}` : '';
 }
 
@@ -2888,7 +2892,8 @@ class DaoModal {
     }
 
     if (state === 'review') {
-      const reviewWindow = getDaoProposalReviewWindow(proposal);
+      const now = getTransactionTimestamp();
+      const reviewWindow = getDaoProposalReviewWindow(proposal, now);
 
       if (reviewWindow.canFinalizeReviewResult) {
         const { acceptCount, withholdCount } = getDaoCommitteeReview(proposal);
@@ -2900,19 +2905,29 @@ class DaoModal {
         });
       }
 
+      let reviewLabel = reviewWindow.label;
+      if (reviewWindow.canFinalizeReviewResult) {
+        reviewLabel = 'Ready to finalize';
+      } else if (now < reviewWindow.start) {
+        reviewLabel = formatDaoReadyAtLabel(reviewWindow.start, now) || reviewLabel;
+      } else if (now <= reviewWindow.end) {
+        const endLabel = formatDaoDayOrTime(reviewWindow.end, now);
+        if (endLabel) reviewLabel = `Ends ${endLabel}`;
+      }
+
       chips.push({
-        value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,
+        value: reviewLabel,
         tone: 'neutral',
       });
     } else if (state === 'voting') {
       const now = getTransactionTimestamp();
       const votingWindow = getDaoProposalVotingWindow(proposal, now);
-      const endDate = formatDaoDate(votingWindow.end);
+      const endLabel = formatDaoDayOrTime(votingWindow.end, now);
       const votingEnded = Boolean(votingWindow.end && now > votingWindow.end);
 
-      if (endDate && !votingEnded) {
+      if (endLabel && !votingEnded) {
         chips.push({
-          value: `Ends ${endDate}`,
+          value: `Ends ${endLabel}`,
           tone: 'neutral',
         });
       }
@@ -4278,7 +4293,7 @@ function getDaoProposalApplyLifecycleAction(
         ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
         : 'Apply timing is unavailable until the proposal includes grace-period timing.',
       false,
-      formatDaoApplyReadyAtLabel(applyWindow.eligibleAt, now),
+      formatDaoReadyAtLabel(applyWindow.eligibleAt, now),
     );
   }
 

--- a/app.js
+++ b/app.js
@@ -2496,34 +2496,6 @@ function formatDaoDate(ts) {
   }
 }
 
-function formatDaoTime(ts) {
-  const n = Number(ts || 0);
-  if (!n) return '';
-  try {
-    return new Date(n).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-  } catch {
-    return '';
-  }
-}
-
-function formatDaoDayOrTime(ts, now = getTransactionTimestamp()) {
-  const at = Number(ts || 0);
-  if (!at) return '';
-  const atDate = new Date(at);
-  const nowDate = new Date(now);
-  const sameDay = (
-    atDate.getFullYear() === nowDate.getFullYear()
-    && atDate.getMonth() === nowDate.getMonth()
-    && atDate.getDate() === nowDate.getDate()
-  );
-  return sameDay ? formatDaoTime(at) : formatDaoDate(at);
-}
-
-function formatDaoReadyAtLabel(ts, now = getTransactionTimestamp()) {
-  const when = formatDaoDayOrTime(ts, now);
-  return when ? `Ready at ${when}` : '';
-}
-
 function formatDaoProposalTitle(proposal) {
   const title = String(proposal.title || '').trim() || 'Proposal';
   return proposal.number ? `#${proposal.number}: ${title}` : title;
@@ -2892,8 +2864,7 @@ class DaoModal {
     }
 
     if (state === 'review') {
-      const now = getTransactionTimestamp();
-      const reviewWindow = getDaoProposalReviewWindow(proposal, now);
+      const reviewWindow = getDaoProposalReviewWindow(proposal);
 
       if (reviewWindow.canFinalizeReviewResult) {
         const { acceptCount, withholdCount } = getDaoCommitteeReview(proposal);
@@ -2905,29 +2876,19 @@ class DaoModal {
         });
       }
 
-      let reviewLabel = reviewWindow.label;
-      if (reviewWindow.canFinalizeReviewResult) {
-        reviewLabel = 'Ready to finalize';
-      } else if (now < reviewWindow.start) {
-        reviewLabel = formatDaoReadyAtLabel(reviewWindow.start, now) || reviewLabel;
-      } else if (now <= reviewWindow.end) {
-        const endLabel = formatDaoDayOrTime(reviewWindow.end, now);
-        if (endLabel) reviewLabel = `Ends ${endLabel}`;
-      }
-
       chips.push({
-        value: reviewLabel,
+        value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,
         tone: 'neutral',
       });
     } else if (state === 'voting') {
       const now = getTransactionTimestamp();
       const votingWindow = getDaoProposalVotingWindow(proposal, now);
-      const endLabel = formatDaoDayOrTime(votingWindow.end, now);
+      const endDate = formatDaoDate(votingWindow.end);
       const votingEnded = Boolean(votingWindow.end && now > votingWindow.end);
 
-      if (endLabel && !votingEnded) {
+      if (endDate && !votingEnded) {
         chips.push({
-          value: `Ends ${endLabel}`,
+          value: `Ends ${endDate}`,
           tone: 'neutral',
         });
       }
@@ -4293,7 +4254,7 @@ function getDaoProposalApplyLifecycleAction(
         ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
         : 'Apply timing is unavailable until the proposal includes grace-period timing.',
       false,
-      formatDaoReadyAtLabel(applyWindow.eligibleAt, now),
+      eligibleAt,
     );
   }
 

--- a/app.js
+++ b/app.js
@@ -2918,11 +2918,11 @@ class DaoModal {
       if (applyAction?.rowPreviewLabel) {
         chips.push({
           value: applyAction.rowPreviewLabel,
-          tone: 'neutral',
+          tone: applyAction.canSubmit ? 'accepted' : 'neutral',
         });
       }
     }
-    if (result) {
+    if (result && state !== 'accepted') {
       chips.push({
         value: result.headline,
         tone: result.tone,
@@ -4254,6 +4254,7 @@ function getDaoProposalApplyLifecycleAction(
         ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
         : 'Apply timing is unavailable until the proposal includes grace-period timing.',
       false,
+      eligibleAt,
     );
   }
 

--- a/app.js
+++ b/app.js
@@ -2496,6 +2496,30 @@ function formatDaoDate(ts) {
   }
 }
 
+function formatDaoTime(ts) {
+  const n = Number(ts || 0);
+  if (!n) return '';
+  try {
+    return new Date(n).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+function formatDaoApplyReadyAtLabel(eligibleAt, now = getTransactionTimestamp()) {
+  const at = Number(eligibleAt || 0);
+  if (!at) return '';
+  const eligibleDate = new Date(at);
+  const nowDate = new Date(now);
+  const sameDay = (
+    eligibleDate.getFullYear() === nowDate.getFullYear()
+    && eligibleDate.getMonth() === nowDate.getMonth()
+    && eligibleDate.getDate() === nowDate.getDate()
+  );
+  const when = sameDay ? formatDaoTime(at) : formatDaoDate(at);
+  return when ? `Ready at ${when}` : '';
+}
+
 function formatDaoProposalTitle(proposal) {
   const title = String(proposal.title || '').trim() || 'Proposal';
   return proposal.number ? `#${proposal.number}: ${title}` : title;
@@ -4254,7 +4278,7 @@ function getDaoProposalApplyLifecycleAction(
         ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
         : 'Apply timing is unavailable until the proposal includes grace-period timing.',
       false,
-      eligibleAt,
+      formatDaoApplyReadyAtLabel(applyWindow.eligibleAt, now),
     );
   }
 

--- a/app.js
+++ b/app.js
@@ -2496,17 +2496,7 @@ function formatDaoDate(ts) {
   }
 }
 
-function formatDaoTime(ts) {
-  const n = Number(ts || 0);
-  if (!n) return '';
-  try {
-    return new Date(n).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-  } catch {
-    return '';
-  }
-}
-
-function formatDaoDayOrTime(ts, now = getTransactionTimestamp()) {
+function formatDaoDayOrTime(ts, now) {
   const at = Number(ts || 0);
   if (!at) return '';
   const atDate = new Date(at);
@@ -2516,10 +2506,15 @@ function formatDaoDayOrTime(ts, now = getTransactionTimestamp()) {
     && atDate.getMonth() === nowDate.getMonth()
     && atDate.getDate() === nowDate.getDate()
   );
-  return sameDay ? formatDaoTime(at) : formatDaoDate(at);
+  if (!sameDay) return formatDaoDate(at);
+  try {
+    return atDate.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  } catch {
+    return '';
+  }
 }
 
-function formatDaoReadyAtLabel(ts, now = getTransactionTimestamp()) {
+function formatDaoReadyAtLabel(ts, now) {
   const when = formatDaoDayOrTime(ts, now);
   return when ? `Ready at ${when}` : '';
 }

--- a/app.js
+++ b/app.js
@@ -2496,6 +2496,34 @@ function formatDaoDate(ts) {
   }
 }
 
+function formatDaoTime(ts) {
+  const n = Number(ts || 0);
+  if (!n) return '';
+  try {
+    return new Date(n).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+function formatDaoDayOrTime(ts, now = getTransactionTimestamp()) {
+  const at = Number(ts || 0);
+  if (!at) return '';
+  const atDate = new Date(at);
+  const nowDate = new Date(now);
+  const sameDay = (
+    atDate.getFullYear() === nowDate.getFullYear()
+    && atDate.getMonth() === nowDate.getMonth()
+    && atDate.getDate() === nowDate.getDate()
+  );
+  return sameDay ? formatDaoTime(at) : formatDaoDate(at);
+}
+
+function formatDaoReadyAtLabel(ts, now = getTransactionTimestamp()) {
+  const when = formatDaoDayOrTime(ts, now);
+  return when ? `Ready at ${when}` : '';
+}
+
 function formatDaoProposalTitle(proposal) {
   const title = String(proposal.title || '').trim() || 'Proposal';
   return proposal.number ? `#${proposal.number}: ${title}` : title;
@@ -2864,7 +2892,8 @@ class DaoModal {
     }
 
     if (state === 'review') {
-      const reviewWindow = getDaoProposalReviewWindow(proposal);
+      const now = getTransactionTimestamp();
+      const reviewWindow = getDaoProposalReviewWindow(proposal, now);
 
       if (reviewWindow.canFinalizeReviewResult) {
         const { acceptCount, withholdCount } = getDaoCommitteeReview(proposal);
@@ -2876,19 +2905,29 @@ class DaoModal {
         });
       }
 
+      let reviewLabel = reviewWindow.label;
+      if (reviewWindow.canFinalizeReviewResult) {
+        reviewLabel = 'Ready to finalize';
+      } else if (now < reviewWindow.start) {
+        reviewLabel = formatDaoReadyAtLabel(reviewWindow.start, now) || reviewLabel;
+      } else if (now <= reviewWindow.end) {
+        const endLabel = formatDaoDayOrTime(reviewWindow.end, now);
+        if (endLabel) reviewLabel = `Ends ${endLabel}`;
+      }
+
       chips.push({
-        value: reviewWindow.canFinalizeReviewResult ? 'Ready to finalize' : reviewWindow.label,
+        value: reviewLabel,
         tone: 'neutral',
       });
     } else if (state === 'voting') {
       const now = getTransactionTimestamp();
       const votingWindow = getDaoProposalVotingWindow(proposal, now);
-      const endDate = formatDaoDate(votingWindow.end);
+      const endLabel = formatDaoDayOrTime(votingWindow.end, now);
       const votingEnded = Boolean(votingWindow.end && now > votingWindow.end);
 
-      if (endDate && !votingEnded) {
+      if (endLabel && !votingEnded) {
         chips.push({
-          value: `Ends ${endDate}`,
+          value: `Ends ${endLabel}`,
           tone: 'neutral',
         });
       }
@@ -4254,7 +4293,7 @@ function getDaoProposalApplyLifecycleAction(
         ? `Apply becomes available after the grace period ends: ${eligibleAt}.`
         : 'Apply timing is unavailable until the proposal includes grace-period timing.',
       false,
-      eligibleAt,
+      formatDaoReadyAtLabel(applyWindow.eligibleAt, now),
     );
   }
 


### PR DESCRIPTION
## What Changed

This PR makes DAO proposal list tokens more actionable and precise across accepted, review, and voting states.

- Accepted rows no longer repeat the redundant **Accepted** result token.
- **Ready to apply** uses the green accepted tone, while proposals still in their grace period show **Ready at** with the applicable date or time.
- Review rows show when review starts, ends, or is ready to finalize.
- Voting rows show the voting deadline, using a localized time for same-day deadlines and a localized date otherwise.
- `formatDaoDayOrTime` centralizes the shared date-or-time formatting without changing the existing label behavior.

## Fixed Flow

1. The DAO list determines the proposal state and its current review, voting, or apply window.
2. Same-day boundaries are displayed as times; later boundaries are displayed as dates.
3. Accepted proposals surface their apply readiness or grace-period deadline instead of repeating their accepted status.
4. Users can identify the next relevant action or deadline directly from the proposal row.

## Why

Accepted-list rows previously repeated status already conveyed by the filter, styled an actionable apply state as neutral, and omitted the remaining grace-period timing. Review and voting rows also lacked precise same-day timing. The updated tokens derive their labels from the existing proposal lifecycle windows so list state stays aligned with proposal details.

## Validation

- `git diff --check main..HEAD`
- `node --check app.js`
- `node --test tests/dao-timeline.test.mjs`
- Formatter equivalence verified across 65 valid and invalid timestamp combinations.

Closes #1504
<img width="586" height="299" alt="image" src="https://github.com/user-attachments/assets/b79cf8fa-9e21-429c-b515-47de16081acd" />
<img width="569" height="848" alt="image" src="https://github.com/user-attachments/assets/7d63dfa9-9516-4297-afde-4509b850b5f4" />
