### PR TITLE
Rename Vote preview Allocation label to Weight

### DIFF
--- a/app.js
+++ b/app.js
@@ -3942,7 +3942,7 @@ const DAO_VOTE_WEIGHT_PRECISION = 1_000_000_000_000;
 const DAO_VOTE_WEIGHT_PRECISION_BIGINT = 1_000_000_000_000n;
 const DAO_CLAIM_REWARD_PRECISION = 10n ** 18n;
 const DAO_VOTE_HELP = {
-  allocation: 'Allocation is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.',
+  weight: 'Weight is a ratio. 1 / 1 splits evenly; 3 / 1 gives 75% / 25%.',
   voteThreshold: 'Minimum wallet balance required to vote on this proposal.',
   minimumSpend: 'Minimum LIB you must spend for a valid vote on this proposal.',
 };
@@ -5246,15 +5246,15 @@ class ProposalInfoModal {
       this.voteOptions.innerHTML = `
         <div class="proposal-vote-options-header">
           <span>Option</span>
-          <span class="proposal-vote-allocation-label">
-            Allocation
+          <span class="proposal-vote-weight-label">
+            Weight
             <button
               type="button"
               class="toll-info-icon proposal-vote-help"
               data-icon="info"
               data-vote-help
-              title="${escapeDaoFormAttribute(DAO_VOTE_HELP.allocation)}"
-              aria-label="About Allocation"
+              title="${escapeDaoFormAttribute(DAO_VOTE_HELP.weight)}"
+              aria-label="About Weight"
             ></button>
           </span>
         </div>
@@ -5330,7 +5330,7 @@ class ProposalInfoModal {
           step="1"
           inputmode="numeric"
           placeholder="0"
-          aria-label="${escapeDaoFormAttribute(`${option} allocation`)}"
+          aria-label="${escapeDaoFormAttribute(`${option} weight`)}"
           data-vote-option-index="${index}"
           value="${escapeDaoFormAttribute(String(weight))}"
         >

--- a/styles.css
+++ b/styles.css
@@ -3044,14 +3044,14 @@ input[type='file'].form-control::file-selector-button {
   text-align: center;
 }
 
-#proposalInfoModal .proposal-vote-allocation-label,
+#proposalInfoModal .proposal-vote-weight-label,
 #proposalInfoModal .proposal-vote-requirement-label {
   align-items: center;
   display: inline-flex;
   gap: 4px;
 }
 
-#proposalInfoModal .proposal-vote-allocation-label {
+#proposalInfoModal .proposal-vote-weight-label {
   justify-content: center;
   justify-self: center;
 }


### PR DESCRIPTION
## Summary
- Renames the Vote preview options column from **Allocation** to **Weight**, including help copy and aria-labels
- Renames the matching CSS class to `proposal-vote-weight-label`
- No behavior changes; base for stacked #1507 percentage column

Closes #1506

## Test plan
- [x] Open a voting proposal → Vote preview header shows **Weight** (not Allocation)
- [x] Info icon toast/title describes Weight as a ratio
- [x] Option input aria-labels say `{option} weight`
- [x] Entering weights / submitting a vote still works as before

Made with [Cursor](https://cursor.com)