### PR TITLE
Add percentage column beside Weight in Vote preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -2471,7 +2471,10 @@ const menuModal = new MenuModal();
 // =====================
 
 // DAO proposals are loaded via `daoRepo` and kept in memory (no localStorage persistence).
-setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
+setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, {
+  isDevNetwork: IS_DEV_NETWORK,
+  getCurrentAddress: getDaoCurrentAccountAddress,
+}));
 
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };
 const DAO_FILTER_OPTIONS = [...DAO_STATES, DAO_CLAIMABLE_FILTER];
@@ -5247,6 +5250,7 @@ class ProposalInfoModal {
       this.voteOptions.innerHTML = `
         <div class="proposal-vote-options-header">
           <span>Option</span>
+          <span>%</span>
           <span class="proposal-vote-weight-label">
             Weight
             <button
@@ -5258,7 +5262,6 @@ class ProposalInfoModal {
               aria-label="About Weight"
             ></button>
           </span>
-          <span>%</span>
         </div>
         ${options.map((option, index) => this.renderVoteOption(option, index, totalWeight)).join('')}
         ${this.renderVoteRequirements(proposal)}
@@ -5324,6 +5327,11 @@ class ProposalInfoModal {
     return `
       <label class="proposal-vote-option">
         <span>${escapeHtml(option)}</span>
+        <span
+          class="proposal-vote-weight-percent"
+          data-vote-weight-percent="${index}"
+          aria-label="${escapeDaoFormAttribute(`${option} percent`)}"
+        >${escapeHtml(this.formatCountPercent(weight, totalWeight))}</span>
         <input
           type="number"
           class="form-control"
@@ -5336,11 +5344,6 @@ class ProposalInfoModal {
           data-vote-option-index="${index}"
           value="${escapeDaoFormAttribute(String(weight))}"
         >
-        <span
-          class="proposal-vote-weight-percent"
-          data-vote-weight-percent="${index}"
-          aria-label="${escapeDaoFormAttribute(`${option} percent`)}"
-        >${escapeHtml(this.formatCountPercent(weight, totalWeight))}</span>
       </label>
     `;
   }

--- a/app.js
+++ b/app.js
@@ -2471,10 +2471,7 @@ const menuModal = new MenuModal();
 // =====================
 
 // DAO proposals are loaded via `daoRepo` and kept in memory (no localStorage persistence).
-setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, {
-  isDevNetwork: IS_DEV_NETWORK,
-  getCurrentAddress: getDaoCurrentAccountAddress,
-}));
+setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
 
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };
 const DAO_FILTER_OPTIONS = [...DAO_STATES, DAO_CLAIMABLE_FILTER];

--- a/app.js
+++ b/app.js
@@ -5243,6 +5243,7 @@ class ProposalInfoModal {
       this.voteSpendInput.value = this.voteSpendLib;
     }
     if (this.voteOptions) {
+      const totalWeight = this.getVoteWeightsTotal();
       this.voteOptions.innerHTML = `
         <div class="proposal-vote-options-header">
           <span>Option</span>
@@ -5257,8 +5258,9 @@ class ProposalInfoModal {
               aria-label="About Weight"
             ></button>
           </span>
+          <span>%</span>
         </div>
-        ${options.map((option, index) => this.renderVoteOption(option, index)).join('')}
+        ${options.map((option, index) => this.renderVoteOption(option, index, totalWeight)).join('')}
         ${this.renderVoteRequirements(proposal)}
       `;
     }
@@ -5317,7 +5319,7 @@ class ProposalInfoModal {
     showToast(helpButton.title, 0, 'info');
   }
 
-  renderVoteOption(option, index) {
+  renderVoteOption(option, index, totalWeight) {
     const weight = this.voteWeights[index] || 0;
     return `
       <label class="proposal-vote-option">
@@ -5334,6 +5336,11 @@ class ProposalInfoModal {
           data-vote-option-index="${index}"
           value="${escapeDaoFormAttribute(String(weight))}"
         >
+        <span
+          class="proposal-vote-weight-percent"
+          data-vote-weight-percent="${index}"
+          aria-label="${escapeDaoFormAttribute(`${option} percent`)}"
+        >${escapeHtml(this.formatCountPercent(weight, totalWeight))}</span>
       </label>
     `;
   }
@@ -5345,7 +5352,24 @@ class ProposalInfoModal {
     if (!Number.isInteger(index) || index < 0 || index >= this.voteWeights.length) return;
     this.voteWeights[index] = this.normalizeVoteWeight(input.value);
     input.value = String(this.voteWeights[index]);
+    this.updateVoteWeightPercents();
     this.updateVotePreview(this.getCurrentProposal());
+  }
+
+  updateVoteWeightPercents() {
+    const percentEls = this.voteOptions?.querySelectorAll('[data-vote-weight-percent]');
+    if (!percentEls?.length) return;
+
+    const totalWeight = this.getVoteWeightsTotal();
+    for (const el of percentEls) {
+      const index = Number(el.dataset.voteWeightPercent);
+      if (!Number.isInteger(index) || index < 0 || index >= this.voteWeights.length) continue;
+      el.textContent = this.formatCountPercent(this.voteWeights[index] || 0, totalWeight);
+    }
+  }
+
+  getVoteWeightsTotal() {
+    return this.voteWeights.reduce((sum, weight) => sum + weight, 0);
   }
 
   handleVoteSpendInput() {
@@ -5448,7 +5472,7 @@ class ProposalInfoModal {
       return { ok: false, message: 'Wallet address unavailable.' };
     }
 
-    const totalWeight = this.voteWeights.reduce((sum, weight) => sum + weight, 0);
+    const totalWeight = this.getVoteWeightsTotal();
     if (totalWeight <= 0) {
       return { ok: false, message: 'Enter at least one positive option weight.' };
     }

--- a/styles.css
+++ b/styles.css
@@ -3036,11 +3036,11 @@ input[type='file'].form-control::file-selector-button {
   font-size: 12px;
   font-weight: var(--font-weight-semibold);
   gap: 8px;
-  grid-template-columns: minmax(0, 1fr) 92px 52px;
+  grid-template-columns: minmax(0, 1fr) 52px 92px;
   line-height: 1.35;
 }
 
-#proposalInfoModal .proposal-vote-options-header span:last-child {
+#proposalInfoModal .proposal-vote-options-header > span:not(:first-child) {
   text-align: center;
 }
 
@@ -3099,7 +3099,7 @@ input[type='file'].form-control::file-selector-button {
 }
 
 #proposalInfoModal .proposal-vote-option {
-  grid-template-columns: minmax(0, 1fr) 92px 52px;
+  grid-template-columns: minmax(0, 1fr) 52px 92px;
 }
 
 #proposalInfoModal .proposal-vote-spend-row {

--- a/styles.css
+++ b/styles.css
@@ -3036,7 +3036,7 @@ input[type='file'].form-control::file-selector-button {
   font-size: 12px;
   font-weight: var(--font-weight-semibold);
   gap: 8px;
-  grid-template-columns: minmax(0, 1fr) 92px;
+  grid-template-columns: minmax(0, 1fr) 92px 52px;
   line-height: 1.35;
 }
 
@@ -3096,11 +3096,21 @@ input[type='file'].form-control::file-selector-button {
   align-items: center;
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(0, 1fr) 92px;
+}
+
+#proposalInfoModal .proposal-vote-option {
+  grid-template-columns: minmax(0, 1fr) 92px 52px;
 }
 
 #proposalInfoModal .proposal-vote-spend-row {
   grid-template-columns: minmax(0, 1fr) auto;
+}
+
+#proposalInfoModal .proposal-vote-weight-percent {
+  font-variant-numeric: tabular-nums;
+  justify-self: center;
+  text-align: center;
+  white-space: nowrap;
 }
 
 #proposalInfoModal .proposal-vote-spend-row .form-group {
@@ -3220,10 +3230,6 @@ input[type='file'].form-control::file-selector-button {
 @media (max-width: 520px) {
   #proposalInfoModal .proposal-result-overview {
     grid-template-columns: minmax(0, 1fr);
-  }
-
-  #proposalInfoModal .proposal-vote-option {
-    grid-template-columns: minmax(0, 1fr) 92px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a `%` column immediately to the right of **Weight** in Vote preview option rows
- Percents update live on weight input (in place, without re-rendering the inputs)
- Zero total weight shows `0%`; formatting reuses `formatCountPercent`
- Stacked on #1508 / #1506

Closes #1507

## Test plan
- [ ] Open a voting proposal → options grid shows Option | Weight | %
- [ ] Enter `3` and `1` on two options → percents show ~75% / 25%
- [ ] Clear all weights → percents show `0%` (no NaN/Infinity)
- [ ] Editing one weight updates all row percents without losing input focus
- [ ] Layout remains readable on narrow viewport
- [ ] Vote preview estimate / submit still works as before

## Stack
Base: #1508 (`issue-1506-allocation-to-weight-label`). Retarget to `main` after #1508 merges.

Made with [Cursor](https://cursor.com)