### PR TITLE
Harden DAO proposal timing validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -3199,7 +3199,7 @@ class AddProposalModal {
     this.renderMaximumWarning(
       this.gracePeriodInput,
       this.gracePeriodLimit,
-      `Maximum from current DAO grace duration: ${maximumSummary}`
+      `Maximum: ${maximumSummary}`
     );
   }
 

--- a/app.js
+++ b/app.js
@@ -3314,8 +3314,8 @@ class AddProposalModal {
     return options;
   }
 
-  async loadDaoProposalDefaults() {
-    const account = await this.fetchNetworkAccountConfig();
+  async loadDaoProposalDefaults({ refresh = false } = {}) {
+    const account = await this.fetchNetworkAccountConfig({ refresh });
     const fee = account?.current?.dao?.proposalFeeUsdStr;
     if (fee === undefined || fee === null || String(fee).trim() === '') {
       throw new Error('Missing DAO proposal fee');
@@ -3330,8 +3330,8 @@ class AddProposalModal {
     };
   }
 
-  async fetchNetworkAccountConfig() {
-    if (!this.networkAccountConfigPromise) {
+  async fetchNetworkAccountConfig({ refresh = false } = {}) {
+    if (refresh || !this.networkAccountConfigPromise) {
       this.networkAccountConfigPromise = queryNetwork(`/account/${NETWORK_ACCOUNT_ID}`)
         .then((result) => result?.account || null);
     }
@@ -3911,10 +3911,12 @@ class ConfirmProposalModal {
     let loadingToastId = showToast('Submitting proposal...', 0, 'loading');
 
     try {
+      const { maxGracePeriodMs } = await addProposalModal.loadDaoProposalDefaults({ refresh: true });
       const result = await daoRepo.createProposal({
         draft: this.currentDraft,
         timestamp: getTransactionTimestamp(),
         networkId: network?.netid || '',
+        maxGracePeriodMs,
         submitTransaction: async (transaction) => {
           if (!myAccount?.keys) throw new Error('Wallet keys unavailable');
           const txid = await signObj(transaction, myAccount.keys);

--- a/app.js
+++ b/app.js
@@ -84,6 +84,7 @@ import {
   DAO_CONFIG_CHANGE_OPTIONS,
   DAO_PROPOSAL_CREATE_TYPE,
   DAO_PROPOSAL_DAY_MS,
+  DAO_PROPOSAL_GRACE_PERIOD_MAX_MS,
   DAO_PROPOSAL_TITLE_MAX_LENGTH,
   daoRepo,
   DAO_STATES,
@@ -3048,7 +3049,11 @@ class AddProposalModal {
     }
     if (this.startDelayInput) this.startDelayInput.addEventListener('input', () => this.renderStartDelayLimit());
     if (this.gracePeriodInput) {
-      this.gracePeriodInput.addEventListener('input', () => this.renderGracePeriodLimitHint());
+      this.gracePeriodInput.addEventListener('input', () => {
+        const maxLength = String(DAO_PROPOSAL_GRACE_PERIOD_MAX_MS).length;
+        this.gracePeriodInput.value = this.gracePeriodInput.value.slice(0, maxLength);
+        this.renderGracePeriodLimitHint();
+      });
     }
 
     if (this.optionsList) {
@@ -3354,7 +3359,8 @@ class AddProposalModal {
     if (Object.values(proposalDurations).some((duration) => !Number.isSafeInteger(duration) || duration < 0)) {
       throw new Error('Missing DAO proposal lifecycle durations');
     }
-    return { proposalFeeUsdStr, maxGracePeriodMs: graceDuration, proposalDurations };
+    const maxGracePeriodMs = Math.min(graceDuration, DAO_PROPOSAL_GRACE_PERIOD_MAX_MS);
+    return { proposalFeeUsdStr, maxGracePeriodMs, proposalDurations };
   }
 
   async fetchNetworkAccountConfig({ refresh = false } = {}) {

--- a/app.js
+++ b/app.js
@@ -3010,9 +3010,10 @@ class AddProposalModal {
     this.addChangeButton = document.getElementById('addProposalChangeButton');
     this.emergencySelect = document.getElementById('addProposalEmergency');
     this.startDelayInput = document.getElementById('addProposalStartDelayDays');
-    this.startDelayHelp = document.getElementById('addProposalStartDelayHelp');
+    this.startDelayLimit = document.getElementById('addProposalStartDelayLimit');
     this.gracePeriodInput = document.getElementById('addProposalGracePeriodMs');
     this.gracePeriodHelp = document.getElementById('addProposalGracePeriodHelp');
+    this.gracePeriodLimit = document.getElementById('addProposalGracePeriodLimit');
     this.submitButton = this.form?.querySelector('button[type="submit"]');
     this.resetConfigCache();
 
@@ -3040,6 +3041,9 @@ class AddProposalModal {
 
     if (this.emergencySelect) {
       this.emergencySelect.addEventListener('change', () => this.renderProposalFee());
+    }
+    if (this.startDelayInput) {
+      this.startDelayInput.addEventListener('input', () => this.renderStartDelayLimit());
     }
     if (this.gracePeriodInput) {
       this.gracePeriodInput.addEventListener('input', () => this.renderGracePeriodLimitHint());
@@ -3149,15 +3153,17 @@ class AddProposalModal {
       this.startDelayInput?.removeAttribute('max');
     }
 
-    if (this.startDelayHelp) {
-      const maximum = this.maxStartDelayDays === null
-        ? 'loading...'
-        : `${this.maxStartDelayDays} days`;
-      this.startDelayHelp.textContent = [
-        'Days from submission. 0 means now.',
-        `Maximum: ${maximum}`,
-      ].join('\n');
-    }
+    this.renderStartDelayLimit();
+  }
+
+  renderStartDelayLimit() {
+    if (!this.startDelayLimit) return;
+    const value = Number(this.startDelayInput?.value);
+    const exceedsMaximum = Number.isSafeInteger(this.maxStartDelayDays)
+      && Number.isFinite(value)
+      && value > this.maxStartDelayDays;
+    this.startDelayLimit.textContent = `Maximum: ${this.maxStartDelayDays} days`;
+    this.startDelayLimit.classList.toggle('hidden', !exceedsMaximum);
   }
 
   renderGracePeriodLimitHint() {
@@ -3171,12 +3177,17 @@ class AddProposalModal {
     if (this.gracePeriodInput) {
       this.gracePeriodInput.placeholder = maximumSummary ? 'Custom ms' : 'Loading maximum...';
     }
-    if (!this.gracePeriodHelp) return;
+    if (this.gracePeriodHelp) {
+      this.gracePeriodHelp.textContent = currentSummary ? `Estimate: ${currentSummary}` : '';
+    }
+    if (!this.gracePeriodLimit) return;
 
-    const summaries = [];
-    if (currentSummary) summaries.push(`Estimate: ${currentSummary}`);
-    summaries.push(`Maximum from current DAO grace duration: ${maximumSummary || 'loading...'}`);
-    this.gracePeriodHelp.textContent = summaries.join('\n');
+    const value = Number(currentValue);
+    const exceedsMaximum = Number.isSafeInteger(this.maxGracePeriodMs)
+      && Number.isFinite(value)
+      && value > this.maxGracePeriodMs;
+    this.gracePeriodLimit.textContent = `Maximum from current DAO grace duration: ${maximumSummary}`;
+    this.gracePeriodLimit.classList.toggle('hidden', !exceedsMaximum);
   }
 
   async refreshProposalFee() {

--- a/app.js
+++ b/app.js
@@ -88,6 +88,7 @@ import {
   DAO_STATES,
   getDaoTransactionMessage,
   getDaoProposalClaimWindow,
+  getDaoProposalMaxStartDelayDays,
   getDaoProposalTimeline,
   getDaoRewardClaimStatus,
   getDaoStateLabel,
@@ -3009,6 +3010,7 @@ class AddProposalModal {
     this.addChangeButton = document.getElementById('addProposalChangeButton');
     this.emergencySelect = document.getElementById('addProposalEmergency');
     this.startDelayInput = document.getElementById('addProposalStartDelayDays');
+    this.startDelayHelp = document.getElementById('addProposalStartDelayHelp');
     this.gracePeriodInput = document.getElementById('addProposalGracePeriodMs');
     this.gracePeriodHelp = document.getElementById('addProposalGracePeriodHelp');
     this.submitButton = this.form?.querySelector('button[type="submit"]');
@@ -3063,11 +3065,15 @@ class AddProposalModal {
     if (this.typeSelect) this.typeSelect.value = 'governance';
     if (this.descriptionInput) this.descriptionInput.value = '';
     if (this.emergencySelect) this.emergencySelect.value = 'false';
-    if (this.startDelayInput) this.startDelayInput.value = '0';
+    if (this.startDelayInput) {
+      this.startDelayInput.value = '0';
+      this.startDelayInput.removeAttribute('max');
+    }
     if (this.gracePeriodInput) {
       this.gracePeriodInput.value = '';
       this.gracePeriodInput.removeAttribute('max');
     }
+    this.refreshStartDelayLimit();
     this.renderOptions(['yes', 'no']);
     this.renderGracePeriodLimitHint();
     this.refreshProposalFee();
@@ -3133,13 +3139,34 @@ class AddProposalModal {
       : 'Unavailable';
   }
 
+  refreshStartDelayLimit() {
+    this.maxStartDelayDays = null;
+    try {
+      this.maxStartDelayDays = getDaoProposalMaxStartDelayDays(getTransactionTimestamp());
+      if (this.startDelayInput) this.startDelayInput.max = String(this.maxStartDelayDays);
+    } catch (error) {
+      console.warn('Could not calculate the DAO proposal review-start limit:', error);
+      this.startDelayInput?.removeAttribute('max');
+    }
+
+    if (this.startDelayHelp) {
+      const maximum = this.maxStartDelayDays === null
+        ? 'loading...'
+        : `${this.maxStartDelayDays} days`;
+      this.startDelayHelp.textContent = [
+        'Days from submission. 0 means now.',
+        `Maximum: ${maximum}`,
+      ].join('\n');
+    }
+  }
+
   renderGracePeriodLimitHint() {
     const maximumSummary = this.maxGracePeriodMs === null
       ? ''
-      : `${formatDaoDurationMsInput(this.maxGracePeriodMs)} ms (${formatDaoDurationDaysEstimate(this.maxGracePeriodMs)})`;
+      : `${formatDaoDurationMsInput(this.maxGracePeriodMs)} ms (${formatDaoDurationEstimate(this.maxGracePeriodMs)})`;
     const currentValue = String(this.gracePeriodInput?.value ?? '').trim();
     const currentSummary = currentValue
-      ? formatDaoDurationDaysEstimate(currentValue)
+      ? formatDaoDurationEstimate(currentValue)
       : '';
     if (this.gracePeriodInput) {
       this.gracePeriodInput.placeholder = maximumSummary ? 'Custom ms' : 'Loading maximum...';
@@ -3148,8 +3175,8 @@ class AddProposalModal {
 
     const summaries = [];
     if (currentSummary) summaries.push(`Estimate: ${currentSummary}`);
-    summaries.push(`Maximum: ${maximumSummary || 'loading...'}`);
-    this.gracePeriodHelp.textContent = summaries.join('. ');
+    summaries.push(`Maximum from current DAO grace duration: ${maximumSummary || 'loading...'}`);
+    this.gracePeriodHelp.textContent = summaries.join('\n');
   }
 
   async refreshProposalFee() {
@@ -3506,6 +3533,15 @@ class AddProposalModal {
     if (!Number.isSafeInteger(n)) {
       throw this.createValidationError(`${label} is too large`, input);
     }
+    if (!Number.isSafeInteger(this.maxStartDelayDays) || this.maxStartDelayDays < 0) {
+      throw this.createValidationError(`${label} maximum is not available`, input);
+    }
+    if (n > this.maxStartDelayDays) {
+      throw this.createValidationError(
+        `${label} must not exceed ${this.maxStartDelayDays} days`,
+        input
+      );
+    }
 
     const delayMs = n * 24 * 60 * 60 * 1000;
     if (!Number.isSafeInteger(delayMs)) {
@@ -3657,12 +3693,7 @@ const addProposalModal = new AddProposalModal();
 function formatDaoDurationSummary(ms) {
   const n = Number(ms || 0);
   if (!n) return '0 ms (now)';
-  const dayMs = 24 * 60 * 60 * 1000;
-  const days = n / dayMs;
-  const human = Number.isInteger(days)
-    ? `${days} day${days === 1 ? '' : 's'}`
-    : `${n} ms`;
-  return `${n} ms (${human})`;
+  return `${n} ms (${formatDaoDurationEstimate(n)})`;
 }
 
 function formatDaoDurationMsInput(ms) {
@@ -3671,16 +3702,30 @@ function formatDaoDurationMsInput(ms) {
   return String(n);
 }
 
-function formatDaoDurationDaysEstimate(ms) {
+function formatDaoDurationEstimate(ms) {
   const n = Number(ms);
   if (!Number.isFinite(n) || n < 0) return '';
-  const days = n / (24 * 60 * 60 * 1000);
-  const value = days === 0
-    ? '0'
-    : days >= 1
-    ? String(Number(days.toFixed(4)))
-    : String(Number(days.toPrecision(3)));
-  return `about ${value} day${value === '1' ? '' : 's'}`;
+  if (n === 0) return '0 sec';
+
+  const units = [
+    ['day', 24 * 60 * 60 * 1000],
+    ['hr', 60 * 60 * 1000],
+    ['min', 60 * 1000],
+    ['sec', 1000],
+  ];
+  let remainingMs = n;
+  const parts = [];
+
+  for (const [unit, unitMs] of units) {
+    const value = Math.floor(remainingMs / unitMs);
+    if (value === 0) continue;
+    parts.push(`${value} ${unit}${unit === 'day' && value !== 1 ? 's' : ''}`);
+    remainingMs -= value * unitMs;
+    if (parts.length === 2) break;
+  }
+
+  if (parts.length === 0) return `${n} ms`;
+  return `${remainingMs > 0 ? 'about ' : ''}${parts.join(' ')}`;
 }
 
 function renderDaoProposalHeading(proposal) {

--- a/app.js
+++ b/app.js
@@ -3043,9 +3043,7 @@ class AddProposalModal {
     if (this.emergencySelect) {
       this.emergencySelect.addEventListener('change', () => this.renderProposalFee());
     }
-    if (this.startDelayInput) {
-      this.startDelayInput.addEventListener('input', () => this.renderStartDelayLimit());
-    }
+    if (this.startDelayInput) this.startDelayInput.addEventListener('input', () => this.renderStartDelayLimit());
     if (this.gracePeriodInput) {
       this.gracePeriodInput.addEventListener('input', () => this.renderGracePeriodLimitHint());
     }
@@ -3158,11 +3156,7 @@ class AddProposalModal {
   }
 
   renderStartDelayLimit() {
-    this.renderMaximumWarning(
-      this.startDelayInput,
-      this.startDelayLimit,
-      `Maximum: ${this.maxStartDelayDays} days`
-    );
+    this.renderMaximumWarning(this.startDelayInput, this.startDelayLimit, `Maximum: ${this.maxStartDelayDays} days`);
   }
 
   renderMaximumWarning(input, warning, message) {
@@ -3176,9 +3170,7 @@ class AddProposalModal {
       ? ''
       : `${this.maxGracePeriodMs} ms (${formatDaoDurationEstimate(this.maxGracePeriodMs)})`;
     const currentValue = String(this.gracePeriodInput?.value ?? '').trim();
-    const currentSummary = currentValue
-      ? formatDaoDurationEstimate(currentValue)
-      : '';
+    const currentSummary = currentValue ? formatDaoDurationEstimate(currentValue) : '';
     if (this.gracePeriodInput) {
       this.gracePeriodInput.placeholder = maximumSummary ? 'Custom ms' : 'Loading maximum...';
     }
@@ -3329,18 +3321,13 @@ class AddProposalModal {
 
   async loadDaoProposalDefaults({ refresh = false } = {}) {
     const account = await this.fetchNetworkAccountConfig({ refresh });
-    const fee = account?.current?.dao?.proposalFeeUsdStr;
-    if (fee === undefined || fee === null || String(fee).trim() === '') {
-      throw new Error('Missing DAO proposal fee');
-    }
+    const proposalFeeUsdStr = String(account?.current?.dao?.proposalFeeUsdStr ?? '').trim();
+    if (!proposalFeeUsdStr) throw new Error('Missing DAO proposal fee');
     const graceDuration = Number(account?.current?.dao?.graceDuration);
     if (!Number.isSafeInteger(graceDuration) || graceDuration < 0) {
       throw new Error('Missing DAO maximum grace duration');
     }
-    return {
-      proposalFeeUsdStr: String(fee).trim(),
-      maxGracePeriodMs: graceDuration,
-    };
+    return { proposalFeeUsdStr, maxGracePeriodMs: graceDuration };
   }
 
   async fetchNetworkAccountConfig({ refresh = false } = {}) {
@@ -3556,10 +3543,7 @@ class AddProposalModal {
       throw this.createValidationError(`${label} maximum is not available`, input);
     }
     if (n > this.maxStartDelayDays) {
-      throw this.createValidationError(
-        `${label} must not exceed ${this.maxStartDelayDays} days`,
-        input
-      );
+      throw this.createValidationError(`${label} must not exceed ${this.maxStartDelayDays} days`, input);
     }
 
     const delayMs = n * DAO_PROPOSAL_DAY_MS;
@@ -3670,11 +3654,7 @@ class AddProposalModal {
       const options = this.getValidatedOptions();
       const changes = this.getValidatedChanges();
       const startDelayDays = this.getDaysValue(this.startDelayInput, 'Review start delay');
-      const gracePeriodMs = this.getMillisecondsValue(
-        this.gracePeriodInput,
-        'Grace period',
-        this.maxGracePeriodMs
-      );
+      const gracePeriodMs = this.getMillisecondsValue(this.gracePeriodInput, 'Grace period', this.maxGracePeriodMs);
       const emergency = this.emergencySelect?.value === 'true';
       if (!emergency && !this.proposalFeeUsdStr) {
         throw this.createValidationError('Current DAO proposal fee is not loaded yet', this.proposalFeeInput);

--- a/app.js
+++ b/app.js
@@ -3041,7 +3041,10 @@ class AddProposalModal {
     }
 
     if (this.emergencySelect) {
-      this.emergencySelect.addEventListener('change', () => this.renderProposalFee());
+      this.emergencySelect.addEventListener('change', () => {
+        this.renderProposalFee();
+        this.refreshStartDelayLimit();
+      });
     }
     if (this.startDelayInput) this.startDelayInput.addEventListener('input', () => this.renderStartDelayLimit());
     if (this.gracePeriodInput) {
@@ -3064,6 +3067,7 @@ class AddProposalModal {
     this.resetConfigCache();
     this.proposalFeeUsdStr = null;
     this.maxGracePeriodMs = null;
+    this.proposalDurations = null;
     if (this.titleInput) this.titleInput.value = '';
     if (this.typeSelect) this.typeSelect.value = 'governance';
     if (this.descriptionInput) this.descriptionInput.value = '';
@@ -3144,8 +3148,18 @@ class AddProposalModal {
 
   refreshStartDelayLimit() {
     this.maxStartDelayDays = null;
+    if (!this.proposalDurations || !Number.isSafeInteger(this.maxGracePeriodMs)) {
+      this.startDelayInput?.removeAttribute('max');
+      this.renderStartDelayLimit();
+      return;
+    }
+
     try {
-      this.maxStartDelayDays = getDaoProposalMaxStartDelayDays(getTransactionTimestamp());
+      this.maxStartDelayDays = getDaoProposalMaxStartDelayDays(getTransactionTimestamp(), {
+        ...this.proposalDurations,
+        emergency: this.emergencySelect?.value === 'true',
+        gracePeriod: this.maxGracePeriodMs,
+      });
       if (this.startDelayInput) this.startDelayInput.max = String(this.maxStartDelayDays);
     } catch (error) {
       console.warn('Could not calculate the DAO proposal review-start limit:', error);
@@ -3189,10 +3203,11 @@ class AddProposalModal {
     this.renderProposalFee();
 
     try {
-      const { proposalFeeUsdStr, maxGracePeriodMs } = await this.loadDaoProposalDefaults();
+      const { proposalFeeUsdStr, maxGracePeriodMs, proposalDurations } = await this.loadDaoProposalDefaults();
       if (!this.isActive() || requestId !== this.proposalDefaultsRequestId) return;
       this.proposalFeeUsdStr = proposalFeeUsdStr;
       this.maxGracePeriodMs = maxGracePeriodMs;
+      this.proposalDurations = proposalDurations;
       if (this.gracePeriodInput) {
         this.gracePeriodInput.max = String(maxGracePeriodMs);
         if (!String(this.gracePeriodInput.value || '').trim()) {
@@ -3200,19 +3215,22 @@ class AddProposalModal {
         }
       }
       this.renderProposalFee();
+      this.refreshStartDelayLimit();
       this.renderGracePeriodLimitHint();
     } catch (error) {
-      console.warn('Could not refresh DAO proposal fee:', error);
+      console.warn('Could not refresh DAO proposal defaults:', error);
       if (!this.isActive() || requestId !== this.proposalDefaultsRequestId) return;
       this.proposalFeeUsdStr = '';
       this.maxGracePeriodMs = null;
+      this.proposalDurations = null;
       if (this.gracePeriodInput) {
         this.gracePeriodInput.value = '';
         this.gracePeriodInput.removeAttribute('max');
       }
       this.renderProposalFee();
+      this.refreshStartDelayLimit();
       this.renderGracePeriodLimitHint();
-      showToast('Could not refresh DAO proposal fee', 2500, 'warning');
+      showToast('Could not refresh DAO proposal defaults', 2500, 'warning');
     }
   }
 
@@ -3321,13 +3339,22 @@ class AddProposalModal {
 
   async loadDaoProposalDefaults({ refresh = false } = {}) {
     const account = await this.fetchNetworkAccountConfig({ refresh });
-    const proposalFeeUsdStr = String(account?.current?.dao?.proposalFeeUsdStr ?? '').trim();
+    const daoConfig = account?.current?.dao;
+    const proposalFeeUsdStr = String(daoConfig?.proposalFeeUsdStr ?? '').trim();
     if (!proposalFeeUsdStr) throw new Error('Missing DAO proposal fee');
-    const graceDuration = Number(account?.current?.dao?.graceDuration);
+    const graceDuration = Number(daoConfig?.graceDuration);
     if (!Number.isSafeInteger(graceDuration) || graceDuration < 0) {
       throw new Error('Missing DAO maximum grace duration');
     }
-    return { proposalFeeUsdStr, maxGracePeriodMs: graceDuration };
+    const proposalDurations = {
+      reviewDuration: Number(daoConfig?.reviewDuration),
+      votingDuration: Number(daoConfig?.votingDuration),
+      claimDuration: Number(daoConfig?.claimDuration),
+    };
+    if (Object.values(proposalDurations).some((duration) => !Number.isSafeInteger(duration) || duration < 0)) {
+      throw new Error('Missing DAO proposal lifecycle durations');
+    }
+    return { proposalFeeUsdStr, maxGracePeriodMs: graceDuration, proposalDurations };
   }
 
   async fetchNetworkAccountConfig({ refresh = false } = {}) {
@@ -3897,12 +3924,13 @@ class ConfirmProposalModal {
     let loadingToastId = showToast('Submitting proposal...', 0, 'loading');
 
     try {
-      const { maxGracePeriodMs } = await addProposalModal.loadDaoProposalDefaults({ refresh: true });
+      const { maxGracePeriodMs, proposalDurations } = await addProposalModal.loadDaoProposalDefaults({ refresh: true });
       const result = await daoRepo.createProposal({
         draft: this.currentDraft,
         timestamp: getTransactionTimestamp(),
         networkId: network?.netid || '',
         maxGracePeriodMs,
+        proposalDurations,
         submitTransaction: async (transaction) => {
           if (!myAccount?.keys) throw new Error('Wallet keys unavailable');
           const txid = await signObj(transaction, myAccount.keys);

--- a/app.js
+++ b/app.js
@@ -83,6 +83,7 @@ import {
   DAO_ACTION_TYPES,
   DAO_CONFIG_CHANGE_OPTIONS,
   DAO_PROPOSAL_CREATE_TYPE,
+  DAO_PROPOSAL_DAY_MS,
   DAO_PROPOSAL_TITLE_MAX_LENGTH,
   daoRepo,
   DAO_STATES,
@@ -3080,7 +3081,7 @@ class AddProposalModal {
     this.refreshStartDelayLimit();
     this.renderOptions(['yes', 'no']);
     this.renderGracePeriodLimitHint();
-    this.refreshProposalFee();
+    this.refreshProposalDefaults();
     this.refreshSelectedConfigOptions();
     setTimeout(() => {
       this.titleInput?.focus();
@@ -3102,7 +3103,7 @@ class AddProposalModal {
     this.networkAccountConfigPromise = null;
     this.protocolConfigPromise = null;
     this.configRequestId = 0;
-    this.proposalFeeRequestId = 0;
+    this.proposalDefaultsRequestId = 0;
   }
 
   getConfigOptions() {
@@ -3157,19 +3158,23 @@ class AddProposalModal {
   }
 
   renderStartDelayLimit() {
-    if (!this.startDelayLimit) return;
-    const value = Number(this.startDelayInput?.value);
-    const exceedsMaximum = Number.isSafeInteger(this.maxStartDelayDays)
-      && Number.isFinite(value)
-      && value > this.maxStartDelayDays;
-    this.startDelayLimit.textContent = `Maximum: ${this.maxStartDelayDays} days`;
-    this.startDelayLimit.classList.toggle('hidden', !exceedsMaximum);
+    this.renderMaximumWarning(
+      this.startDelayInput,
+      this.startDelayLimit,
+      `Maximum: ${this.maxStartDelayDays} days`
+    );
+  }
+
+  renderMaximumWarning(input, warning, message) {
+    if (!warning) return;
+    warning.textContent = message;
+    warning.classList.toggle('hidden', !input?.validity.rangeOverflow);
   }
 
   renderGracePeriodLimitHint() {
     const maximumSummary = this.maxGracePeriodMs === null
       ? ''
-      : `${formatDaoDurationMsInput(this.maxGracePeriodMs)} ms (${formatDaoDurationEstimate(this.maxGracePeriodMs)})`;
+      : `${this.maxGracePeriodMs} ms (${formatDaoDurationEstimate(this.maxGracePeriodMs)})`;
     const currentValue = String(this.gracePeriodInput?.value ?? '').trim();
     const currentSummary = currentValue
       ? formatDaoDurationEstimate(currentValue)
@@ -3180,36 +3185,33 @@ class AddProposalModal {
     if (this.gracePeriodHelp) {
       this.gracePeriodHelp.textContent = currentSummary ? `Estimate: ${currentSummary}` : '';
     }
-    if (!this.gracePeriodLimit) return;
-
-    const value = Number(currentValue);
-    const exceedsMaximum = Number.isSafeInteger(this.maxGracePeriodMs)
-      && Number.isFinite(value)
-      && value > this.maxGracePeriodMs;
-    this.gracePeriodLimit.textContent = `Maximum from current DAO grace duration: ${maximumSummary}`;
-    this.gracePeriodLimit.classList.toggle('hidden', !exceedsMaximum);
+    this.renderMaximumWarning(
+      this.gracePeriodInput,
+      this.gracePeriodLimit,
+      `Maximum from current DAO grace duration: ${maximumSummary}`
+    );
   }
 
-  async refreshProposalFee() {
-    const requestId = ++this.proposalFeeRequestId;
+  async refreshProposalDefaults() {
+    const requestId = ++this.proposalDefaultsRequestId;
     this.renderProposalFee();
 
     try {
       const { proposalFeeUsdStr, maxGracePeriodMs } = await this.loadDaoProposalDefaults();
-      if (!this.isActive() || requestId !== this.proposalFeeRequestId) return;
+      if (!this.isActive() || requestId !== this.proposalDefaultsRequestId) return;
       this.proposalFeeUsdStr = proposalFeeUsdStr;
       this.maxGracePeriodMs = maxGracePeriodMs;
       if (this.gracePeriodInput) {
-        this.gracePeriodInput.max = formatDaoDurationMsInput(maxGracePeriodMs);
+        this.gracePeriodInput.max = String(maxGracePeriodMs);
         if (!String(this.gracePeriodInput.value || '').trim()) {
-          this.gracePeriodInput.value = formatDaoDurationMsInput(maxGracePeriodMs);
+          this.gracePeriodInput.value = String(maxGracePeriodMs);
         }
       }
       this.renderProposalFee();
       this.renderGracePeriodLimitHint();
     } catch (error) {
       console.warn('Could not refresh DAO proposal fee:', error);
-      if (!this.isActive() || requestId !== this.proposalFeeRequestId) return;
+      if (!this.isActive() || requestId !== this.proposalDefaultsRequestId) return;
       this.proposalFeeUsdStr = '';
       this.maxGracePeriodMs = null;
       if (this.gracePeriodInput) {
@@ -3535,15 +3537,21 @@ class AddProposalModal {
     this.renderParameterChanges(rows);
   }
 
-  getDaysValue(input, label) {
+  getIntegerValue(input, label, unit = '') {
     const value = String(input?.value ?? '').trim();
+    const unitSuffix = unit ? ` of ${unit}` : '';
     if (!/^\d+$/.test(value)) {
-      throw this.createValidationError(`${label} must be a non-negative whole number`, input);
+      throw this.createValidationError(`${label} must be a non-negative whole number${unitSuffix}`, input);
     }
     const n = Number(value);
     if (!Number.isSafeInteger(n)) {
       throw this.createValidationError(`${label} is too large`, input);
     }
+    return n;
+  }
+
+  getDaysValue(input, label) {
+    const n = this.getIntegerValue(input, label);
     if (!Number.isSafeInteger(this.maxStartDelayDays) || this.maxStartDelayDays < 0) {
       throw this.createValidationError(`${label} maximum is not available`, input);
     }
@@ -3554,7 +3562,7 @@ class AddProposalModal {
       );
     }
 
-    const delayMs = n * 24 * 60 * 60 * 1000;
+    const delayMs = n * DAO_PROPOSAL_DAY_MS;
     if (!Number.isSafeInteger(delayMs)) {
       throw this.createValidationError(`${label} is too large`, input);
     }
@@ -3567,17 +3575,10 @@ class AddProposalModal {
   }
 
   getMillisecondsValue(input, label, maximumMs) {
-    const value = String(input?.value ?? '').trim();
     if (!Number.isSafeInteger(maximumMs) || maximumMs < 0) {
       throw this.createValidationError(`${label} maximum is not loaded yet`, input);
     }
-    if (!/^\d+$/.test(value)) {
-      throw this.createValidationError(`${label} must be a non-negative whole number of milliseconds`, input);
-    }
-    const n = Number(value);
-    if (!Number.isSafeInteger(n)) {
-      throw this.createValidationError(`${label} is too large`, input);
-    }
+    const n = this.getIntegerValue(input, label, 'milliseconds');
     if (n > maximumMs) {
       throw this.createValidationError(`${label} must not exceed ${maximumMs} milliseconds`, input);
     }
@@ -3707,19 +3708,13 @@ function formatDaoDurationSummary(ms) {
   return `${n} ms (${formatDaoDurationEstimate(n)})`;
 }
 
-function formatDaoDurationMsInput(ms) {
-  const n = Number(ms || 0);
-  if (!Number.isInteger(n) || n < 0) return '';
-  return String(n);
-}
-
 function formatDaoDurationEstimate(ms) {
   const n = Number(ms);
   if (!Number.isFinite(n) || n < 0) return '';
   if (n === 0) return '0 sec';
 
   const units = [
-    ['day', 24 * 60 * 60 * 1000],
+    ['day', DAO_PROPOSAL_DAY_MS],
     ['hr', 60 * 60 * 1000],
     ['min', 60 * 1000],
     ['sec', 1000],

--- a/app.js
+++ b/app.js
@@ -3040,7 +3040,7 @@ class AddProposalModal {
       this.emergencySelect.addEventListener('change', () => this.renderProposalFee());
     }
     if (this.gracePeriodInput) {
-      this.gracePeriodInput.addEventListener('input', () => this.renderGracePeriodDefaultHint());
+      this.gracePeriodInput.addEventListener('input', () => this.renderGracePeriodLimitHint());
     }
 
     if (this.optionsList) {
@@ -3058,15 +3058,18 @@ class AddProposalModal {
     enterFullscreen();
     this.resetConfigCache();
     this.proposalFeeUsdStr = null;
-    this.defaultGracePeriodMs = null;
+    this.maxGracePeriodMs = null;
     if (this.titleInput) this.titleInput.value = '';
     if (this.typeSelect) this.typeSelect.value = 'governance';
     if (this.descriptionInput) this.descriptionInput.value = '';
     if (this.emergencySelect) this.emergencySelect.value = 'false';
     if (this.startDelayInput) this.startDelayInput.value = '0';
-    if (this.gracePeriodInput) this.gracePeriodInput.value = '';
+    if (this.gracePeriodInput) {
+      this.gracePeriodInput.value = '';
+      this.gracePeriodInput.removeAttribute('max');
+    }
     this.renderOptions(['yes', 'no']);
-    this.renderGracePeriodDefaultHint();
+    this.renderGracePeriodLimitHint();
     this.refreshProposalFee();
     this.refreshSelectedConfigOptions();
     setTimeout(() => {
@@ -3130,28 +3133,23 @@ class AddProposalModal {
       : 'Unavailable';
   }
 
-  renderGracePeriodDefaultHint() {
-    const defaultSummary = this.defaultGracePeriodMs === null
+  renderGracePeriodLimitHint() {
+    const maximumSummary = this.maxGracePeriodMs === null
       ? ''
-      : `${formatDaoDurationMsInput(this.defaultGracePeriodMs)} ms (${formatDaoDurationDaysEstimate(this.defaultGracePeriodMs)})`;
+      : `${formatDaoDurationMsInput(this.maxGracePeriodMs)} ms (${formatDaoDurationDaysEstimate(this.maxGracePeriodMs)})`;
     const currentValue = String(this.gracePeriodInput?.value ?? '').trim();
     const currentSummary = currentValue
       ? formatDaoDurationDaysEstimate(currentValue)
       : '';
     if (this.gracePeriodInput) {
-      this.gracePeriodInput.placeholder = defaultSummary ? 'Custom ms' : 'Loading default...';
+      this.gracePeriodInput.placeholder = maximumSummary ? 'Custom ms' : 'Loading maximum...';
     }
-    if (this.gracePeriodHelp) {
-      if (currentSummary && defaultSummary) {
-        this.gracePeriodHelp.textContent = `Estimate: ${currentSummary}. Default: ${defaultSummary}`;
-      } else if (currentSummary) {
-        this.gracePeriodHelp.textContent = `Estimate: ${currentSummary}. Default: loading...`;
-      } else if (defaultSummary) {
-        this.gracePeriodHelp.textContent = `Default: ${defaultSummary}`;
-      } else {
-        this.gracePeriodHelp.textContent = 'Default: loading...';
-      }
-    }
+    if (!this.gracePeriodHelp) return;
+
+    const summaries = [];
+    if (currentSummary) summaries.push(`Estimate: ${currentSummary}`);
+    summaries.push(`Maximum: ${maximumSummary || 'loading...'}`);
+    this.gracePeriodHelp.textContent = summaries.join('. ');
   }
 
   async refreshProposalFee() {
@@ -3159,23 +3157,29 @@ class AddProposalModal {
     this.renderProposalFee();
 
     try {
-      const { proposalFeeUsdStr, defaultGracePeriodMs } = await this.loadDaoProposalDefaults();
+      const { proposalFeeUsdStr, maxGracePeriodMs } = await this.loadDaoProposalDefaults();
       if (!this.isActive() || requestId !== this.proposalFeeRequestId) return;
       this.proposalFeeUsdStr = proposalFeeUsdStr;
-      this.defaultGracePeriodMs = defaultGracePeriodMs;
-      if (this.gracePeriodInput && !String(this.gracePeriodInput.value || '').trim()) {
-        this.gracePeriodInput.value = formatDaoDurationMsInput(defaultGracePeriodMs);
+      this.maxGracePeriodMs = maxGracePeriodMs;
+      if (this.gracePeriodInput) {
+        this.gracePeriodInput.max = formatDaoDurationMsInput(maxGracePeriodMs);
+        if (!String(this.gracePeriodInput.value || '').trim()) {
+          this.gracePeriodInput.value = formatDaoDurationMsInput(maxGracePeriodMs);
+        }
       }
       this.renderProposalFee();
-      this.renderGracePeriodDefaultHint();
+      this.renderGracePeriodLimitHint();
     } catch (error) {
       console.warn('Could not refresh DAO proposal fee:', error);
       if (!this.isActive() || requestId !== this.proposalFeeRequestId) return;
       this.proposalFeeUsdStr = '';
-      this.defaultGracePeriodMs = null;
-      if (this.gracePeriodInput) this.gracePeriodInput.value = '';
+      this.maxGracePeriodMs = null;
+      if (this.gracePeriodInput) {
+        this.gracePeriodInput.value = '';
+        this.gracePeriodInput.removeAttribute('max');
+      }
       this.renderProposalFee();
-      this.renderGracePeriodDefaultHint();
+      this.renderGracePeriodLimitHint();
       showToast('Could not refresh DAO proposal fee', 2500, 'warning');
     }
   }
@@ -3290,12 +3294,12 @@ class AddProposalModal {
       throw new Error('Missing DAO proposal fee');
     }
     const graceDuration = Number(account?.current?.dao?.graceDuration);
-    if (!Number.isInteger(graceDuration) || graceDuration < 0) {
-      throw new Error('Missing DAO default grace duration');
+    if (!Number.isSafeInteger(graceDuration) || graceDuration < 0) {
+      throw new Error('Missing DAO maximum grace duration');
     }
     return {
       proposalFeeUsdStr: String(fee).trim(),
-      defaultGracePeriodMs: graceDuration,
+      maxGracePeriodMs: graceDuration,
     };
   }
 
@@ -3494,20 +3498,41 @@ class AddProposalModal {
   }
 
   getDaysValue(input, label) {
-    const value = String(input?.value || '0').trim();
-    const n = Number(value);
-    if (!Number.isInteger(n) || n < 0) {
+    const value = String(input?.value ?? '').trim();
+    if (!/^\d+$/.test(value)) {
       throw this.createValidationError(`${label} must be a non-negative whole number`, input);
+    }
+    const n = Number(value);
+    if (!Number.isSafeInteger(n)) {
+      throw this.createValidationError(`${label} is too large`, input);
+    }
+
+    const delayMs = n * 24 * 60 * 60 * 1000;
+    if (!Number.isSafeInteger(delayMs)) {
+      throw this.createValidationError(`${label} is too large`, input);
+    }
+
+    const startTime = getTransactionTimestamp() + delayMs;
+    if (!Number.isSafeInteger(startTime) || Number.isNaN(new Date(startTime).getTime())) {
+      throw this.createValidationError(`${label} produces an invalid date`, input);
     }
     return n;
   }
 
-  getMillisecondsValue(input, label) {
+  getMillisecondsValue(input, label, maximumMs) {
     const value = String(input?.value ?? '').trim();
-    if (!value) throw this.createValidationError(`${label} is not loaded yet`, input);
-    const n = Number(value);
-    if (!Number.isInteger(n) || n < 0) {
+    if (!Number.isSafeInteger(maximumMs) || maximumMs < 0) {
+      throw this.createValidationError(`${label} maximum is not loaded yet`, input);
+    }
+    if (!/^\d+$/.test(value)) {
       throw this.createValidationError(`${label} must be a non-negative whole number of milliseconds`, input);
+    }
+    const n = Number(value);
+    if (!Number.isSafeInteger(n)) {
+      throw this.createValidationError(`${label} is too large`, input);
+    }
+    if (n > maximumMs) {
+      throw this.createValidationError(`${label} must not exceed ${maximumMs} milliseconds`, input);
     }
     return n;
   }
@@ -3596,8 +3621,12 @@ class AddProposalModal {
     try {
       const options = this.getValidatedOptions();
       const changes = this.getValidatedChanges();
-      const startDelayDays = this.getDaysValue(this.startDelayInput, 'Start delay');
-      const gracePeriodMs = this.getMillisecondsValue(this.gracePeriodInput, 'Grace period');
+      const startDelayDays = this.getDaysValue(this.startDelayInput, 'Review start delay');
+      const gracePeriodMs = this.getMillisecondsValue(
+        this.gracePeriodInput,
+        'Grace period',
+        this.maxGracePeriodMs
+      );
       const emergency = this.emergencySelect?.value === 'true';
       if (!emergency && !this.proposalFeeUsdStr) {
         throw this.createValidationError('Current DAO proposal fee is not loaded yet', this.proposalFeeInput);
@@ -3614,6 +3643,7 @@ class AddProposalModal {
         proposalFeeUsdStr: this.proposalFeeUsdStr,
         startDelayDays,
         gracePeriodMs,
+        maxGracePeriodMs: this.maxGracePeriodMs,
       });
       confirmProposalModal.open(draft);
     } catch (e) {

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -388,6 +388,8 @@ export function buildDaoProposalCreateTransaction({
     gracePeriod,
   };
 
+  // startTime is derived from validated inputs and must never be trusted from a draft.
+  delete transaction.startTime;
   if (startDelayMs > 0) {
     transaction.startTime = getDaoProposalStartTime(txTimestamp, startDelayMs);
   }

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -76,9 +76,8 @@ export const DAO_STATES = [
   { key: 'applied', label: 'Applied' },
 ];
 
-const DAO_PROPOSAL_DAY_MS = 24 * 60 * 60 * 1000;
-// ECMAScript Date max: 100,000,000 days after the Unix epoch (8.64e15 ms).
-const DAO_PROPOSAL_MAX_DATE_MS = 8_640_000_000_000_000;
+export const DAO_PROPOSAL_DAY_MS = 24 * 60 * 60 * 1000;
+const DAO_PROPOSAL_MAX_DATE_MS = 100_000_000 * DAO_PROPOSAL_DAY_MS; // ECMAScript Date limit.
 const DAO_AFFIRMATIVE_OPTION_STRINGS = ['yes', 'accept', 'approve'];
 const DAO_PROPOSALS_META_ID_STRING = 'dao proposals meta';
 export const DAO_PROPOSAL_TITLE_MAX_LENGTH = 100;
@@ -322,12 +321,7 @@ export function buildDaoProposalCreateDraft({
   const isEmergency = emergency === true;
   const feeUsdStr = isEmergency ? '0' : requireDaoDraftString(proposalFeeUsdStr, 'DAO proposal fee');
   const startDelayMs = normalizeDaoDraftStartDelayMs(startDelayDays);
-  const safeMaxGracePeriodMs = normalizeDaoDraftInteger(
-    maxGracePeriodMs,
-    'Maximum grace period',
-    'milliseconds'
-  );
-  const safeGracePeriodMs = normalizeDaoDraftGracePeriodMs(gracePeriodMs, safeMaxGracePeriodMs);
+  const safeGracePeriodMs = normalizeDaoDraftGracePeriodMs(gracePeriodMs, maxGracePeriodMs);
   const safeOptions = normalizeDaoDraftOptions(options);
   const safeChanges = normalizeDaoDraftChanges(changes);
 

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -77,6 +77,7 @@ export const DAO_STATES = [
 ];
 
 const DAO_PROPOSAL_DAY_MS = 24 * 60 * 60 * 1000;
+// ECMAScript Date max: 100,000,000 days after the Unix epoch (8.64e15 ms).
 const DAO_PROPOSAL_MAX_DATE_MS = 8_640_000_000_000_000;
 const DAO_AFFIRMATIVE_OPTION_STRINGS = ['yes', 'accept', 'approve'];
 const DAO_PROPOSALS_META_ID_STRING = 'dao proposals meta';

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -77,6 +77,7 @@ export const DAO_STATES = [
 ];
 
 const DAO_PROPOSAL_DAY_MS = 24 * 60 * 60 * 1000;
+const DAO_PROPOSAL_MAX_DATE_MS = 8_640_000_000_000_000;
 const DAO_AFFIRMATIVE_OPTION_STRINGS = ['yes', 'accept', 'approve'];
 const DAO_PROPOSALS_META_ID_STRING = 'dao proposals meta';
 export const DAO_PROPOSAL_TITLE_MAX_LENGTH = 100;
@@ -241,6 +242,18 @@ function normalizeDaoDraftGracePeriodMs(value, maxGracePeriodMs) {
   return gracePeriodMs;
 }
 
+export function getDaoProposalMaxStartDelayDays(timestamp) {
+  const txTimestamp = normalizeDaoDraftInteger(
+    timestamp,
+    'DAO proposal timestamp',
+    'milliseconds'
+  );
+  if (txTimestamp <= 0 || txTimestamp > DAO_PROPOSAL_MAX_DATE_MS) {
+    throw new Error('DAO proposal timestamp must be a valid date');
+  }
+  return Math.floor((DAO_PROPOSAL_MAX_DATE_MS - txTimestamp) / DAO_PROPOSAL_DAY_MS);
+}
+
 function getDaoProposalStartTime(timestamp, startDelayMs) {
   const startTime = timestamp + startDelayMs;
   if (!Number.isSafeInteger(startTime) || Number.isNaN(new Date(startTime).getTime())) {
@@ -308,7 +321,12 @@ export function buildDaoProposalCreateDraft({
   const isEmergency = emergency === true;
   const feeUsdStr = isEmergency ? '0' : requireDaoDraftString(proposalFeeUsdStr, 'DAO proposal fee');
   const startDelayMs = normalizeDaoDraftStartDelayMs(startDelayDays);
-  const safeGracePeriodMs = normalizeDaoDraftGracePeriodMs(gracePeriodMs, maxGracePeriodMs);
+  const safeMaxGracePeriodMs = normalizeDaoDraftInteger(
+    maxGracePeriodMs,
+    'Maximum grace period',
+    'milliseconds'
+  );
+  const safeGracePeriodMs = normalizeDaoDraftGracePeriodMs(gracePeriodMs, safeMaxGracePeriodMs);
   const safeOptions = normalizeDaoDraftOptions(options);
   const safeChanges = normalizeDaoDraftChanges(changes);
 
@@ -327,6 +345,7 @@ export function buildDaoProposalCreateDraft({
     displayTitle: transaction.title,
     proposalFeeUsdStr: feeUsdStr,
     startDelayMs,
+    maxGracePeriodMs: safeMaxGracePeriodMs,
     transaction,
   };
 }
@@ -348,17 +367,20 @@ export function buildDaoProposalCreateTransaction({
   }
 
   const proposalId = getDaoProposalAccountId(proposalNumber);
-  const txTimestamp = requireDaoNonNegativeNumber(timestamp, 'DAO proposal timestamp');
+  const txTimestamp = normalizeDaoDraftInteger(
+    timestamp,
+    'DAO proposal timestamp',
+    'milliseconds'
+  );
   if (txTimestamp <= 0) throw new Error('DAO proposal timestamp is required');
   const startDelayMs = normalizeDaoDraftInteger(
     draft.startDelayMs ?? 0,
     'Review start delay',
     'milliseconds'
   );
-  const gracePeriod = normalizeDaoDraftInteger(
+  const gracePeriod = normalizeDaoDraftGracePeriodMs(
     draftTx.gracePeriod,
-    'Grace period',
-    'milliseconds'
+    draft.maxGracePeriodMs
   );
 
   const transaction = {

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -215,22 +215,11 @@ function requireDaoNonNegativeNumber(value, label) {
 function normalizeDaoDraftInteger(value, label, unit = '') {
   const text = String(value ?? '').trim();
   const unitSuffix = unit ? ` of ${unit}` : '';
-  if (!/^\d+$/.test(text)) {
-    throw new Error(`${label} must be a non-negative whole number${unitSuffix}`);
-  }
+  if (!/^\d+$/.test(text)) throw new Error(`${label} must be a non-negative whole number${unitSuffix}`);
 
   const n = Number(text);
   if (!Number.isSafeInteger(n)) throw new Error(`${label} is too large`);
   return n;
-}
-
-function normalizeDaoDraftStartDelayMs(value) {
-  const days = normalizeDaoDraftInteger(value, 'Review start delay');
-  const milliseconds = days * DAO_PROPOSAL_DAY_MS;
-  if (!Number.isSafeInteger(milliseconds)) {
-    throw new Error('Review start delay is too large');
-  }
-  return milliseconds;
 }
 
 function normalizeDaoDraftGracePeriodMs(value, maxGracePeriodMs) {
@@ -243,23 +232,11 @@ function normalizeDaoDraftGracePeriodMs(value, maxGracePeriodMs) {
 }
 
 export function getDaoProposalMaxStartDelayDays(timestamp) {
-  const txTimestamp = normalizeDaoDraftInteger(
-    timestamp,
-    'DAO proposal timestamp',
-    'milliseconds'
-  );
+  const txTimestamp = normalizeDaoDraftInteger(timestamp, 'DAO proposal timestamp', 'milliseconds');
   if (txTimestamp <= 0 || txTimestamp > DAO_PROPOSAL_MAX_DATE_MS) {
     throw new Error('DAO proposal timestamp must be a valid date');
   }
   return Math.floor((DAO_PROPOSAL_MAX_DATE_MS - txTimestamp) / DAO_PROPOSAL_DAY_MS);
-}
-
-function getDaoProposalStartTime(timestamp, startDelayMs) {
-  const startTime = timestamp + startDelayMs;
-  if (!Number.isSafeInteger(startTime) || Number.isNaN(new Date(startTime).getTime())) {
-    throw new Error('Review start delay produces an invalid date');
-  }
-  return startTime;
 }
 
 function normalizeDaoDraftChanges(changes) {
@@ -320,7 +297,8 @@ export function buildDaoProposalCreateDraft({
 
   const isEmergency = emergency === true;
   const feeUsdStr = isEmergency ? '0' : requireDaoDraftString(proposalFeeUsdStr, 'DAO proposal fee');
-  const startDelayMs = normalizeDaoDraftStartDelayMs(startDelayDays);
+  const startDelayMs = normalizeDaoDraftInteger(startDelayDays, 'Review start delay') * DAO_PROPOSAL_DAY_MS;
+  if (!Number.isSafeInteger(startDelayMs)) throw new Error('Review start delay is too large');
   const safeGracePeriodMs = normalizeDaoDraftGracePeriodMs(gracePeriodMs, maxGracePeriodMs);
   const safeOptions = normalizeDaoDraftOptions(options);
   const safeChanges = normalizeDaoDraftChanges(changes);
@@ -362,21 +340,10 @@ export function buildDaoProposalCreateTransaction({
   }
 
   const proposalId = getDaoProposalAccountId(proposalNumber);
-  const txTimestamp = normalizeDaoDraftInteger(
-    timestamp,
-    'DAO proposal timestamp',
-    'milliseconds'
-  );
+  const txTimestamp = normalizeDaoDraftInteger(timestamp, 'DAO proposal timestamp', 'milliseconds');
   if (txTimestamp <= 0) throw new Error('DAO proposal timestamp is required');
-  const startDelayMs = normalizeDaoDraftInteger(
-    draft.startDelayMs ?? 0,
-    'Review start delay',
-    'milliseconds'
-  );
-  const gracePeriod = normalizeDaoDraftGracePeriodMs(
-    draftTx.gracePeriod,
-    maxGracePeriodMs
-  );
+  const startDelayMs = normalizeDaoDraftInteger(draft.startDelayMs ?? 0, 'Review start delay', 'milliseconds');
+  const gracePeriod = normalizeDaoDraftGracePeriodMs(draftTx.gracePeriod, maxGracePeriodMs);
 
   const transaction = {
     ...draftTx,
@@ -391,7 +358,11 @@ export function buildDaoProposalCreateTransaction({
   // startTime is derived from validated inputs and must never be trusted from a draft.
   delete transaction.startTime;
   if (startDelayMs > 0) {
-    transaction.startTime = getDaoProposalStartTime(txTimestamp, startDelayMs);
+    const startTime = txTimestamp + startDelayMs;
+    if (!Number.isSafeInteger(startTime) || Number.isNaN(new Date(startTime).getTime())) {
+      throw new Error('Review start delay produces an invalid date');
+    }
+    transaction.startTime = startTime;
   }
 
   return transaction;

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -211,22 +211,42 @@ function requireDaoNonNegativeNumber(value, label) {
   return n;
 }
 
-function normalizeDaoDraftDayCount(value, label) {
-  const n = Number(value || 0);
-  if (!Number.isInteger(n) || n < 0) {
-    throw new Error(`${label} must be a non-negative whole number`);
+function normalizeDaoDraftInteger(value, label, unit = '') {
+  const text = String(value ?? '').trim();
+  const unitSuffix = unit ? ` of ${unit}` : '';
+  if (!/^\d+$/.test(text)) {
+    throw new Error(`${label} must be a non-negative whole number${unitSuffix}`);
   }
+
+  const n = Number(text);
+  if (!Number.isSafeInteger(n)) throw new Error(`${label} is too large`);
   return n;
 }
 
-function normalizeDaoDraftDurationMs(value, label) {
-  const text = String(value ?? '').trim();
-  if (!text) throw new Error(`${label} is required`);
-  const n = Number(text);
-  if (!Number.isInteger(n) || n < 0) {
-    throw new Error(`${label} must be a non-negative whole number of milliseconds`);
+function normalizeDaoDraftStartDelayMs(value) {
+  const days = normalizeDaoDraftInteger(value, 'Review start delay');
+  const milliseconds = days * DAO_PROPOSAL_DAY_MS;
+  if (!Number.isSafeInteger(milliseconds)) {
+    throw new Error('Review start delay is too large');
   }
-  return n;
+  return milliseconds;
+}
+
+function normalizeDaoDraftGracePeriodMs(value, maxGracePeriodMs) {
+  const gracePeriodMs = normalizeDaoDraftInteger(value, 'Grace period', 'milliseconds');
+  const maximumMs = normalizeDaoDraftInteger(maxGracePeriodMs, 'Maximum grace period', 'milliseconds');
+  if (gracePeriodMs > maximumMs) {
+    throw new Error(`Grace period must not exceed ${maximumMs} milliseconds`);
+  }
+  return gracePeriodMs;
+}
+
+function getDaoProposalStartTime(timestamp, startDelayMs) {
+  const startTime = timestamp + startDelayMs;
+  if (!Number.isSafeInteger(startTime) || Number.isNaN(new Date(startTime).getTime())) {
+    throw new Error('Review start delay produces an invalid date');
+  }
+  return startTime;
 }
 
 function normalizeDaoDraftChanges(changes) {
@@ -278,6 +298,7 @@ export function buildDaoProposalCreateDraft({
   proposalFeeUsdStr,
   startDelayDays,
   gracePeriodMs,
+  maxGracePeriodMs,
 } = {}) {
   const safeProposalType = requireDaoDraftString(proposalType, 'DAO proposal type');
   if (!DAO_CONFIG_CHANGE_OPTIONS[safeProposalType]) {
@@ -286,8 +307,8 @@ export function buildDaoProposalCreateDraft({
 
   const isEmergency = emergency === true;
   const feeUsdStr = isEmergency ? '0' : requireDaoDraftString(proposalFeeUsdStr, 'DAO proposal fee');
-  const startDelayMs = normalizeDaoDraftDayCount(startDelayDays, 'Review start delay') * DAO_PROPOSAL_DAY_MS;
-  const safeGracePeriodMs = normalizeDaoDraftDurationMs(gracePeriodMs, 'Grace period');
+  const startDelayMs = normalizeDaoDraftStartDelayMs(startDelayDays);
+  const safeGracePeriodMs = normalizeDaoDraftGracePeriodMs(gracePeriodMs, maxGracePeriodMs);
   const safeOptions = normalizeDaoDraftOptions(options);
   const safeChanges = normalizeDaoDraftChanges(changes);
 
@@ -298,10 +319,9 @@ export function buildDaoProposalCreateDraft({
     title: requireDaoDraftString(displayTitle, 'DAO proposal title', DAO_PROPOSAL_TITLE_MAX_LENGTH),
     description: requireDaoDraftString(description, 'DAO proposal description'),
     options: safeOptions,
+    gracePeriod: safeGracePeriodMs,
     [safeProposalType]: { changes: safeChanges },
   };
-
-  transaction.gracePeriod = safeGracePeriodMs;
 
   return {
     displayTitle: transaction.title,
@@ -330,8 +350,16 @@ export function buildDaoProposalCreateTransaction({
   const proposalId = getDaoProposalAccountId(proposalNumber);
   const txTimestamp = requireDaoNonNegativeNumber(timestamp, 'DAO proposal timestamp');
   if (txTimestamp <= 0) throw new Error('DAO proposal timestamp is required');
-  const startDelayMs = requireDaoNonNegativeNumber(draft.startDelayMs ?? 0, 'Review start delay');
-  const gracePeriod = requireDaoNonNegativeNumber(draftTx.gracePeriod, 'Grace period');
+  const startDelayMs = normalizeDaoDraftInteger(
+    draft.startDelayMs ?? 0,
+    'Review start delay',
+    'milliseconds'
+  );
+  const gracePeriod = normalizeDaoDraftInteger(
+    draftTx.gracePeriod,
+    'Grace period',
+    'milliseconds'
+  );
 
   const transaction = {
     ...draftTx,
@@ -344,7 +372,7 @@ export function buildDaoProposalCreateTransaction({
   };
 
   if (startDelayMs > 0) {
-    transaction.startTime = txTimestamp + startDelayMs;
+    transaction.startTime = getDaoProposalStartTime(txTimestamp, startDelayMs);
   }
 
   return transaction;

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -231,12 +231,34 @@ function normalizeDaoDraftGracePeriodMs(value, maxGracePeriodMs) {
   return gracePeriodMs;
 }
 
-export function getDaoProposalMaxStartDelayDays(timestamp) {
+function getDaoProposalLifecycleDurationMs({
+  emergency = false,
+  reviewDuration,
+  votingDuration,
+  claimDuration,
+  gracePeriod,
+} = {}) {
+  const reviewDurationMs = normalizeDaoDraftInteger(reviewDuration, 'Review duration', 'milliseconds');
+  const votingDurationMs = normalizeDaoDraftInteger(votingDuration, 'Voting duration', 'milliseconds');
+  const claimDurationMs = normalizeDaoDraftInteger(claimDuration, 'Claim duration', 'milliseconds');
+  const gracePeriodMs = normalizeDaoDraftInteger(gracePeriod, 'Grace period', 'milliseconds');
+  // claimEnd and applyEligibleAt both start at claimStart, so reserve whichever finishes later.
+  const durationMs = reviewDurationMs
+    + (emergency === true ? 0 : votingDurationMs)
+    + Math.max(claimDurationMs, gracePeriodMs);
+  if (!Number.isSafeInteger(durationMs)) throw new Error('DAO proposal lifecycle duration is too large');
+  return durationMs;
+}
+
+export function getDaoProposalMaxStartDelayDays(timestamp, proposalTiming) {
   const txTimestamp = normalizeDaoDraftInteger(timestamp, 'DAO proposal timestamp', 'milliseconds');
   if (txTimestamp <= 0 || txTimestamp > DAO_PROPOSAL_MAX_DATE_MS) {
     throw new Error('DAO proposal timestamp must be a valid date');
   }
-  return Math.floor((DAO_PROPOSAL_MAX_DATE_MS - txTimestamp) / DAO_PROPOSAL_DAY_MS);
+  const lifecycleDurationMs = getDaoProposalLifecycleDurationMs(proposalTiming);
+  const availableDelayMs = DAO_PROPOSAL_MAX_DATE_MS - txTimestamp - lifecycleDurationMs;
+  if (availableDelayMs < 0) throw new Error('DAO proposal lifecycle must end on a valid date');
+  return Math.floor(availableDelayMs / DAO_PROPOSAL_DAY_MS);
 }
 
 function normalizeDaoDraftChanges(changes) {
@@ -328,6 +350,7 @@ export function buildDaoProposalCreateTransaction({
   networkId,
   proposalNumber,
   maxGracePeriodMs,
+  proposalDurations,
 } = {}) {
   const draftTx = draft?.transaction;
   if (!draftTx || typeof draftTx !== 'object') {
@@ -357,12 +380,18 @@ export function buildDaoProposalCreateTransaction({
 
   // startTime is derived from validated inputs and must never be trusted from a draft.
   delete transaction.startTime;
+  const reviewStart = txTimestamp + startDelayMs;
+  const lifecycleDurationMs = getDaoProposalLifecycleDurationMs({
+    ...proposalDurations,
+    emergency: transaction.emergency,
+    gracePeriod,
+  });
+  if (!Number.isSafeInteger(reviewStart)
+    || reviewStart > DAO_PROPOSAL_MAX_DATE_MS - lifecycleDurationMs) {
+    throw new Error('DAO proposal lifecycle must end on a valid date');
+  }
   if (startDelayMs > 0) {
-    const startTime = txTimestamp + startDelayMs;
-    if (!Number.isSafeInteger(startTime) || Number.isNaN(new Date(startTime).getTime())) {
-      throw new Error('Review start delay produces an invalid date');
-    }
-    transaction.startTime = startTime;
+    transaction.startTime = reviewStart;
   }
 
   return transaction;
@@ -1044,7 +1073,14 @@ export const daoRepo = {
     return storeToUiList(_store, groupKey);
   },
 
-  async createProposal({ draft, timestamp, networkId, maxGracePeriodMs, submitTransaction } = {}) {
+  async createProposal({
+    draft,
+    timestamp,
+    networkId,
+    maxGracePeriodMs,
+    proposalDurations,
+    submitTransaction,
+  } = {}) {
     let transaction = null;
     let proposalNumber = 0;
     let proposalStoreId = '';
@@ -1062,6 +1098,7 @@ export const daoRepo = {
         networkId,
         proposalNumber,
         maxGracePeriodMs,
+        proposalDurations,
       });
       proposalStoreId = daoProposalId(proposalNumber, transaction.proposalId);
 

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -345,7 +345,6 @@ export function buildDaoProposalCreateDraft({
     displayTitle: transaction.title,
     proposalFeeUsdStr: feeUsdStr,
     startDelayMs,
-    maxGracePeriodMs: safeMaxGracePeriodMs,
     transaction,
   };
 }
@@ -355,6 +354,7 @@ export function buildDaoProposalCreateTransaction({
   timestamp,
   networkId,
   proposalNumber,
+  maxGracePeriodMs,
 } = {}) {
   const draftTx = draft?.transaction;
   if (!draftTx || typeof draftTx !== 'object') {
@@ -380,7 +380,7 @@ export function buildDaoProposalCreateTransaction({
   );
   const gracePeriod = normalizeDaoDraftGracePeriodMs(
     draftTx.gracePeriod,
-    draft.maxGracePeriodMs
+    maxGracePeriodMs
   );
 
   const transaction = {
@@ -1076,7 +1076,7 @@ export const daoRepo = {
     return storeToUiList(_store, groupKey);
   },
 
-  async createProposal({ draft, timestamp, networkId, submitTransaction } = {}) {
+  async createProposal({ draft, timestamp, networkId, maxGracePeriodMs, submitTransaction } = {}) {
     let transaction = null;
     let proposalNumber = 0;
     let proposalStoreId = '';
@@ -1093,6 +1093,7 @@ export const daoRepo = {
         timestamp,
         networkId,
         proposalNumber,
+        maxGracePeriodMs,
       });
       proposalStoreId = daoProposalId(proposalNumber, transaction.proposalId);
 

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -77,6 +77,7 @@ export const DAO_STATES = [
 ];
 
 export const DAO_PROPOSAL_DAY_MS = 24 * 60 * 60 * 1000;
+export const DAO_PROPOSAL_GRACE_PERIOD_MAX_MS = 999_999_999_999;
 const DAO_PROPOSAL_MAX_DATE_MS = 100_000_000 * DAO_PROPOSAL_DAY_MS; // ECMAScript Date limit.
 const DAO_AFFIRMATIVE_OPTION_STRINGS = ['yes', 'accept', 'approve'];
 const DAO_PROPOSALS_META_ID_STRING = 'dao proposals meta';
@@ -224,7 +225,8 @@ function normalizeDaoDraftInteger(value, label, unit = '') {
 
 function normalizeDaoDraftGracePeriodMs(value, maxGracePeriodMs) {
   const gracePeriodMs = normalizeDaoDraftInteger(value, 'Grace period', 'milliseconds');
-  const maximumMs = normalizeDaoDraftInteger(maxGracePeriodMs, 'Maximum grace period', 'milliseconds');
+  const configuredMaximumMs = normalizeDaoDraftInteger(maxGracePeriodMs, 'Maximum grace period', 'milliseconds');
+  const maximumMs = Math.min(configuredMaximumMs, DAO_PROPOSAL_GRACE_PERIOD_MAX_MS);
   if (gracePeriodMs > maximumMs) {
     throw new Error(`Grace period must not exceed ${maximumMs} milliseconds`);
   }

--- a/index.html
+++ b/index.html
@@ -527,13 +527,13 @@
                 <div class="dao-form-grid dao-form-grid--timing">
                   <div class="form-group">
                     <label for="addProposalStartDelayDays">Review Starts (days)</label>
-                    <input id="addProposalStartDelayDays" class="form-control" type="number" min="0" step="1" value="0" inputmode="numeric" />
+                    <input id="addProposalStartDelayDays" class="form-control" type="number" min="0" step="1" value="0" inputmode="numeric" required />
                     <div class="dao-form-help">Days from submission. 0 means now.</div>
                   </div>
                   <div class="form-group">
                     <label for="addProposalGracePeriodMs">Grace Period (ms)</label>
-                    <input id="addProposalGracePeriodMs" class="form-control" type="number" min="0" step="1" inputmode="numeric" placeholder="Loading default..." />
-                    <div class="dao-form-help" id="addProposalGracePeriodHelp">Default: loading...</div>
+                    <input id="addProposalGracePeriodMs" class="form-control" type="number" min="0" step="1" inputmode="numeric" placeholder="Loading maximum..." required />
+                    <div class="dao-form-help" id="addProposalGracePeriodHelp">Maximum: loading...</div>
                   </div>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -528,12 +528,14 @@
                   <div class="form-group">
                     <label for="addProposalStartDelayDays">Review Starts (days)</label>
                     <input id="addProposalStartDelayDays" class="form-control" type="number" min="0" step="1" value="0" inputmode="numeric" required />
-                    <div class="dao-form-help" id="addProposalStartDelayHelp">Days from submission. 0 means now.<br />Maximum: loading...</div>
+                    <div class="dao-form-help">Days from submission. 0 means now.</div>
+                    <div class="dao-form-help dao-form-limit hidden" id="addProposalStartDelayLimit"></div>
                   </div>
                   <div class="form-group">
                     <label for="addProposalGracePeriodMs">Grace Period (ms)</label>
                     <input id="addProposalGracePeriodMs" class="form-control" type="number" min="0" step="1" inputmode="numeric" placeholder="Loading maximum..." required />
-                    <div class="dao-form-help" id="addProposalGracePeriodHelp">Estimate: loading...<br />Maximum from current DAO grace duration: loading...</div>
+                    <div class="dao-form-help" id="addProposalGracePeriodHelp">Estimate: loading...</div>
+                    <div class="dao-form-help dao-form-limit hidden" id="addProposalGracePeriodLimit"></div>
                   </div>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -528,12 +528,12 @@
                   <div class="form-group">
                     <label for="addProposalStartDelayDays">Review Starts (days)</label>
                     <input id="addProposalStartDelayDays" class="form-control" type="number" min="0" step="1" value="0" inputmode="numeric" required />
-                    <div class="dao-form-help">Days from submission. 0 means now.</div>
+                    <div class="dao-form-help" id="addProposalStartDelayHelp">Days from submission. 0 means now.<br />Maximum: loading...</div>
                   </div>
                   <div class="form-group">
                     <label for="addProposalGracePeriodMs">Grace Period (ms)</label>
                     <input id="addProposalGracePeriodMs" class="form-control" type="number" min="0" step="1" inputmode="numeric" placeholder="Loading maximum..." required />
-                    <div class="dao-form-help" id="addProposalGracePeriodHelp">Maximum: loading...</div>
+                    <div class="dao-form-help" id="addProposalGracePeriodHelp">Estimate: loading...<br />Maximum from current DAO grace duration: loading...</div>
                   </div>
                 </div>
               </div>

--- a/styles.css
+++ b/styles.css
@@ -2031,9 +2031,8 @@ input[type='file'].form-control::file-selector-button {
   line-height: 1.35;
 }
 
-#addProposalStartDelayHelp,
-#addProposalGracePeriodHelp {
-  white-space: pre-line;
+#addProposalModal .dao-form-limit {
+  color: var(--danger-color);
 }
 
 #addProposalModal .dao-form-grid {

--- a/styles.css
+++ b/styles.css
@@ -2031,6 +2031,11 @@ input[type='file'].form-control::file-selector-button {
   line-height: 1.35;
 }
 
+#addProposalStartDelayHelp,
+#addProposalGracePeriodHelp {
+  white-space: pre-line;
+}
+
 #addProposalModal .dao-form-grid {
   display: grid;
   align-items: start;


### PR DESCRIPTION
## What Changed

This PR prevents DAO proposals from being signed with timing values that cannot produce a complete, renderable lifecycle.

- Validates review delays, lifecycle durations, and grace periods as non-negative safe integers at the form and repository boundaries.
- Calculates the maximum review delay after reserving review, voting, and the later of the claim or grace-period endpoints; emergency proposals omit community voting time.
- Reloads the current DAO duration and grace limits before signing, reconstructs `startTime` from validated inputs, and rejects any lifecycle that exceeds the ECMAScript Date range.
- Adds input limits, duration estimates, and field-level feedback for invalid timing values.

## Fixed Flow

1. The proposal form loads the current DAO timing configuration.
2. The maximum selectable review delay is calculated with room for every scheduled lifecycle stage.
3. Form values are validated before the confirmation modal opens.
4. Current network limits are fetched again immediately before signing.
5. The transaction builder derives the final review start and verifies that the complete lifecycle remains renderable.

## Why

The previous checks accepted safe numeric values even when the resulting dates were unusable. Checking only `startTime` was also insufficient because review, voting, claim, or apply eligibility could extend beyond the Date limit. Reserving the full lifecycle and repeating validation at the signing boundary prevents unreachable proposals even if configuration changes while the modal is open.

## Validation

- `node --check app.js`
- `node --check dao.repo.js`
- `git diff --check`
- `git range-diff 979581d1..324fa5f1 2c5c6804..b56f07ca`

Closes #1510
