### PR TITLE
Add inline DAO filter bar

### DIFF
--- a/app.js
+++ b/app.js
@@ -2477,6 +2477,15 @@ setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
 
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };
 const DAO_FILTER_OPTIONS = [...DAO_STATES, DAO_CLAIMABLE_FILTER];
+const DAO_FILTER_CHIP_LABELS = {
+  review: 'Review',
+  voting: 'Vote',
+  accepted: 'Accept',
+  claimable: 'Claim',
+  withheld: 'Withheld',
+  rejected: 'Rejected',
+  applied: 'Applied',
+};
 
 function formatDaoTimestamp(ts) {
   const n = Number(ts || 0);
@@ -2526,11 +2535,13 @@ function formatDaoProposalTitle(proposal) {
   return proposal.number ? `#${proposal.number}: ${title}` : title;
 }
 
+const DAO_FILTER_OVERFLOW_KEYS = ['withheld', 'rejected', 'applied'];
+
 class DaoModal {
   constructor() {
     this.selectedGroupKey = 'active';
     this.selectedFilterKey = 'voting';
-    this._outsideClickHandler = null;
+    this.filtersExpanded = false;
     this.refreshState = 'loading';
     this.refreshSequence = 0;
     this.openRefreshId = 0;
@@ -2541,9 +2552,10 @@ class DaoModal {
     this.modal = document.getElementById('daoModal');
     this.closeButton = document.getElementById('closeDaoModal');
     this.titleEl = document.getElementById('daoModalTitle');
-    this.statusMenuButton = document.getElementById('daoFilterButton');
-    this.statusMenu = document.getElementById('daoStatusContextMenu');
-    this.groupToolbar = this.modal.querySelector('.dao-toolbar');
+    this.filterBar = document.getElementById('daoFilterBar');
+    this.filterOverflow = document.getElementById('daoFilterOverflow');
+    this.filterExpandButton = document.getElementById('daoFilterExpandButton');
+    this.groupToggle = this.modal.querySelector('.dao-group-toggle');
     this.groupActiveButton = document.getElementById('daoGroupActiveButton');
     this.groupArchivedButton = document.getElementById('daoGroupArchivedButton');
     this.list = document.getElementById('daoProposalList');
@@ -2553,8 +2565,18 @@ class DaoModal {
     if (this.closeButton) this.closeButton.addEventListener('click', () => this.close());
     if (this.addButton) this.addButton.addEventListener('click', () => addProposalModal.open());
 
-    if (this.statusMenuButton) {
-      this.statusMenuButton.addEventListener('click', (e) => this.toggleStatusMenu(e));
+    if (this.filterBar) {
+      this.filterBar.addEventListener('click', (e) => {
+        const chip = e.target.closest('.dao-filter-chip');
+        if (!chip || !this.filterBar.contains(chip)) return;
+        const key = chip.dataset.filterKey;
+        if (!key) return;
+        this.setFilter(key);
+      });
+    }
+
+    if (this.filterExpandButton) {
+      this.filterExpandButton.addEventListener('click', () => this.toggleFilterExpand());
     }
 
     if (this.groupActiveButton) {
@@ -2569,25 +2591,6 @@ class DaoModal {
       });
       this.groupArchivedButton.setAttribute('role', 'tab');
     }
-
-    if (this.statusMenu) {
-      this.statusMenu.addEventListener('click', (e) => {
-        const option = e.target.closest('.context-menu-option');
-        if (!option) return;
-        const key = option.dataset.filterKey;
-        if (!key) return;
-        this.setFilter(key);
-      });
-    }
-
-    // Close the DAO menu on outside click
-    this._outsideClickHandler = (e) => {
-      if (!this.statusMenu || this.statusMenu.style.display !== 'block') return;
-      if (this.statusMenu.contains(e.target)) return;
-      if (this.statusMenuButton && this.statusMenuButton.contains(e.target)) return;
-      this.closeStatusMenu();
-    };
-    document.addEventListener('click', this._outsideClickHandler);
   }
 
   open() {
@@ -2629,7 +2632,6 @@ class DaoModal {
 
   close() {
     this.openRefreshId = ++this.refreshSequence;
-    this.closeStatusMenu();
     this.modal.classList.remove('active');
     enterFullscreen();
 
@@ -2684,49 +2686,32 @@ class DaoModal {
     return didRefreshDaoData;
   }
 
-  toggleStatusMenu(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!this.statusMenu) return;
-    if (this.statusMenu.style.display === 'block') {
-      this.closeStatusMenu();
-      return;
-    }
-    this.showStatusMenu();
+  isOverflowFilter(key) {
+    return DAO_FILTER_OVERFLOW_KEYS.includes(key);
   }
 
-  showStatusMenu() {
-    if (!this.statusMenu || !this.statusMenuButton) return;
-    const buttonRect = this.statusMenuButton.getBoundingClientRect();
-    const menuWidth = 176;
-    const approxMenuHeight = 16 + DAO_FILTER_OPTIONS.length * 40; // padding + items
-
-    let left = buttonRect.right - menuWidth;
-    let top = buttonRect.bottom + 8;
-
-    if (left < 10) left = 10;
-    if (top + approxMenuHeight > window.innerHeight - 10) {
-      top = buttonRect.top - approxMenuHeight - 8;
-    }
-
-    Object.assign(this.statusMenu.style, {
-      left: `${left}px`,
-      top: `${top}px`,
-      display: 'block',
-    });
-
-    if (this.statusMenuButton) this.statusMenuButton.setAttribute('aria-expanded', 'true');
+  toggleFilterExpand() {
+    this.setFiltersExpanded(!this.filtersExpanded);
   }
 
-  closeStatusMenu() {
-    if (!this.statusMenu) return;
-    this.statusMenu.style.display = 'none';
-    if (this.statusMenuButton) this.statusMenuButton.setAttribute('aria-expanded', 'false');
+  setFiltersExpanded(expanded) {
+    this.filtersExpanded = Boolean(expanded);
+    if (this.filterBar) this.filterBar.classList.toggle('expanded', this.filtersExpanded);
+    if (this.filterOverflow) this.filterOverflow.hidden = !this.filtersExpanded;
+    if (this.filterExpandButton) {
+      this.filterExpandButton.setAttribute('aria-expanded', this.filtersExpanded ? 'true' : 'false');
+      this.filterExpandButton.setAttribute(
+        'aria-label',
+        this.filtersExpanded ? 'Hide extra filters' : 'Show more filters'
+      );
+    }
   }
 
   setFilter(key) {
     this.selectedFilterKey = key;
-    this.closeStatusMenu();
+    if (this.isOverflowFilter(key) && !this.filtersExpanded) {
+      this.setFiltersExpanded(true);
+    }
     this.render();
   }
 
@@ -2759,27 +2744,45 @@ class DaoModal {
     const label = DAO_FILTER_OPTIONS.find((filter) => filter.key === this.selectedFilterKey)?.label
       || this.selectedFilterKey;
     if (this.titleEl) this.titleEl.textContent = isClaimableFilter ? 'DAO - Claimable' : `DAO - ${groupLabel} - ${label}`;
-    if (this.groupToolbar) this.groupToolbar.classList.toggle('hidden', isClaimableFilter);
+    // Claimable spans both groups, so hide Active/Archived while keeping the filter bar.
+    if (this.groupToggle) this.groupToggle.classList.toggle('hidden', isClaimableFilter);
+
+    // Sync expand affordance without forcing the overflow open on every render.
+    this.setFiltersExpanded(this.filtersExpanded);
 
     // Update group toggle labels + selection
     if (this.groupActiveButton) {
-      this.groupActiveButton.textContent = `Active ${hasFreshData ? proposalsActive.length : '—'}`;
+      const activeCountEl = this.groupActiveButton.querySelector('.dao-group-toggle-count');
+      if (activeCountEl) {
+        activeCountEl.textContent = hasFreshData ? String(proposalsActive.length) : '—';
+        activeCountEl.setAttribute(
+          'aria-label',
+          hasFreshData ? `${proposalsActive.length} active proposals` : 'Active count unavailable'
+        );
+      }
       this.groupActiveButton.classList.toggle('active', this.selectedGroupKey !== 'archived');
       this.groupActiveButton.setAttribute('aria-selected', this.selectedGroupKey !== 'archived' ? 'true' : 'false');
     }
     if (this.groupArchivedButton) {
-      this.groupArchivedButton.textContent = `Archived ${hasFreshData ? proposalsArchived.length : '—'}`;
+      const archivedCountEl = this.groupArchivedButton.querySelector('.dao-group-toggle-count');
+      if (archivedCountEl) {
+        archivedCountEl.textContent = hasFreshData ? String(proposalsArchived.length) : '—';
+        archivedCountEl.setAttribute(
+          'aria-label',
+          hasFreshData ? `${proposalsArchived.length} archived proposals` : 'Archived count unavailable'
+        );
+      }
       this.groupArchivedButton.classList.toggle('active', this.selectedGroupKey === 'archived');
       this.groupArchivedButton.setAttribute('aria-selected', this.selectedGroupKey === 'archived' ? 'true' : 'false');
     }
 
     for (const filter of DAO_FILTER_OPTIONS) {
-      const option = this.statusMenu?.querySelector(`[data-filter-key="${filter.key}"]`);
-      const labelEl = option?.querySelector('.dao-status-label');
-      const countEl = option?.querySelector('.dao-status-count');
+      const chip = this.filterBar?.querySelector(`.dao-filter-chip[data-filter-key="${filter.key}"]`);
+      const labelEl = chip?.querySelector('.dao-filter-chip-label');
+      const countEl = chip?.querySelector('.dao-filter-chip-count');
       const count = counts[filter.key] || 0;
 
-      if (labelEl) labelEl.textContent = filter.label;
+      if (labelEl) labelEl.textContent = DAO_FILTER_CHIP_LABELS[filter.key] || filter.label;
       if (countEl) {
         countEl.textContent = hasFreshData ? String(count) : '—';
         countEl.setAttribute(
@@ -2787,10 +2790,10 @@ class DaoModal {
           hasFreshData ? `${count} ${filter.label.toLowerCase()} proposals` : `${filter.label} count unavailable`
         );
       }
-      if (option) {
+      if (chip) {
         const selected = filter.key === this.selectedFilterKey;
-        option.classList.toggle('active', selected);
-        option.setAttribute('aria-checked', selected ? 'true' : 'false');
+        chip.classList.toggle('active', selected);
+        chip.setAttribute('aria-selected', selected ? 'true' : 'false');
       }
     }
 

--- a/app.js
+++ b/app.js
@@ -2477,15 +2477,7 @@ setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
 
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };
 const DAO_FILTER_OPTIONS = [...DAO_STATES, DAO_CLAIMABLE_FILTER];
-const DAO_FILTER_CHIP_LABELS = {
-  review: 'Review',
-  voting: 'Vote',
-  accepted: 'Accept',
-  claimable: 'Claim',
-  withheld: 'Withheld',
-  rejected: 'Rejected',
-  applied: 'Applied',
-};
+const DAO_FILTER_OVERFLOW_KEYS = ['withheld', 'rejected', 'applied'];
 
 function formatDaoTimestamp(ts) {
   const n = Number(ts || 0);
@@ -2535,13 +2527,10 @@ function formatDaoProposalTitle(proposal) {
   return proposal.number ? `#${proposal.number}: ${title}` : title;
 }
 
-const DAO_FILTER_OVERFLOW_KEYS = ['withheld', 'rejected', 'applied'];
-
 class DaoModal {
   constructor() {
     this.selectedGroupKey = 'active';
     this.selectedFilterKey = 'voting';
-    this.filtersExpanded = false;
     this.refreshState = 'loading';
     this.refreshSequence = 0;
     this.openRefreshId = 0;
@@ -2568,7 +2557,7 @@ class DaoModal {
     if (this.filterBar) {
       this.filterBar.addEventListener('click', (e) => {
         const chip = e.target.closest('.dao-filter-chip');
-        if (!chip || !this.filterBar.contains(chip)) return;
+        if (!chip) return;
         const key = chip.dataset.filterKey;
         if (!key) return;
         this.setFilter(key);
@@ -2576,20 +2565,20 @@ class DaoModal {
     }
 
     if (this.filterExpandButton) {
-      this.filterExpandButton.addEventListener('click', () => this.toggleFilterExpand());
+      this.filterExpandButton.addEventListener('click', () => {
+        this.setFiltersExpanded(this.filterOverflow.hidden);
+      });
     }
 
     if (this.groupActiveButton) {
       this.groupActiveButton.addEventListener('click', () => {
         this.setGroupFilter('active');
       });
-      this.groupActiveButton.setAttribute('role', 'tab');
     }
     if (this.groupArchivedButton) {
       this.groupArchivedButton.addEventListener('click', () => {
         this.setGroupFilter('archived');
       });
-      this.groupArchivedButton.setAttribute('role', 'tab');
     }
   }
 
@@ -2686,30 +2675,21 @@ class DaoModal {
     return didRefreshDaoData;
   }
 
-  isOverflowFilter(key) {
-    return DAO_FILTER_OVERFLOW_KEYS.includes(key);
-  }
-
-  toggleFilterExpand() {
-    this.setFiltersExpanded(!this.filtersExpanded);
-  }
-
   setFiltersExpanded(expanded) {
-    this.filtersExpanded = Boolean(expanded);
-    if (this.filterBar) this.filterBar.classList.toggle('expanded', this.filtersExpanded);
-    if (this.filterOverflow) this.filterOverflow.hidden = !this.filtersExpanded;
+    if (this.filterBar) this.filterBar.classList.toggle('expanded', expanded);
+    if (this.filterOverflow) this.filterOverflow.hidden = !expanded;
     if (this.filterExpandButton) {
-      this.filterExpandButton.setAttribute('aria-expanded', this.filtersExpanded ? 'true' : 'false');
+      this.filterExpandButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
       this.filterExpandButton.setAttribute(
         'aria-label',
-        this.filtersExpanded ? 'Hide extra filters' : 'Show more filters'
+        expanded ? 'Hide extra filters' : 'Show more filters'
       );
     }
   }
 
   setFilter(key) {
     this.selectedFilterKey = key;
-    if (this.isOverflowFilter(key) && !this.filtersExpanded) {
+    if (DAO_FILTER_OVERFLOW_KEYS.includes(key) && this.filterOverflow.hidden) {
       this.setFiltersExpanded(true);
     }
     this.render();
@@ -2747,42 +2727,31 @@ class DaoModal {
     // Claimable spans both groups, so hide Active/Archived while keeping the filter bar.
     if (this.groupToggle) this.groupToggle.classList.toggle('hidden', isClaimableFilter);
 
-    // Sync expand affordance without forcing the overflow open on every render.
-    this.setFiltersExpanded(this.filtersExpanded);
-
     // Update group toggle labels + selection
-    if (this.groupActiveButton) {
-      const activeCountEl = this.groupActiveButton.querySelector('.dao-group-toggle-count');
-      if (activeCountEl) {
-        activeCountEl.textContent = hasFreshData ? String(proposalsActive.length) : '—';
-        activeCountEl.setAttribute(
+    const groups = [
+      { key: 'active', label: 'Active', button: this.groupActiveButton, count: proposalsActive.length },
+      { key: 'archived', label: 'Archived', button: this.groupArchivedButton, count: proposalsArchived.length },
+    ];
+    for (const { key, label: groupName, button, count } of groups) {
+      if (!button) continue;
+      const countEl = button.querySelector('.dao-group-toggle-count');
+      if (countEl) {
+        countEl.textContent = hasFreshData ? String(count) : '—';
+        countEl.setAttribute(
           'aria-label',
-          hasFreshData ? `${proposalsActive.length} active proposals` : 'Active count unavailable'
+          hasFreshData ? `${count} ${key} proposals` : `${groupName} count unavailable`
         );
       }
-      this.groupActiveButton.classList.toggle('active', this.selectedGroupKey !== 'archived');
-      this.groupActiveButton.setAttribute('aria-selected', this.selectedGroupKey !== 'archived' ? 'true' : 'false');
-    }
-    if (this.groupArchivedButton) {
-      const archivedCountEl = this.groupArchivedButton.querySelector('.dao-group-toggle-count');
-      if (archivedCountEl) {
-        archivedCountEl.textContent = hasFreshData ? String(proposalsArchived.length) : '—';
-        archivedCountEl.setAttribute(
-          'aria-label',
-          hasFreshData ? `${proposalsArchived.length} archived proposals` : 'Archived count unavailable'
-        );
-      }
-      this.groupArchivedButton.classList.toggle('active', this.selectedGroupKey === 'archived');
-      this.groupArchivedButton.setAttribute('aria-selected', this.selectedGroupKey === 'archived' ? 'true' : 'false');
+      const selected = this.selectedGroupKey === key;
+      button.classList.toggle('active', selected);
+      button.setAttribute('aria-selected', selected ? 'true' : 'false');
     }
 
     for (const filter of DAO_FILTER_OPTIONS) {
       const chip = this.filterBar?.querySelector(`.dao-filter-chip[data-filter-key="${filter.key}"]`);
-      const labelEl = chip?.querySelector('.dao-filter-chip-label');
       const countEl = chip?.querySelector('.dao-filter-chip-count');
       const count = counts[filter.key] || 0;
 
-      if (labelEl) labelEl.textContent = DAO_FILTER_CHIP_LABELS[filter.key] || filter.label;
       if (countEl) {
         countEl.textContent = hasFreshData ? String(count) : '—';
         countEl.setAttribute(

--- a/app.js
+++ b/app.js
@@ -2676,22 +2676,25 @@ class DaoModal {
   }
 
   setFiltersExpanded(expanded) {
-    if (this.filterBar) this.filterBar.classList.toggle('expanded', expanded);
-    if (this.filterOverflow) this.filterOverflow.hidden = !expanded;
+    const overflowFilterSelected = DAO_FILTER_OVERFLOW_KEYS.includes(this.selectedFilterKey);
+    const keepExpanded = expanded || overflowFilterSelected;
+    if (this.filterBar) this.filterBar.classList.toggle('expanded', keepExpanded);
+    if (this.filterOverflow) this.filterOverflow.hidden = !keepExpanded;
     if (this.filterExpandButton) {
-      this.filterExpandButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      this.filterExpandButton.disabled = overflowFilterSelected;
+      this.filterExpandButton.setAttribute('aria-expanded', keepExpanded ? 'true' : 'false');
       this.filterExpandButton.setAttribute(
         'aria-label',
-        expanded ? 'Hide extra filters' : 'Show more filters'
+        overflowFilterSelected
+          ? 'Extra filters remain visible while selected'
+          : keepExpanded ? 'Hide extra filters' : 'Show more filters'
       );
     }
   }
 
   setFilter(key) {
     this.selectedFilterKey = key;
-    if (DAO_FILTER_OVERFLOW_KEYS.includes(key) && this.filterOverflow.hidden) {
-      this.setFiltersExpanded(true);
-    }
+    this.setFiltersExpanded(!this.filterOverflow.hidden);
     this.render();
   }
 

--- a/index.html
+++ b/index.html
@@ -445,6 +445,8 @@
                 </button>
               </div>
             </div>
+          </div>
+          <div class="dao-list-pane">
             <div class="dao-group-toggle" role="tablist" aria-label="Proposal group">
               <button class="dao-group-toggle-button" id="daoGroupActiveButton" type="button" role="tab" aria-selected="true">
                 <span class="dao-group-toggle-label">Active</span>
@@ -455,14 +457,14 @@
                 <span class="dao-group-toggle-count" aria-label="0 archived proposals">0</span>
               </button>
             </div>
+            <ul class="chat-list" id="daoProposalList">
+              <div class="empty-state" id="daoProposalEmptyState">
+                <div></div>
+                <div>No proposals found</div>
+                <div>Proposal data appears here when available</div>
+              </div>
+            </ul>
           </div>
-          <ul class="chat-list" id="daoProposalList">
-            <div class="empty-state" id="daoProposalEmptyState">
-              <div></div>
-              <div>No proposals found</div>
-              <div>Proposal data appears here when available</div>
-            </div>
-          </ul>
           <button class="floating-button" id="daoAddProposalButton" aria-label="Add proposal"><span class="plus-glyph" aria-hidden="true">+</span></button>
         </div>
         <a class="last-item" href="#"> </a>

--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@
                   <span class="dao-filter-chip-count" aria-label="0 voting proposals">0</span>
                 </button>
                 <button class="dao-filter-chip" type="button" role="tab" data-filter-key="accepted" aria-selected="false">
-                  <span class="dao-filter-chip-label">Accept</span>
+                  <span class="dao-filter-chip-label">Accepted</span>
                   <span class="dao-filter-chip-count" aria-label="0 accepted proposals">0</span>
                 </button>
                 <button class="dao-filter-chip" type="button" role="tab" data-filter-key="claimable" aria-selected="false">

--- a/index.html
+++ b/index.html
@@ -407,13 +407,53 @@
         <div class="modal-header">
           <button class="back-button" id="closeDaoModal"></button>
           <div class="modal-title" id="daoModalTitle">DAO</div>
-          <button class="icon-button filter-icon" id="daoFilterButton" aria-label="Filter" aria-haspopup="true" aria-expanded="false"></button>
         </div>
         <div class="modal-content">
           <div class="dao-toolbar">
+            <div class="dao-filter-bar" id="daoFilterBar" role="tablist" aria-label="Proposal filter">
+              <div class="dao-filter-primary">
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="review" aria-selected="false">
+                  <span class="dao-filter-chip-label">Review</span>
+                  <span class="dao-filter-chip-count" aria-label="0 review proposals">0</span>
+                </button>
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="voting" aria-selected="false">
+                  <span class="dao-filter-chip-label">Vote</span>
+                  <span class="dao-filter-chip-count" aria-label="0 voting proposals">0</span>
+                </button>
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="accepted" aria-selected="false">
+                  <span class="dao-filter-chip-label">Accept</span>
+                  <span class="dao-filter-chip-count" aria-label="0 accepted proposals">0</span>
+                </button>
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="claimable" aria-selected="false">
+                  <span class="dao-filter-chip-label">Claim</span>
+                  <span class="dao-filter-chip-count" aria-label="0 claimable proposals">0</span>
+                </button>
+                <button class="dao-filter-expand" id="daoFilterExpandButton" type="button" aria-label="Show more filters" aria-expanded="false" aria-controls="daoFilterOverflow"></button>
+              </div>
+              <div class="dao-filter-overflow" id="daoFilterOverflow" hidden>
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="withheld" aria-selected="false">
+                  <span class="dao-filter-chip-label">Withheld</span>
+                  <span class="dao-filter-chip-count" aria-label="0 withheld proposals">0</span>
+                </button>
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="rejected" aria-selected="false">
+                  <span class="dao-filter-chip-label">Rejected</span>
+                  <span class="dao-filter-chip-count" aria-label="0 rejected proposals">0</span>
+                </button>
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="applied" aria-selected="false">
+                  <span class="dao-filter-chip-label">Applied</span>
+                  <span class="dao-filter-chip-count" aria-label="0 applied proposals">0</span>
+                </button>
+              </div>
+            </div>
             <div class="dao-group-toggle" role="tablist" aria-label="Proposal group">
-              <button class="dao-group-toggle-button" id="daoGroupActiveButton" type="button">Active</button>
-              <button class="dao-group-toggle-button" id="daoGroupArchivedButton" type="button">Archived</button>
+              <button class="dao-group-toggle-button" id="daoGroupActiveButton" type="button" role="tab" aria-selected="true">
+                <span class="dao-group-toggle-label">Active</span>
+                <span class="dao-group-toggle-count" aria-label="0 active proposals">0</span>
+              </button>
+              <button class="dao-group-toggle-button" id="daoGroupArchivedButton" type="button" role="tab" aria-selected="false">
+                <span class="dao-group-toggle-label">Archived</span>
+                <span class="dao-group-toggle-count" aria-label="0 archived proposals">0</span>
+              </button>
             </div>
           </div>
           <ul class="chat-list" id="daoProposalList">
@@ -424,39 +464,6 @@
             </div>
           </ul>
           <button class="floating-button" id="daoAddProposalButton" aria-label="Add proposal"><span class="plus-glyph" aria-hidden="true">+</span></button>
-        </div>
-        <a class="last-item" href="#"> </a>
-      </div>
-
-      <!-- DAO Status Context Menu -->
-      <div class="message-context-menu" id="daoStatusContextMenu" role="menu" aria-label="DAO proposal filter" style="display: none;">
-        <div class="context-menu-option dao-status-option" data-filter-key="review" role="menuitemradio" aria-checked="false">
-          <span class="context-menu-text dao-status-label" id="daoStatusOptionReview">Review</span>
-          <span class="dao-status-count" aria-label="0 review proposals">0</span>
-        </div>
-        <div class="context-menu-option dao-status-option" data-filter-key="withheld" role="menuitemradio" aria-checked="false">
-          <span class="context-menu-text dao-status-label" id="daoStatusOptionWithheld">Withheld</span>
-          <span class="dao-status-count" aria-label="0 withheld proposals">0</span>
-        </div>
-        <div class="context-menu-option dao-status-option" data-filter-key="voting" role="menuitemradio" aria-checked="false">
-          <span class="context-menu-text dao-status-label" id="daoStatusOptionVoting">Voting</span>
-          <span class="dao-status-count" aria-label="0 voting proposals">0</span>
-        </div>
-        <div class="context-menu-option dao-status-option" data-filter-key="rejected" role="menuitemradio" aria-checked="false">
-          <span class="context-menu-text dao-status-label" id="daoStatusOptionRejected">Rejected</span>
-          <span class="dao-status-count" aria-label="0 rejected proposals">0</span>
-        </div>
-        <div class="context-menu-option dao-status-option" data-filter-key="accepted" role="menuitemradio" aria-checked="false">
-          <span class="context-menu-text dao-status-label" id="daoStatusOptionAccepted">Accepted</span>
-          <span class="dao-status-count" aria-label="0 accepted proposals">0</span>
-        </div>
-        <div class="context-menu-option dao-status-option" data-filter-key="applied" role="menuitemradio" aria-checked="false">
-          <span class="context-menu-text dao-status-label" id="daoStatusOptionApplied">Applied</span>
-          <span class="dao-status-count" aria-label="0 applied proposals">0</span>
-        </div>
-        <div class="context-menu-option dao-status-option" data-filter-key="claimable" role="menuitemradio" aria-checked="false">
-          <span class="context-menu-text dao-status-label" id="daoStatusOptionClaimable">Claimable</span>
-          <span class="dao-status-count" aria-label="0 claimable proposals">0</span>
         </div>
         <a class="last-item" href="#"> </a>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -8358,6 +8358,7 @@ small {
 }
 
 #daoModal .dao-filter-primary {
+  flex-wrap: wrap;
   min-width: 0;
 }
 
@@ -8380,7 +8381,7 @@ small {
   cursor: pointer;
   display: inline-flex;
   font-family: var(--font-primary);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
   gap: 6px;
   justify-content: center;
@@ -8397,7 +8398,7 @@ small {
 #daoModal .dao-filter-chip {
   flex: 1 1 0;
   line-height: 1.2;
-  min-width: 0;
+  min-width: max-content;
   padding: 8px 6px;
   transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
@@ -8448,18 +8449,34 @@ small {
   border-radius: 6px;
   cursor: pointer;
   flex: 0 0 36px;
+  margin-left: auto;
   min-height: 36px;
   padding: 0;
   transition: background-color 0.2s ease, transform 0.2s ease;
   width: 36px;
 }
 
-#daoModal .dao-filter-expand:hover {
+#daoModal .dao-filter-expand:not(:disabled):hover {
   background-color: var(--hover-background-dark);
+}
+
+#daoModal .dao-filter-expand:disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 
 #daoModal .dao-filter-bar.expanded .dao-filter-expand {
   transform: rotate(90deg);
+}
+
+@media (max-width: 400px) {
+  #daoModal .dao-filter-expand {
+    display: none;
+  }
+
+  #daoModal .dao-filter-overflow[hidden] {
+    display: flex;
+  }
 }
 
 #daoModal .dao-group-toggle {

--- a/styles.css
+++ b/styles.css
@@ -8327,16 +8327,20 @@ small {
   position: relative;
 }
 
-/* DAO modal: filter bar + Active/Archived toggle */
+/* DAO modal: filter bar stays fixed; Active/Archived scrolls with the list. */
 #daoModal .dao-toolbar {
+  background: var(--background-color);
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 0 0 10px;
-  position: sticky;
-  top: 0;
+  flex: 0 0 auto;
   z-index: 2;
-  background: var(--background-color);
+}
+
+#daoModal .dao-list-pane {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 #daoModal .dao-filter-bar {
@@ -8486,7 +8490,7 @@ small {
   display: grid;
   gap: 4px;
   grid-template-columns: 1fr 1fr;
-  margin: 0 16px;
+  margin: 10px 16px;
   padding: 4px;
 }
 
@@ -8505,9 +8509,8 @@ small {
 }
 
 #daoModal #daoProposalList {
-  flex: 1 1 auto;
   min-height: 0;
-  overflow-y: auto;
+  overflow: visible;
   padding-bottom: calc(160px + env(safe-area-inset-bottom, 0px));
 }
 

--- a/styles.css
+++ b/styles.css
@@ -8363,7 +8363,6 @@ small {
   background: rgba(61, 61, 206, 0.14);
   border-bottom: 1px solid rgba(61, 61, 206, 0.22);
   border-top: 1px solid rgba(61, 61, 206, 0.22);
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -8371,27 +8370,27 @@ small {
   width: 100%;
 }
 
-#daoModal .dao-filter-primary {
-  align-items: stretch;
+#daoModal .dao-filter-primary,
+#daoModal .dao-filter-overflow {
   display: flex;
   gap: 6px;
-  min-width: 0;
   width: 100%;
 }
 
+#daoModal .dao-filter-primary {
+  min-width: 0;
+}
+
 #daoModal .dao-filter-overflow {
-  align-items: stretch;
-  display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  width: 100%;
 }
 
 #daoModal .dao-filter-overflow[hidden] {
   display: none;
 }
 
-#daoModal .dao-filter-chip {
+#daoModal .dao-filter-chip,
+#daoModal .dao-group-toggle-button {
   align-items: center;
   appearance: none;
   background: transparent;
@@ -8400,23 +8399,27 @@ small {
   color: var(--text-color);
   cursor: pointer;
   display: inline-flex;
-  flex: 1 1 0;
   font-family: var(--font-primary);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   gap: 6px;
   justify-content: center;
-  line-height: 1.2;
   min-height: 36px;
-  min-width: 0;
   overflow: hidden;
-  padding: 8px 6px;
-  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
   white-space: nowrap;
 }
 
-#daoModal .dao-filter-chip:hover {
+#daoModal .dao-filter-chip:hover,
+#daoModal .dao-group-toggle-button:hover {
   background: var(--hover-background-dark);
+}
+
+#daoModal .dao-filter-chip {
+  flex: 1 1 0;
+  line-height: 1.2;
+  min-width: 0;
+  padding: 8px 6px;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
 
 #daoModal .dao-filter-chip.active {
@@ -8425,11 +8428,13 @@ small {
   color: var(--background-color);
 }
 
-#daoModal .dao-filter-chip-label {
+#daoModal .dao-filter-chip-label,
+#daoModal .dao-group-toggle-label {
   flex: 0 0 auto;
 }
 
-#daoModal .dao-filter-chip-count {
+#daoModal .dao-filter-chip-count,
+#daoModal .dao-group-toggle-count {
   align-items: center;
   background: var(--hover-background);
   border: 1px solid var(--border-color);
@@ -8437,7 +8442,6 @@ small {
   color: var(--secondary-text-color);
   display: inline-flex;
   flex: 0 0 auto;
-  font-family: var(--font-primary);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
   font-weight: var(--font-weight-semibold);
@@ -8445,8 +8449,6 @@ small {
   min-height: 20px;
   min-width: 22px;
   padding: 2px 6px;
-  position: relative;
-  z-index: 1;
 }
 
 #daoModal .dao-filter-chip.active .dao-filter-chip-count {
@@ -8456,7 +8458,6 @@ small {
 }
 
 #daoModal .dao-filter-expand {
-  align-items: center;
   appearance: none;
   background-color: transparent;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2.25' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='9 18 15 12 9 6'/%3E%3C/svg%3E");
@@ -8466,10 +8467,7 @@ small {
   border: 0;
   border-radius: 6px;
   cursor: pointer;
-  display: inline-flex;
   flex: 0 0 36px;
-  height: auto;
-  justify-content: center;
   min-height: 36px;
   padding: 0;
   transition: background-color 0.2s ease, transform 0.2s ease;
@@ -8496,64 +8494,17 @@ small {
 }
 
 #daoModal .dao-group-toggle-button {
-  align-items: center;
-  appearance: none;
-  background: transparent;
-  border: 0;
-  border-radius: 6px;
-  color: var(--text-color);
-  cursor: pointer;
-  display: inline-flex;
-  font-family: var(--font-primary);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  gap: 6px;
-  justify-content: center;
-  min-height: 36px;
-  overflow: hidden;
   padding: 8px 10px;
   transition: background-color 0.15s ease, color 0.15s ease;
-  white-space: nowrap;
-}
-
-#daoModal .dao-group-toggle-button:hover {
-  background: var(--hover-background-dark);
 }
 
 #daoModal .dao-group-toggle-button.active {
   background: var(--hover-background-dark);
-  box-shadow: none;
-  color: var(--text-color);
-}
-
-#daoModal .dao-group-toggle-label {
-  flex: 0 0 auto;
-}
-
-#daoModal .dao-group-toggle-count {
-  align-items: center;
-  background: var(--hover-background);
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-  color: var(--secondary-text-color);
-  display: inline-flex;
-  flex: 0 0 auto;
-  font-family: var(--font-primary);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-  font-weight: var(--font-weight-semibold);
-  justify-content: center;
-  min-height: 20px;
-  min-width: 22px;
-  padding: 2px 6px;
-  position: relative;
-  z-index: 1;
 }
 
 #daoModal .dao-group-toggle-button.active .dao-group-toggle-count {
   background: rgba(0, 0, 0, 0.08);
   border-color: rgba(0, 0, 0, 0.1);
-  color: var(--secondary-text-color);
 }
 
 #daoModal #daoProposalList {

--- a/styles.css
+++ b/styles.css
@@ -8337,12 +8337,6 @@ small {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 2l9 5-9 5-9-5 9-5z'/%3E%3Cpath d='M3 7v10l9 5 9-5V7'/%3E%3Cpath d='M12 12v10'/%3E%3C/svg%3E");
 }
 
-/* DAO modal: place the header menu button on the right */
-#daoModal #daoFilterButton {
-  position: absolute;
-  right: 16px;
-}
-
 /* DAO modal: keep the header fixed while the proposal list scrolls. */
 #daoModal .modal-content {
   display: flex;
@@ -8353,37 +8347,173 @@ small {
   position: relative;
 }
 
-/* DAO modal: Active/Archived toggle */
+/* DAO modal: filter bar + Active/Archived toggle */
 #daoModal .dao-toolbar {
-  padding: 0 16px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 0 10px;
   position: sticky;
   top: 0;
   z-index: 2;
   background: var(--background-color);
 }
 
-#daoModal .dao-group-toggle {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
-  padding: 6px;
-  border: 1px solid var(--border-color, rgba(0,0,0,0.12));
-  border-radius: 8px;
-  background: var(--hover-background-purple);
+#daoModal .dao-filter-bar {
+  background: rgba(61, 61, 206, 0.14);
+  border-bottom: 1px solid rgba(61, 61, 206, 0.22);
+  border-top: 1px solid rgba(61, 61, 206, 0.22);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  width: 100%;
 }
 
-#daoModal .dao-group-toggle-button {
+#daoModal .dao-filter-primary {
+  align-items: stretch;
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+  width: 100%;
+}
+
+#daoModal .dao-filter-overflow {
+  align-items: stretch;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  width: 100%;
+}
+
+#daoModal .dao-filter-overflow[hidden] {
+  display: none;
+}
+
+#daoModal .dao-filter-chip {
+  align-items: center;
   appearance: none;
+  background: transparent;
   border: 0;
   border-radius: 6px;
-  padding: 9px 10px;
+  color: var(--text-color);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 1 1 0;
   font-family: var(--font-primary);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
+  gap: 6px;
+  justify-content: center;
+  line-height: 1.2;
+  min-height: 36px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 8px 6px;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  white-space: nowrap;
+}
+
+#daoModal .dao-filter-chip:hover {
+  background: var(--hover-background-dark);
+}
+
+#daoModal .dao-filter-chip.active {
+  background: var(--primary-color);
+  box-shadow: var(--elev-1, 0 1px 2px rgba(0,0,0,0.1));
+  color: var(--background-color);
+}
+
+#daoModal .dao-filter-chip-label {
+  flex: 0 0 auto;
+}
+
+#daoModal .dao-filter-chip-count {
+  align-items: center;
+  background: var(--hover-background);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  color: var(--secondary-text-color);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: var(--font-primary);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-weight-semibold);
+  justify-content: center;
+  min-height: 20px;
+  min-width: 22px;
+  padding: 2px 6px;
+  position: relative;
+  z-index: 1;
+}
+
+#daoModal .dao-filter-chip.active .dao-filter-chip-count {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.28);
+  color: var(--background-color);
+}
+
+#daoModal .dao-filter-expand {
+  align-items: center;
+  appearance: none;
+  background-color: transparent;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2.25' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='9 18 15 12 9 6'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 16px;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 36px;
+  height: auto;
+  justify-content: center;
+  min-height: 36px;
+  padding: 0;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  width: 36px;
+}
+
+#daoModal .dao-filter-expand:hover {
+  background-color: var(--hover-background-dark);
+}
+
+#daoModal .dao-filter-bar.expanded .dao-filter-expand {
+  transform: rotate(90deg);
+}
+
+#daoModal .dao-group-toggle {
+  background: var(--input-background);
+  border: 1px solid var(--border-color, rgba(0,0,0,0.12));
+  border-radius: 8px;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: 1fr 1fr;
+  margin: 0 16px;
+  padding: 4px;
+}
+
+#daoModal .dao-group-toggle-button {
+  align-items: center;
+  appearance: none;
   background: transparent;
+  border: 0;
+  border-radius: 6px;
   color: var(--text-color);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  display: inline-flex;
+  font-family: var(--font-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  gap: 6px;
+  justify-content: center;
+  min-height: 36px;
+  overflow: hidden;
+  padding: 8px 10px;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
 }
 
 #daoModal .dao-group-toggle-button:hover {
@@ -8391,9 +8521,39 @@ small {
 }
 
 #daoModal .dao-group-toggle-button.active {
-  background: var(--button-background);
-  color: var(--button-text);
-  box-shadow: var(--elev-1, 0 1px 2px rgba(0,0,0,0.1));
+  background: var(--hover-background-dark);
+  box-shadow: none;
+  color: var(--text-color);
+}
+
+#daoModal .dao-group-toggle-label {
+  flex: 0 0 auto;
+}
+
+#daoModal .dao-group-toggle-count {
+  align-items: center;
+  background: var(--hover-background);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  color: var(--secondary-text-color);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: var(--font-primary);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-weight-semibold);
+  justify-content: center;
+  min-height: 20px;
+  min-width: 22px;
+  padding: 2px 6px;
+  position: relative;
+  z-index: 1;
+}
+
+#daoModal .dao-group-toggle-button.active .dao-group-toggle-count {
+  background: rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.1);
+  color: var(--secondary-text-color);
 }
 
 #daoModal #daoProposalList {
@@ -8537,52 +8697,6 @@ small {
 #daoModal .dao-row-preview--emergency {
   background: rgba(239, 108, 0, 0.12);
   border-color: rgba(239, 108, 0, 0.32);
-}
-
-#daoStatusContextMenu {
-  background: var(--background-color);
-  border: 1px solid var(--border-color, rgba(0,0,0,0.1));
-  border-radius: 12px;
-  box-shadow: var(--overlay-shadow-large);
-  max-width: calc(100vw - 24px);
-  min-width: 176px;
-  padding: 8px;
-  width: 176px;
-}
-
-#daoStatusContextMenu .dao-status-option {
-  border-radius: 8px;
-  gap: 12px;
-  justify-content: space-between;
-  min-height: 40px;
-  padding: 8px 10px;
-}
-
-#daoStatusContextMenu .dao-status-option:hover,
-#daoStatusContextMenu .dao-status-option.active {
-  background: var(--hover-background-purple);
-}
-
-#daoStatusContextMenu .dao-status-label {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-#daoStatusContextMenu .dao-status-count {
-  align-items: center;
-  background: var(--hover-background);
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-  color: var(--secondary-text-color);
-  display: inline-flex;
-  flex: 0 0 auto;
-  font-family: var(--font-primary);
-  font-size: 12px;
-  font-weight: var(--font-weight-semibold);
-  justify-content: center;
-  min-height: 20px;
-  min-width: 28px;
-  padding: 2px 8px;
 }
 
 #lockModal p {

--- a/styles.css
+++ b/styles.css
@@ -7105,26 +7105,6 @@ small {
   min-height: var(--icon-button-height);
 }
 
-/* Filter icon button (funnel) */
-.icon-button.filter-icon {
-  border: none;
-  cursor: pointer;
-  color: var(--primary-color);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 20px;
-  opacity: 0.7;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M22 3H2l8 9v7l4 2v-9l8-9z'/%3E%3C/svg%3E");
-  width: var(--icon-button-width);
-  height: var(--icon-button-height);
-  padding: 5px;
-  min-width: var(--icon-button-width);
-  min-height: var(--icon-button-height);
-}
-
 .hidden {
   display: none;
 }


### PR DESCRIPTION
## What Changed

This PR replaces the DAO modal's header filter menu with an always-visible inline filter bar.

- Shows Review, Vote, Accept, and Claim as primary filter chips with proposal counts.
- Expands Withheld, Rejected, and Applied filters inline and wraps them across rows when needed.
- Keeps Active/Archived counts synchronized while preserving Claimable's cross-group behavior.
- Removes the former header filter button, context menu, outside-click handling, and unused funnel icon CSS.

## Fixed Flow

1. The user opens the DAO modal and sees the primary filters immediately.
2. Selecting a chip updates the proposal list, count states, and accessible selection state.
3. The arrow reveals or hides the remaining filters without opening a detached menu.
4. Overflow selections remain visible, and the proposal group controls continue to reflect the selected filter.

## Why

The header menu hid available statuses and required separate positioning, dismissal, and synchronization logic. Keeping the filters inline makes their state and counts visible while removing the redundant menu state and handlers.

## Validation

- `node --check app.js`
- `git diff --check origin/main...HEAD`
- `cmp /tmp/dao-filter-baseline.png /tmp/dao-filter-current.png` (pixel-identical cleanup comparison at 400×800)

Closes #1517

<img width="521" height="1041" alt="image" src="https://github.com/user-attachments/assets/a650bfa2-d15a-4a5a-a90b-2f6ba3aedd69" />
<img width="521" height="1041" alt="image" src="https://github.com/user-attachments/assets/c26b5b82-c563-45c4-b2b4-fd955400a7bc" />
