### PR TITLE
Show required fields in proposal form

### DIFF
--- a/app.js
+++ b/app.js
@@ -3446,7 +3446,7 @@ class AddProposalModal {
         </div>
         <div class="dao-form-change-box">
           <div class="dao-form-change-line">
-            <label for="${configId}">Select</label>
+            <label for="${configId}">Select <span class="dao-form-required" aria-hidden="true">*</span></label>
             <select id="${configId}" class="form-control" data-dao-change-key required>${selectOptions}</select>
           </div>
           <div class="dao-form-change-line">
@@ -3454,7 +3454,7 @@ class AddProposalModal {
             <input id="${currentId}" class="form-control dao-form-current-value" type="text" value="${escapeDaoFormAttribute(option.current)}" readonly />
           </div>
           <div class="dao-form-change-line">
-            <label for="${proposedId}">Enter</label>
+            <label for="${proposedId}">Enter <span class="dao-form-required" aria-hidden="true">*</span></label>
             ${this.renderProposedValueControl(option, row.value, proposedId)}
           </div>
           <div class="dao-form-meta">${escapeHtml(option.path)} · ${escapeHtml(option.valueType)}</div>

--- a/index.html
+++ b/index.html
@@ -503,7 +503,7 @@
               </div>
               <div class="form-group dao-form-section">
                 <div class="dao-form-section-header">
-                  <label>Parameter Changes <span class="dao-form-required" aria-hidden="true">*</span></label>
+                  <label>Parameter Changes</label>
                 </div>
                 <div class="dao-form-list" id="addProposalChangesList"></div>
                 <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalChangeButton">

--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
             <form id="addProposalForm" class="form--narrow dao-proposal-form" novalidate>
               <div class="dao-form-grid">
                 <div class="form-group">
-                  <label for="addProposalEmergency">Emergency</label>
+                  <label for="addProposalEmergency">Emergency <span class="dao-form-required" aria-hidden="true">*</span></label>
                   <select id="addProposalEmergency" class="form-control" required>
                     <option value="false">No</option>
                     <option value="true">Yes</option>
@@ -485,11 +485,11 @@
                 </div>
               </div>
               <div class="form-group">
-                <label for="addProposalTitle">Title</label>
+                <label for="addProposalTitle">Title <span class="dao-form-required" aria-hidden="true">*</span></label>
                 <input id="addProposalTitle" class="form-control" type="text" maxlength="100" placeholder="Proposal title" required />
               </div>
               <div class="form-group">
-                <label for="addProposalType">Proposal Type</label>
+                <label for="addProposalType">Proposal Type <span class="dao-form-required" aria-hidden="true">*</span></label>
                 <select id="addProposalType" class="form-control" required>
                   <option value="governance">Governance</option>
                   <option value="economic">Economic</option>
@@ -498,12 +498,12 @@
                 <div class="dao-form-help">Choose governance, economic, or protocol. This controls which parameters can be selected below.</div>
               </div>
               <div class="form-group">
-                <label for="addProposalDescription">Description</label>
+                <label for="addProposalDescription">Description <span class="dao-form-required" aria-hidden="true">*</span></label>
                 <textarea id="addProposalDescription" class="form-control" rows="6" maxlength="10000" placeholder="Describe the proposal" required></textarea>
               </div>
               <div class="form-group dao-form-section">
                 <div class="dao-form-section-header">
-                  <label>Parameter Changes</label>
+                  <label>Parameter Changes <span class="dao-form-required" aria-hidden="true">*</span></label>
                 </div>
                 <div class="dao-form-list" id="addProposalChangesList"></div>
                 <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalChangeButton">
@@ -513,7 +513,7 @@
               </div>
               <div class="form-group dao-form-section">
                 <div class="dao-form-section-header">
-                  <label>Options</label>
+                  <label>Options <span class="dao-form-required" aria-hidden="true">*</span></label>
                 </div>
                 <div class="dao-form-list" id="addProposalOptionsList"></div>
                 <button type="button" class="btn btn--secondary dao-form-add-button" id="addProposalOptionButton">
@@ -542,7 +542,7 @@
                   </div>
                   <div class="form-group">
                     <div class="dao-form-label-with-help">
-                      <label for="addProposalGracePeriodMs">Grace Period (ms)</label>
+                      <label for="addProposalGracePeriodMs">Grace Period (ms) <span class="dao-form-required" aria-hidden="true">*</span></label>
                       <button
                         type="button"
                         class="toll-info-icon dao-form-tooltip"

--- a/styles.css
+++ b/styles.css
@@ -1876,6 +1876,12 @@ input[type='file'].form-control::file-selector-button {
   margin: 0;
 }
 
+#addProposalModal .dao-form-required {
+  color: var(--danger-color);
+  font-weight: var(--font-weight-semibold);
+  margin-left: 2px;
+}
+
 #addProposalModal .dao-form-label-with-help {
   align-items: center;
   display: flex;


### PR DESCRIPTION
## What Changed

This PR makes required inputs visible before submission in the create-proposal modal.

- Adds red asterisks to the modal's required top-level fields and required collection sections.
- Adds the same indicator to dynamically rendered parameter selection and proposed-value labels.
- Keeps the existing validation behavior unchanged and hides decorative asterisks from assistive technology.

## Fixed Flow

1. The user opens the create-proposal modal.
2. Required fields are immediately identifiable from their labels.
3. Dynamically added parameter controls use the same required-field treatment.
4. Existing submission validation continues to enforce the form requirements.

## Why

Required fields were previously communicated only during validation or through supporting text. Showing a consistent indicator beside each required label makes the form requirements clear before submission.

## Validation

- `node --check app.js`
- `git diff --check origin/main...HEAD`
- Required-indicator assertion: 7 static and 2 dynamically rendered indicators

Closes #1518