### PR TITLE
Prevent account creation and migration overlap

### DIFF
--- a/app.js
+++ b/app.js
@@ -13698,6 +13698,10 @@ function updateUIForConnectivity() {
  * buttons aren't incorrectly enabled if they should remain disabled for other reasons.
  */
 function revalidateButtonStates() {
+  if (typeof createAccountModal !== 'undefined' && createAccountModal.controls) {
+    createAccountModal.refreshControlStates();
+  }
+
   // Check if validator modal is open and refresh it to re-validate all button states
   if (typeof validatorStakingModal !== 'undefined' && validatorStakingModal.isActive()) {
     validatorStakingModal.close();
@@ -29290,14 +29294,24 @@ class CreateAccountModal {
 
   setAccountCreationInProgress(isInProgress) {
     this.isCreatingAccount = isInProgress;
+    this.refreshControlStates();
+  }
+
+  refreshControlStates() {
     this.controls.forEach((control) => {
-      control.disabled = isInProgress;
+      const requiresConnection = control.hasAttribute('data-requires-connection');
+      const isMigrationLoading = control === this.migrateAccountsButton && migrateAccountsModal.isOpening;
+      control.disabled = this.isCreatingAccount || isMigrationLoading || (requiresConnection && !isOnline);
     });
     this.refreshSubmitButton();
   }
 
   refreshSubmitButton() {
-    this.submitButton.disabled = this.isCreatingAccount || !this.isUsernameAvailable;
+    this.submitButton.disabled =
+      this.isCreatingAccount ||
+      migrateAccountsModal.isOpening ||
+      !this.isUsernameAvailable ||
+      !isOnline;
   }
 
   handleUsernameInput(e) {
@@ -31500,16 +31514,14 @@ class MigrateAccountsModal {
     if (this.isOpening || this.isActive() || createAccountModal.isCreatingAccount) return;
 
     this.isOpening = true;
-    createAccountModal.migrateAccountsButton.disabled = true;
+    createAccountModal.refreshControlStates();
     try {
       await this.populateAccounts();
       if (createAccountModal.isCreatingAccount) return;
       this.modal.classList.add('active');
     } finally {
       this.isOpening = false;
-      if (!createAccountModal.isCreatingAccount) {
-        createAccountModal.migrateAccountsButton.disabled = false;
-      }
+      createAccountModal.refreshControlStates();
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -29163,6 +29163,7 @@ class CreateAccountModal {
   constructor() {
     this.checkTimeout = null;
     this.isCreatingAccount = false;
+    this.isUsernameAvailable = false;
   }
 
   load() {
@@ -29184,22 +29185,10 @@ class CreateAccountModal {
     this.privateAccountCheckbox = document.getElementById('togglePrivateAccount');
     this.privateAccountHelpButton = document.getElementById('privateAccountHelpButton');
     this.privateAccountTemplate = document.getElementById('privateAccountHelpMessageTemplate');
+    this.controls = this.modal.querySelectorAll('button, input');
 
     // Setup event listeners
-    this.form.addEventListener('submit', withButtonCooldown(
-      [
-        this.submitButton,
-        this.migrateAccountsButton,
-        this.toggleButton,
-        this.usernameInput,
-        this.privateKeyInput,
-        this.backButton,
-        this.privateAccountCheckbox
-      ],
-      BUTTON_COOLDOWN_MS,
-      null,
-      (e) => this.handleSubmit(e)
-    ));
+    this.form.addEventListener('submit', (event) => this.handleSubmit(event));
     this.usernameInput.addEventListener('input', (e) => this.handleUsernameInput(e));
     this.toggleButton.addEventListener('change', () => this.handleTogglePrivateKeyInput());
     this.toggleMoreOptions.addEventListener('change', () => this.handleToggleMoreOptions());
@@ -29222,10 +29211,12 @@ class CreateAccountModal {
       showToast(message, 0, 'info', true);
     });
 
-    this.migrateAccountsButton.addEventListener('click', async () => await migrateAccountsModal.open());
+    this.migrateAccountsButton.addEventListener('click', () => migrateAccountsModal.open());
   }
 
   open() {
+    if (this.isCreatingAccount) return;
+
     if (migrateAccountsModal.hasMigratableAccounts()) {
       this.migrateAccountsSection.style.display = 'block';
     } else {
@@ -29242,12 +29233,16 @@ class CreateAccountModal {
 
   // we still need to keep this since it can be called by other modals
   close() {
+    if (this.isCreatingAccount) return;
+
     // reload the welcome page so that if accounts were migrated the signin button will be shown
     this.modal.classList.remove('active');
   }
 
   // this is called by the back button on the create account modal
   closeWithReload() {
+    if (this.isCreatingAccount) return;
+
     // reload the welcome page so that if accounts were migrated the signin button will be shown
     const newUrl = window.location.href.split('?')[0];
     window.location.replace(newUrl);
@@ -29255,11 +29250,15 @@ class CreateAccountModal {
   }
 
   openWithReset() {
+    if (this.isCreatingAccount) return;
+
     // Clear form fields
     this.usernameInput.value = '';
     this.privateKeyInput.value = '';
     this.usernameAvailable.style.display = 'none';
     this.privateKeyError.style.display = 'none';
+    this.isUsernameAvailable = false;
+    this.refreshSubmitButton();
     
     // Reset More Options section
     this.toggleMoreOptions.checked = false;
@@ -29289,12 +29288,16 @@ class CreateAccountModal {
     return this.modal?.classList.contains('active') || false;
   }
 
-  startAccountCreationUnloadWarning() {
-    this.isCreatingAccount = true;
+  setAccountCreationInProgress(isInProgress) {
+    this.isCreatingAccount = isInProgress;
+    this.controls.forEach((control) => {
+      control.disabled = isInProgress;
+    });
+    this.refreshSubmitButton();
   }
 
-  stopAccountCreationUnloadWarning() {
-    this.isCreatingAccount = false;
+  refreshSubmitButton() {
+    this.submitButton.disabled = this.isCreatingAccount || !this.isUsernameAvailable;
   }
 
   handleUsernameInput(e) {
@@ -29308,7 +29311,8 @@ class CreateAccountModal {
 
     // Reset display
     this.usernameAvailable.style.display = 'none';
-    this.submitButton.disabled = true;
+    this.isUsernameAvailable = false;
+    this.refreshSubmitButton();
 
     // Check if username is too short
     if (username.length < 3) {
@@ -29321,22 +29325,25 @@ class CreateAccountModal {
     // Check network availability
     this.checkTimeout = setTimeout(async () => {
       const taken = await checkUsernameAvailability(username);
+      if (username !== normalizeUsername(this.usernameInput.value)) return;
+
       if (taken == 'taken') {
         this.usernameAvailable.textContent = 'taken';
         this.usernameAvailable.style.color = '#dc3545';
         this.usernameAvailable.style.display = 'inline';
-        this.submitButton.disabled = true;
+        this.isUsernameAvailable = false;
       } else if (taken == 'available') {
         this.usernameAvailable.textContent = 'available';
         this.usernameAvailable.style.color = '#28a745';
         this.usernameAvailable.style.display = 'inline';
-        this.submitButton.disabled = false;
+        this.isUsernameAvailable = true;
       } else {
         this.usernameAvailable.textContent = 'network error';
         this.usernameAvailable.style.color = '#dc3545';
         this.usernameAvailable.style.display = 'inline';
-        this.submitButton.disabled = true;
+        this.isUsernameAvailable = false;
       }
+      this.refreshSubmitButton();
     }, 1000);
   }
 
@@ -29401,6 +29408,8 @@ class CreateAccountModal {
 
   async handleSubmit(event) {
     event.preventDefault();
+
+    if (this.isCreatingAccount || migrateAccountsModal.isActive() || !this.isUsernameAvailable) return;
     
     // Validate username at submit time after normalization
     const username = normalizeUsername(this.usernameInput.value);
@@ -29448,8 +29457,6 @@ class CreateAccountModal {
       this.privateKeyError.style.display = 'none'; // Ensure hidden if generated
     }
 
-    this.startAccountCreationUnloadWarning();
-
     // Generate uncompressed public key
     const publicKey = getPublicKey(privateKey);
     const publicKeyHex = bin2hex(publicKey);
@@ -29458,6 +29465,8 @@ class CreateAccountModal {
     // Generate address from public key
     const address = generateAddress(publicKey);
     const addressHex = bin2hex(address);
+
+    this.setAccountCreationInProgress(true);
 
     // If a private key was provided, check if the derived address already exists on the network
     if (providedPrivateKey) {
@@ -29472,7 +29481,7 @@ class CreateAccountModal {
           this.privateKeyError.textContent = 'An account already exists for this private key.';
           this.privateKeyError.style.color = '#dc3545';
           this.privateKeyError.style.display = 'inline';
-          this.stopAccountCreationUnloadWarning();
+          this.setAccountCreationInProgress(false);
           return; // Stop the account creation process
         } else {
           this.privateKeyError.style.display = 'none';
@@ -29482,7 +29491,7 @@ class CreateAccountModal {
         this.privateKeyError.textContent = 'Network error checking key. Please try again.';
         this.privateKeyError.style.color = '#dc3545';
         this.privateKeyError.style.display = 'inline';
-        this.stopAccountCreationUnloadWarning();
+        this.setAccountCreationInProgress(false);
         return; // Stop process on error
       }
     }
@@ -29521,7 +29530,7 @@ class CreateAccountModal {
       if (waitingToastId) hideToast(waitingToastId);
       showToast(`Failed to fetch network parameters, try again later.`, 0, 'error');
       console.error('Failed to fetch network parameters, using defaults:', error);
-      this.stopAccountCreationUnloadWarning();
+      this.setAccountCreationInProgress(false);
       return;
     }
 
@@ -29545,16 +29554,15 @@ class CreateAccountModal {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         if (waitingToastId) hideToast(waitingToastId);
 //        showToast('Account created successfully!', 3000, 'success');
-        this.close();
-        welcomeScreen.close();
         // TODO: may not need to get set since gets set in `getChats`. Need to check signin flow.
         //getChats.lastCall = getCorrectedTimestamp();
         // Store updated accounts back in localStorage
         existingAccounts.netids[netid].usernames[username] = { address: myAccount.keys.address };
         localStorage.setItem('accounts', stringify(existingAccounts));
         saveState();
-        this.stopAccountCreationUnloadWarning();
-
+        this.setAccountCreationInProgress(false);
+        this.close();
+        welcomeScreen.close();
         // Refresh wallet balance immediately after account creation for fee-dependent screens.
         try {
           myData.wallet.timestamp = 0;
@@ -29578,7 +29586,7 @@ class CreateAccountModal {
         }
 
         clearMyData();
-        this.stopAccountCreationUnloadWarning();
+        this.setAccountCreationInProgress(false);
 
         // Note: `checkPendingTransactions` will also remove the item from `myData.pending` if it's rejected by the service.
         return;
@@ -29598,7 +29606,7 @@ class CreateAccountModal {
       }
 
       clearMyData();
-      this.stopAccountCreationUnloadWarning();
+      this.setAccountCreationInProgress(false);
 
       // no toast here since injectTx will show it
       return;

--- a/app.js
+++ b/app.js
@@ -29300,8 +29300,10 @@ class CreateAccountModal {
   refreshControlStates() {
     this.controls.forEach((control) => {
       const requiresConnection = control.hasAttribute('data-requires-connection');
-      const isMigrationLoading = control === this.migrateAccountsButton && migrateAccountsModal.isOpening;
-      control.disabled = this.isCreatingAccount || isMigrationLoading || (requiresConnection && !isOnline);
+      const isMigrationBusy =
+        control === this.migrateAccountsButton &&
+        (migrateAccountsModal.isOpening || migrateAccountsModal.isMigrating);
+      control.disabled = this.isCreatingAccount || isMigrationBusy || (requiresConnection && !isOnline);
     });
     this.refreshSubmitButton();
   }
@@ -29310,6 +29312,7 @@ class CreateAccountModal {
     this.submitButton.disabled =
       this.isCreatingAccount ||
       migrateAccountsModal.isOpening ||
+      migrateAccountsModal.isMigrating ||
       !this.isUsernameAvailable ||
       !isOnline;
   }
@@ -29426,6 +29429,7 @@ class CreateAccountModal {
     if (
       this.isCreatingAccount ||
       migrateAccountsModal.isOpening ||
+      migrateAccountsModal.isMigrating ||
       migrateAccountsModal.isActive() ||
       !this.isUsernameAvailable
     ) return;
@@ -31486,6 +31490,7 @@ const bridgeModal = new BridgeModal();
 class MigrateAccountsModal {
   constructor() {
     this.isOpening = false;
+    this.isMigrating = false;
   }
 
   load() {
@@ -31511,7 +31516,7 @@ class MigrateAccountsModal {
   }
 
   async open() {
-    if (this.isOpening || this.isActive() || createAccountModal.isCreatingAccount) return;
+    if (this.isOpening || this.isMigrating || this.isActive() || createAccountModal.isCreatingAccount) return;
 
     this.isOpening = true;
     createAccountModal.refreshControlStates();
@@ -31526,6 +31531,8 @@ class MigrateAccountsModal {
   }
 
   close() {
+    if (this.isMigrating) return;
+
     this.modal.classList.remove('active');
     this.clearForm();
   }
@@ -31698,6 +31705,19 @@ class MigrateAccountsModal {
   async handleSubmit(event) {
     event.preventDefault();
 
+    if (this.isMigrating) return;
+
+    this.isMigrating = true;
+    try {
+      createAccountModal.refreshControlStates();
+      await this.migrateSelectedAccounts();
+    } finally {
+      this.isMigrating = false;
+      createAccountModal.refreshControlStates();
+    }
+  }
+
+  async migrateSelectedAccounts() {
     const selectedAccounts = this.accountList.querySelectorAll('input[type="checkbox"]:checked');
   
     const results = {}

--- a/app.js
+++ b/app.js
@@ -29409,7 +29409,12 @@ class CreateAccountModal {
   async handleSubmit(event) {
     event.preventDefault();
 
-    if (this.isCreatingAccount || migrateAccountsModal.isActive() || !this.isUsernameAvailable) return;
+    if (
+      this.isCreatingAccount ||
+      migrateAccountsModal.isOpening ||
+      migrateAccountsModal.isActive() ||
+      !this.isUsernameAvailable
+    ) return;
     
     // Validate username at submit time after normalization
     const username = normalizeUsername(this.usernameInput.value);

--- a/app.js
+++ b/app.js
@@ -31465,7 +31465,9 @@ const bridgeModal = new BridgeModal();
  * @description A modal for migrating accounts from different networks
  */
 class MigrateAccountsModal {
-  constructor() { }
+  constructor() {
+    this.isOpening = false;
+  }
 
   load() {
     this.modal = document.getElementById('migrateAccountsModal');
@@ -31490,8 +31492,20 @@ class MigrateAccountsModal {
   }
 
   async open() {
-    await this.populateAccounts();
-    this.modal.classList.add('active');
+    if (this.isOpening || this.isActive() || createAccountModal.isCreatingAccount) return;
+
+    this.isOpening = true;
+    createAccountModal.migrateAccountsButton.disabled = true;
+    try {
+      await this.populateAccounts();
+      if (createAccountModal.isCreatingAccount) return;
+      this.modal.classList.add('active');
+    } finally {
+      this.isOpening = false;
+      if (!createAccountModal.isCreatingAccount) {
+        createAccountModal.migrateAccountsButton.disabled = false;
+      }
+    }
   }
 
   close() {


### PR DESCRIPTION
## What Changed

This PR prevents account creation and account migration from overlapping while either asynchronous flow is still running.

- `CreateAccountModal` keeps its controls locked until registration settles and ignores stale username-availability responses.
- `MigrateAccountsModal` blocks duplicate opens, account creation, and Back-button closure while migration is loading or processing.
- Control state now composes creation, migration, username availability, and connectivity instead of allowing one state update to overwrite another.

## Fixed Flow

1. The user starts account creation or migration.
2. The selected flow records its loading or processing state and locks conflicting controls.
3. Modal, Back-button, reconnect, and repeated-submit paths consult the same state.
4. The lock is released in the completion or error path, preventing concurrent account data and session mutations.

## Why

Account creation and migration previously relied mainly on short button cooldowns and modal visibility. A delayed migration modal or a Back action could allow both asynchronous flows to mutate shared account state, causing a migrated account to replace or merge with a newly created account.

## Validation

- `node --check app.js`
- `git diff --check 2673505a0bc183d2fcfbaea72fe652cd3a0032d6 HEAD`

Closes #1279