### PR TITLE
Fix browser Back handling for Backup modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -35214,7 +35214,7 @@ function closeTopModal(topModal){
     case 'createAccountModal':
       createAccountModal.close();
       break;
-    case 'backupAccountModal':
+    case 'backupModal':
       backupAccountModal.close();
       break;
     case 'restoreAccountModal':


### PR DESCRIPTION
## Summary

- Match the browser-back dispatcher to the Backup modal's actual DOM ID.
- Allow Firefox/Android system Back to close the Backup modal through its existing `close()` method.

## Root cause

`closeTopModal()` switches on DOM element IDs. The Backup element is `backupModal`, but its switch case used the JavaScript instance name `backupAccountModal`. The dispatcher therefore treated the active Backup modal as unknown and left it open.

## Impact

Browser and Android system Back now close Backup consistently with the modal's onscreen back button. This is a targeted navigation fix and does not change startup or sign-out behavior.

## Validation

- `node --check app.js`
- `git diff --check HEAD^ HEAD`
- Confirmed the dispatcher case matches `id="backupModal"` in `index.html`.