### PR TITLE
Consolidate browser-back modal handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -28853,7 +28853,7 @@ class NewChatModal {
     this.recipientInput = document.getElementById('chatRecipient');
     this.submitButton = document.querySelector('#newChatForm button[type="submit"]');
 
-    this.closeNewChatModalButton.addEventListener('click', this.closeNewChatModal.bind(this));
+    this.closeNewChatModalButton.addEventListener('click', this.close.bind(this));
     this.newChatForm.addEventListener('submit', withButtonCooldown(
       this.submitButton,
       BUTTON_COOLDOWN_MS,
@@ -28904,7 +28904,7 @@ class NewChatModal {
    * It will close the modal and reset the form
    * @returns {void}
    */
-  closeNewChatModal() {
+  close() {
     this.modal.classList.remove('active');
     this.newChatForm.reset();
     if (chatsScreen.isActive()) {
@@ -29008,7 +29008,7 @@ class NewChatModal {
     chatsData.contacts[recipientAddress].username = username;
 
     // Close new chat modal and open chat modal
-    this.closeNewChatModal();
+    this.close();
     chatModal.open(recipientAddress);
   }
 

--- a/app.js
+++ b/app.js
@@ -6978,14 +6978,7 @@ class SignInModal {
     this.actionRecreateButton.addEventListener('click', runSheetAction((username) => this.openRecreateFlow(username)));
     this.actionRemoveButton.addEventListener('click', runSheetAction((username) => removeAccountModal.removeAccount(username)));
 
-    this.backButton.addEventListener('click', () => {
-      if (this.isCompletingSignIn) return;
-      if (this.actionSheetOverlay.classList.contains('active')) {
-        this.closeActionSheet();
-        return;
-      }
-      this.close();
-    });
+    this.backButton.addEventListener('click', () => this.close());
   }
 
   /** Hide the account error action sheet. */
@@ -7028,7 +7021,7 @@ class SignInModal {
 
     createAccountModal.usernameInput.value = username;
     createAccountModal.privateKeyInput.value = privateKey;
-    this.close();
+    this.forceClose();
     createAccountModal.open();
     createAccountModal.usernameInput.dispatchEvent(new Event('input'));
   }
@@ -7300,7 +7293,7 @@ class SignInModal {
 
       // No accounts on this device — open Create Account instead.
       if (usernames.length === 0) {
-        this.close();
+        this.forceClose();
         createAccountModal.open();
         return;
       }
@@ -7329,6 +7322,16 @@ class SignInModal {
   }
 
   close() {
+    if (this.isCompletingSignIn) return;
+    if (this.actionSheetOverlay.classList.contains('active')) {
+      this.closeActionSheet();
+      return;
+    }
+
+    this.forceClose();
+  }
+
+  forceClose() {
     this.accountClickSeq++;
     this.selectedUsername = null;
     this.setCompletingSignIn(false);
@@ -7404,7 +7407,7 @@ class SignInModal {
     }
 
     // Close modal and proceed to app
-    this.close();
+    this.forceClose();
     welcomeScreen.close();
     
     // Log storage information after successful sign-in

--- a/app.js
+++ b/app.js
@@ -27724,12 +27724,10 @@ class CallScheduleChoiceModal {
 
     const onNow = () => this._select('now');
     const onSchedule = () => this._select('schedule');
-    const onCancel = () => this._select(null);
-
     if (this.nowBtn) this.nowBtn.addEventListener('click', withButtonCooldown(this.nowBtn, BUTTON_COOLDOWN_MS, null, onNow));
     if (this.scheduleBtn) this.scheduleBtn.addEventListener('click', withButtonCooldown(this.scheduleBtn, BUTTON_COOLDOWN_MS, null, onSchedule));
-    if (this.cancelBtn) this.cancelBtn.addEventListener('click', onCancel);
-    if (this.closeBtn) this.closeBtn.addEventListener('click', onCancel);
+    if (this.cancelBtn) this.cancelBtn.addEventListener('click', () => this.close());
+    if (this.closeBtn) this.closeBtn.addEventListener('click', () => this.close());
   }
 
   open(onSelect) {
@@ -27744,6 +27742,10 @@ class CallScheduleChoiceModal {
     const cb = this.onSelect;
     this.onSelect = null;
     if (cb) cb(value);
+  }
+
+  close() {
+    this._select(null);
   }
 
   _startRecipientTimeUpdates() {
@@ -27882,6 +27884,10 @@ class DateTimePickerModal {
   }
 
   _onCancel() {
+    this.close();
+  }
+
+  close() {
     this._closeWith(null);
   }
 
@@ -35213,9 +35219,6 @@ function handleBrowserBackButton(event) {
   const topModal = findTopModal();
   
   if (topModal) {
-    const modalId = topModal.id;
-    const modalInstance = window[modalId];
-    
     const closed = closeTopModal(topModal)
     if (closed){
       return true;
@@ -35231,135 +35234,47 @@ function findTopModal() {
   return topModal;
 }
 
-function closeTopModal(topModal){
-  const modalId = topModal.id;
-  switch (modalId) {
-    case 'chatModal':
-      chatModal.close();
-      break;
-    case 'menuModal':
-      menuModal.close();
-      break;
-    case 'assetsModal':
-      evmAssets.close(modalId);
-      break;
-    case 'assetDetailsModal':
-      evmAssets.close(modalId);
-      break;
-    case 'daoModal':
-      daoModal.close();
-      break;
-    case 'addProposalModal':
-      addProposalModal.close();
-      break;
-    case 'confirmProposalModal':
-      confirmProposalModal.close();
-      break;
-    case 'proposalInfoModal':
-      proposalInfoModal.close();
-      break;
-    case 'settingsModal':
-      settingsModal.close();
-      break;
-    case 'chatSettingsModal':
-      chatSettingsModal.handleClose();
-      break;
-    case 'sendAssetFormModal':
-      sendAssetFormModal.close();
-      break;
-    case 'historyModal':
-      historyModal.close();
-      break;
-    case 'scanQRModal':
-      scanQRModal.close();
-      break;
-    case 'newChatModal':
-      newChatModal.close();
-      break;
-    case 'createAccountModal':
-      createAccountModal.close();
-      break;
-    case 'backupModal':
-      backupAccountModal.close();
-      break;
-    case 'restoreAccountModal':
-      restoreAccountModal.close();
-      break;
-    case 'tollModal':
-      tollModal.close();
-      break;
-    case 'inviteModal':
-      inviteModal.close();
-      break;
-    case 'aboutModal':
-      aboutModal.close();
-      break;
-    case 'helpModal':
-      helpModal.close();
-      break;
-    case 'farmModal':
-      farmModal.close();
-      break;
-    case 'logsModal':
-      logsModal.close();
-      break;
-    case 'myProfileModal':
-      myProfileModal.close();
-      break;
-    case 'validatorStakingModal':
-      validatorStakingModal.close();
-      break;
-    case 'stakeValidatorModal':
-      stakeValidatorModal.close();
-      break;
-    case 'contactInfoModal':
-      contactInfoModal.close();
-      break;
-    case 'friendModal':
-      friendModal.close();
-      break;
-    case 'editContactModal':
-      editContactModal.close();
-      break;
-    case 'searchMessagesModal':
-      searchMessagesModal.close();
-      break;
-    case 'searchContactsModal':
-      searchContactsModal.close();
-      break;
-    case 'receiveModal':
-      receiveModal.close();
-      break;
-    case 'sendAssetConfirmModal':
-      sendAssetConfirmModal.close();
-      break;
-    case 'failedTransactionModal':
-      failedTransactionModal.close();
-      break;
-    case 'bridgeModal':
-      bridgeModal.close();
-      break;
-    case 'migrateAccountsModal':
-      migrateAccountsModal.close();
-      break;
-    case 'lockModal':
-      lockModal.close();
-      break;
-    case 'unlockModal':
-      unlockModal.close();
-      break;
-    case 'launchModal':
-      launchModal.close();
-      break;
-    case 'updateWarningModal':
-      updateWarningModal.close();
-      break;
-    case 'removeAccountModal':
-      removeAccountModal.close();
-      break;
-    default:
-      console.warn('Unknown modal:', modalId);
-      return false;
+function createModalCloseHandlers(modals) {
+  return Object.entries(modals).map(([modalId, modal]) => [modalId, () => modal.close()]);
+}
+
+const modalCloseHandlers = new Map([
+  ...createModalCloseHandlers({
+    chatModal, menuModal, daoModal, addProposalModal,
+    confirmProposalModal, proposalInfoModal, settingsModal, manageContactsModal,
+    welcomeMenuModal, sendAssetFormModal, historyModal, newChatModal,
+    createAccountModal, tollModal, inviteModal, aboutModal,
+    sourceModal, helpModal, farmModal, logsModal,
+    signInModal, myInfoModal, contactInfoModal, friendModal,
+    editContactModal, avatarEditModal, receiveModal, sendAssetConfirmModal,
+    failedTransactionModal, bridgeModal, migrateAccountsModal, lockModal,
+    unlockModal, launchModal, updateWarningModal, removeAccountModal,
+    removeAccountsModal, secretModal, callsModal, groupCallParticipantsModal,
+    callScheduleChoiceModal, dateTimePickerModal, callInviteModal, shareAttachmentModal,
+  }),
+  ['assetsModal', () => evmAssets.close('assetsModal')],
+  ['assetDetailsModal', () => evmAssets.close('assetDetailsModal')],
+  ['chatSettingsModal', () => chatSettingsModal.handleClose()],
+  ['qrScanModal', () => scanQRModal.close()],
+  ['backupModal', () => backupAccountModal.close()],
+  ['importModal', () => restoreAccountModal.close()],
+  ['googleDrivePickerModal', () => restoreAccountModal.closeGoogleDrivePicker()],
+  ['accountModal', () => myProfileModal.close()],
+  ['validatorModal', () => validatorStakingModal.close()],
+  ['stakeModal', () => stakeValidatorModal.close()],
+  ['searchModal', () => searchMessagesModal.close()],
+  ['contactSearchModal', () => searchContactsModal.close()],
+  ['importContactsModal', () => importContactsModal.handleClose()],
+  ['shareContactsModal', () => shareContactsModal.handleClose()],
+]);
+
+function closeTopModal({ id: modalId }) {
+  const closeModal = modalCloseHandlers.get(modalId);
+  if (!closeModal) {
+    console.warn('Unknown modal:', modalId);
+    return false;
   }
-  return true; // means we closed a modal
+
+  closeModal();
+  return true;
 }


### PR DESCRIPTION
## What Changed

This PR consolidates browser-back handling for active modals into one exhaustive handler registry.

- `modalCloseHandlers` replaces the repeated switch cases with generated handlers for conventional `.close()` controllers and explicit mappings for structural exceptions.
- Scheduling dialogs expose standard `.close()` methods while preserving cancellation callbacks and timer cleanup.
- Guarded contact sharing and importing continue through their existing discard-warning paths.
- All 58 `.modal` DOM IDs have a registered browser-back handler.

## Consolidated Flow

1. A modal receives the `active` class.
2. The user presses the browser back button.
3. `findTopModal` passes the modal's DOM ID to `closeTopModal`.
4. The registry invokes that modal's established close or cancel behavior, including controller-specific cleanup.

## Why

PR #1523 fixed the immediate Backup modal mismatch. This follow-up consolidates the broader dispatcher so DOM IDs, controller behavior, and modal coverage live in one compact source of truth.

The previous switch still mixed DOM IDs with controller names and omitted 17 active modals. The registry removes that drift-prone case scaffolding while preserving cleanup such as stopping QR capture, clearing picker state, resolving scheduling callbacks, and warning before selected contacts are discarded.

## Validation

- `git diff --check origin/main...HEAD`
- `node --check app.js`
- `node tests/modal-close-coverage.test.mjs` (local ignored coverage check)

Closes #1524