### PR TITLE
Add all DAO proposal filter

### DIFF
--- a/DAO.md
+++ b/DAO.md
@@ -13,8 +13,9 @@ This document describes the DAO / proposals feature as currently implemented in 
 1. **DAO Modal**
    - Shows a list of proposals.
    - Includes an **Active / Archived** segmented toggle.
-   - Includes a **Status filter** (funnel icon) that filters by proposal status and shows **counts**.
-   - The proposal list is filtered by the selected status.
+   - Includes a **Status filter** that filters by proposal status and shows **counts**.
+   - The **All** status filter displays every proposal in the selected Active / Archived group.
+   - The proposal list is filtered by the selected option.
    - List ordering is **newest to enter the selected state first** (sort by `stateEnteredAt` descending, falling back to `createdAt`).
    - Clicking a proposal opens the Proposal Info modal.
    - A floating **“+”** button opens the Add Proposal modal.

--- a/app.js
+++ b/app.js
@@ -2475,8 +2475,9 @@ const menuModal = new MenuModal();
 // DAO proposals are loaded via `daoRepo` and kept in memory (no localStorage persistence).
 setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
 
+const DAO_ALL_FILTER = { key: 'all', label: 'All' };
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };
-const DAO_FILTER_OPTIONS = [...DAO_STATES, DAO_CLAIMABLE_FILTER];
+const DAO_FILTER_OPTIONS = [DAO_ALL_FILTER, ...DAO_STATES, DAO_CLAIMABLE_FILTER];
 const DAO_FILTER_OVERFLOW_KEYS = ['withheld', 'rejected', 'applied'];
 
 function formatDaoTimestamp(ts) {
@@ -2709,6 +2710,7 @@ class DaoModal {
     const proposalsArchived = hasFreshData ? daoRepo.getProposalsForUi('archived') : [];
     const currentAddress = getDaoCurrentAccountAddress();
     const now = getTransactionTimestamp();
+    const isAllFilter = this.selectedFilterKey === DAO_ALL_FILTER.key;
     const isClaimableFilter = this.selectedFilterKey === DAO_CLAIMABLE_FILTER.key;
     const groupedProposals = this.selectedGroupKey === 'archived' ? proposalsArchived : proposalsActive;
     const claimableProposals = [...proposalsActive, ...proposalsArchived]
@@ -2720,6 +2722,7 @@ class DaoModal {
       const state = getEffectiveDaoState(p);
       if (counts[state] !== undefined) counts[state] += 1;
     }
+    counts[DAO_ALL_FILTER.key] = groupedProposals.length;
     counts[DAO_CLAIMABLE_FILTER.key] = claimableProposals.length;
 
     // Update header title
@@ -2770,9 +2773,12 @@ class DaoModal {
     }
 
     // Filter + sort (newest entered into state first)
-    const filtered = (isClaimableFilter
+    const matchingProposals = isClaimableFilter
       ? claimableProposals
-      : groupedProposals.filter((proposal) => getEffectiveDaoState(proposal) === this.selectedFilterKey))
+      : groupedProposals.filter((proposal) => (
+        isAllFilter || getEffectiveDaoState(proposal) === this.selectedFilterKey
+      ));
+    const filtered = matchingProposals
       .sort((a, b) => Number(b.stateEnteredAt || b.createdAt || 0) - Number(a.stateEnteredAt || a.createdAt || 0));
 
     // Clear old list items

--- a/app.js
+++ b/app.js
@@ -2478,7 +2478,7 @@ setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
 const DAO_ALL_FILTER = { key: 'all', label: 'All' };
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };
 const DAO_FILTER_OPTIONS = [DAO_ALL_FILTER, ...DAO_STATES, DAO_CLAIMABLE_FILTER];
-const DAO_FILTER_OVERFLOW_KEYS = ['withheld', 'rejected', 'applied'];
+const DAO_FILTER_OVERFLOW_KEYS = ['withheld', 'rejected', 'applied', DAO_ALL_FILTER.key];
 
 function formatDaoTimestamp(ts) {
   const n = Number(ts || 0);

--- a/index.html
+++ b/index.html
@@ -412,6 +412,10 @@
           <div class="dao-toolbar">
             <div class="dao-filter-bar" id="daoFilterBar" role="tablist" aria-label="Proposal filter">
               <div class="dao-filter-primary">
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="all" aria-selected="false">
+                  <span class="dao-filter-chip-label">All</span>
+                  <span class="dao-filter-chip-count" aria-label="0 all proposals">0</span>
+                </button>
                 <button class="dao-filter-chip" type="button" role="tab" data-filter-key="review" aria-selected="false">
                   <span class="dao-filter-chip-label">Review</span>
                   <span class="dao-filter-chip-count" aria-label="0 review proposals">0</span>

--- a/index.html
+++ b/index.html
@@ -412,10 +412,6 @@
           <div class="dao-toolbar">
             <div class="dao-filter-bar" id="daoFilterBar" role="tablist" aria-label="Proposal filter">
               <div class="dao-filter-primary">
-                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="all" aria-selected="false">
-                  <span class="dao-filter-chip-label">All</span>
-                  <span class="dao-filter-chip-count" aria-label="0 all proposals">0</span>
-                </button>
                 <button class="dao-filter-chip" type="button" role="tab" data-filter-key="review" aria-selected="false">
                   <span class="dao-filter-chip-label">Review</span>
                   <span class="dao-filter-chip-count" aria-label="0 review proposals">0</span>
@@ -446,6 +442,10 @@
                 <button class="dao-filter-chip" type="button" role="tab" data-filter-key="applied" aria-selected="false">
                   <span class="dao-filter-chip-label">Applied</span>
                   <span class="dao-filter-chip-count" aria-label="0 applied proposals">0</span>
+                </button>
+                <button class="dao-filter-chip" type="button" role="tab" data-filter-key="all" aria-selected="false">
+                  <span class="dao-filter-chip-label">All</span>
+                  <span class="dao-filter-chip-count" aria-label="0 all proposals">0</span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## What Changed

This PR adds an `All` option to the DAO proposal filters so users can view every proposal in the selected Active or Archived group.

- Adds `All` as the last option in the expandable second filter row, with a count for the selected group.
- Makes `All` bypass lifecycle-status filtering while preserving the existing newest-first ordering.
- Keeps the second row expanded while `All` is selected so the active filter remains visible.

## Fixed Flow

1. The user expands the second proposal-filter row.
2. The user selects `All`.
3. The list includes proposals across every lifecycle status in the selected Active or Archived group.
4. The `All` count and selected state remain visible in the expanded row.

## Why

Previously, every available option restricted the list to one lifecycle status or the special Claimable view. Users had no way to see all proposals in the selected group without switching between filters.

## Validation

- `node --check app.js`
- `git diff --check main...HEAD`

Closes #1516