### PR TITLE
Close EVM confirmation from modal registry

### DIFF
--- a/app.js
+++ b/app.js
@@ -35249,7 +35249,7 @@ const modalCloseHandlers = new Map([
     createAccountModal, tollModal, inviteModal, aboutModal,
     sourceModal, helpModal, farmModal, logsModal,
     signInModal, myInfoModal, contactInfoModal, friendModal,
-    editContactModal, avatarEditModal, receiveModal, sendAssetConfirmModal,
+    editContactModal, avatarEditModal, receiveModal,
     failedTransactionModal, bridgeModal, migrateAccountsModal, lockModal,
     unlockModal, launchModal, updateWarningModal, removeAccountModal,
     removeAccountsModal, secretModal, callsModal, groupCallParticipantsModal,
@@ -35261,6 +35261,10 @@ const modalCloseHandlers = new Map([
   // Structural exceptions require an id or a controller-specific close method.
   ['assetsModal', () => evmAssets.close('assetsModal')],
   ['assetDetailsModal', () => evmAssets.close('assetDetailsModal')],
+  ['sendAssetConfirmModal', () => {
+    evmAssets.confirmationModal.reset();
+    sendAssetConfirmModal.close();
+  }],
   ['googleDrivePickerModal', () => importModal.closeGoogleDrivePicker()],
 ]);
 


### PR DESCRIPTION
## What Changed

This PR makes browser-back dismissal close the shared send confirmation modal correctly for both Liberdus and EVM sends.

- Moves `sendAssetConfirmModal` from the standard close-handler set to a controller-specific registry entry.
- Cancels any pending EVM confirmation before closing the shared modal element.
- Keeps the existing Liberdus confirmation close behavior unchanged.

## Fixed Flow

1. An EVM transfer opens `sendAssetConfirmModal` and waits for confirmation.
2. The user dismisses the modal with browser back.
3. The registry resets the pending EVM confirmation and closes the shared modal.
4. The transfer flow resolves as cancelled instead of relying on mutation-observer cleanup.

## Why

The EVM confirmation controller and the existing Liberdus controller share the same modal DOM ID. The standard registry entry only invoked the Liberdus controller, so EVM cancellation depended indirectly on observing the modal class change. The custom handler closes both pieces of state explicitly.

## Validation

- `node --check app.js`
- `node --check evm-assets.js`
- `git diff --check origin/main..HEAD`