### PR TITLE
Open pending Contact Status read-only

### DIFF
--- a/app.js
+++ b/app.js
@@ -7946,6 +7946,7 @@ const FRIEND_STATUS_PENDING_STALE_MS = 60 * 1000;
 const FRIEND_STATUS_REFRESH_TIMEOUT_MS = 10 * 1000;
 const VALID_FRIEND_STATUSES = new Set([0, 1, 2]);
 const FRIEND_STATUS_REFRESH_MESSAGES = Object.freeze({
+  pending: 'Status update pending\u2026',
   checking: 'Checking current status\u2026',
   offline: 'You are offline. Showing saved status; editing is unavailable.',
   failed: 'Could not refresh current status. Showing saved status; editing is unavailable.',
@@ -8074,10 +8075,6 @@ class FriendModal {
     if (!contactAddress) return;
     const contact = myData.contacts[contactAddress];
     if (!contact) return;
-    if (this.hasPendingFriendStatusUpdate(contactAddress)) {
-      showToast('You have a pending transaction to update the friend status. Come back to this page later.', 0, 'warning');
-      return;
-    }
 
     this.statusRefreshAbortController?.abort();
     this.statusRefreshAbortController = null;
@@ -8087,6 +8084,10 @@ class FriendModal {
     this.initialFriendStatus = contact.friend;
     this.warningShown = false;
     this.modal.classList.add('active');
+
+    if (this.showPendingStatusIfNeeded(contactAddress)) {
+      return;
+    }
 
     await this.refreshStatus(contactAddress, contact);
   }
@@ -8157,15 +8158,46 @@ class FriendModal {
     this.statusRefreshAbortController?.abort();
     this.statusRefreshAbortController = null;
 
+    const contactAddress = normalizeAddress(this.currentContactAddress);
+    if (this.showPendingStatusIfNeeded(contactAddress)) {
+      return;
+    }
+
     if (!isOnline) {
       this.setStatusRefreshState('offline');
       return;
     }
 
-    const contactAddress = normalizeAddress(this.currentContactAddress);
     const contact = myData.contacts?.[contactAddress];
     assert(contact, `Missing contact while refreshing friend status: ${contactAddress}`);
     this.refreshStatus(contactAddress, contact);
+  }
+
+  handlePendingStatusSettled(address) {
+    const contactAddress = normalizeAddress(address);
+    if (!this.isActive() || this.currentContactAddress !== contactAddress) {
+      return;
+    }
+
+    const contact = myData.contacts?.[contactAddress];
+    assert(contact, `Missing contact after friend status settled: ${contactAddress}`);
+    this.selectFriendStatus(contact.friend);
+    this.initialFriendStatus = contact.friend;
+
+    if (this.showPendingStatusIfNeeded(contactAddress)) {
+      return;
+    }
+
+    this.refreshStatus(contactAddress, contact);
+  }
+
+  showPendingStatusIfNeeded(contactAddress) {
+    if (!this.hasPendingFriendStatusUpdate(contactAddress)) {
+      return false;
+    }
+
+    this.setStatusRefreshState('pending');
+    return true;
   }
 
   getNetworkFriendStatus(networkRequired) {
@@ -8200,7 +8232,7 @@ class FriendModal {
       );
     }
 
-    const showInlineMessage = state === 'offline' || state === 'failed';
+    const showInlineMessage = state === 'pending' || state === 'offline' || state === 'failed';
     this.statusRefreshState = state;
     this.statusRefreshMessage.textContent = showInlineMessage ? FRIEND_STATUS_REFRESH_MESSAGES[state] : '';
     this.statusRefreshMessage.hidden = !showInlineMessage;
@@ -33471,6 +33503,7 @@ async function checkPendingTransactionsOnce() {
         }
         if (type === 'update_toll_required') {
           const { currentFriendStatus, previousFriendStatus, didRemoveStatusHistory } = revertPendingUpdateTollRequired(pendingTxInfo);
+          friendModal.handlePendingStatusSettled(pendingTxInfo.to);
           showToast('Update contact status timed out. Reverting contact to old status.', 0, 'error');
           await contactsScreen.updateContactsList();
           if (didRemoveStatusHistory || currentFriendStatus === 0 || previousFriendStatus === 0) {
@@ -33535,6 +33568,7 @@ async function checkPendingTransactionsOnce() {
           // log used by e2e tests do not delete
           console.log(`DEBUG: update_toll_required transaction successfully processed!`);
           syncPendingUpdateTollRequiredSuccess(pendingTxInfo, res.transaction);
+          friendModal.handlePendingStatusSettled(pendingTxInfo.to);
         }
 
         if (type === 'read') {
@@ -33611,6 +33645,7 @@ async function checkPendingTransactionsOnce() {
           } else if (type === 'update_toll_required') {
             showToast(`Update contact status failed: ${userFailureReason}. Reverting contact to old status.`, 0, 'error');
             const { currentFriendStatus, previousFriendStatus, didRemoveStatusHistory } = revertPendingUpdateTollRequired(pendingTxInfo);
+            friendModal.handlePendingStatusSettled(pendingTxInfo.to);
             // update contact list since friend status was reverted
             await contactsScreen.updateContactsList();
             // Refresh when removing the optimistic divider or when the revert enters/exits "blocked"

--- a/app.js
+++ b/app.js
@@ -8222,9 +8222,10 @@ class FriendModal {
     assert(FRIEND_STATUS_REFRESH_MESSAGES[state] !== undefined, `Unknown friend status refresh state: ${state}`);
 
     this.hideStatusRefreshToast();
-    if (state === 'checking') {
+    const showLoadingToast = state === 'pending' || state === 'checking';
+    if (showLoadingToast) {
       this.statusRefreshToastId = showToast(
-        FRIEND_STATUS_REFRESH_MESSAGES.checking,
+        FRIEND_STATUS_REFRESH_MESSAGES[state],
         0,
         'loading',
         false,
@@ -8232,7 +8233,7 @@ class FriendModal {
       );
     }
 
-    const showInlineMessage = state === 'pending' || state === 'offline' || state === 'failed';
+    const showInlineMessage = state === 'offline' || state === 'failed';
     this.statusRefreshState = state;
     this.statusRefreshMessage.textContent = showInlineMessage ? FRIEND_STATUS_REFRESH_MESSAGES[state] : '';
     this.statusRefreshMessage.hidden = !showInlineMessage;


### PR DESCRIPTION
## What Changed

This PR keeps Contact Status available for viewing while an `update_toll_required` transaction is pending.

- `FriendModal.open` now activates the modal and displays the cached or optimistic selection before applying the pending guard.
- A dedicated pending state uses the existing animated “Status update pending…” loading toast while keeping the radio options and Update button disabled.
- Connectivity changes preserve the pending state instead of replacing it with an editable refresh state.
- Success, failure, and timeout settlement paths dismiss the pending toast, refresh the selected status, and confirm it with the network when online.
- Offline and failed confirmation states retain persistent inline feedback.

## Fixed Flow

1. The user opens Contact Status while a status transaction is pending.
2. The modal immediately displays the cached or optimistic status read-only with an animated pending toast.
3. The client continues preventing overlapping status submissions while the transaction remains pending.
4. When the transaction settles, the pending toast is replaced by the existing network-confirmation flow.
5. Editing becomes available only after confirmation succeeds; offline and failed refreshes remain read-only.

## Why

The previous pending guard returned before the modal became active. That prevented conflicting submissions, but also hid the entire status interface and blocked offline, reaction, and video-call setup flows waiting for it to open. Moving the guard into the modal state preserves the original transaction protection while restoring read access.

## Validation

- `node --check app.js`
- `node --test /tmp/contact-status-refresh.test.mjs` (temporary focused harness covering pending open/toast, connectivity, settlement refresh, offline, failure, and timeout)
- `git diff --check origin/main...HEAD`

Closes #1536