### PR TITLE
Open Contact Status read-only while updates are pending

### DIFF
--- a/app.js
+++ b/app.js
@@ -7947,6 +7947,7 @@ const FRIEND_STATUS_REFRESH_TIMEOUT_MS = 10 * 1000;
 const VALID_FRIEND_STATUSES = new Set([0, 1, 2]);
 const FRIEND_STATUS_REFRESH_MESSAGES = Object.freeze({
   checking: 'Checking current status\u2026',
+  pending: 'Status update pending\u2026',
   offline: 'You are offline. Showing saved status; editing is unavailable.',
   failed: 'Could not refresh current status. Showing saved status; editing is unavailable.',
   ready: '',
@@ -8034,6 +8035,15 @@ class FriendModal {
     return false;
   }
 
+  showPendingStatusIfNeeded(address) {
+    if (!this.hasPendingFriendStatusUpdate(address)) {
+      return false;
+    }
+
+    this.setStatusRefreshState('pending');
+    return true;
+  }
+
   /**
    * Restores stale local pending friend state so users are not blocked forever.
    * @param {Object} contact
@@ -8074,10 +8084,6 @@ class FriendModal {
     if (!contactAddress) return;
     const contact = myData.contacts[contactAddress];
     if (!contact) return;
-    if (this.hasPendingFriendStatusUpdate(contactAddress)) {
-      showToast('You have a pending transaction to update the friend status. Come back to this page later.', 0, 'warning');
-      return;
-    }
 
     this.statusRefreshAbortController?.abort();
     this.statusRefreshAbortController = null;
@@ -8087,6 +8093,10 @@ class FriendModal {
     this.initialFriendStatus = contact.friend;
     this.warningShown = false;
     this.modal.classList.add('active');
+
+    if (this.showPendingStatusIfNeeded(contactAddress)) {
+      return;
+    }
 
     await this.refreshStatus(contactAddress, contact);
   }
@@ -8157,15 +8167,34 @@ class FriendModal {
     this.statusRefreshAbortController?.abort();
     this.statusRefreshAbortController = null;
 
+    const contactAddress = normalizeAddress(this.currentContactAddress);
+    const contact = myData.contacts?.[contactAddress];
+    assert(contact, `Missing contact while refreshing friend status: ${contactAddress}`);
+    if (this.showPendingStatusIfNeeded(contactAddress)) {
+      return;
+    }
+
     if (!isOnline) {
       this.setStatusRefreshState('offline');
       return;
     }
 
-    const contactAddress = normalizeAddress(this.currentContactAddress);
-    const contact = myData.contacts?.[contactAddress];
-    assert(contact, `Missing contact while refreshing friend status: ${contactAddress}`);
     this.refreshStatus(contactAddress, contact);
+  }
+
+  async refreshAfterPendingStatusSettlement(contactAddress) {
+    if (!this.isActive()) {
+      return;
+    }
+
+    const normalizedAddress = normalizeAddress(contactAddress);
+    if (normalizeAddress(this.currentContactAddress) !== normalizedAddress) {
+      return;
+    }
+
+    const contact = myData.contacts?.[normalizedAddress];
+    assert(contact, `Missing contact after friend status settlement: ${normalizedAddress}`);
+    await this.refreshStatus(normalizedAddress, contact);
   }
 
   getNetworkFriendStatus(networkRequired) {
@@ -8200,8 +8229,9 @@ class FriendModal {
       );
     }
 
-    const showInlineMessage = state === 'offline' || state === 'failed';
+    const showInlineMessage = state === 'pending' || state === 'offline' || state === 'failed';
     this.statusRefreshState = state;
+    this.modal.dataset.statusState = state;
     this.statusRefreshMessage.textContent = showInlineMessage ? FRIEND_STATUS_REFRESH_MESSAGES[state] : '';
     this.statusRefreshMessage.hidden = !showInlineMessage;
     this.updateSubmitButtonState();
@@ -8234,6 +8264,7 @@ class FriendModal {
     this.statusRefreshAbortController = null;
     this.hideStatusRefreshToast();
     this.modal.classList.remove('active');
+    delete this.modal.dataset.statusState;
     this.initialFriendStatus = null;
     this.statusRefreshState = null;
     this.warningShown = false;
@@ -33477,6 +33508,7 @@ async function checkPendingTransactionsOnce() {
             await chatsScreen.updateChatList();
           }
           chatModal.refreshCurrentView(txid);
+          await friendModal.refreshAfterPendingStatusSettlement(pendingTxInfo.to);
         }
         if (type === 'message') {
           updateTransactionStatus(txid, pendingTxInfo.to, 'failed', type);
@@ -33535,6 +33567,7 @@ async function checkPendingTransactionsOnce() {
           // log used by e2e tests do not delete
           console.log(`DEBUG: update_toll_required transaction successfully processed!`);
           syncPendingUpdateTollRequiredSuccess(pendingTxInfo, res.transaction);
+          await friendModal.refreshAfterPendingStatusSettlement(pendingTxInfo.to);
         }
 
         if (type === 'read') {
@@ -33617,6 +33650,7 @@ async function checkPendingTransactionsOnce() {
             if (didRemoveStatusHistory || currentFriendStatus === 0 || previousFriendStatus === 0) {
               await chatsScreen.updateChatList();
             }
+            await friendModal.refreshAfterPendingStatusSettlement(pendingTxInfo.to);
           } else if (type === 'read') {
             showToast(`Read transaction failed: ${userFailureReason}`, 0, 'error');
             // revert the local myData.contacts[toAddress].timestamp to the old value


### PR DESCRIPTION
## What changed

- Made pending friend-status updates a first-class Contact Status refresh state.
- Opened the modal with the cached/optimistic selection before checking the pending guard.
- Displayed `Status update pending…` inline and exposed the current state on the modal.
- Kept all status radios and Update disabled while pending.
- Reused one pending-state guard for modal open and connectivity changes.
- Refreshed an open modal after status receipt success, failure, or timeout.

## Fixed flow

1. Open Contact Status immediately with the cached or optimistic status selected.
2. If a status transaction is pending, show the pending message and keep controls read-only.
3. Reconnects re-check the pending transaction and cannot enable editing early.
4. Receipt success, failure, or timeout removes/reconciles the pending state.
5. If the modal is still open, refresh status from the network.
6. Enable editing only after a successful online refresh; otherwise retain the existing offline/failed read-only states.

## Why

The previous guard returned before activating the modal. That prevented overlapping updates, but it also prevented users from seeing the pending status and conflicted with the newer open-while-refreshing flow.

The protection remains in both the disabled controls and the submit handler; only visibility changes.

Related test-helper coverage: [client-testing #72](https://github.com/Liberdus/client-testing/pull/72).

## Validation

- Local headless Chromium state-machine check:
  - modal opened with cached Connection status
  - pending message and DOM state were visible
  - all radios and Update were disabled
  - forced submit produced zero injects
  - reconnect remained pending
  - settlement triggered one refresh and enabled editing in ready state
- `node --check app.js`
- `git diff --check`

Closes #1536