### PR TITLE
feat(dao): load proposal list from summary index

### DIFF
--- a/DAO.md
+++ b/DAO.md
@@ -1,6 +1,6 @@
 # DAO (Proposals) UI
 
-This document describes the DAO / proposals feature as currently implemented in the web client, and what remains after the proposal list query integration.
+This document describes the DAO / proposals feature as currently implemented in the web client.
 
 ## What’s implemented (current behavior)
 
@@ -97,13 +97,12 @@ Important implementation detail:
 
 ## Backend Data Boundary
 
-- `app.js` registers `setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK))`.
+- `app.js` registers `setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork))`.
 - `dao.repo.js` keeps endpoint querying and backend-to-UI mapping behind the repository boundary.
 - Proposal list loading uses the current server DAO query shape:
-  - `GET /dao/proposals/meta` for `meta.count`
-  - `GET /dao/proposals/:number` for each proposal number from `1..count`
-- On Devnet, proposal numbers `1`, `3`, `4`, `5`, `6`, and `31` are removed from the query list before proposal details are fetched.
-- The fetcher skips missing numbered proposals so nodes that have not yet surfaced an account do not block the whole list.
+  - `GET /dao/proposals/summary` for the recent-activity index and total count
+  - `GET /dao/proposals/:number` for each indexed proposal's details
+- The fetcher skips an unavailable detail response so it does not block the remaining indexed proposals from rendering.
 
 ## What must change for a live backend
 
@@ -113,13 +112,13 @@ This section is the remaining integration checklist after moving the DAO list to
 
 `daoRepo` uses an injected fetcher and otherwise returns an empty store.
 
-The app passes `queryNetwork` and its Devnet flag into `createDaoBackendFetcher(...)`; the repository maps backend `DaoProposalAccount` payloads into the store shape the UI expects.
+The app passes `queryNetwork` into `createDaoBackendFetcher(...)`; the repository maps the summary index and `DaoProposalAccount` payloads into the store shape the UI expects.
 
 ### 2) Define backend endpoints / payloads
 
 Known read endpoints:
 
-- `GET /dao/proposals/meta`
+- `GET /dao/proposals/summary`
 - `GET /dao/proposals/:number`
 
 Still needed for later phases:

--- a/app.js
+++ b/app.js
@@ -2473,7 +2473,7 @@ const menuModal = new MenuModal();
 // =====================
 
 // DAO proposals are loaded via `daoRepo` and kept in memory (no localStorage persistence).
-setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork, IS_DEV_NETWORK));
+setDaoBackendFetcher(createDaoBackendFetcher(queryNetwork));
 
 const DAO_ALL_FILTER = { key: 'all', label: 'All' };
 const DAO_CLAIMABLE_FILTER = { key: 'claimable', label: 'Claimable' };

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -193,9 +193,6 @@ export function getEffectiveDaoState(proposal) {
   return proposal?.status || proposal?.state || 'review';
 }
 
-const DAO_PROPOSAL_QUERY_BATCH_SIZE = 10;
-const DAO_DEVNET_EXCLUDED_PROPOSAL_NUMBERS = new Set([1, 3, 4, 5, 6, 31]);
-
 function requireDaoDraftString(value, label, maxLength) {
   const text = String(value ?? '').trim();
   if (!text) throw new Error(`${label} is required`);
@@ -773,7 +770,23 @@ export function isDaoProposalClaimable(proposal, currentAddress, now = Date.now(
   return getDaoRewardClaimStatus(proposal, currentAddress, now) === 'Claimable';
 }
 
-function mapBackendProposalToStoreProposal(proposal) {
+function normalizeDaoProposalSummaryEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+
+  const proposal = normalizeDaoPositiveInteger(entry.proposal);
+  const status = String(entry.status || '').trim();
+  const timestamp = normalizeDaoTimestamp(entry.timestamp);
+  if (!proposal || !status || !timestamp) return null;
+
+  return {
+    proposal,
+    status,
+    emergencyFlag: entry.emergencyFlag === true,
+    timestamp,
+  };
+}
+
+function mapBackendProposalToStoreProposal(proposal, summaryEntry) {
   if (!proposal || typeof proposal !== 'object') return null;
 
   const number = normalizeDaoPositiveInteger(proposal.number);
@@ -786,9 +799,9 @@ function mapBackendProposalToStoreProposal(proposal) {
   const proposalType = String(proposal.proposalType || '').trim();
   if (!proposalType) return null;
 
-  const state = getEffectiveDaoState(proposal);
+  const state = summaryEntry.status;
   const created = normalizeDaoTimestamp(proposal.creationTime);
-  const stateChanged = normalizeDaoTimestamp(proposal.timestamp);
+  const stateChanged = summaryEntry.timestamp;
   const title = String(proposal.title || proposal.description || '').trim();
 
   return {
@@ -799,6 +812,7 @@ function mapBackendProposalToStoreProposal(proposal) {
     title,
     description: String(proposal.description || '').trim(),
     proposalType,
+    emergency: summaryEntry.emergencyFlag,
     state,
     status: state,
     state_changed: stateChanged,
@@ -818,19 +832,17 @@ function getDaoStoreMeta(proposal) {
   };
 }
 
-function buildStoreFromBackendProposals(meta, proposals) {
+function buildStoreFromBackendProposals(count, summaryProposals) {
   const store = createEmptyDaoStore();
-  const safeMeta = meta && typeof meta === 'object' ? meta : {};
 
   store.meta = {
-    ...safeMeta,
-    count: Math.max(normalizeDaoPositiveInteger(safeMeta.count), proposals.length),
+    count: Math.max(normalizeDaoPositiveInteger(count), summaryProposals.length),
     active: 0,
     archived: 0,
   };
 
-  for (const rawProposal of proposals) {
-    const proposal = mapBackendProposalToStoreProposal(rawProposal);
+  for (const { proposal: rawProposal, summaryEntry } of summaryProposals) {
+    const proposal = mapBackendProposalToStoreProposal(rawProposal, summaryEntry);
     if (!proposal) continue;
 
     const id = daoProposalId(proposal.number, proposal.nonce);
@@ -841,54 +853,41 @@ function buildStoreFromBackendProposals(meta, proposals) {
   return store;
 }
 
-async function fetchBackendProposal(queryDaoApi, proposalNumber) {
-  const body = await queryDaoApi(`/dao/proposals/${proposalNumber}`);
+async function fetchBackendProposal(queryDaoApi, summaryEntry) {
+  const body = await queryDaoApi(`/dao/proposals/${summaryEntry.proposal}`);
   if (!body) {
-    console.warn(`Skipping DAO proposal #${proposalNumber}: no response`);
+    console.warn(`Skipping DAO proposal #${summaryEntry.proposal}: no response`);
     return null;
   }
   if (body.error || !body.proposal) {
-    console.warn(`Skipping DAO proposal #${proposalNumber}: proposal unavailable`, body.error || body);
+    console.warn(`Skipping DAO proposal #${summaryEntry.proposal}: proposal unavailable`, body.error || body);
     return null;
   }
-  return body.proposal;
+  return { proposal: body.proposal, summaryEntry };
 }
 
-export function createDaoBackendFetcher(queryDaoApi, isDevNetwork) {
+export function createDaoBackendFetcher(queryDaoApi) {
   if (typeof queryDaoApi !== 'function') {
     return async () => createEmptyDaoStore();
   }
 
   return async () => {
-    const body = await queryDaoApi('/dao/proposals/meta');
+    const body = await queryDaoApi('/dao/proposals/summary');
     if (!body) {
-      throw new Error('Failed to load DAO proposal metadata');
+      throw new Error('Failed to load DAO proposal summary');
     }
     if (body.error) {
       throw new Error(String(body.error));
     }
 
-    const meta = body.meta && typeof body.meta === 'object' ? body.meta : null;
-    const count = normalizeDaoPositiveInteger(meta?.count);
-    if (!count) return buildStoreFromBackendProposals(meta, []);
+    const summaryEntries = (Array.isArray(body.proposals) ? body.proposals : [])
+      .map(normalizeDaoProposalSummaryEntry)
+      .filter(Boolean);
+    const proposals = await Promise.all(
+      summaryEntries.map((summaryEntry) => fetchBackendProposal(queryDaoApi, summaryEntry))
+    );
 
-    const proposalNumbers = Array.from({ length: count }, (_, index) => index + 1)
-      .filter((proposalNumber) => (
-        !isDevNetwork || !DAO_DEVNET_EXCLUDED_PROPOSAL_NUMBERS.has(proposalNumber)
-      ));
-    const proposals = [];
-    for (let batchStart = 0; batchStart < proposalNumbers.length; batchStart += DAO_PROPOSAL_QUERY_BATCH_SIZE) {
-      const batchProposalNumbers = proposalNumbers.slice(
-        batchStart,
-        batchStart + DAO_PROPOSAL_QUERY_BATCH_SIZE
-      );
-      const batch = await Promise.all(
-        batchProposalNumbers.map((proposalNumber) => fetchBackendProposal(queryDaoApi, proposalNumber))
-      );
-      proposals.push(...batch.filter(Boolean));
-    }
-
-    return buildStoreFromBackendProposals(meta, proposals);
+    return buildStoreFromBackendProposals(body.count, proposals.filter(Boolean));
   };
 }
 


### PR DESCRIPTION
## What Changed

This PR loads the DAO list from the server's recent-proposal summary index.

- Requests `GET /dao/proposals/summary`, then loads details only for each indexed proposal number.
- Uses summary status, timestamp, and emergency metadata so list rows reflect the index's current lifecycle state.
- Removes the previous full sequential scan and Devnet-specific skipped-number list.

## Fixed Flow

1. A user opens the DAO modal.
2. The client requests the compact summary index.
3. The client requests details for the proposal numbers returned by that index.
4. The UI renders only those compatible, recent proposals.

## Intentional Scope

The client intentionally does not fall back to loading older proposal records when they are absent from the summary index. Those historical Devnet records use an older data structure and are deliberately excluded from this summary-list view. The backend `count` remains unchanged because proposal creation uses it to determine the next sequential proposal number; it is not used to choose list entries.

## Validation

- `node --check dao.repo.js`
- `node --test tests/dao-summary-fetcher.test.mjs`
- `git diff --check main...HEAD`

Closes #1544
<img width="587" height="530" alt="image" src="https://github.com/user-attachments/assets/bbe9e050-5ba3-432f-aa7b-21d69f3ba51b" />
