### PR TITLE
Remove active and archived DAO proposal views

### DIFF
--- a/DAO.md
+++ b/DAO.md
@@ -12,9 +12,8 @@ This document describes the DAO / proposals feature as currently implemented in 
 
 1. **DAO Modal**
    - Shows a list of proposals.
-   - Includes an **Active / Archived** segmented toggle.
-   - Includes a **Status filter** that filters by proposal status and shows **counts**.
-   - The **All** status filter displays every proposal in the selected Active / Archived group.
+   - Includes a **Status filter** for server-provided proposal statuses and their **counts**.
+   - The **All** status filter displays every proposal returned by the server summary.
    - The proposal list is filtered by the selected option.
    - List ordering is **newest to enter the selected state first** (sort by `stateEnteredAt` descending, falling back to `createdAt`).
    - Clicking a proposal opens the Proposal Info modal.
@@ -51,21 +50,11 @@ The UI uses these statuses:
 - `accepted`
 - `applied`
 
-### Archived is a group, not a status
-
-- “Archived” is a **category/group** in the UI (Active vs Archived), not a status.
-- Archived proposals keep their underlying status (e.g. `applied`) and can still be filtered by status.
-- Auto-archiving rule:
-  - Proposals in these statuses are eligible to be auto-archived after 30 days in that state:
-    - `withheld`, `rejected`, `accepted`, `applied`
-
 ## Data model used by the UI
 
 The UI consumes an in-memory “store” shape:
 
-- `meta`: `{ count, active, archived }`
-- `activeProposals`: list of lightweight proposal metadata
-- `archivedProposals`: list of lightweight proposal metadata
+- `meta`: `{ count }`
 - `proposals`: map of `proposalId -> full proposal`
 
 Identifiers:
@@ -88,7 +77,7 @@ Full proposal fields (current shape in memory):
 
 - DAO UI implementation: [app.js](app.js)
 - In-memory repository abstraction: [dao.repo.js](dao.repo.js)
-- Shared constants/helpers (states, type labels, archiving constants): [dao.repo.js](dao.repo.js)
+- Shared constants/helpers (states and type labels): [dao.repo.js](dao.repo.js)
 
 Important implementation detail:
 
@@ -144,18 +133,7 @@ For production you likely want:
   - refresh the proposal, or
   - patch the vote totals from server response.
 
-### 4) Decide how “Archived” is represented server-side
-
-The UI rule is “Archived is a group, not a status.”
-
-Options:
-
-- Server only stores status + timestamps; client derives archived group via the 30-day rule.
-- Server stores an explicit archived flag / archivedAt; client uses it.
-
-If you choose server-side archiving, update `normalizeDaoStore()` accordingly.
-
-### 5) Loading / errors / pagination
+### 4) Loading / errors / pagination
 
 The UI already shows a basic loading empty-state while `daoRepo.refresh()` is running.
 
@@ -165,7 +143,7 @@ For production, consider adding:
 - Incremental refresh (don’t blow away list on refresh)
 - Better error states (retry button)
 
-### 6) Auth / permissions
+### 5) Auth / permissions
 
 The UI derives a `voterId` from the account in memory, but a real backend will likely require:
 

--- a/app.js
+++ b/app.js
@@ -2530,7 +2530,6 @@ function formatDaoProposalTitle(proposal) {
 
 class DaoModal {
   constructor() {
-    this.selectedGroupKey = 'active';
     this.selectedFilterKey = 'voting';
     this.refreshState = 'loading';
     this.refreshSequence = 0;
@@ -2545,9 +2544,6 @@ class DaoModal {
     this.filterBar = document.getElementById('daoFilterBar');
     this.filterOverflow = document.getElementById('daoFilterOverflow');
     this.filterExpandButton = document.getElementById('daoFilterExpandButton');
-    this.groupToggle = this.modal.querySelector('.dao-group-toggle');
-    this.groupActiveButton = document.getElementById('daoGroupActiveButton');
-    this.groupArchivedButton = document.getElementById('daoGroupArchivedButton');
     this.list = document.getElementById('daoProposalList');
     this.emptyState = document.getElementById('daoProposalEmptyState');
     this.addButton = document.getElementById('daoAddProposalButton');
@@ -2568,17 +2564,6 @@ class DaoModal {
     if (this.filterExpandButton) {
       this.filterExpandButton.addEventListener('click', () => {
         this.setFiltersExpanded(this.filterOverflow.hidden);
-      });
-    }
-
-    if (this.groupActiveButton) {
-      this.groupActiveButton.addEventListener('click', () => {
-        this.setGroupFilter('active');
-      });
-    }
-    if (this.groupArchivedButton) {
-      this.groupArchivedButton.addEventListener('click', () => {
-        this.setGroupFilter('archived');
       });
     }
   }
@@ -2602,7 +2587,6 @@ class DaoModal {
 
     // Default filter is Voting
     this.selectedFilterKey = this.selectedFilterKey || 'voting';
-    this.selectedGroupKey = this.selectedGroupKey || 'active';
     this.render();
 
     try {
@@ -2699,59 +2683,28 @@ class DaoModal {
     this.render();
   }
 
-  setGroupFilter(key) {
-    this.selectedGroupKey = key;
-    this.render();
-  }
-
   render() {
     const hasFreshData = this.refreshState === 'ready';
-    const proposalsActive = hasFreshData ? daoRepo.getProposalsForUi('active') : [];
-    const proposalsArchived = hasFreshData ? daoRepo.getProposalsForUi('archived') : [];
+    const proposals = hasFreshData ? daoRepo.getProposalsForUi() : [];
     const currentAddress = getDaoCurrentAccountAddress();
     const now = getTransactionTimestamp();
     const isAllFilter = this.selectedFilterKey === DAO_ALL_FILTER.key;
     const isClaimableFilter = this.selectedFilterKey === DAO_CLAIMABLE_FILTER.key;
-    const groupedProposals = this.selectedGroupKey === 'archived' ? proposalsArchived : proposalsActive;
-    const claimableProposals = [...proposalsActive, ...proposalsArchived]
-      .filter((proposal) => isDaoProposalClaimable(proposal, currentAddress, now));
+    const claimableProposals = proposals.filter(
+      (proposal) => isDaoProposalClaimable(proposal, currentAddress, now)
+    );
 
-    // State counts follow the selected group; Claimable spans both groups.
     const counts = Object.fromEntries(DAO_FILTER_OPTIONS.map((filter) => [filter.key, 0]));
-    for (const p of groupedProposals) {
+    for (const p of proposals) {
       const state = getEffectiveDaoState(p);
       if (counts[state] !== undefined) counts[state] += 1;
     }
-    counts[DAO_ALL_FILTER.key] = groupedProposals.length;
+    counts[DAO_ALL_FILTER.key] = proposals.length;
     counts[DAO_CLAIMABLE_FILTER.key] = claimableProposals.length;
 
-    // Update header title
-    const groupLabel = this.selectedGroupKey === 'archived' ? 'Archived' : 'Active';
     const label = DAO_FILTER_OPTIONS.find((filter) => filter.key === this.selectedFilterKey)?.label
       || this.selectedFilterKey;
-    if (this.titleEl) this.titleEl.textContent = isClaimableFilter ? 'DAO - Claimable' : `DAO - ${groupLabel} - ${label}`;
-    // Claimable spans both groups, so hide Active/Archived while keeping the filter bar.
-    if (this.groupToggle) this.groupToggle.classList.toggle('hidden', isClaimableFilter);
-
-    // Update group toggle labels + selection
-    const groups = [
-      { key: 'active', label: 'Active', button: this.groupActiveButton, count: proposalsActive.length },
-      { key: 'archived', label: 'Archived', button: this.groupArchivedButton, count: proposalsArchived.length },
-    ];
-    for (const { key, label: groupName, button, count } of groups) {
-      if (!button) continue;
-      const countEl = button.querySelector('.dao-group-toggle-count');
-      if (countEl) {
-        countEl.textContent = hasFreshData ? String(count) : '—';
-        countEl.setAttribute(
-          'aria-label',
-          hasFreshData ? `${count} ${key} proposals` : `${groupName} count unavailable`
-        );
-      }
-      const selected = this.selectedGroupKey === key;
-      button.classList.toggle('active', selected);
-      button.setAttribute('aria-selected', selected ? 'true' : 'false');
-    }
+    if (this.titleEl) this.titleEl.textContent = `DAO - ${label}`;
 
     for (const filter of DAO_FILTER_OPTIONS) {
       const chip = this.filterBar?.querySelector(`.dao-filter-chip[data-filter-key="${filter.key}"]`);
@@ -2775,7 +2728,7 @@ class DaoModal {
     // Filter + sort (newest entered into state first)
     const matchingProposals = isClaimableFilter
       ? claimableProposals
-      : groupedProposals.filter((proposal) => (
+      : proposals.filter((proposal) => (
         isAllFilter || getEffectiveDaoState(proposal) === this.selectedFilterKey
       ));
     const filtered = matchingProposals
@@ -2789,13 +2742,11 @@ class DaoModal {
     const hasAny = filtered.length > 0;
     if (this.emptyState) this.emptyState.style.display = hasAny ? 'none' : 'block';
 
-    // Update empty state copy based on group.
     if (this.emptyState && !hasAny) {
       const lines = Array.from(this.emptyState.querySelectorAll('div'));
       // Structure is: [0]=spacer, [1]=headline, [2]=subline, [3]=optional third line.
       const headlineEl = lines[1] || null;
       const sublineEl = lines[2] || null;
-      const isArchived = this.selectedGroupKey === 'archived';
 
       if (this.refreshState === 'loading') {
         if (headlineEl) headlineEl.textContent = 'Loading proposals…';
@@ -2807,12 +2758,8 @@ class DaoModal {
         if (headlineEl) headlineEl.textContent = 'No claimable proposals found';
         if (sublineEl) sublineEl.textContent = 'You have no voter rewards ready to claim';
       } else {
-        if (headlineEl) headlineEl.textContent = isArchived ? 'No archived proposals found' : 'No proposals found';
-        if (sublineEl) {
-          sublineEl.textContent = isArchived
-            ? 'Archived proposals appear here after they age out'
-            : 'Proposal data appears here when available';
-        }
+        if (headlineEl) headlineEl.textContent = 'No proposals found';
+        if (sublineEl) sublineEl.textContent = 'Proposal data appears here when available';
       }
     }
 

--- a/dao.repo.js
+++ b/dao.repo.js
@@ -4,10 +4,6 @@ import { normalizeAddress, utf82bin } from './lib.js';
 // Shared DAO constants and light helper functions.
 // Kept here so UI + repo can share one import surface.
 
-export const DAO_ARCHIVE_AFTER_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-
-export const DAO_ARCHIVABLE_STATE_KEYS = ['withheld', 'rejected', 'accepted', 'applied'];
-
 const DAO_REWARD_STATE_KEYS = ['accepted', 'rejected', 'applied'];
 
 export const DAO_TYPE_OPTIONS = [
@@ -639,9 +635,7 @@ async function submitDaoProposalAction({
 
 function createEmptyDaoStore() {
   return {
-    meta: { count: 0, active: 0, archived: 0 },
-    activeProposals: [],
-    archivedProposals: [],
+    meta: { count: 0 },
     proposals: {},
   };
 }
@@ -820,25 +814,11 @@ function mapBackendProposalToStoreProposal(proposal, summaryEntry) {
   };
 }
 
-function getDaoStoreMeta(proposal) {
-  return {
-    number: proposal.number,
-    title: proposal.title,
-    state: proposal.state,
-    status: proposal.status,
-    state_changed: proposal.state_changed,
-    proposalType: proposal.proposalType,
-    nonce: proposal.nonce,
-  };
-}
-
 function buildStoreFromBackendProposals(count, summaryProposals) {
   const store = createEmptyDaoStore();
 
   store.meta = {
     count: Math.max(normalizeDaoPositiveInteger(count), summaryProposals.length),
-    active: 0,
-    archived: 0,
   };
 
   for (const { proposal: rawProposal, summaryEntry } of summaryProposals) {
@@ -847,7 +827,6 @@ function buildStoreFromBackendProposals(count, summaryProposals) {
 
     const id = daoProposalId(proposal.number, proposal.nonce);
     store.proposals[id] = proposal;
-    store.activeProposals.push(getDaoStoreMeta(proposal));
   }
 
   return store;
@@ -893,114 +872,52 @@ export function createDaoBackendFetcher(queryDaoApi) {
 
 function normalizeDaoStore(store) {
   const safe = store && typeof store === 'object' ? store : createEmptyDaoStore();
-  safe.meta = safe.meta && typeof safe.meta === 'object' ? safe.meta : { count: 0, active: 0, archived: 0 };
-  safe.activeProposals = Array.isArray(safe.activeProposals) ? safe.activeProposals : [];
-  safe.archivedProposals = Array.isArray(safe.archivedProposals) ? safe.archivedProposals : [];
   safe.proposals = safe.proposals && typeof safe.proposals === 'object' ? safe.proposals : {};
 
-  // If store is missing count, reconstruct from proposals.
-  if (!Number.isFinite(Number(safe.meta.count))) {
-    const nums = Object.values(safe.proposals)
-      .map((p) => Number(p?.number || 0))
-      .filter((n) => n > 0);
-    safe.meta.count = nums.length ? Math.max(...nums) : 0;
-  }
-
-  // Auto-archive proposals that have been in certain states for > 30 days.
-  // Archived is a *category* (group), not a proposal state.
-  const now = Date.now();
-  const activeNext = [];
-  const archivedIds = new Set(safe.archivedProposals.map((m) => daoProposalId(m.number, m.nonce)));
-
-  for (const meta of safe.activeProposals) {
-    const id = daoProposalId(meta.number, meta.nonce);
-    const full = safe.proposals[id];
-    if (!full) continue;
-
-    const state = getEffectiveDaoState({ status: full.status || meta.status, state: full.state || meta.state });
-    const enteredAt = Number(full.state_changed || meta.state_changed || full.created || 0);
-    const isArchivable = DAO_ARCHIVABLE_STATE_KEYS.includes(state);
-
-    if (isArchivable && enteredAt && now - enteredAt >= DAO_ARCHIVE_AFTER_MS) {
-      const archivedAt = Number(full.archivedAt || (enteredAt + DAO_ARCHIVE_AFTER_MS));
-      full.archivedAt = archivedAt;
-
-      if (!archivedIds.has(id)) {
-        safe.archivedProposals.push({
-          number: meta.number,
-          title: meta.title,
-          state,
-          state_changed: enteredAt,
-          proposalType: meta.proposalType,
-          nonce: meta.nonce,
-        });
-        archivedIds.add(id);
-      }
-      continue;
-    }
-
-    activeNext.push(meta);
-  }
-
-  safe.activeProposals = activeNext;
-
-  // Remove archived metas whose full proposal no longer exists.
-  safe.archivedProposals = safe.archivedProposals.filter((m) => {
-    const id = daoProposalId(m.number, m.nonce);
-    return Boolean(safe.proposals[id]);
-  });
-
-  safe.meta.active = safe.activeProposals.length;
-  safe.meta.archived = safe.archivedProposals.length;
-  safe.meta.count = Math.max(
-    Number(safe.meta.count || 0),
-    ...safe.activeProposals.map((m) => Number(m.number || 0)),
-    ...safe.archivedProposals.map((m) => Number(m.number || 0))
-  );
+  const proposalNumbers = Object.values(safe.proposals)
+    .map((proposal) => normalizeDaoPositiveInteger(proposal?.number));
+  safe.meta = {
+    count: Math.max(normalizeDaoPositiveInteger(safe.meta?.count), ...proposalNumbers),
+  };
 
   return safe;
 }
 
-function storeToUiList(store, groupKey) {
-  const safe = store || createEmptyDaoStore();
-  const metas = groupKey === 'archived' ? safe.archivedProposals : safe.activeProposals;
-  return metas
-    .map((m) => {
-      const id = daoProposalId(m.number, m.nonce);
-      const p = safe.proposals?.[id];
-      if (!p) return null;
-      const state = getEffectiveDaoState({ status: p.status || m.status, state: p.state || m.state });
+function storeToUiList(store) {
+  return Object.values(store?.proposals || {})
+    .map((proposal) => {
+      if (!proposal || typeof proposal !== 'object') return null;
+      const state = getEffectiveDaoState(proposal);
       return {
-        id,
-        number: p.number,
-        accountId: p.accountId,
-        nonce: p.nonce,
-        title: p.title,
-        description: p.description,
-        proposalType: p.proposalType,
-        emergency: Boolean(p.emergency),
-        createdAt: p.created,
+        id: daoProposalId(proposal.number, proposal.nonce),
+        number: proposal.number,
+        accountId: proposal.accountId,
+        nonce: proposal.nonce,
+        title: proposal.title,
+        description: proposal.description,
+        proposalType: proposal.proposalType,
+        emergency: Boolean(proposal.emergency),
+        createdAt: proposal.created,
         state,
         status: state,
-        stateEnteredAt: p.state_changed,
-        options: p.options,
-        totalVote: p.totalVote,
-        committeeVotes: p.committeeVotes,
-        committeeAddresses: p.committeeAddresses,
-        voterRewardPool: p.voterRewardPool,
-        claimedReward: p.claimedReward,
-        initialBurnedReward: p.initialBurnedReward,
-        finalBurnedReward: p.finalBurnedReward,
-        voterList: p.voterList,
-        claimList: p.claimList,
-        startTime: p.startTime,
-        reviewDuration: p.reviewDuration,
-        votingStartedAt: p.votingStartedAt,
-        votingEndedAt: p.votingEndedAt,
-        votingDuration: p.votingDuration,
-        claimDuration: p.claimDuration,
-        gracePeriod: p.gracePeriod,
-        archivedAt: p.archivedAt || 0,
+        stateEnteredAt: proposal.state_changed,
+        options: proposal.options,
+        totalVote: proposal.totalVote,
+        committeeVotes: proposal.committeeVotes,
+        committeeAddresses: proposal.committeeAddresses,
+        voterRewardPool: proposal.voterRewardPool,
+        claimedReward: proposal.claimedReward,
+        initialBurnedReward: proposal.initialBurnedReward,
+        finalBurnedReward: proposal.finalBurnedReward,
+        voterList: proposal.voterList,
+        claimList: proposal.claimList,
+        startTime: proposal.startTime,
+        reviewDuration: proposal.reviewDuration,
+        votingStartedAt: proposal.votingStartedAt,
+        votingEndedAt: proposal.votingEndedAt,
+        votingDuration: proposal.votingDuration,
+        claimDuration: proposal.claimDuration,
+        gracePeriod: proposal.gracePeriod,
       };
     })
     .filter(Boolean);
@@ -1011,8 +928,7 @@ let _loadingPromise = null;
 let _refreshVersion = 0;
 let _latestCommittedRefreshVersion = 0;
 
-// Backend integration hook. The fetcher should return the DAO store shape
-// consumed by this repository: meta, activeProposals, archivedProposals, proposals.
+// Backend integration hook. The fetcher returns a count and the loaded proposal details.
 let _backendFetcher = null;
 
 export function setDaoBackendFetcher(fetcher) {
@@ -1069,8 +985,8 @@ export const daoRepo = {
     return _store?.proposals?.[proposalId] || null;
   },
 
-  getProposalsForUi(groupKey) {
-    return storeToUiList(_store, groupKey);
+  getProposalsForUi() {
+    return storeToUiList(_store);
   },
 
   async createProposal({

--- a/index.html
+++ b/index.html
@@ -451,16 +451,6 @@
             </div>
           </div>
           <div class="dao-list-pane">
-            <div class="dao-group-toggle" role="tablist" aria-label="Proposal group">
-              <button class="dao-group-toggle-button" id="daoGroupActiveButton" type="button" role="tab" aria-selected="true">
-                <span class="dao-group-toggle-label">Active</span>
-                <span class="dao-group-toggle-count" aria-label="0 active proposals">0</span>
-              </button>
-              <button class="dao-group-toggle-button" id="daoGroupArchivedButton" type="button" role="tab" aria-selected="false">
-                <span class="dao-group-toggle-label">Archived</span>
-                <span class="dao-group-toggle-count" aria-label="0 archived proposals">0</span>
-              </button>
-            </div>
             <ul class="chat-list" id="daoProposalList">
               <div class="empty-state" id="daoProposalEmptyState">
                 <div></div>

--- a/styles.css
+++ b/styles.css
@@ -8343,7 +8343,7 @@ small {
   position: relative;
 }
 
-/* DAO modal: filter bar stays fixed; Active/Archived scrolls with the list. */
+/* DAO modal: filter bar stays fixed while the list scrolls. */
 #daoModal .dao-toolbar {
   background: var(--background-color);
   display: flex;
@@ -8390,8 +8390,7 @@ small {
   display: none;
 }
 
-#daoModal .dao-filter-chip,
-#daoModal .dao-group-toggle-button {
+#daoModal .dao-filter-chip {
   align-items: center;
   appearance: none;
   background: transparent;
@@ -8410,8 +8409,7 @@ small {
   white-space: nowrap;
 }
 
-#daoModal .dao-filter-chip:hover,
-#daoModal .dao-group-toggle-button:hover {
+#daoModal .dao-filter-chip:hover {
   background: var(--hover-background-dark);
 }
 
@@ -8429,13 +8427,11 @@ small {
   color: var(--background-color);
 }
 
-#daoModal .dao-filter-chip-label,
-#daoModal .dao-group-toggle-label {
+#daoModal .dao-filter-chip-label {
   flex: 0 0 auto;
 }
 
-#daoModal .dao-filter-chip-count,
-#daoModal .dao-group-toggle-count {
+#daoModal .dao-filter-chip-count {
   align-items: center;
   background: var(--hover-background);
   border: 1px solid var(--border-color);
@@ -8497,31 +8493,6 @@ small {
   #daoModal .dao-filter-overflow[hidden] {
     display: flex;
   }
-}
-
-#daoModal .dao-group-toggle {
-  background: var(--input-background);
-  border: 1px solid var(--border-color, rgba(0,0,0,0.12));
-  border-radius: 8px;
-  display: grid;
-  gap: 4px;
-  grid-template-columns: 1fr 1fr;
-  margin: 10px 16px;
-  padding: 4px;
-}
-
-#daoModal .dao-group-toggle-button {
-  padding: 8px 10px;
-  transition: background-color 0.15s ease, color 0.15s ease;
-}
-
-#daoModal .dao-group-toggle-button.active {
-  background: var(--hover-background-dark);
-}
-
-#daoModal .dao-group-toggle-button.active .dao-group-toggle-count {
-  background: rgba(0, 0, 0, 0.08);
-  border-color: rgba(0, 0, 0, 0.1);
 }
 
 #daoModal #daoProposalList {


### PR DESCRIPTION
## What Changed

This PR removes the DAO Active/Archived proposal split and renders the server summary as one status-filtered list.

- The DAO modal now filters every loaded proposal by its server-provided status.
- Client-side archive aging and the associated store metadata have been removed.
- The DAO documentation now describes the simplified proposal store and list behavior.

## Fixed Flow

1. The DAO modal refreshes the proposal summary.
2. Loaded proposal details are stored in a single proposal map.
3. Status and claimable filters run across that complete loaded set.
4. Proposals no longer disappear from the UI after a client-side archive threshold.

## Why

Proposal visibility is now determined by the server summary and its statuses, rather than a client-derived Active/Archived grouping.

## Validation

- `node tests/dao-summary-fetcher.test.mjs`

Closes #1547